### PR TITLE
Sub-orchestration: Enable Orchestrator Functions to call other Orchestrator Functions

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
@@ -365,16 +365,25 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             }
         }
 
-        internal void AssertActivityExists(string name, string version)
+        internal FunctionType GetFunctionType(string name, string version)
         {
             var functionName = new FunctionName(name, version);
-            if (!this.registeredActivities.ContainsKey(functionName))
+
+            if (this.registeredActivities.ContainsKey(functionName))
             {
-                throw new ArgumentException(
-                    string.Format("The function '{0}' doesn't exist, is disabled, or is not an activity function. The following are the active activity functions: {1}.",
-                        functionName,
-                        string.Join(", ", this.registeredActivities.Keys)));
+                return FunctionType.Activity;
             }
+
+            if (this.registeredOrchestrators.ContainsKey(functionName))
+            {
+                return FunctionType.Orchestrator;
+            }
+
+            throw new ArgumentException(
+                    string.Format("The function '{0}' doesn't exist, is disabled, or is not an activity or orchestrator function. The following are the active activity functions: '{1}', orchestrator functions: '{2}'",
+                        functionName,
+                        string.Join(", ", this.registeredActivities.Keys),
+                        string.Join(", ", this.registeredOrchestrators.Keys)));
         }
 
         internal async Task<bool> StartTaskHubWorkerIfNotStartedAsync()

--- a/src/WebJobs.Extensions.DurableTask/FunctionType.cs
+++ b/src/WebJobs.Extensions.DurableTask/FunctionType.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+namespace Microsoft.Azure.WebJobs
+{
+    /// <summary>
+    /// The type of a function.
+    /// </summary>
+    public enum FunctionType
+    {
+        Activity,
+        Orchestrator
+    }
+}

--- a/test/DurableTaskEndToEndTests.cs
+++ b/test/DurableTaskEndToEndTests.cs
@@ -2,7 +2,10 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Host;
+using Newtonsoft.Json;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -339,6 +342,95 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
                 // There aren't any exception details in the output: https://github.com/Azure/azure-webjobs-sdk-script-pr/issues/36
                 Assert.True(status?.Output.ToString().Contains("Exception"));
+
+                await host.StopAsync();
+            }
+        }
+
+        /// <summary>
+        /// End-to-end test which runs a orchestrator function that calls a non-existent orchestrator function.
+        /// </summary>
+        [Fact]
+        public async Task StartOrchestration_OnNonExistentOrchestrator()
+        {
+            const string functionName = "UnregisteredOrchestrator";
+            string errorMessage = $"The function '{functionName}' doesn't exist, is disabled, or is not an orchestrator function";
+
+            using (JobHost host = TestHelpers.GetJobHost(nameof(StartOrchestration_OnNonExistentOrchestrator)))
+            {
+                await host.StartAsync();
+
+                Exception ex = await Assert.ThrowsAsync<FunctionInvocationException>(async () => await host.StartFunctionAsync("UnregisteredOrchestrator", "Unregistered", this.output));
+                
+                Assert.NotNull(ex.InnerException);
+                Assert.Contains(errorMessage, ex.InnerException?.ToString());
+
+                await host.StopAsync();
+            }
+        }
+
+        /// <summary>
+        /// End-to-end test which runs a orchestrator function that calls a non-existent activity function.
+        /// </summary>
+        [Fact]
+        public async Task Orchestration_OnNonExistentActivity()
+        {
+            const string functionName = "UnregisteredActivity";
+            string errorMessage = $"The function '{functionName}' doesn't exist, is disabled, or is not an activity or orchestrator function";
+
+            using (JobHost host = TestHelpers.GetJobHost(nameof(Orchestration_OnNonExistentActivity)))
+            {
+                await host.StartAsync();
+
+                var startArgs = new StartOrchestrationArgs
+                {
+                    FunctionName = functionName,
+                    Input = new {Foo = "Bar"}
+                };
+
+                var client = await host.StartFunctionAsync(nameof(TestOrchestrations.CallUnregisteredActivity), startArgs, this.output);
+                var status = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(30), this.output);
+
+                Assert.Equal("Failed", status?.RuntimeStatus);
+
+                // There aren't any exception details in the output: https://github.com/Azure/azure-webjobs-sdk-script-pr/issues/36
+                Assert.True(status?.Output.ToString().Contains(errorMessage));
+
+                await host.StopAsync();
+            }
+        }
+
+        /// <summary>
+        /// End-to-end test which runs a orchestrator function that calls another orchestrator function.
+        /// </summary>
+        [Fact]
+        public async Task Orchestration_OnValidOrchestrator()
+        {
+            const string greetingName = "ValidOrchestrator";
+            const string validOrchestratorName = "SayHelloInline";
+            var input = new {Foo = greetingName};
+            var inputJson = JsonConvert.SerializeObject(input);
+
+            using (JobHost host = TestHelpers.GetJobHost(nameof(Orchestration_OnValidOrchestrator)))
+            {
+                await host.StartAsync();
+
+                var startArgs = new StartOrchestrationArgs
+                {
+                    FunctionName = nameof(TestOrchestrations.SayHelloInline),
+                    Input = input
+                };
+
+                var client = await host.StartFunctionAsync(nameof(TestOrchestrations.CallRegisteredOrchestrator), startArgs, this.output);
+                var status = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(30), this.output);
+                var statusInput = JsonConvert.DeserializeObject<Dictionary<string, object>>(status?.Input.ToString());
+
+                Assert.NotNull(status);
+                Assert.Equal("Completed", status.RuntimeStatus);
+                Assert.Equal(client.InstanceId, status.InstanceId);
+                Assert.Equal(validOrchestratorName, statusInput["FunctionName"].ToString());
+                Assert.Contains(greetingName, statusInput["Input"].ToString());
+                Assert.Equal($"Hello, [{inputJson}]!", status.Output.ToString());
 
                 await host.StopAsync();
             }

