### PR TITLE
Added support for retry options for activity functions.

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/RetryOptions.cs
+++ b/src/WebJobs.Extensions.DurableTask/RetryOptions.cs
@@ -1,0 +1,90 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using DurableTaskCore = DurableTask.Core;
+
+namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
+{
+    /// <summary>
+    ///     Contains retry policies that can be passed as parameters to various operations
+    /// </summary>
+    public class RetryOptions
+    {
+        private DurableTaskCore.RetryOptions retryOptions;
+
+        /// <summary>
+        /// Creates a new instance RetryOptions with the supplied first retry and max attempts
+        /// </summary>
+        /// <param name="firstRetryInterval">Timespan to wait for the first retry</param>
+        /// <param name="maxNumberOfAttempts">Max number of attempts to retry</param>
+        /// <exception cref="ArgumentException"></exception>
+        public RetryOptions(TimeSpan firstRetryInterval, int maxNumberOfAttempts)
+        {
+            retryOptions = new DurableTaskCore.RetryOptions(firstRetryInterval, maxNumberOfAttempts);
+        }
+
+        /// <summary>
+        /// Gets or sets the first retry interval
+        /// </summary>
+        public TimeSpan FirstRetryInterval
+        {
+            get { return this.retryOptions.FirstRetryInterval; }
+            set { this.retryOptions.FirstRetryInterval = value; }
+        }
+
+        /// <summary>
+        /// Gets or sets the max retry interval
+        /// defaults to TimeSpan.MaxValue
+        /// </summary>
+        public TimeSpan MaxRetryInterval
+        {
+            get { return this.retryOptions.MaxRetryInterval; }
+            set { this.retryOptions.MaxRetryInterval = value; }
+        }
+
+
+        /// <summary>
+        /// Gets or sets the backoff coefficient
+        /// defaults to 1, used to determine rate of increase of backoff
+        /// </summary>
+        public double BackoffCoefficient
+        {
+            get { return this.retryOptions.BackoffCoefficient; }
+            set { this.retryOptions.BackoffCoefficient = value; }
+        }
+
+        /// <summary>
+        /// Gets or sets the timeout for retries
+        /// defaults to TimeSpan.MaxValue
+        /// </summary>
+        public TimeSpan RetryTimeout
+        {
+            get { return this.retryOptions.RetryTimeout; }
+            set { this.retryOptions.RetryTimeout = value; }
+        }
+
+        /// <summary>
+        /// Gets or sets the max number of attempts
+        /// </summary>
+        public int MaxNumberOfAttempts
+        {
+            get { return this.retryOptions.MaxNumberOfAttempts; }
+            set { this.retryOptions.MaxNumberOfAttempts = value; }
+        }
+
+        /// <summary>
+        /// Gets or sets a Func to call on exception to determine if retries should proceed
+        /// </summary>
+        public Func<Exception, bool> Handle
+        {
+            get { return this.retryOptions.Handle; }
+            set { this.retryOptions.Handle = value; }
+        }
+
+        internal DurableTaskCore.RetryOptions GetRetryOptions()
+        {
+            return this.retryOptions;
+        }
+    }
+}

--- a/src/WebJobs.Extensions.DurableTask/RetryOptions.cs
+++ b/src/WebJobs.Extensions.DurableTask/RetryOptions.cs
@@ -4,21 +4,23 @@
 using System;
 using DurableTaskCore = DurableTask.Core;
 
-namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
+namespace Microsoft.Azure.WebJobs
 {
     /// <summary>
     ///     Contains retry policies that can be passed as parameters to various operations
     /// </summary>
     public class RetryOptions
     {
-        private DurableTaskCore.RetryOptions retryOptions;
+        private readonly DurableTaskCore.RetryOptions retryOptions;
 
         /// <summary>
         /// Creates a new instance RetryOptions with the supplied first retry and max attempts
         /// </summary>
         /// <param name="firstRetryInterval">Timespan to wait for the first retry</param>
         /// <param name="maxNumberOfAttempts">Max number of attempts to retry</param>
-        /// <exception cref="ArgumentException"></exception>
+        /// <exception cref="ArgumentException">
+        /// The TimeSpan value must be greater than TimeSpan.Zero.
+        /// </exception>
         public RetryOptions(TimeSpan firstRetryInterval, int maxNumberOfAttempts)
         {
             retryOptions = new DurableTaskCore.RetryOptions(firstRetryInterval, maxNumberOfAttempts);
@@ -27,6 +29,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// <summary>
         /// Gets or sets the first retry interval
         /// </summary>
+        /// <value>
+        /// The TimeSpan to wait for the first retries
+        /// </value>
         public TimeSpan FirstRetryInterval
         {
             get { return this.retryOptions.FirstRetryInterval; }
@@ -35,8 +40,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
         /// <summary>
         /// Gets or sets the max retry interval
-        /// defaults to TimeSpan.MaxValue
         /// </summary>
+        /// <value>
+        /// The TimeSpan of the max retry interval, defaults to TimeSpan.MaxValue
+        /// </value>
         public TimeSpan MaxRetryInterval
         {
             get { return this.retryOptions.MaxRetryInterval; }
@@ -46,8 +53,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
         /// <summary>
         /// Gets or sets the backoff coefficient
-        /// defaults to 1, used to determine rate of increase of backoff
         /// </summary>
+        /// <value>
+        /// The backoff coefficient used to determine rate of increase of backoff, defaults to 1.
+        /// </value>
         public double BackoffCoefficient
         {
             get { return this.retryOptions.BackoffCoefficient; }
@@ -56,8 +65,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
         /// <summary>
         /// Gets or sets the timeout for retries
-        /// defaults to TimeSpan.MaxValue
         /// </summary>
+        /// <value>
+        /// The TimeSpan timeout for retries, defaults to TimeSpan.MaxValue
+        /// </value>
         public TimeSpan RetryTimeout
         {
             get { return this.retryOptions.RetryTimeout; }
@@ -67,6 +78,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// <summary>
         /// Gets or sets the max number of attempts
         /// </summary>
+        /// <value>
+        /// The maximum number of retry attempts
+        /// </value>
         public int MaxNumberOfAttempts
         {
             get { return this.retryOptions.MaxNumberOfAttempts; }
@@ -76,6 +90,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// <summary>
         /// Gets or sets a Func to call on exception to determine if retries should proceed
         /// </summary>
+        /// <value>
+        /// The Func to handle exception to determie if retries should proceed
+        /// </value>
         public Func<Exception, bool> Handle
         {
             get { return this.retryOptions.Handle; }

--- a/test/DurableTaskEndToEndTests.cs
+++ b/test/DurableTaskEndToEndTests.cs
@@ -416,7 +416,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         {
             string[] orchestratorFunctionNames =
             {
-                nameof(TestOrchestrations.Throw)
+                nameof(TestOrchestrations.OrchestratorThrow)
             };
 
             using (JobHost host = TestHelpers.GetJobHost(this.loggerFactory, nameof(UnhandledOrchestrationException)))
@@ -424,7 +424,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 await host.StartAsync();
 
                 // Null input should result in ArgumentNullException in the orchestration code.
-                var client = await host.StartFunctionAsync(nameof(TestOrchestrations.Throw), null, this.output);
+                var client = await host.StartFunctionAsync(orchestratorFunctionNames[0], null, this.output);
                 var status = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(10), this.output);
 
                 Assert.Equal("Failed", status?.RuntimeStatus);
@@ -443,6 +443,70 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         }
 
         /// <summary>
+        /// End-to-end test which validates the retries of unhandled exceptions generated from orchestrator functions.
+        /// </summary>
+        [Fact]
+        public async Task UnhandledOrchestrationExceptionWithRetry()
+        {
+            string[] orchestratorFunctionNames =
+            {
+                nameof(TestOrchestrations.OrchestratorThrowWithRetry)
+            };
+
+            using (JobHost host =
+                TestHelpers.GetJobHost(loggerFactory, nameof(UnhandledOrchestrationExceptionWithRetry)))
+            {
+                await host.StartAsync();
+
+                // Null input should result in ArgumentNullException in the orchestration code.
+                var client = await host.StartFunctionAsync(orchestratorFunctionNames[0], null, this.output);
+                var status = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(50), this.output);
+
+                Assert.Equal("Failed", status?.RuntimeStatus);
+
+                // There aren't any exception details in the output: https://github.com/Azure/azure-webjobs-sdk-script-pr/issues/36
+                Assert.True(status?.Output.ToString().Contains("Value cannot be null"));
+
+                await host.StopAsync();
+            }
+
+            if (this.useTestLogger)
+            {
+                TestHelpers.UnhandledOrchesterationExceptionWithRetry_AssertLogMessageSequence(loggerProvider, "UnhandledOrchestrationExceptionWithRetry",
+                    orchestratorFunctionNames);
+            }
+        }
+
+        /// <summary>
+        /// End-to-end test which validates the retries for an orchestrator function with null RetryOptions fails.
+        /// </summary>
+        [Fact]
+        public async Task OrchestrationWithRetry_NullRetryOptions()
+        {
+            string[] orchestratorFunctionNames =
+            {
+                nameof(TestOrchestrations.OrchestratorWithRetry_NullRetryOptions)
+            };
+
+            using (JobHost host =
+                TestHelpers.GetJobHost(loggerFactory, nameof(OrchestrationWithRetry_NullRetryOptions)))
+            {
+                await host.StartAsync();
+
+                // Null input should result in ArgumentNullException in the orchestration code.
+                var client = await host.StartFunctionAsync(orchestratorFunctionNames[0], null, this.output);
+                var status = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(50), this.output);
+
+                Assert.Equal("Failed", status?.RuntimeStatus);
+
+                // There aren't any exception details in the output: https://github.com/Azure/azure-webjobs-sdk-script-pr/issues/36
+                Assert.True(status?.Output.ToString().Contains("Value cannot be null.\r\nParameter name: retryOptions"));
+
+                await host.StopAsync();
+            }
+        }
+
+        /// <summary>
         /// End-to-end test which validates the handling of unhandled exceptions generated from activity code.
         /// </summary>
         [Fact]
@@ -450,9 +514,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         {
             string[] orchestratorFunctionNames =
             {
-                nameof(TestOrchestrations.Throw)
+                nameof(TestOrchestrations.OrchestratorThrow)
             };
-            string activityFunctioName = nameof(TestActivities.Throw);
+            string activityFunctionName = nameof(TestActivities.Throw);
 
             using (JobHost host = TestHelpers.GetJobHost(this.loggerFactory, nameof(UnhandledActivityException)))
             {
@@ -473,23 +537,23 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             if (this.useTestLogger)
             {
                 TestHelpers.AssertLogMessageSequence(loggerProvider, "UnhandledActivityException",
-                    orchestratorFunctionNames, activityFunctioName);
+                    orchestratorFunctionNames, activityFunctionName);
             }
         }
 
         /// <summary>
-        /// End-to-end test which validates the retries of unhandled exceptions generated from activity code.
+        /// End-to-end test which validates the retries of unhandled exceptions generated from activity functions.
         /// </summary>
         [Fact]
         public async Task UnhandledActivityExceptionWithRetry()
         {
             string[] orchestratorFunctionNames =
             {
-                nameof(TestOrchestrations.ThrowWithRetry)
+                nameof(TestOrchestrations.ActivityThrowWithRetry)
             };
-            string activityFunctioName = nameof(TestActivities.Throw);
+            string activityFunctionName = nameof(TestActivities.Throw);
 
-            using (JobHost host = TestHelpers.GetJobHost(loggerFactory, nameof(UnhandledActivityException)))
+            using (JobHost host = TestHelpers.GetJobHost(loggerFactory, nameof(UnhandledActivityExceptionWithRetry)))
             {
                 await host.StartAsync();
 
@@ -508,7 +572,36 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             if (this.useTestLogger)
             {
                 TestHelpers.AssertLogMessageSequence(loggerProvider, "UnhandledActivityExceptionWithRetry",
-                    orchestratorFunctionNames, activityFunctioName);
+                    orchestratorFunctionNames, activityFunctionName);
+            }
+        }
+
+        /// <summary>
+        /// End-to-end test which validates the retries for an activity function with null RetryOptions fails.
+        /// </summary>
+        [Fact]
+        public async Task ActivityWithRetry_NullRetryOptions()
+        {
+            string[] orchestratorFunctionNames =
+            {
+                nameof(TestOrchestrations.ActivityWithRetry_NullRetryOptions)
+            };
+            string activityFunctionName = nameof(TestActivities.Throw);
+
+            using (JobHost host = TestHelpers.GetJobHost(loggerFactory, nameof(ActivityWithRetry_NullRetryOptions)))
+            {
+                await host.StartAsync();
+
+                string message = "Kah-BOOOOM!!!";
+                var client = await host.StartFunctionAsync(orchestratorFunctionNames[0], message, this.output);
+                var status = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(40), this.output);
+
+                Assert.Equal("Failed", status?.RuntimeStatus);
+
+                // There aren't any exception details in the output: https://github.com/Azure/azure-webjobs-sdk-script-pr/issues/36
+                Assert.True(status?.Output.ToString().Contains("Value cannot be null.\r\nParameter name: retryOptions"));
+
+                await host.StopAsync();
             }
         }
 

--- a/test/TestHelpers.cs
+++ b/test/TestHelpers.cs
@@ -98,6 +98,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 case "Orchestration_OnValidOrchestrator":
                     messages = GetLogs_Orchestration_OnValidOrchestrator(messageIds.ToArray(), orchestratorFunctionNames, activityFunctionName);
                     break;
+                case "UnhandledActivityExceptionWithRetry":
+                    messages = GetLogs_UnhandledActivityExceptionWithRetry(messageIds[0], orchestratorFunctionNames, activityFunctionName);
+                    break;
                 default:
                     break;
             }
@@ -221,6 +224,43 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Activity})', version '' failed with an error. Reason: Microsoft.Azure.WebJobs.Host.FunctionInvocationException",
                 $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' started. IsReplay: True. Input: \"Kah-BOOOOM!!!\"",
                 $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Activity})', version '' scheduled. Reason: Throw. IsReplay: True.",
