### PR TITLE
Added Extension Version to log and trace entries.

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/EndToEndTraceHelper.cs
+++ b/src/WebJobs.Extensions.DurableTask/EndToEndTraceHelper.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             bool isReplay)
         {
             EtwEventSource.Instance.FunctionScheduled(hubName, LocalAppName, LocalSlotName, functionName, version,
-                instanceId, reason, functionType.ToString(), isReplay);
+                instanceId, reason, functionType.ToString(), ExtensionVersion, IsReplay: isReplay);
 
             this.logger.LogInformation(
                 "{instanceId}: Function '{functionName} ({functionType})', version '{version}' scheduled. Reason: {reason}. IsReplay: {isReplay}. State: {state}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}.",
@@ -80,7 +80,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             bool isReplay)
         {
             EtwEventSource.Instance.FunctionStarting(hubName, LocalAppName, LocalSlotName, functionName, version,
-                instanceId, input, functionType.ToString(), isReplay);
+                instanceId, input, functionType.ToString(), ExtensionVersion, IsReplay: isReplay);
             this.logger.LogInformation(
                 "{instanceId}: Function '{functionName} ({functionType})', version '{version}' started. IsReplay: {isReplay}. Input: {input}. State: {state}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}.",
                 instanceId, functionName, functionType, version, isReplay, input, FunctionState.Started, hubName,
@@ -99,7 +99,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             FunctionType functionType = FunctionType.Orchestrator;
 
             EtwEventSource.Instance.FunctionAwaited(hubName, LocalAppName, LocalSlotName, functionName, version,
-                instanceId, functionType.ToString(), IsReplay: isReplay);
+                instanceId, functionType.ToString(), ExtensionVersion, IsReplay: isReplay);
             this.logger.LogInformation(
                 "{instanceId}: Function '{functionName} ({functionType})', version '{version}' awaited. IsReplay: {isReplay}. State: {state}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}.",
                 instanceId, functionName, functionType, version, isReplay, FunctionState.Awaited, hubName,
@@ -119,7 +119,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             FunctionType functionType = FunctionType.Orchestrator;
 
             EtwEventSource.Instance.FunctionListening(hubName, LocalAppName, LocalSlotName, functionName, version,
-                instanceId, reason, functionType.ToString(), IsReplay: isReplay);
+                instanceId, reason, functionType.ToString(), ExtensionVersion, IsReplay: isReplay);
 
             this.logger.LogInformation(
                 "{instanceId}: Function '{functionName} ({functionType})', version '{version}' is waiting for input. Reason: {reason}. IsReplay: {isReplay}. State: {state}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}.",
@@ -140,7 +140,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             bool isReplay)
         {
             EtwEventSource.Instance.FunctionCompleted(hubName, LocalAppName, LocalSlotName, functionName, version,
-                instanceId, output, continuedAsNew, functionType.ToString(), isReplay);
+                instanceId, output, continuedAsNew, functionType.ToString(), ExtensionVersion, IsReplay: isReplay);
 
             this.logger.LogInformation(
                 "{instanceId}: Function '{functionName} ({functionType})', version '{version}' completed. ContinuedAsNew: {continuedAsNew}. IsReplay: {isReplay}. Output: {output}. State: {state}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}.",
@@ -160,7 +160,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             FunctionType functionType = FunctionType.Orchestrator;
 
             EtwEventSource.Instance.FunctionTerminated(hubName, LocalAppName, LocalSlotName, functionName, version,
-                instanceId, reason, functionType.ToString(), IsReplay: false);
+                instanceId, reason, functionType.ToString(), ExtensionVersion, IsReplay: false);
 
             this.logger.LogWarning(
                 "{instanceId}: Function '{functionName} ({functionType})', version '{version}' was terminated. Reason: {reason}. State: {state}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}.",
@@ -180,7 +180,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             bool isReplay)
         {
             EtwEventSource.Instance.FunctionFailed(hubName, LocalAppName, LocalSlotName, functionName, version,
-                instanceId, reason, functionType.ToString(), IsReplay: false);
+                instanceId, reason, functionType.ToString(), ExtensionVersion, IsReplay: false);
 
             this.logger.LogError(
                 "{instanceId}: Function '{functionName} ({functionType})', version '{version}' failed with an error. Reason: {reason}. IsReplay: {isReplay}. State: {state}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}.",
@@ -202,7 +202,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             FunctionType functionType = FunctionType.Orchestrator;
 
             EtwEventSource.Instance.ExternalEventRaised(hubName, LocalAppName, LocalSlotName, functionName, version,
-                instanceId, eventName, input, functionType.ToString(), IsReplay: isReplay);
+                instanceId, eventName, input, functionType.ToString(), ExtensionVersion, IsReplay: isReplay);
 
             this.logger.LogInformation(
                 "{instanceId}: Function '{functionName} ({functionType})', version '{version}' received a '{eventName}' event. State: {state}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}.",

--- a/src/WebJobs.Extensions.DurableTask/EndToEndTraceHelper.cs
+++ b/src/WebJobs.Extensions.DurableTask/EndToEndTraceHelper.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.Diagnostics;
 using Microsoft.Azure.WebJobs.Host;
 using Microsoft.Extensions.Logging;
 
@@ -12,6 +13,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         private const string CategoryName = "Host.Triggers.DurableTask";
         private static string appName;
         private static string slotName;
+        private static readonly string ExtensionVersion = FileVersionInfo.GetVersionInfo(typeof(DurableTaskExtension).Assembly.Location).FileVersion;
 
         private readonly TraceWriter appTraceWriter;
         private readonly ILogger logger;
@@ -61,11 +63,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 instanceId, reason, functionType.ToString(), isReplay);
 
             this.logger.LogInformation(
-                "{instanceId}: Function '{functionName} ({functionType})', version '{version}' scheduled. Reason: {reason}. IsReplay: {isReplay}. State: {state}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}.",
+                "{instanceId}: Function '{functionName} ({functionType})', version '{version}' scheduled. Reason: {reason}. IsReplay: {isReplay}. State: {state}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}.",
                 instanceId, functionName, functionType, version, reason, isReplay, FunctionState.Scheduled, hubName,
-                LocalAppName, LocalSlotName);
+                LocalAppName, LocalSlotName, ExtensionVersion);
             this.appTraceWriter.Info(
-                $"{instanceId}: Function '{functionName} ({functionType})', version '{version}' scheduled. Reason: {reason}. IsReplay: {isReplay}. State: {FunctionState.Scheduled}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}.");
+                $"{instanceId}: Function '{functionName} ({functionType})', version '{version}' scheduled. Reason: {reason}. IsReplay: {isReplay}. State: {FunctionState.Scheduled}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {ExtensionVersion}.");
         }
 
         public void FunctionStarting(
@@ -80,11 +82,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             EtwEventSource.Instance.FunctionStarting(hubName, LocalAppName, LocalSlotName, functionName, version,
                 instanceId, input, functionType.ToString(), isReplay);
             this.logger.LogInformation(
-                "{instanceId}: Function '{functionName} ({functionType})', version '{version}' started. IsReplay: {isReplay}. Input: {input}. State: {state}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}.",
+                "{instanceId}: Function '{functionName} ({functionType})', version '{version}' started. IsReplay: {isReplay}. Input: {input}. State: {state}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}.",
                 instanceId, functionName, functionType, version, isReplay, input, FunctionState.Started, hubName,
-                LocalAppName, LocalSlotName);
+                LocalAppName, LocalSlotName, ExtensionVersion);
             this.appTraceWriter.Info(
-                $"{instanceId}: Function '{functionName} ({functionType})', version '{version}' started. IsReplay: {isReplay}. Input: {input}. State: {FunctionState.Started}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}.");
+                $"{instanceId}: Function '{functionName} ({functionType})', version '{version}' started. IsReplay: {isReplay}. Input: {input}. State: {FunctionState.Started}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {ExtensionVersion}.");
         }
 
         public void FunctionAwaited(
@@ -99,11 +101,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             EtwEventSource.Instance.FunctionAwaited(hubName, LocalAppName, LocalSlotName, functionName, version,
                 instanceId, functionType.ToString(), IsReplay: isReplay);
             this.logger.LogInformation(
-                "{instanceId}: Function '{functionName} ({functionType})', version '{version}' awaited. IsReplay: {isReplay}. State: {state}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}.",
-                instanceId, functionName, functionType, version, isReplay, FunctionState.Awaited, hubName, LocalAppName,
-                LocalSlotName);
+                "{instanceId}: Function '{functionName} ({functionType})', version '{version}' awaited. IsReplay: {isReplay}. State: {state}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}.",
+                instanceId, functionName, functionType, version, isReplay, FunctionState.Awaited, hubName,
+                LocalAppName, LocalSlotName, ExtensionVersion);
             this.appTraceWriter.Info(
-                $"{instanceId}: Function '{functionName} ({functionType})', version '{version}' awaited. IsReplay: {isReplay}. State: {FunctionState.Awaited}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}.");
+                $"{instanceId}: Function '{functionName} ({functionType})', version '{version}' awaited. IsReplay: {isReplay}. State: {FunctionState.Awaited}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {ExtensionVersion}.");
         }
 
         public void FunctionListening(
@@ -120,11 +122,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 instanceId, reason, functionType.ToString(), IsReplay: isReplay);
 
             this.logger.LogInformation(
-                "{instanceId}: Function '{functionName} ({functionType})', version '{version}' is waiting for input. Reason: {reason}. IsReplay: {isReplay}. State: {state}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}.",
+                "{instanceId}: Function '{functionName} ({functionType})', version '{version}' is waiting for input. Reason: {reason}. IsReplay: {isReplay}. State: {state}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}.",
                 instanceId, functionName, functionType, version, reason, isReplay, FunctionState.Listening, hubName,
-                LocalAppName, LocalSlotName);
+                LocalAppName, LocalSlotName, ExtensionVersion);
             this.appTraceWriter.Info(
-                $"{instanceId}: Function '{functionName} ({functionType})', version '{version}' is waiting for input. Reason: {reason}. IsReplay: {isReplay}. State: {FunctionState.Listening}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}.");
+                $"{instanceId}: Function '{functionName} ({functionType})', version '{version}' is waiting for input. Reason: {reason}. IsReplay: {isReplay}. State: {FunctionState.Listening}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}.  ExtensionVersion: {ExtensionVersion}.");
         }
 
         public void FunctionCompleted(
@@ -141,11 +143,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 instanceId, output, continuedAsNew, functionType.ToString(), isReplay);
 
             this.logger.LogInformation(
-                "{instanceId}: Function '{functionName} ({functionType})', version '{version}' completed. ContinuedAsNew: {continuedAsNew}. IsReplay: {isReplay}. Output: {output}. State: {state}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}.",
+                "{instanceId}: Function '{functionName} ({functionType})', version '{version}' completed. ContinuedAsNew: {continuedAsNew}. IsReplay: {isReplay}. Output: {output}. State: {state}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}.",
                 instanceId, functionName, functionType, version, continuedAsNew, isReplay, output,
-                FunctionState.Completed, hubName, LocalAppName, LocalSlotName);
+                FunctionState.Completed, hubName, LocalAppName, LocalSlotName, ExtensionVersion);
             this.appTraceWriter.Info(
-                $"{instanceId}: Function '{functionName} ({functionType})', version '{version}' completed. ContinuedAsNew: {continuedAsNew}. IsReplay: {isReplay}. Output: {output}. State: {FunctionState.Completed}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}.");
+                $"{instanceId}: Function '{functionName} ({functionType})', version '{version}' completed. ContinuedAsNew: {continuedAsNew}. IsReplay: {isReplay}. Output: {output}. State: {FunctionState.Completed}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {ExtensionVersion}.");
         }
 
         public void FunctionTerminated(
@@ -161,11 +163,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 instanceId, reason, functionType.ToString(), IsReplay: false);
 
             this.logger.LogWarning(
-                "{instanceId}: Function '{functionName} ({functionType})', version '{version}' was terminated. Reason: {reason}. State: {state}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}.",
+                "{instanceId}: Function '{functionName} ({functionType})', version '{version}' was terminated. Reason: {reason}. State: {state}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}.",
                 instanceId, functionName, functionType, version, reason, FunctionState.Terminated, hubName,
-                LocalAppName, LocalSlotName);
+                LocalAppName, LocalSlotName, ExtensionVersion);
             this.appTraceWriter.Info(
-                $"{instanceId}: Function '{functionName} ({functionType})', version '{version}' was terminated. Reason: {reason}. State: {FunctionState.Terminated}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}.");
+                $"{instanceId}: Function '{functionName} ({functionType})', version '{version}' was terminated. Reason: {reason}. State: {FunctionState.Terminated}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {ExtensionVersion}.");
         }
 
         public void FunctionFailed(
@@ -181,11 +183,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 instanceId, reason, functionType.ToString(), IsReplay: false);
 
             this.logger.LogError(
-                "{instanceId}: Function '{functionName} ({functionType})', version '{version}' failed with an error. Reason: {reason}. IsReplay: {isReplay}. State: {state}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}.",
+                "{instanceId}: Function '{functionName} ({functionType})', version '{version}' failed with an error. Reason: {reason}. IsReplay: {isReplay}. State: {state}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}.",
                 instanceId, functionName, functionType, version, reason, isReplay, FunctionState.Failed, hubName,
-                LocalAppName, LocalSlotName);
+                LocalAppName, LocalSlotName, ExtensionVersion);
             this.appTraceWriter.Info(
-                $"{instanceId}: Function '{functionName} ({functionType})', version '{version}' failed with an error. Reason: {reason}. IsReplay: {isReplay}. State: {FunctionState.Failed}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}.");
+                $"{instanceId}: Function '{functionName} ({functionType})', version '{version}' failed with an error. Reason: {reason}. IsReplay: {isReplay}. State: {FunctionState.Failed}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {ExtensionVersion}.");
         }
 
         public void ExternalEventRaised(
@@ -203,11 +205,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 instanceId, eventName, input, functionType.ToString(), IsReplay: isReplay);
 
             this.logger.LogInformation(
-                "{instanceId}: Function '{functionName} ({functionType})', version '{version}' received a '{eventName}' event. State: {state}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}.",
+                "{instanceId}: Function '{functionName} ({functionType})', version '{version}' received a '{eventName}' event. State: {state}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}.",
                 instanceId, functionName, functionType, version, eventName, FunctionState.ExternalEventRaised,
-                hubName, LocalAppName, LocalSlotName);
+                hubName, LocalAppName, LocalSlotName, ExtensionVersion);
             this.appTraceWriter.Info(
-                $"{instanceId}: Function '{functionName} ({functionType})', version '{version}' received a '{eventName}' event. State: {FunctionState.ExternalEventRaised}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}.");
+                $"{instanceId}: Function '{functionName} ({functionType})', version '{version}' received a '{eventName}' event. State: {FunctionState.ExternalEventRaised}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {ExtensionVersion}.");
         }
     }
 }

