### PR TITLE
Structured Logging to Application Insights.

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/AssemblyInfo.cs
+++ b/src/WebJobs.Extensions.DurableTask/AssemblyInfo.cs
@@ -1,0 +1,6 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("WebJobs.Extensions.DurableTask.Tests")]

--- a/src/WebJobs.Extensions.DurableTask/DurableOrchestrationClient.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableOrchestrationClient.cs
@@ -85,7 +85,7 @@ namespace Microsoft.Azure.WebJobs
                 DefaultVersion,
                 instance.InstanceId,
                 reason: "NewInstance",
-                isOrchestrator: true,
+                functionType: FunctionType.Orchestrator, 
                 isReplay: false);
 
             return instance.InstanceId;
@@ -120,7 +120,7 @@ namespace Microsoft.Azure.WebJobs
                     state.Version,
                     state.OrchestrationInstance.InstanceId,
                     reason: "RaiseEvent:" + eventName,
-                    isOrchestrator: true,
+                    functionType: FunctionType.Orchestrator,
                     isReplay: false);
             }
         }

--- a/src/WebJobs.Extensions.DurableTask/DurableOrchestrationContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableOrchestrationContext.cs
@@ -262,7 +262,7 @@ namespace Microsoft.Azure.WebJobs
                 version,
                 this.InstanceId,
                 reason: sourceFunctionId,
-                isOrchestrator: true,
+                functionType: functionType,
                 isReplay: this.innerContext.IsReplaying);
 
             TResult output;
@@ -283,7 +283,7 @@ namespace Microsoft.Azure.WebJobs
                         version,
                         this.InstanceId,
                         reason: $"(replayed {e.GetType().Name})",
-                        isOrchestrator: false,
+                        functionType: FunctionType.Activity,
                         isReplay: true);
                 }
 
@@ -301,7 +301,7 @@ namespace Microsoft.Azure.WebJobs
                     this.InstanceId,
                     output: "(replayed)",
                     continuedAsNew: false,
-                    isOrchestrator: false,
+                    functionType: FunctionType.Activity,
                     isReplay: true);
             }
 

--- a/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
@@ -158,7 +158,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             // Register the trigger bindings
             JobHostConfiguration hostConfig = context.Config;
 
-            this.traceHelper = new EndToEndTraceHelper(context.Trace);
+            this.traceHelper = new EndToEndTraceHelper(hostConfig, context.Trace);
             this.httpApiHandler = new HttpApiHandler(this, context.Trace);
 
             // Register the non-trigger bindings, which have a different model.

--- a/src/WebJobs.Extensions.DurableTask/EtwEventSource.cs
+++ b/src/WebJobs.Extensions.DurableTask/EtwEventSource.cs
@@ -26,10 +26,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             string Version,
             string InstanceId,
             string Reason,
-            bool IsOrchestrator,
+            string FunctionType,
             bool IsReplay)
         {
-            this.WriteEvent(201, HubName, AppName, SlotName, FunctionName, Version ?? "", InstanceId, Reason, IsOrchestrator, IsReplay);
+            this.WriteEvent(201, HubName, AppName, SlotName, FunctionName, Version ?? "", InstanceId, Reason, FunctionType, IsReplay);
         }
 
         [Event(202, Level = EventLevel.Informational)]
@@ -41,10 +41,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             string Version,
             string InstanceId,
             string Input,
-            bool IsOrchestrator,
+            string FunctionType,
             bool IsReplay)
         {
-            this.WriteEvent(202, HubName, AppName, SlotName, FunctionName, Version ?? "", InstanceId, Input ?? "(null)", IsOrchestrator, IsReplay);
+            this.WriteEvent(202, HubName, AppName, SlotName, FunctionName, Version ?? "", InstanceId, Input ?? "(null)", FunctionType, IsReplay);
         }
 
         [Event(203, Level = EventLevel.Informational)]
@@ -55,10 +55,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             string FunctionName,
             string Version,
             string InstanceId,