+                $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' failed with an error. Reason: DurableTask.Core.Exceptions.TaskFailedException",
+            };
+
+            return list;
+        }
+
+        private static List<string> GetLogs_UnhandledActivityExceptionWithRetry(string messageId, string[] orchestratorFunctionNames, string activityFunctionName)
+        {
+            var list = new List<string>()
+            {
+                $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' scheduled. Reason: NewInstance. IsReplay: False.",
+                $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' started. IsReplay: False. Input: \"Kah-BOOOOM!!!\"",
+                $"{messageId}: Function '{activityFunctionName} ({FunctionType.Activity})', version '' scheduled. Reason: ThrowWithRetry. IsReplay: False.",
+                $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' awaited. IsReplay: False.",
+                $"{messageId}: Function '{activityFunctionName} ({FunctionType.Activity})', version '' started. IsReplay: False. Input: [\"Kah-BOOOOM!!!\"]",
+                $"{messageId}: Function '{activityFunctionName} ({FunctionType.Activity})', version '' failed with an error. Reason: Microsoft.Azure.WebJobs.Host.FunctionInvocationException",
+                $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' started. IsReplay: True. Input: \"Kah-BOOOOM!!!\"",
+                $"{messageId}: Function '{activityFunctionName} ({FunctionType.Activity})', version '' scheduled. Reason: ThrowWithRetry. IsReplay: True.",
+                $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' awaited. IsReplay: False.",
+                $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' started. IsReplay: True. Input: \"Kah-BOOOOM!!!\"",
+                $"{messageId}: Function '{activityFunctionName} ({FunctionType.Activity})', version '' scheduled. Reason: ThrowWithRetry. IsReplay: True.",
+                $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' awaited. IsReplay: False.",
+                $"{messageId}: Function '{activityFunctionName} ({FunctionType.Activity})', version '' started. IsReplay: False. Input: [\"Kah-BOOOOM!!!\"]",
+                $"{messageId}: Function '{activityFunctionName} ({FunctionType.Activity})', version '' failed with an error. Reason: Microsoft.Azure.WebJobs.Host.FunctionInvocationException",
+                $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' started. IsReplay: True. Input: \"Kah-BOOOOM!!!\"",
+                $"{messageId}: Function '{activityFunctionName} ({FunctionType.Activity})', version '' scheduled. Reason: ThrowWithRetry. IsReplay: True.",
+                $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' awaited. IsReplay: False.",
+                $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' started. IsReplay: True.",
+                $"{messageId}: Function '{activityFunctionName} ({FunctionType.Activity})', version '' scheduled. Reason: ThrowWithRetry. IsReplay: True.",
+                $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' awaited. IsReplay: False.",
+                $"{messageId}: Function '{activityFunctionName} ({FunctionType.Activity})', version '' started. IsReplay: False. Input: [\"Kah-BOOOOM!!!\"]",
+                $"{messageId}: Function '{activityFunctionName} ({FunctionType.Activity})', version '' failed with an error. Reason: Microsoft.Azure.WebJobs.Host.FunctionInvocationException",
+                $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' started. IsReplay: True. Input: \"Kah-BOOOOM!!!\"",
+                $"{messageId}: Function '{activityFunctionName} ({FunctionType.Activity})', version '' scheduled. Reason: ThrowWithRetry. IsReplay: True.",
+                $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' awaited. IsReplay: False.",
+                $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' started. IsReplay: True. Input: \"Kah-BOOOOM!!!\"",
+                $"{messageId}: Function '{activityFunctionName} ({FunctionType.Activity})', version '' scheduled. Reason: ThrowWithRetry. IsReplay: True.",
                 $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' failed with an error. Reason: DurableTask.Core.Exceptions.TaskFailedException",
             };
 

--- a/test/TestHelpers.cs
+++ b/test/TestHelpers.cs
@@ -38,15 +38,43 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         public static void AssertLogMessageSequence(TestLoggerProvider loggerProvider, string testName,
             string[] orchestratorFunctionNames, string activityFunctionName = null)
         {
+            List<string> messageIds;
+            string timeStamp;
+            var logMessages = GetLogMessages(loggerProvider, testName, out messageIds, out timeStamp);
+
+            var expectedLogMessages = GetExpectedLogMessages(testName, messageIds, orchestratorFunctionNames, activityFunctionName, timeStamp);
+            var actualLogMessages = logMessages.Select(m => m.FormattedMessage).ToList();
+
+            Assert.Equal(expectedLogMessages.Count, logMessages.Count);
+            AssertLogMessages(expectedLogMessages, actualLogMessages);
+        }
+
+        public static void UnhandledOrchesterationExceptionWithRetry_AssertLogMessageSequence(TestLoggerProvider loggerProvider, string testName,
+            string[] orchestratorFunctionNames, string activityFunctionName = null)
+        {
+            List<string> messageIds;
+            string timeStamp;
+            var logMessages = GetLogMessages(loggerProvider, testName, out messageIds, out timeStamp);
+
+            var actualLogMessages = logMessages.Select(m => m.FormattedMessage).ToList();
+            var exceptionCount =
+                actualLogMessages.FindAll(m => m.Contains("failed with an error")).Count;
+
+            Assert.Equal(4, exceptionCount);
+        }
+
+        private static List<LogMessage> GetLogMessages(TestLoggerProvider loggerProvider, string testName, out List<string> messageIds,
+            out string timeStamp)
+        {
             var logger = loggerProvider.CreatedLoggers.Single(l => l.Category == LogCategory);
             var logMessages = logger.LogMessages.ToList();
-            var messageIds = new List<string>()
+            messageIds = new List<string>()
             {
                 GetMessageId(logMessages[0].FormattedMessage)
             };
 
-            string timeStamp = string.Empty;
-            
+            timeStamp = string.Empty;
+
             if (testName.Equals("TimerCancellation", StringComparison.InvariantCultureIgnoreCase)
                 || testName.Equals("TimerExpiration", StringComparison.InvariantCultureIgnoreCase))
             {
@@ -57,13 +85,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 messageIds.Add(GetMessageId(logMessages[4].FormattedMessage));
             }
 
-            var expectedLogMessages = GetExpectedLogMessages(testName, messageIds, orchestratorFunctionNames, activityFunctionName, timeStamp);
-            var actualLogMessage = logMessages.Select(m => m.FormattedMessage).ToList();
-
             Assert.True(
                 logMessages.TrueForAll(m => m.Category.Equals(LogCategory, StringComparison.InvariantCultureIgnoreCase)));
-            Assert.Equal(expectedLogMessages.Count, logMessages.Count);
-            AssertLogMessages(expectedLogMessages, actualLogMessage);
+            return logMessages;
         }
 
         private static IList<string> GetExpectedLogMessages(string testName, List<string> messageIds, string[] orchestratorFunctionNames, string activityFunctionName = null, string timeStamp = null)
@@ -92,14 +116,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 case "UnhandledActivityException":
                     messages = GetLogs_UnhandledActivityException(messageIds[0], orchestratorFunctionNames, activityFunctionName);
                     break;
+                case "UnhandledActivityExceptionWithRetry":
+                    messages = GetLogs_UnhandledActivityExceptionWithRetry(messageIds[0], orchestratorFunctionNames, activityFunctionName);
+                    break;
                 case "Orchestration_OnUnregisteredActivity":
                     messages = GetLogs_Orchestration_OnUnregisteredActivity(messageIds[0], orchestratorFunctionNames);
                     break;
                 case "Orchestration_OnValidOrchestrator":
                     messages = GetLogs_Orchestration_OnValidOrchestrator(messageIds.ToArray(), orchestratorFunctionNames, activityFunctionName);
-                    break;
-                case "UnhandledActivityExceptionWithRetry":
-                    messages = GetLogs_UnhandledActivityExceptionWithRetry(messageIds[0], orchestratorFunctionNames, activityFunctionName);
                     break;
                 default:
                     break;
@@ -218,12 +242,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             {
                 $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' scheduled. Reason: NewInstance. IsReplay: False.",
                 $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' started. IsReplay: False. Input: \"Kah-BOOOOM!!!\"",
-                $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Activity})', version '' scheduled. Reason: Throw. IsReplay: False.",
+                $"{messageId}: Function '{activityFunctionName} ({FunctionType.Activity})', version '' scheduled. Reason: OrchestratorThrow. IsReplay: False.",
                 $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' awaited. IsReplay: False.",