--- a/src/WebJobs.Extensions.DurableTask/EtwEventSource.cs
+++ b/src/WebJobs.Extensions.DurableTask/EtwEventSource.cs
@@ -27,9 +27,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             string InstanceId,
             string Reason,
             string FunctionType,
+            string ExtensionVersion,
             bool IsReplay)
         {
-            this.WriteEvent(201, HubName, AppName, SlotName, FunctionName, Version ?? "", InstanceId, Reason, FunctionType, IsReplay);
+            this.WriteEvent(201, HubName, AppName, SlotName, FunctionName, Version ?? "", InstanceId, Reason, FunctionType, ExtensionVersion, IsReplay);
         }
 
         [Event(202, Level = EventLevel.Informational)]
@@ -42,9 +43,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             string InstanceId,
             string Input,
             string FunctionType,
+            string ExtensionVersion, 
             bool IsReplay)
         {
-            this.WriteEvent(202, HubName, AppName, SlotName, FunctionName, Version ?? "", InstanceId, Input ?? "(null)", FunctionType, IsReplay);
+            this.WriteEvent(202, HubName, AppName, SlotName, FunctionName, Version ?? "", InstanceId, Input ?? "(null)", FunctionType, ExtensionVersion, IsReplay);
         }
 
         [Event(203, Level = EventLevel.Informational)]