--- a/test/TestOrchestrations.cs
+++ b/test/TestOrchestrations.cs
@@ -154,5 +154,19 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             var result = await ctx.CallFunctionAsync<object>(startArgs.FunctionName, startArgs.Input);
             return result;
         }
+
+        public static async Task<string> CallUnregisteredActivity([OrchestrationTrigger] DurableOrchestrationContext ctx)
+        {
+            var startArgs = ctx.GetInput<StartOrchestrationArgs>();
+            string output = await ctx.CallFunctionAsync<string>(startArgs.FunctionName, startArgs.Input);
+            return output;
+        }
+
+        public static async Task<string> CallRegisteredOrchestrator([OrchestrationTrigger] DurableOrchestrationContext ctx)
+        {
+            var startArgs = ctx.GetInput<StartOrchestrationArgs>();
+            string output = await ctx.CallFunctionAsync<string>(startArgs.FunctionName, startArgs.Input);
+            return output;
+        }
     }
 }

--- a/test/TestOrchestrations.cs
+++ b/test/TestOrchestrations.cs
@@ -168,5 +168,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             string output = await ctx.CallFunctionAsync<string>(startArgs.FunctionName, startArgs.Input);
             return output;
         }
+
+        public static async Task<string> CallUnregisteredOrchestrator([OrchestrationTrigger] DurableOrchestrationContext ctx)
+        {
+            var startArgs = ctx.GetInput<StartOrchestrationArgs>();
+            string output = await ctx.CallFunctionAsync<string>(startArgs.FunctionName, startArgs.Input);
+            return output;
+        }
     }
 }

--- a/test/WebJobs.Extensions.DurableTask.Tests.csproj
+++ b/test/WebJobs.Extensions.DurableTask.Tests.csproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <PackageReference Include="DurableTask.AzureStorage" Version="0.1.0-alpha" />
     <PackageReference Include="Microsoft.AspNet.WebApi.Core" Version="5.2.3" />
-    <PackageReference Include="Microsoft.Azure.WebJobs" Version="2.1.0-beta1-10927" />
+    <PackageReference Include="Microsoft.Azure.WebJobs" Version="2.1.0-beta1-10950"/>
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
   </ItemGroup>


### PR DESCRIPTION
Addressed issue:
https://github.com/Azure/azure-functions-durable-extension/issues/15

1. Added functionality for Orchestrator Functions to call other Orchestrator Functions
2. Added end-to-end tests for error cases and happy path.