-            bool IsOrchestrator,
+            string FunctionType,
             bool IsReplay)
         {
-            this.WriteEvent(203, HubName, AppName, SlotName, FunctionName, Version ?? "", InstanceId, IsOrchestrator, IsReplay);
+            this.WriteEvent(203, HubName, AppName, SlotName, FunctionName, Version ?? "", InstanceId, FunctionType, IsReplay);
         }
 
         [Event(204, Level = EventLevel.Informational)]
@@ -70,10 +70,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             string Version,
             string InstanceId,
             string Reason,
-            bool IsOrchestrator,
+            string FunctionType,
             bool IsReplay)
         {
-            this.WriteEvent(204, HubName, AppName, SlotName, FunctionName, Version ?? "", InstanceId, Reason, IsOrchestrator, IsReplay);
+            this.WriteEvent(204, HubName, AppName, SlotName, FunctionName, Version ?? "", InstanceId, Reason, FunctionType, IsReplay);
         }
 
         [Event(205, Level = EventLevel.Informational)]
@@ -86,10 +86,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             string InstanceId,
             string EventName,
             string Input,
-            bool IsOrchestrator,
+            string FunctionType,
             bool IsReplay)
         {
-            this.WriteEvent(205, HubName, AppName, SlotName, FunctionName, Version ?? "", InstanceId, EventName, Input ?? "(null)", IsOrchestrator, IsReplay);
+            this.WriteEvent(205, HubName, AppName, SlotName, FunctionName, Version ?? "", InstanceId, EventName, Input ?? "(null)", FunctionType, IsReplay);
         }
 
         [Event(206, Level = EventLevel.Informational)]
@@ -102,10 +102,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             string InstanceId,
             string Output,
             bool ContinuedAsNew,
-            bool IsOrchestrator,
+            string FunctionType,
             bool IsReplay)
         {
-            this.WriteEvent(206, HubName, AppName, SlotName, FunctionName, Version ?? "", InstanceId, Output ?? "(null)", ContinuedAsNew, IsOrchestrator, IsReplay);
+            this.WriteEvent(206, HubName, AppName, SlotName, FunctionName, Version ?? "", InstanceId, Output ?? "(null)", ContinuedAsNew, FunctionType, IsReplay);
         }
 
         [Event(207, Level = EventLevel.Warning)]
@@ -117,10 +117,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             string Version,
             string InstanceId,
             string Reason,
-            bool IsOrchestrator,
+            string FunctionType,
             bool IsReplay)
         {
-            this.WriteEvent(207, HubName, AppName, SlotName, FunctionName, Version ?? "", InstanceId, Reason, IsOrchestrator, IsReplay);
+            this.WriteEvent(207, HubName, AppName, SlotName, FunctionName, Version ?? "", InstanceId, Reason, FunctionType, IsReplay);
         }
 
         [Event(208, Level = EventLevel.Error)]
@@ -132,10 +132,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             string Version,
             string InstanceId,
             string Reason,
-            bool IsOrchestrator,
+            string FunctionType,
             bool IsReplay)
         {
-            this.WriteEvent(208, HubName, AppName, SlotName, FunctionName, Version ?? "", InstanceId, Reason, IsOrchestrator, IsReplay);
+            this.WriteEvent(208, HubName, AppName, SlotName, FunctionName, Version ?? "", InstanceId, Reason, FunctionType, IsReplay);
         }
     }
 }

--- a/src/WebJobs.Extensions.DurableTask/FunctionState.cs
+++ b/src/WebJobs.Extensions.DurableTask/FunctionState.cs
@@ -3,12 +3,15 @@
 
 namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 {
-    /// <summary>
-    /// The type of a function.
-    /// </summary>
-    internal enum FunctionType
+    internal enum FunctionState
     {
-        Activity,
-        Orchestrator
+        Scheduled,
+        Started,
+        Awaited,
+        Listening,
+        Completed,
+        Terminated,
+        Failed,
+        ExternalEventRaised
     }
 }