@@ -56,9 +58,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             string Version,
             string InstanceId,
             string FunctionType,
+            string ExtensionVersion, 
             bool IsReplay)
         {
-            this.WriteEvent(203, HubName, AppName, SlotName, FunctionName, Version ?? "", InstanceId, FunctionType, IsReplay);
+            this.WriteEvent(203, HubName, AppName, SlotName, FunctionName, Version ?? "", InstanceId, FunctionType, ExtensionVersion, IsReplay);
         }
 
         [Event(204, Level = EventLevel.Informational)]
@@ -71,9 +74,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             string InstanceId,
             string Reason,
             string FunctionType,
+            string ExtensionVersion,
             bool IsReplay)
         {
-            this.WriteEvent(204, HubName, AppName, SlotName, FunctionName, Version ?? "", InstanceId, Reason, FunctionType, IsReplay);
+            this.WriteEvent(204, HubName, AppName, SlotName, FunctionName, Version ?? "", InstanceId, Reason, FunctionType, ExtensionVersion, IsReplay);
         }
 
         [Event(205, Level = EventLevel.Informational)]
@@ -87,9 +91,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             string EventName,
             string Input,
             string FunctionType,
+            string ExtensionVersion,
             bool IsReplay)
         {
-            this.WriteEvent(205, HubName, AppName, SlotName, FunctionName, Version ?? "", InstanceId, EventName, Input ?? "(null)", FunctionType, IsReplay);
+            this.WriteEvent(205, HubName, AppName, SlotName, FunctionName, Version ?? "", InstanceId, EventName, Input ?? "(null)", FunctionType, ExtensionVersion, IsReplay);
         }
 
         [Event(206, Level = EventLevel.Informational)]
