### PR TITLE
Fix timer test regressions.

### DIFF
--- a/test/TestHelpers.cs
+++ b/test/TestHelpers.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text.RegularExpressions;
 using Microsoft.Azure.WebJobs.Host.TestCommon;
 using Microsoft.Extensions.Logging;
 using Xunit;
@@ -266,18 +265,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
         private static string GetMessageId(string message)
         {
-            string regexPattern = @"([A-Za-z0-9])\w+";
-            var matches = Regex.Match(message, regexPattern).Groups[0];
-            return matches.Value;
+            return message.Substring(0, message.IndexOf(':'));
         }
 
         private static string GetTimerTimestamp(string message)
         {
-            string regexPattern = @"CreateTimer\:.*\.\w+";
-            var match = Regex.Match(message, regexPattern).Groups[0];
-            Regex rgx = new Regex(@"CreateTimer:");
-            string result = rgx.Replace(match.Value, string.Empty);
-            return result;
+            const string CreateTimerPrefix = "CreateTimer:";
+            int start = message.IndexOf(CreateTimerPrefix) + CreateTimerPrefix.Length;
+            int end = message.IndexOf('Z', start) + 1;
+            return message.Substring(start, end - start);
         }
     }
 }


### PR DESCRIPTION
I think a previous change I made may have possibly regressed the two timer tests, `TimerCancellation` and `TimerExpiration`. The problem was that some regex logic was returning incorrect data when parsing the log messages.

My fix was to replace the regex with a few simple string parsing rules. I tend to trust string parsing more than regex when possible anyways. :)