--- a/src/WebJobs.Extensions.DurableTask/Listener/TaskActivityShim.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/TaskActivityShim.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 this.activityVersion,
                 instanceId,
                 this.config.GetIntputOutputTrace(rawInput),
-                isOrchestrator: false,
+                functionType: FunctionType.Activity,
                 isReplay: false);
 
             FunctionResult result = await this.executor.TryExecuteAsync(triggerInput, CancellationToken.None);
@@ -65,7 +65,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     this.activityVersion,
                     instanceId,
                     result.Exception?.ToString() ?? string.Empty,
-                    isOrchestrator: false,
+                    functionType: FunctionType.Activity,
                     isReplay: false);
 
                 if (result.Exception != null)
@@ -84,7 +84,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 instanceId,
                 this.config.GetIntputOutputTrace(serializedOutput),
                 continuedAsNew: false,
-                isOrchestrator: false,
+                functionType: FunctionType.Activity,
                 isReplay: false);
 
             return serializedOutput;

--- a/src/WebJobs.Extensions.DurableTask/Listener/TaskOrchestrationShim.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/TaskOrchestrationShim.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 this.context.Version,
                 this.context.InstanceId,
                 this.config.GetIntputOutputTrace(serializedInput),
-                true /* isOrchestrator */,
+                FunctionType.Orchestrator,
                 this.context.IsReplaying);
 
             object returnValue;
@@ -77,7 +77,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     this.context.Version,
                     this.context.InstanceId,
                     e.ToString(),
-                    true /* isOrchestrator */,
+                    FunctionType.Orchestrator,
                     this.context.IsReplaying);
                 throw;
             }
@@ -100,7 +100,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 this.context.InstanceId,
                 this.config.GetIntputOutputTrace(serializedOutput),
                 this.context.ContinuedAsNew,
-                true /* isOrchestrator */,
+                FunctionType.Orchestrator,
                 this.context.IsReplaying);
 
             return serializedOutput;

--- a/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
+++ b/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
@@ -13,7 +13,8 @@
   <ItemGroup>
     <PackageReference Include="DurableTask.AzureStorage" Version="0.1.0-alpha" />
     <PackageReference Include="Microsoft.AspNet.WebApi.Core" Version="5.2.3" />
-    <PackageReference Include="Microsoft.Azure.WebJobs" Version="2.1.0-beta1-10950" />
+    <PackageReference Include="Microsoft.Azure.WebJobs" Version="2.1.0-beta1-11013" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="1.1.1" />
   </ItemGroup>
 
   <!-- NuGet Publishing Metadata -->

--- a/test/BindingTests.cs
+++ b/test/BindingTests.cs
@@ -4,6 +4,8 @@
 using System;
 using System.Diagnostics;
 using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Host.TestCommon;