@@ -103,9 +108,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             string Output,
             bool ContinuedAsNew,
             string FunctionType,
+            string ExtensionVersion,
             bool IsReplay)
         {
-            this.WriteEvent(206, HubName, AppName, SlotName, FunctionName, Version ?? "", InstanceId, Output ?? "(null)", ContinuedAsNew, FunctionType, IsReplay);
+            this.WriteEvent(206, HubName, AppName, SlotName, FunctionName, Version ?? "", InstanceId, Output ?? "(null)", ContinuedAsNew, FunctionType, ExtensionVersion, IsReplay);
         }
 
         [Event(207, Level = EventLevel.Warning)]
@@ -118,9 +124,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             string InstanceId,
             string Reason,
             string FunctionType,
+            string ExtensionVersion,
             bool IsReplay)
         {
-            this.WriteEvent(207, HubName, AppName, SlotName, FunctionName, Version ?? "", InstanceId, Reason, FunctionType, IsReplay);
+            this.WriteEvent(207, HubName, AppName, SlotName, FunctionName, Version ?? "", InstanceId, Reason, FunctionType, ExtensionVersion, IsReplay);
         }
 
         [Event(208, Level = EventLevel.Error)]
@@ -133,9 +140,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             string InstanceId,
             string Reason,
             string FunctionType,