-                $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Activity})', version '' started. IsReplay: False. Input: [\"Kah-BOOOOM!!!\"]",
-                $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Activity})', version '' failed with an error. Reason: Microsoft.Azure.WebJobs.Host.FunctionInvocationException",
+                $"{messageId}: Function '{activityFunctionName} ({FunctionType.Activity})', version '' started. IsReplay: False. Input: [\"Kah-BOOOOM!!!\"]",
+                $"{messageId}: Function '{activityFunctionName} ({FunctionType.Activity})', version '' failed with an error. Reason: Microsoft.Azure.WebJobs.Host.FunctionInvocationException",
                 $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' started. IsReplay: True. Input: \"Kah-BOOOOM!!!\"",
-                $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Activity})', version '' scheduled. Reason: Throw. IsReplay: True.",
+                $"{messageId}: Function '{activityFunctionName} ({FunctionType.Activity})', version '' scheduled. Reason: OrchestratorThrow. IsReplay: True.",
                 $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' failed with an error. Reason: DurableTask.Core.Exceptions.TaskFailedException",
             };
 
@@ -236,31 +260,31 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             {
                 $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' scheduled. Reason: NewInstance. IsReplay: False.",
                 $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' started. IsReplay: False. Input: \"Kah-BOOOOM!!!\"",
-                $"{messageId}: Function '{activityFunctionName} ({FunctionType.Activity})', version '' scheduled. Reason: ThrowWithRetry. IsReplay: False.",
+                $"{messageId}: Function '{activityFunctionName} ({FunctionType.Activity})', version '' scheduled. Reason: ActivityThrowWithRetry. IsReplay: False.",
                 $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' awaited. IsReplay: False.",
                 $"{messageId}: Function '{activityFunctionName} ({FunctionType.Activity})', version '' started. IsReplay: False. Input: [\"Kah-BOOOOM!!!\"]",
                 $"{messageId}: Function '{activityFunctionName} ({FunctionType.Activity})', version '' failed with an error. Reason: Microsoft.Azure.WebJobs.Host.FunctionInvocationException",
                 $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' started. IsReplay: True. Input: \"Kah-BOOOOM!!!\"",
-                $"{messageId}: Function '{activityFunctionName} ({FunctionType.Activity})', version '' scheduled. Reason: ThrowWithRetry. IsReplay: True.",
+                $"{messageId}: Function '{activityFunctionName} ({FunctionType.Activity})', version '' scheduled. Reason: ActivityThrowWithRetry. IsReplay: True.",
                 $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' awaited. IsReplay: False.",
                 $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' started. IsReplay: True. Input: \"Kah-BOOOOM!!!\"",
-                $"{messageId}: Function '{activityFunctionName} ({FunctionType.Activity})', version '' scheduled. Reason: ThrowWithRetry. IsReplay: True.",
+                $"{messageId}: Function '{activityFunctionName} ({FunctionType.Activity})', version '' scheduled. Reason: ActivityThrowWithRetry. IsReplay: True.",
                 $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' awaited. IsReplay: False.",
                 $"{messageId}: Function '{activityFunctionName} ({FunctionType.Activity})', version '' started. IsReplay: False. Input: [\"Kah-BOOOOM!!!\"]",
                 $"{messageId}: Function '{activityFunctionName} ({FunctionType.Activity})', version '' failed with an error. Reason: Microsoft.Azure.WebJobs.Host.FunctionInvocationException",
                 $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' started. IsReplay: True. Input: \"Kah-BOOOOM!!!\"",
-                $"{messageId}: Function '{activityFunctionName} ({FunctionType.Activity})', version '' scheduled. Reason: ThrowWithRetry. IsReplay: True.",
+                $"{messageId}: Function '{activityFunctionName} ({FunctionType.Activity})', version '' scheduled. Reason: ActivityThrowWithRetry. IsReplay: True.",
                 $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' awaited. IsReplay: False.",
                 $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' started. IsReplay: True.",
-                $"{messageId}: Function '{activityFunctionName} ({FunctionType.Activity})', version '' scheduled. Reason: ThrowWithRetry. IsReplay: True.",
+                $"{messageId}: Function '{activityFunctionName} ({FunctionType.Activity})', version '' scheduled. Reason: ActivityThrowWithRetry. IsReplay: True.",
                 $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' awaited. IsReplay: False.",
                 $"{messageId}: Function '{activityFunctionName} ({FunctionType.Activity})', version '' started. IsReplay: False. Input: [\"Kah-BOOOOM!!!\"]",
                 $"{messageId}: Function '{activityFunctionName} ({FunctionType.Activity})', version '' failed with an error. Reason: Microsoft.Azure.WebJobs.Host.FunctionInvocationException",
                 $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' started. IsReplay: True. Input: \"Kah-BOOOOM!!!\"",
-                $"{messageId}: Function '{activityFunctionName} ({FunctionType.Activity})', version '' scheduled. Reason: ThrowWithRetry. IsReplay: True.",
+                $"{messageId}: Function '{activityFunctionName} ({FunctionType.Activity})', version '' scheduled. Reason: ActivityThrowWithRetry. IsReplay: True.",
                 $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' awaited. IsReplay: False.",
                 $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' started. IsReplay: True. Input: \"Kah-BOOOOM!!!\"",
-                $"{messageId}: Function '{activityFunctionName} ({FunctionType.Activity})', version '' scheduled. Reason: ThrowWithRetry. IsReplay: True.",
+                $"{messageId}: Function '{activityFunctionName} ({FunctionType.Activity})', version '' scheduled. Reason: ActivityThrowWithRetry. IsReplay: True.",
                 $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' failed with an error. Reason: DurableTask.Core.Exceptions.TaskFailedException",
             };
 