+using Microsoft.Extensions.Logging;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -13,15 +15,21 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
     {
         private readonly ITestOutputHelper output;
 
+        private readonly ILoggerFactory loggerFactory;
+        private readonly TestLoggerProvider loggerProvider;
+
         public BindingTests(ITestOutputHelper output)
         {
             this.output = output;
+            loggerProvider = new TestLoggerProvider();
+            loggerFactory = new LoggerFactory();
+            loggerFactory.AddProvider(loggerProvider);
         }
 
         [Fact]
         public async Task ActivityTriggerAsJObject()
         {
-            using (JobHost host = TestHelpers.GetJobHost(nameof(ActivityTriggerAsJObject)))
+            using (JobHost host = TestHelpers.GetJobHost(loggerFactory, nameof(ActivityTriggerAsJObject)))
             {
                 await host.StartAsync();
 
@@ -46,7 +54,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         [Fact]
         public async Task ActivityTriggerAsPOCO()
         {
-            using (JobHost host = TestHelpers.GetJobHost(nameof(ActivityTriggerAsPOCO)))
+            using (JobHost host = TestHelpers.GetJobHost(loggerFactory, nameof(ActivityTriggerAsPOCO)))
             {
                 await host.StartAsync();
 
@@ -73,7 +81,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         [Fact]
         public async Task ActivityTriggerAsNumber()
         {
-            using (JobHost host = TestHelpers.GetJobHost(nameof(ActivityTriggerAsNumber)))
+            using (JobHost host = TestHelpers.GetJobHost(loggerFactory, nameof(ActivityTriggerAsNumber)))
             {
                 await host.StartAsync();
 

--- a/test/LogMessage.cs
+++ b/test/LogMessage.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
+{
+    public class LogMessage
+    {
+        public LogLevel Level { get; set; }
+        public EventId EventId { get; set; }
+        public IEnumerable<KeyValuePair<string, object>> State { get; set; }
+        public Exception Exception { get; set; }
+        public string FormattedMessage { get; set; }
+
+        public string Category { get; set; }
+    }
+}

--- a/test/TestHelpers.cs
+++ b/test/TestHelpers.cs
@@ -1,11 +1,21 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Microsoft.Azure.WebJobs.Host.TestCommon;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
 namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 {
     internal static class TestHelpers
     {
-        public static JobHost GetJobHost(string taskHub = "CommonTestHub")
+        public const string LogCategory = "Host.Triggers.DurableTask";
+
+        public static JobHost GetJobHost(ILoggerFactory loggerFactory, string taskHub = "CommonTestHub")
         {
             var config = new JobHostConfiguration { HostId = "durable-task-host" };
             config.ConfigureDurableFunctionTypeLocator(typeof(TestOrchestrations), typeof(TestActivities));
@@ -19,8 +29,255 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             // when running in the storage emulator. Disabling to keep tests running quickly.
             config.DashboardConnectionString = null;
 
+            // Add test logger
+            config.LoggerFactory = loggerFactory;
+
             var host = new JobHost(config);
             return host;
+        }
+
+        public static void AssertLogMessageSequence(TestLoggerProvider loggerProvider, string testName,
+            string[] orchestratorFunctionNames, string activityFunctionName = null)
+        {
+            var logger = loggerProvider.CreatedLoggers.Single(l => l.Category == LogCategory);
+            var logMessages = logger.LogMessages.ToList();
+            var messageIds = new List<string>()
+            {
+                GetMessageId(logMessages[0].FormattedMessage)
+            };
+
+            string timeStamp = string.Empty;
+            
+            if (testName.Equals("TimerCancellation", StringComparison.InvariantCultureIgnoreCase)
+                || testName.Equals("TimerExpiration", StringComparison.InvariantCultureIgnoreCase))
+            {
+                timeStamp = GetTimerTimestamp(logMessages[3].FormattedMessage);
+            }
+            else if (testName.Equals("Orchestration_OnValidOrchestrator", StringComparison.InvariantCultureIgnoreCase))
+            {
+                messageIds.Add(GetMessageId(logMessages[4].FormattedMessage));
+            }
+
+            var expectedLogMessages = GetExpectedLogMessages(testName, messageIds, orchestratorFunctionNames, activityFunctionName, timeStamp);
+            var actualLogMessage = logMessages.Select(m => m.FormattedMessage).ToList();
+
+            Assert.True(
+                logMessages.TrueForAll(m => m.Category.Equals(LogCategory, StringComparison.InvariantCultureIgnoreCase)));
+            Assert.Equal(expectedLogMessages.Count, logMessages.Count);
+            AssertLogMessages(expectedLogMessages, actualLogMessage);
+        }
+
+        private static IList<string> GetExpectedLogMessages(string testName, List<string> messageIds, string[] orchestratorFunctionNames, string activityFunctionName = null, string timeStamp = null)
+        {
+            var messages = new List<string>();
+            switch (testName)
+            {
+                case "HelloWorldOrchestration_Inline":
+                    messages = GetLogs_HelloWorldOrchestration_Inline(messageIds[0], orchestratorFunctionNames);
+                    break;
+                case "HelloWorldOrchestration_Activity":
+                    messages = GetLogs_HelloWorldOrchestration_Activity(messageIds[0], orchestratorFunctionNames, activityFunctionName);
+                    break;
+                case "TerminateOrchestration":
+                    messages = GetLogs_TerminateOrchestration(messageIds[0], orchestratorFunctionNames);
+                    break;
+                case "TimerCancellation":
+                    messages = GetLogs_TimerCancellation(messageIds[0], orchestratorFunctionNames, timeStamp);
+                    break;
+                case "TimerExpiration":
+                    messages = GetLogs_TimerExpiration(messageIds[0], orchestratorFunctionNames, timeStamp);
+                    break;
+                case "UnhandledOrchestrationException":
+                    messages = GetLogs_UnhandledOrchestrationException(messageIds[0], orchestratorFunctionNames);
+                    break;
+                case "UnhandledActivityException":
+                    messages = GetLogs_UnhandledActivityException(messageIds[0], orchestratorFunctionNames, activityFunctionName);
+                    break;
+                case "Orchestration_OnUnregisteredActivity":
+                    messages = GetLogs_Orchestration_OnUnregisteredActivity(messageIds[0], orchestratorFunctionNames);
+                    break;
+                case "Orchestration_OnValidOrchestrator":
+                    messages = GetLogs_Orchestration_OnValidOrchestrator(messageIds.ToArray(), orchestratorFunctionNames, activityFunctionName);
+                    break;
+                default:
+                    break;
+            }
+
+            return messages;
+        }
+
+        private static void AssertLogMessages(IList<string> expected, IList<string> actual)
+        {
+            for (int i = 0; i < expected.Count; i++)
+            {
+                Assert.StartsWith(expected[i], actual[i]);
+            }
+        }
+        private static List<string> GetLogs_HelloWorldOrchestration_Inline(string messageId, string[] functionNames)
+        {
+            var list = new List<string>()
+            {
+                $"{messageId}: Function '{functionNames[0]} ({FunctionType.Orchestrator})', version '' scheduled. Reason: NewInstance. IsReplay: False.",
+                $"{messageId}: Function '{functionNames[0]} ({FunctionType.Orchestrator})', version '' started. IsReplay: False. Input: \"World\"",
+                $"{messageId}: Function '{functionNames[0]} ({FunctionType.Orchestrator})', version '' completed. ContinuedAsNew: False. IsReplay: False. Output: \"Hello, World!\"",
+            };
+
+            return list;
+        }
+
+        private static List<string> GetLogs_HelloWorldOrchestration_Activity(string messageId, string[] orchestratorFunctionNames, string activityFunctionName)
+        {
+            var list = new List<string>()
+            {
+                $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' scheduled. Reason: NewInstance. IsReplay: False.",
+                $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' started. IsReplay: False. Input: \"World\"",
+                $"{messageId}: Function '{activityFunctionName} ({FunctionType.Activity})', version '' scheduled. Reason: {orchestratorFunctionNames[0]}. IsReplay: False.",
+                $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' awaited. IsReplay: False.",
+                $"{messageId}: Function '{activityFunctionName} ({FunctionType.Activity})', version '' started. IsReplay: False. Input: [\"World\"]",
+                $"{messageId}: Function '{activityFunctionName} ({FunctionType.Activity})', version '' completed. ContinuedAsNew: False. IsReplay: False. Output: \"Hello, World!\"",
+                $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' started. IsReplay: True. Input: \"World\"",
+                $"{messageId}: Function '{activityFunctionName} ({FunctionType.Activity})', version '' scheduled. Reason: {orchestratorFunctionNames[0]}. IsReplay: True.",
+                $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' completed. ContinuedAsNew: False. IsReplay: False. Output: \"Hello, World!\"",
+            };
+
+            return list;
+        }
+
+        private static List<string> GetLogs_TerminateOrchestration(string messageId, string[] orchestratorFunctionNames)
+        {
+            var list = new List<string>()
+            {
+                $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' scheduled. Reason: NewInstance. IsReplay: False.",
+                $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' started. IsReplay: False. Input: 0",
+                $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' is waiting for input. Reason: WaitForExternalEvent:operation. IsReplay: False.",
+                $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' awaited. IsReplay: False.",
+                $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' was terminated. Reason: sayōnara",
+                $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' started. IsReplay: True. Input: 0",
+                $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' is waiting for input. Reason: WaitForExternalEvent:operation. IsReplay: True.",
+                $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' awaited. IsReplay: False."
+            };
+
+            return list;
+        }
+
+        private static List<string> GetLogs_TimerCancellation(string messageId, string[] orchestratorFunctionNames, string timerTimestamp)
+        {
+            var list = new List<string>()
+            {
+                $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' scheduled. Reason: NewInstance. IsReplay: False.",
+                $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' started. IsReplay: False. Input: \"00:00:10\"",
+                $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' is waiting for input. Reason: WaitForExternalEvent:approval. IsReplay: False.",
+                $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' is waiting for input. Reason: CreateTimer:{timerTimestamp}. IsReplay: False.",
+                $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' awaited. IsReplay: False.",
+                $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' scheduled. Reason: RaiseEvent:approval. IsReplay: False.",
+                $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' started. IsReplay: True. Input: \"00:00:10\"",
+                $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' is waiting for input. Reason: WaitForExternalEvent:approval. IsReplay: True.",
+                $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' is waiting for input. Reason: CreateTimer:{timerTimestamp}. IsReplay: True.",
+                $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' received a 'approval' event.",
+                $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' completed. ContinuedAsNew: False. IsReplay: False. Output: \"Approved\""
+            };
+
+            return list;
+        }
+
+        private static List<string> GetLogs_TimerExpiration(string messageId, string[] orchestratorFunctionNames, string timerTimestamp)
+        {
+            var list = new List<string>()
+            {
+                $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' scheduled. Reason: NewInstance. IsReplay: False.",
+                $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' started. IsReplay: False. Input: \"00:00:10\"",
+                $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' is waiting for input. Reason: WaitForExternalEvent:approval. IsReplay: False.",
+                $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' is waiting for input. Reason: CreateTimer:{timerTimestamp}. IsReplay: False.",
+                $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' awaited. IsReplay: False.",
+                $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' started. IsReplay: True. Input: \"00:00:10\"",
+                $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' is waiting for input. Reason: WaitForExternalEvent:approval. IsReplay: True.",
+                $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' is waiting for input. Reason: CreateTimer:{timerTimestamp}. IsReplay: True.",
+                $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' completed. ContinuedAsNew: False. IsReplay: False. Output: \"Expired\"",
+            };
+
+            return list;
+        }
+
+        private static List<string> GetLogs_UnhandledOrchestrationException(string messageId, string[] orchestratorFunctionNames)
+        {
+            var list = new List<string>()
+            {
+                $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' scheduled. Reason: NewInstance. IsReplay: False.",
+                $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' started. IsReplay: False. Input: null",
+                $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' failed with an error. Reason: System.ArgumentNullException: Value cannot be null.",
+            };
+
+            return list;
+        }
+
+        private static List<string> GetLogs_UnhandledActivityException(string messageId, string[] orchestratorFunctionNames, string activityFunctionName)
+        {
+            var list = new List<string>()
+            {
+                $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' scheduled. Reason: NewInstance. IsReplay: False.",
+                $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' started. IsReplay: False. Input: \"Kah-BOOOOM!!!\"",
+                $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Activity})', version '' scheduled. Reason: Throw. IsReplay: False.",
+                $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' awaited. IsReplay: False.",
+                $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Activity})', version '' started. IsReplay: False. Input: [\"Kah-BOOOOM!!!\"]",
+                $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Activity})', version '' failed with an error. Reason: Microsoft.Azure.WebJobs.Host.FunctionInvocationException",
+                $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' started. IsReplay: True. Input: \"Kah-BOOOOM!!!\"",
+                $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Activity})', version '' scheduled. Reason: Throw. IsReplay: True.",
+                $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' failed with an error. Reason: DurableTask.Core.Exceptions.TaskFailedException",
+            };
+
+            return list;
+        }
+
+        private static List<string> GetLogs_Orchestration_OnUnregisteredActivity(string messageId, string[] orchestratorFunctionNames)
+        {
+            var list = new List<string>()
+            {
+                $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' scheduled. Reason: NewInstance. IsReplay: False.",
+                $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' started. IsReplay: False.",
+                $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' failed with an error. Reason: System.ArgumentException: The function 'UnregisteredActivity' doesn't exist, is disabled, or is not an activity or orchestrator function.",
+            };
+
+            return list;
+        }
+
+        private static List<string> GetLogs_Orchestration_OnValidOrchestrator(string[] messageIds, string[] orchestratorFunctionNames, string activityFunctionName)
+        {
+            var list = new List<string>()
+            {
+                $"{messageIds[0]}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' scheduled. Reason: NewInstance. IsReplay: False.",
+                $"{messageIds[0]}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' started. IsReplay: False.",
+                $"{messageIds[0]}: Function '{orchestratorFunctionNames[1]} ({FunctionType.Orchestrator})', version '' scheduled. Reason: CallActivity. IsReplay: False.",
+                $"{messageIds[0]}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' awaited. IsReplay: False.",
+                $"{messageIds[1]}:0: Function '{orchestratorFunctionNames[1]} ({FunctionType.Orchestrator})', version '' started. IsReplay: False.",
+                $"{messageIds[1]}:0: Function '{activityFunctionName} ({FunctionType.Activity})', version '' scheduled. Reason: SayHelloWithActivity. IsReplay: False.",
+                $"{messageIds[1]}:0: Function '{orchestratorFunctionNames[1]} ({FunctionType.Orchestrator})', version '' awaited. IsReplay: False.",
+                $"{messageIds[1]}:0: Function '{activityFunctionName} ({FunctionType.Activity})', version '' started. IsReplay: False.",
+                $"{messageIds[1]}:0: Function '{activityFunctionName} ({FunctionType.Activity})', version '' completed. ContinuedAsNew: False. IsReplay: False. Output: \"Hello, ",
+                $"{messageIds[1]}:0: Function '{orchestratorFunctionNames[1]} ({FunctionType.Orchestrator})', version '' started. IsReplay: True.",
+                $"{messageIds[1]}:0: Function '{activityFunctionName} ({FunctionType.Activity})', version '' scheduled. Reason: SayHelloWithActivity. IsReplay: True.",
+                $"{messageIds[1]}:0: Function '{orchestratorFunctionNames[1]} ({FunctionType.Orchestrator})', version '' completed. ContinuedAsNew: False. IsReplay: False. Output: \"Hello,",
+                $"{messageIds[0]}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' started. IsReplay: True.",
+                $"{messageIds[0]}: Function '{orchestratorFunctionNames[1]} ({FunctionType.Orchestrator})', version '' scheduled. Reason: CallActivity. IsReplay: True.",
+                $"{messageIds[0]}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' completed. ContinuedAsNew: False. IsReplay: False. Output: \"Hello,",
+            };
+
+            return list;
+        }
+
+        private static string GetMessageId(string message)
+        {
+            string regexPattern = @"([A-Za-z0-9])\w+";
+            var matches = Regex.Match(message, regexPattern).Groups[0];
+            return matches.Value;
+        }
+
+        private static string GetTimerTimestamp(string message)
+        {
+            string regexPattern = @"CreateTimer\:.*\.\w+";
+            var match = Regex.Match(message, regexPattern).Groups[0];
+            Regex rgx = new Regex(@"CreateTimer:");
+            string result = rgx.Replace(match.Value, string.Empty);
+            return result;
         }
     }
 }