+            string ExtensionVersion,
             bool IsReplay)
         {
-            this.WriteEvent(208, HubName, AppName, SlotName, FunctionName, Version ?? "", InstanceId, Reason, FunctionType, IsReplay);
+            this.WriteEvent(208, HubName, AppName, SlotName, FunctionName, Version ?? "", InstanceId, Reason, FunctionType, ExtensionVersion, IsReplay);
         }
     }
 }


### PR DESCRIPTION
Addressing issue https://github.com/Azure/azure-functions-durable-extension/issues/39

**Sample query for structure log on Application Insights:**
```
traces
| extend isReplay = customDimensions["prop__isReplay"]
| extend hubName = customDimensions["prop__hubName"]
| extend functionName = customDimensions ["prop__functionName"]
| extend state = customDimensions ["prop__state"]
| extend instanceId = customDimensions ["prop__instanceId"]
| extend category = customDimensions ["Category"]
| extend extensionVersion = customDimensions ["prop__extensionVersion"]
| where timestamp >= ago(10m)
| where category == "Host.Triggers.DurableTask"
| where hubName == "UnhandledActivityException"
| order by timestamp asc
| project timestamp, extensionVersion, instanceId, category, hubName, state, isReplay, message
```

**Snapshot of sample output:**

![appinsights3](https://user-images.githubusercontent.com/14911331/30142514-1ccb8918-9336-11e7-9a0a-b5f9ff30984b.PNG)