--- a/test/TestOrchestrations.cs
+++ b/test/TestOrchestrations.cs
@@ -115,6 +115,21 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             await ctx.CallFunctionAsync(nameof(TestActivities.Throw), message);
         }
 
+        public static async Task ThrowWithRetry([OrchestrationTrigger] DurableOrchestrationContext ctx)
+        {
+            string message = ctx.GetInput<string>();
+            if (string.IsNullOrEmpty(message))
+            {
+                // This throw happens directly in the orchestration.
+                throw new ArgumentNullException(nameof(message));
+            }
+
+            RetryOptions options = new RetryOptions(TimeSpan.FromSeconds(5), 3);
+
+            // This throw happens in the implementation of an activity.
+            await ctx.CallFunctionWithRetryAsync(nameof(TestActivities.Throw), options, message);
+        }
+
         public static async Task<int> TryCatchLoop([OrchestrationTrigger] DurableOrchestrationContext ctx)
         {
             int iterations = ctx.GetInput<int>();

--- a/test/TestOrchestrations.cs
+++ b/test/TestOrchestrations.cs
@@ -102,10 +102,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             }
         }
 
-        public static async Task Throw([OrchestrationTrigger] DurableOrchestrationContext ctx)
+        public static async Task OrchestratorThrow([OrchestrationTrigger] DurableOrchestrationContext ctx)
         {
             string message = ctx.GetInput<string>();
-            if (string.IsNullOrEmpty(message))
+            if (string.IsNullOrEmpty(message) || message.Contains("null"))
             {
                 // This throw happens directly in the orchestration.
                 throw new ArgumentNullException(nameof(message));
@@ -115,7 +115,27 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             await ctx.CallFunctionAsync(nameof(TestActivities.Throw), message);
         }
 
-        public static async Task ThrowWithRetry([OrchestrationTrigger] DurableOrchestrationContext ctx)
+        public static async Task OrchestratorThrowWithRetry([OrchestrationTrigger] DurableOrchestrationContext ctx)
+        {
+            string message = ctx.GetInput<string>();
+
+            RetryOptions options = new RetryOptions(TimeSpan.FromSeconds(5), 3);
+
+            // This throw happens in the implementation of an activity.
+            await ctx.CallFunctionWithRetryAsync(nameof(TestOrchestrations.OrchestratorThrow), options, message);
+        }
+
+        public static async Task OrchestratorWithRetry_NullRetryOptions([OrchestrationTrigger] DurableOrchestrationContext ctx)
+        {
+            string message = ctx.GetInput<string>();
+
+            RetryOptions options = null;
+
+            // This throw happens in the implementation of an activity.
+            await ctx.CallFunctionWithRetryAsync(nameof(TestOrchestrations.OrchestratorThrow), options, message);
+        }
+
+        public static async Task ActivityThrowWithRetry([OrchestrationTrigger] DurableOrchestrationContext ctx)
         {
             string message = ctx.GetInput<string>();
             if (string.IsNullOrEmpty(message))
@@ -125,6 +145,21 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             }
 
             RetryOptions options = new RetryOptions(TimeSpan.FromSeconds(5), 3);
+
+            // This throw happens in the implementation of an activity.
+            await ctx.CallFunctionWithRetryAsync(nameof(TestActivities.Throw), options, message);
+        }
+
+        public static async Task ActivityWithRetry_NullRetryOptions([OrchestrationTrigger] DurableOrchestrationContext ctx)
+        {
+            string message = ctx.GetInput<string>();
+            if (string.IsNullOrEmpty(message))
+            {
+                // This throw happens directly in the orchestration.
+                throw new ArgumentNullException(nameof(message));
+            }
+
+            RetryOptions options = null;
 
             // This throw happens in the implementation of an activity.
             await ctx.CallFunctionWithRetryAsync(nameof(TestActivities.Throw), options, message);


### PR DESCRIPTION
Addressing issue https://github.com/Azure/azure-functions-durable-extension/issues/30

1. Added support for retry options using `DurableTask.Core.OrchestrationContext.ScheduleWithRetry`.

      **Sample client code snippet:**
      ```
     // Given RetryOptions scoped to Extensions.DurableTask.RetryOptions, 
     RetryOptions options = new RetryOptions(TimeSpan.FromSeconds(5), 3); // FirstRetryInterval = 5 seconds, MaxNumberOfAttempts = 3
     await ctx.CallFunctionWithRetryAsync(nameof(TestActivities.Throw), options, message);
     ```
2. Added end-to-end tests.