--- a/test/TestLogger.cs
+++ b/test/TestLogger.cs
@@ -1,0 +1,52 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
+{
+    public class TestLogger : ILogger
+    {
+        private readonly Func<string, LogLevel, bool> filter;
+
+        public string Category { get; private set; }
+
+        public IList<LogMessage> LogMessages = new List<LogMessage>();
+
+        public TestLogger(string category, Func<string, LogLevel, bool> filter = null)
+        {
+            Category = category;
+            this.filter = filter;
+        }
+
+        public IDisposable BeginScope<TState>(TState state)
+        {
+            return null;
+        }
+
+        public bool IsEnabled(LogLevel logLevel)
+        {
+            return filter?.Invoke(Category, logLevel) ?? true;
+        }
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+        {
+            if (!IsEnabled(logLevel))
+            {
+                return;
+            }
+
+            LogMessages.Add(new LogMessage
+            {
+                Level = logLevel,
+                EventId = eventId,
+                State = state as IEnumerable<KeyValuePair<string, object>>,
+                Exception = exception,
+                FormattedMessage = formatter(state, exception),
+                Category = Category
+            });
+        }
+    }
+}

--- a/test/TestLoggerProvider.cs
+++ b/test/TestLoggerProvider.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests;
+using Microsoft.Azure.WebJobs.Logging;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Azure.WebJobs.Host.TestCommon
+{
+    public class TestLoggerProvider : ILoggerProvider
+    {
+        private readonly Func<string, LogLevel, bool> filter;
+
+        public IList<TestLogger> CreatedLoggers = new List<TestLogger>();
+
+        public TestLoggerProvider(Func<string, LogLevel, bool> filter = null)
+        {
+            this.filter = filter ?? new LogCategoryFilter().Filter;
+        }
+
+        public ILogger CreateLogger(string categoryName)
+        {
+            var logger = new TestLogger(categoryName, filter);
+            CreatedLoggers.Add(logger);
+            return logger;
+        }
+
+        public IEnumerable<LogMessage> GetAllLogMessages()
+        {
+            return CreatedLoggers.SelectMany(l => l.LogMessages);
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/test/WebJobs.Extensions.DurableTask.Tests.csproj
+++ b/test/WebJobs.Extensions.DurableTask.Tests.csproj
@@ -8,7 +8,8 @@
   <ItemGroup>
     <PackageReference Include="DurableTask.AzureStorage" Version="0.1.0-alpha" />
     <PackageReference Include="Microsoft.AspNet.WebApi.Core" Version="5.2.3" />
-    <PackageReference Include="Microsoft.Azure.WebJobs" Version="2.1.0-beta1-10950"/>
+    <PackageReference Include="Microsoft.Azure.WebJobs" Version="2.1.0-beta1-11013" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" Version="2.1.0-beta1-11013" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
   </ItemGroup>


### PR DESCRIPTION
Addressing open issue https://github.com/Azure/azure-functions-durable-extension/issues/35

1. Added support for structured logs to Application Insights.
2. Added tests.

**Sample query for structure log on Application Insights:**
```
traces
| extend isReplay = customDimensions["prop__isReplay"]
| extend hubName = customDimensions["prop__hubName"]
| extend functionName = customDimensions ["prop__functionName"]
| extend state = customDimensions ["prop__state"]
| extend instanceId = customDimensions ["prop__instanceId"]
| extend category = customDimensions ["Category"]
| where timestamp >= ago(10m)
| where category == "Microsoft.Azure.WebJobs.Extensions.DurableTask"
| where hubName == "UnhandledActivityException"
| order by timestamp asc
| project timestamp, instanceId, category, hubName, state, isReplay, message 
```

**Snapshot of sample output:**
![appinsights](https://user-images.githubusercontent.com/14911331/29917503-0a491024-8df7-11e7-907e-46ccdb410905.PNG)

**Snapshot of a typical message's custom dimensions**:
![appinsights2](https://user-images.githubusercontent.com/14911331/29917962-7a0f5afc-8df8-11e7-8f6f-29ef71588fde.PNG)

