### PR TITLE
Added CallOrchestratorAsync and CallOrchestratorWithRetryAsync APIs.

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/DurableOrchestrationContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableOrchestrationContext.cs
@@ -208,9 +208,9 @@ namespace Microsoft.Azure.WebJobs
         /// <exception cref="DurableTask.Core.Exceptions.TaskFailedException">
         /// The activity function failed with an unhandled exception.
         /// </exception>
-        public Task CallFunctionAsync(string functionName, params object[] parameters)
+        public Task CallActivityAsync(string functionName, params object[] parameters)
         {
-            return this.CallFunctionAsync<string>(functionName, parameters);
+            return this.CallActivityAsync<string>(functionName, parameters);
         }
 
         /// <summary>
@@ -232,14 +232,14 @@ namespace Microsoft.Azure.WebJobs
         /// <exception cref="DurableTask.Core.Exceptions.TaskFailedException">
         /// The activity function failed with an unhandled exception.
         /// </exception>
-        public Task CallFunctionWithRetryAsync(string functionName, RetryOptions retryOptions, params object[] parameters)
+        public Task CallActivityWithRetryAsync(string functionName, RetryOptions retryOptions, params object[] parameters)
         {
             if (retryOptions == null)
             {
                 throw new ArgumentNullException(nameof(retryOptions));    
             }
 
-            return this.CallFunctionWithRetryAsync<string>(functionName, retryOptions, parameters);
+            return this.CallActivityWithRetryAsync<string>(functionName, retryOptions, parameters);
         }
 
         /// <summary>
@@ -257,9 +257,9 @@ namespace Microsoft.Azure.WebJobs
         /// <exception cref="DurableTask.Core.Exceptions.TaskFailedException">
         /// The activity function failed with an unhandled exception.
         /// </exception>
-        public Task CallOrchestratorAsync(string functionName, params object[] parameters)
+        public Task CallSubOrchestratorAsync(string functionName, params object[] parameters)
         {
-            return this.CallOrchestratorAsync<string>(functionName, parameters);
+            return this.CallSubOrchestratorAsync<string>(functionName, parameters);
         }
 
         /// <summary>
@@ -281,14 +281,14 @@ namespace Microsoft.Azure.WebJobs
         /// <exception cref="DurableTask.Core.Exceptions.TaskFailedException">
         /// The activity function failed with an unhandled exception.
         /// </exception>
-        public Task CallOrchestratorWithRetryAsync(string functionName, RetryOptions retryOptions, params object[] parameters)
+        public Task CallSubOrchestratorWithRetryAsync(string functionName, RetryOptions retryOptions, params object[] parameters)
         {
             if (retryOptions == null)
             {
                 throw new ArgumentNullException(nameof(retryOptions));
             }
 
-            return this.CallOrchestratorWithRetryAsync<string>(functionName, retryOptions, parameters);
+            return this.CallSubOrchestratorWithRetryAsync<string>(functionName, retryOptions, parameters);
         }
 
         /// <summary>
@@ -307,7 +307,7 @@ namespace Microsoft.Azure.WebJobs
         /// <exception cref="DurableTask.Core.Exceptions.TaskFailedException">
         /// The activity function failed with an unhandled exception.
         /// </exception>
-        public async Task<TResult> CallFunctionAsync<TResult>(string functionName, params object[] parameters)
+        public async Task<TResult> CallActivityAsync<TResult>(string functionName, params object[] parameters)
         {
             return await CallDurableTaskFunctionAsync<TResult>(functionName, FunctionType.Activity, null, parameters);
         }
@@ -332,7 +332,7 @@ namespace Microsoft.Azure.WebJobs
         /// <exception cref="DurableTask.Core.Exceptions.TaskFailedException">
         /// The activity function failed with an unhandled exception.
         /// </exception>
-        public async Task<TResult> CallFunctionWithRetryAsync<TResult>(string functionName, RetryOptions retryOptions, params object[] parameters)
+        public async Task<TResult> CallActivityWithRetryAsync<TResult>(string functionName, RetryOptions retryOptions, params object[] parameters)
         {
             if (retryOptions == null)
             {
@@ -358,7 +358,7 @@ namespace Microsoft.Azure.WebJobs
         /// <exception cref="DurableTask.Core.Exceptions.TaskFailedException">
         /// The activity function failed with an unhandled exception.
         /// </exception>
-        public async Task<TResult> CallOrchestratorAsync<TResult>(string functionName, params object[] parameters)
+        public async Task<TResult> CallSubOrchestratorAsync<TResult>(string functionName, params object[] parameters)
         {
             return await CallDurableTaskFunctionAsync<TResult>(functionName, FunctionType.Orchestrator, null, parameters);
         }
@@ -383,7 +383,7 @@ namespace Microsoft.Azure.WebJobs
         /// <exception cref="DurableTask.Core.Exceptions.TaskFailedException">
         /// The activity function failed with an unhandled exception.
         /// </exception>
-        public async Task<TResult> CallOrchestratorWithRetryAsync<TResult>(string functionName, RetryOptions retryOptions, params object[] parameters)
+        public async Task<TResult> CallSubOrchestratorWithRetryAsync<TResult>(string functionName, RetryOptions retryOptions, params object[] parameters)
         {
             if (retryOptions == null)
             {

--- a/src/WebJobs.Extensions.DurableTask/DurableOrchestrationContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableOrchestrationContext.cs
@@ -214,7 +214,7 @@ namespace Microsoft.Azure.WebJobs
         }
 
         /// <summary>
-        /// Schedules an activity function named <paramref name="functionName"/> for execution.
+        /// Schedules an activity function named <paramref name="functionName"/> for execution with retry options.
         /// </summary>
         /// <param name="functionName">The name of the activity function to call.</param>
         /// <param name="retryOptions">The retry option for the activity function.</param>
@@ -243,6 +243,55 @@ namespace Microsoft.Azure.WebJobs
         }
 
         /// <summary>
+        /// Schedules an orchestrator function named <paramref name="functionName"/> for execution.
+        /// </summary>
+        /// <param name="functionName">The name of the orchestrator function to call.</param>
+        /// <param name="parameters">The JSON-serializeable parameters to pass as input to the function.</param>
+        /// <returns>A durable task that completes when the called function completes or fails.</returns>
+        /// <exception cref="ArgumentException">
+        /// The specified function does not exist, is disabled, or is not an orchestrator function.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">
+        /// The current thread is different than the thread which started the orchestrator execution.
+        /// </exception>
+        /// <exception cref="DurableTask.Core.Exceptions.TaskFailedException">
+        /// The activity function failed with an unhandled exception.
+        /// </exception>
+        public Task CallOrchestratorAsync(string functionName, params object[] parameters)
+        {
+            return this.CallOrchestratorAsync<string>(functionName, parameters);
+        }
+
+        /// <summary>
+        /// Schedules an orchestrator function named <paramref name="functionName"/> for execution with retry options.
+        /// </summary>
+        /// <param name="functionName">The name of the orchestrator function to call.</param>
+        /// <param name="retryOptions">The retry option for the orchestrator function.</param>
+        /// <param name="parameters">The JSON-serializeable parameters to pass as input to the function.</param>
+        /// <returns>A durable task that completes when the called function completes or fails.</returns>
+        /// <exception cref="ArgumentNullException">
+        /// The retry option object is null.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        /// The specified function does not exist, is disabled, or is not an orchestrator function.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">
+        /// The current thread is different than the thread which started the orchestrator execution.
+        /// </exception>
+        /// <exception cref="DurableTask.Core.Exceptions.TaskFailedException">
+        /// The activity function failed with an unhandled exception.
+        /// </exception>
+        public Task CallOrchestratorWithRetryAsync(string functionName, RetryOptions retryOptions, params object[] parameters)
+        {
+            if (retryOptions == null)
+            {
+                throw new ArgumentNullException(nameof(retryOptions));
+            }
+
+            return this.CallOrchestratorWithRetryAsync<string>(functionName, retryOptions, parameters);
+        }
+
+        /// <summary>
         /// Schedules an activity function named <paramref name="functionName"/> for execution.
         /// </summary>
         /// <typeparam name="TResult">The return type of the scheduled activity function.</typeparam>
@@ -260,11 +309,11 @@ namespace Microsoft.Azure.WebJobs
         /// </exception>
         public async Task<TResult> CallFunctionAsync<TResult>(string functionName, params object[] parameters)
         {
-            return await CallDurableTaskFunctionAsync<TResult>(functionName, null, parameters);
+            return await CallDurableTaskFunctionAsync<TResult>(functionName, FunctionType.Activity, null, parameters);
         }
 
         /// <summary>
-        /// Schedules an activity function named <paramref name="functionName"/> for execution.
+        /// Schedules an activity function named <paramref name="functionName"/> for execution with retry options.
         /// </summary>
         /// <typeparam name="TResult">The return type of the scheduled activity function.</typeparam>
         /// <param name="functionName">The name of the activity function to call.</param>
@@ -290,7 +339,58 @@ namespace Microsoft.Azure.WebJobs
                 throw new ArgumentNullException(nameof(retryOptions));
             }
 
-            return await CallDurableTaskFunctionAsync<TResult>(functionName, retryOptions, parameters);
+            return await CallDurableTaskFunctionAsync<TResult>(functionName, FunctionType.Activity, retryOptions, parameters);
+        }
+
+        /// <summary>
+        /// Schedules an orchestration function named <paramref name="functionName"/> for execution.
+        /// </summary>
+        /// <typeparam name="TResult">The return type of the scheduled orchestrator function.</typeparam>
+        /// <param name="functionName">The name of the orchestrator function to call.</param>
+        /// <param name="parameters">The JSON-serializeable parameters to pass as input to the function.</param>
+        /// <returns>A durable task that completes when the called function completes or fails.</returns>
+        /// <exception cref="ArgumentException">
+        /// The specified function does not exist, is disabled, or is not an orchestrator function.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">
+        /// The current thread is different than the thread which started the orchestrator execution.
+        /// </exception>
+        /// <exception cref="DurableTask.Core.Exceptions.TaskFailedException">
+        /// The activity function failed with an unhandled exception.
+        /// </exception>
+        public async Task<TResult> CallOrchestratorAsync<TResult>(string functionName, params object[] parameters)
+        {
+            return await CallDurableTaskFunctionAsync<TResult>(functionName, FunctionType.Orchestrator, null, parameters);
+        }
+
+        /// <summary>
+        /// Schedules an orchestrator function named <paramref name="functionName"/> for execution with retry options.
+        /// </summary>
+        /// <typeparam name="TResult">The return type of the scheduled orchestrator function.</typeparam>
+        /// <param name="functionName">The name of the orchestrator function to call.</param>
+        /// <param name="retryOptions">The retry option for the orchestrator function.</param>
+        /// <param name="parameters">The JSON-serializeable parameters to pass as input to the function.</param>
+        /// <returns>A durable task that completes when the called function completes or fails.</returns>
+        /// <exception cref="ArgumentNullException">
+        /// The retry option object is null.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        /// The specified function does not exist, is disabled, or is not an orchestrator function.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">
+        /// The current thread is different than the thread which started the orchestrator execution.
+        /// </exception>
+        /// <exception cref="DurableTask.Core.Exceptions.TaskFailedException">
+        /// The activity function failed with an unhandled exception.
+        /// </exception>
+        public async Task<TResult> CallOrchestratorWithRetryAsync<TResult>(string functionName, RetryOptions retryOptions, params object[] parameters)
+        {
+            if (retryOptions == null)
+            {
+                throw new ArgumentNullException(nameof(retryOptions));
+            }
+
+            return await CallDurableTaskFunctionAsync<TResult>(functionName, FunctionType.Orchestrator, retryOptions, parameters);
         }
 
         /// <summary>
@@ -391,6 +491,7 @@ namespace Microsoft.Azure.WebJobs
         }
 
         private async Task<TResult> CallDurableTaskFunctionAsync<TResult>(string functionName,
+            FunctionType functionType,
             RetryOptions retryOptions,
             object[] parameters)
         {
@@ -398,7 +499,7 @@ namespace Microsoft.Azure.WebJobs
 
             // TODO: Support for versioning
             string version = DefaultVersion;
-            FunctionType functionType = this.config.GetFunctionType(functionName, version);
+            this.config.ThrowIfInvalidFunctionType(functionName, functionType, version);
 
             Task<TResult> callTask;
 

--- a/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
@@ -364,22 +364,41 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             }
         }
 
-        internal FunctionType GetFunctionType(string name, string version)
+        internal FunctionType ThrowIfInvalidFunctionType(string name, FunctionType functionType, string version)
         {
             var functionName = new FunctionName(name, version);
 
-            if (this.registeredActivities.ContainsKey(functionName))
+            if (functionType == FunctionType.Activity)
             {
-                return FunctionType.Activity;
+                if (this.registeredActivities.ContainsKey(functionName))
+                {
+                    return FunctionType.Activity;
+                }
+
+                throw new ArgumentException(
+                        string.Format(
+                            "The function '{0}' doesn't exist, is disabled, or is not an activity function. The following are the active activity functions: '{1}'",
+                            functionName,
+                            string.Join(", ", this.registeredActivities.Keys)));
             }
 
-            if (this.registeredOrchestrators.ContainsKey(functionName))
+            if (functionType == FunctionType.Orchestrator)
             {
-                return FunctionType.Orchestrator;
+                if (this.registeredOrchestrators.ContainsKey(functionName))
+                {
+                    return FunctionType.Orchestrator;
+                }
+
+                throw new ArgumentException(
+                    string.Format(
+                        "The function '{0}' doesn't exist, is disabled, or is not an orchestrator function. The following are the active orchestrator functions: '{1}'",
+                        functionName,
+                        string.Join(", ", this.registeredOrchestrators.Keys)));
             }
 
             throw new ArgumentException(
-                string.Format("The function '{0}' doesn't exist, is disabled, or is not an activity or orchestrator function. The following are the active activity functions: '{1}', orchestrator functions: '{2}'",
+                string.Format(
+                    "The function '{0}' doesn't exist, is disabled, or is not an activity or orchestrator function. The following are the active activity functions: '{1}', orchestrator functions: '{2}'",
                     functionName,
                     string.Join(", ", this.registeredActivities.Keys),
                     string.Join(", ", this.registeredOrchestrators.Keys)));

--- a/test/DurableTaskEndToEndTests.cs
+++ b/test/DurableTaskEndToEndTests.cs
@@ -443,7 +443,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         }
 
         /// <summary>
-        /// End-to-end test which validates the handling of unhandled exceptions generated from orchestrator code.
+        /// End-to-end test which validates calling an orchestrator function.
         /// </summary>
         [Fact]
         public async Task Orchestration_Activity()
@@ -460,9 +460,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             {
                 await host.StartAsync();
 
-                // Null input should result in ArgumentNullException in the orchestration code.
                 var client = await host.StartFunctionAsync(orchestratorFunctionNames[0], null, this.output);
-                var status = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(10), this.output);
+                var status = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(20), this.output);
 
                 Assert.NotNull(status);
                 Assert.Equal("Completed", status.RuntimeStatus);

--- a/test/DurableTaskEndToEndTests.cs
+++ b/test/DurableTaskEndToEndTests.cs
@@ -416,7 +416,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         {
             string[] orchestratorFunctionNames =
             {
-                nameof(TestOrchestrations.OrchestratorThrow)
+                nameof(TestOrchestrations.Throw)
             };
 
             using (JobHost host = TestHelpers.GetJobHost(this.loggerFactory, nameof(UnhandledOrchestrationException)))
@@ -439,6 +439,43 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             {
                 TestHelpers.AssertLogMessageSequence(loggerProvider, "UnhandledOrchestrationException",
                     orchestratorFunctionNames);
+            }
+        }
+
+        /// <summary>
+        /// End-to-end test which validates the handling of unhandled exceptions generated from orchestrator code.
+        /// </summary>
+        [Fact]
+        public async Task Orchestration_Activity()
+        {
+            string[] orchestratorFunctionNames =
+            {
+                nameof(TestOrchestrations.OrchestratorGreeting),
+                nameof(TestOrchestrations.SayHelloWithActivity)
+            };
+
+            string activityFunctionName = nameof(TestActivities.Hello);
+
+            using (JobHost host = TestHelpers.GetJobHost(this.loggerFactory, nameof(Orchestration_Activity)))
+            {
+                await host.StartAsync();
+
+                // Null input should result in ArgumentNullException in the orchestration code.
+                var client = await host.StartFunctionAsync(orchestratorFunctionNames[0], null, this.output);
+                var status = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(10), this.output);
+
+                Assert.NotNull(status);
+                Assert.Equal("Completed", status.RuntimeStatus);
+                Assert.Equal(client.InstanceId, status.InstanceId);
+                Assert.Equal(orchestratorFunctionNames[0], status?.Name);
+
+                await host.StopAsync();
+            }
+
+            if (this.useTestLogger)
+            {
+                TestHelpers.AssertLogMessageSequence(loggerProvider, "Orchestration_Activity",
+                    orchestratorFunctionNames, activityFunctionName);
             }
         }
 
@@ -514,7 +551,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         {
             string[] orchestratorFunctionNames =
             {
-                nameof(TestOrchestrations.OrchestratorThrow)
+                nameof(TestOrchestrations.Throw)
             };
             string activityFunctionName = nameof(TestActivities.Throw);
 
@@ -638,7 +675,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 nameof(TestOrchestrations.CallActivity)
             };
             const string activityFunctionName = "UnregisteredActivity";
-            string errorMessage = $"The function '{activityFunctionName}' doesn't exist, is disabled, or is not an activity or orchestrator function";
+            string errorMessage = $"The function '{activityFunctionName}' doesn't exist, is disabled, or is not an activity function";
 
             using (JobHost host = TestHelpers.GetJobHost(this.loggerFactory, nameof(Orchestration_OnUnregisteredActivity)))
             {
@@ -678,7 +715,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             const string validOrchestratorName = "SayHelloWithActivity";
             string[] orchestratorFunctionNames =
             {
-                nameof(TestOrchestrations.CallActivity),
+                nameof(TestOrchestrations.CallOrchestrator),
                 validOrchestratorName
             };
             string activityFunctionName = nameof(TestActivities.Hello);
@@ -691,7 +728,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
                 var startArgs = new StartOrchestrationArgs
                 {
-                    FunctionName = nameof(TestOrchestrations.SayHelloWithActivity),
+                    FunctionName = orchestratorFunctionNames[1],
                     Input = input
                 };
 
@@ -735,6 +772,49 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 Assert.True(status.Output.ToString().Contains("fireAt"));
 
                 await host.StopAsync();
+            }
+        }
+
+        /// <summary>
+        /// End-to-end test which runs a orchestrator function that calls a non-existent activity function.
+        /// </summary>
+        [Fact]
+        public async Task Orchestration_OnUnregisteredOrchestrator()
+        {
+            const string unregisteredOrchestrator = "UnregisteredOrchestrator";
+            string[] orchestratorFunctionNames =
+            {
+                nameof(TestOrchestrations.CallOrchestrator),
+                unregisteredOrchestrator
+            };
+            
+            string errorMessage = $"The function '{unregisteredOrchestrator}' doesn't exist, is disabled, or is not an orchestrator function";
+
+            using (JobHost host = TestHelpers.GetJobHost(this.loggerFactory, nameof(Orchestration_OnUnregisteredActivity)))
+            {
+                await host.StartAsync();
+
+                var startArgs = new StartOrchestrationArgs
+                {
+                    FunctionName = unregisteredOrchestrator,
+                    Input = new { Foo = "Bar" }
+                };
+
+                var client = await host.StartFunctionAsync(orchestratorFunctionNames[0], startArgs, this.output);
+                var status = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(30), this.output);
+
+                Assert.Equal("Failed", status?.RuntimeStatus);
+
+                // There aren't any exception details in the output: https://github.com/Azure/azure-webjobs-sdk-script-pr/issues/36
+                Assert.True(status?.Output.ToString().Contains(errorMessage));
+
+                await host.StopAsync();
+            }
+
+            if (this.useTestLogger)
+            {
+                TestHelpers.AssertLogMessageSequence(loggerProvider, "Orchestration_OnUnregisteredOrchestrator",
+                    orchestratorFunctionNames);
             }
         }
     }

--- a/test/TestHelpers.cs
+++ b/test/TestHelpers.cs
@@ -80,7 +80,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             {
                 timeStamp = GetTimerTimestamp(logMessages[3].FormattedMessage);
             }
-            else if (testName.Equals("Orchestration_OnValidOrchestrator", StringComparison.InvariantCultureIgnoreCase))
+            else if (testName.Equals("Orchestration_OnValidOrchestrator", StringComparison.InvariantCultureIgnoreCase) ||
+                     testName.Equals("Orchestration_Activity", StringComparison.InvariantCultureIgnoreCase))
             {
                 messageIds.Add(GetMessageId(logMessages[4].FormattedMessage));
             }
@@ -122,8 +123,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 case "Orchestration_OnUnregisteredActivity":
                     messages = GetLogs_Orchestration_OnUnregisteredActivity(messageIds[0], orchestratorFunctionNames);
                     break;
+                case "Orchestration_OnUnregisteredOrchestrator":
+                    messages = GetLogs_Orchestration_OnUnregisteredOrchestrator(messageIds[0], orchestratorFunctionNames);
+                    break;
                 case "Orchestration_OnValidOrchestrator":
                     messages = GetLogs_Orchestration_OnValidOrchestrator(messageIds.ToArray(), orchestratorFunctionNames, activityFunctionName);
+                    break;
+                case "Orchestration_Activity":
+                    messages = GetLogs_Orchestration_Activity(messageIds.ToArray(), orchestratorFunctionNames, activityFunctionName);
                     break;
                 default:
                     break;
@@ -242,12 +249,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             {
                 $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' scheduled. Reason: NewInstance. IsReplay: False.",
                 $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' started. IsReplay: False. Input: \"Kah-BOOOOM!!!\"",
-                $"{messageId}: Function '{activityFunctionName} ({FunctionType.Activity})', version '' scheduled. Reason: OrchestratorThrow. IsReplay: False.",
+                $"{messageId}: Function '{activityFunctionName} ({FunctionType.Activity})', version '' scheduled. Reason: Throw. IsReplay: False.",
                 $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' awaited. IsReplay: False.",
                 $"{messageId}: Function '{activityFunctionName} ({FunctionType.Activity})', version '' started. IsReplay: False. Input: [\"Kah-BOOOOM!!!\"]",
                 $"{messageId}: Function '{activityFunctionName} ({FunctionType.Activity})', version '' failed with an error. Reason: Microsoft.Azure.WebJobs.Host.FunctionInvocationException",
                 $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' started. IsReplay: True. Input: \"Kah-BOOOOM!!!\"",
-                $"{messageId}: Function '{activityFunctionName} ({FunctionType.Activity})', version '' scheduled. Reason: OrchestratorThrow. IsReplay: True.",
+                $"{messageId}: Function '{activityFunctionName} ({FunctionType.Activity})', version '' scheduled. Reason: Throw. IsReplay: True.",
                 $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' failed with an error. Reason: DurableTask.Core.Exceptions.TaskFailedException",
             };
 
@@ -297,7 +304,19 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             {
                 $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' scheduled. Reason: NewInstance. IsReplay: False.",
                 $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' started. IsReplay: False.",
-                $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' failed with an error. Reason: System.ArgumentException: The function 'UnregisteredActivity' doesn't exist, is disabled, or is not an activity or orchestrator function.",
+                $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' failed with an error. Reason: System.ArgumentException: The function 'UnregisteredActivity' doesn't exist, is disabled, or is not an activity function.",
+            };
+
+            return list;
+        }
+
+        private static List<string> GetLogs_Orchestration_OnUnregisteredOrchestrator(string messageId, string[] orchestratorFunctionNames)
+        {
+            var list = new List<string>()
+            {
+                $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' scheduled. Reason: NewInstance. IsReplay: False.",
+                $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' started. IsReplay: False.",
+                $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' failed with an error. Reason: System.ArgumentException: The function 'UnregisteredOrchestrator' doesn't exist, is disabled, or is not an orchestrator function.",
             };
 
             return list;
@@ -309,7 +328,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             {
                 $"{messageIds[0]}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' scheduled. Reason: NewInstance. IsReplay: False.",
                 $"{messageIds[0]}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' started. IsReplay: False.",
-                $"{messageIds[0]}: Function '{orchestratorFunctionNames[1]} ({FunctionType.Orchestrator})', version '' scheduled. Reason: CallActivity. IsReplay: False.",
+                $"{messageIds[0]}: Function '{orchestratorFunctionNames[1]} ({FunctionType.Orchestrator})', version '' scheduled. Reason: CallOrchestrator. IsReplay: False.",
                 $"{messageIds[0]}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' awaited. IsReplay: False.",
                 $"{messageIds[1]}:0: Function '{orchestratorFunctionNames[1]} ({FunctionType.Orchestrator})', version '' started. IsReplay: False.",
                 $"{messageIds[1]}:0: Function '{activityFunctionName} ({FunctionType.Activity})', version '' scheduled. Reason: SayHelloWithActivity. IsReplay: False.",
@@ -320,8 +339,32 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 $"{messageIds[1]}:0: Function '{activityFunctionName} ({FunctionType.Activity})', version '' scheduled. Reason: SayHelloWithActivity. IsReplay: True.",
                 $"{messageIds[1]}:0: Function '{orchestratorFunctionNames[1]} ({FunctionType.Orchestrator})', version '' completed. ContinuedAsNew: False. IsReplay: False. Output: \"Hello,",
                 $"{messageIds[0]}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' started. IsReplay: True.",
-                $"{messageIds[0]}: Function '{orchestratorFunctionNames[1]} ({FunctionType.Orchestrator})', version '' scheduled. Reason: CallActivity. IsReplay: True.",
+                $"{messageIds[0]}: Function '{orchestratorFunctionNames[1]} ({FunctionType.Orchestrator})', version '' scheduled. Reason: CallOrchestrator. IsReplay: True.",
                 $"{messageIds[0]}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' completed. ContinuedAsNew: False. IsReplay: False. Output: \"Hello,",
+            };
+
+            return list;
+        }
+
+        private static List<string> GetLogs_Orchestration_Activity(string[] messageIds, string[] orchestratorFunctionNames, string activityFunctionName)
+        {
+            var list = new List<string>()
+            {
+                $"{messageIds[0]}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' scheduled. Reason: NewInstance. IsReplay: False.",
+                $"{messageIds[0]}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' started. IsReplay: False.",
+                $"{messageIds[0]}: Function '{orchestratorFunctionNames[1]} ({FunctionType.Orchestrator})', version '' scheduled. Reason: OrchestratorGreeting. IsReplay: False.",
+                $"{messageIds[0]}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' awaited. IsReplay: False.",
+                $"{messageIds[1]}:0: Function '{orchestratorFunctionNames[1]} ({FunctionType.Orchestrator})', version '' started. IsReplay: False.",
+                $"{messageIds[1]}:0: Function '{activityFunctionName} ({FunctionType.Activity})', version '' scheduled. Reason: SayHelloWithActivity. IsReplay: False.",
+                $"{messageIds[1]}:0: Function '{orchestratorFunctionNames[1]} ({FunctionType.Orchestrator})', version '' awaited. IsReplay: False.",
+                $"{messageIds[1]}:0: Function '{activityFunctionName} ({FunctionType.Activity})', version '' started. IsReplay: False.",
+                $"{messageIds[1]}:0: Function '{activityFunctionName} ({FunctionType.Activity})', version '' completed. ContinuedAsNew: False. IsReplay: False. Output: \"Hello, ",
+                $"{messageIds[1]}:0: Function '{orchestratorFunctionNames[1]} ({FunctionType.Orchestrator})', version '' started. IsReplay: True.",
+                $"{messageIds[1]}:0: Function '{activityFunctionName} ({FunctionType.Activity})', version '' scheduled. Reason: SayHelloWithActivity. IsReplay: True.",
+                $"{messageIds[1]}:0: Function '{orchestratorFunctionNames[1]} ({FunctionType.Orchestrator})', version '' completed. ContinuedAsNew: False. IsReplay: False. Output: \"Hello,",
+                $"{messageIds[0]}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' started. IsReplay: True.",
+                $"{messageIds[0]}: Function '{orchestratorFunctionNames[1]} ({FunctionType.Orchestrator})', version '' scheduled. Reason: OrchestratorGreeting. IsReplay: True.",
+                $"{messageIds[0]}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' completed. ContinuedAsNew: False. IsReplay: False. Output: (null)",
             };
 
             return list;

--- a/test/TestOrchestrations.cs
+++ b/test/TestOrchestrations.cs
@@ -102,7 +102,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             }
         }
 
-        public static async Task OrchestratorThrow([OrchestrationTrigger] DurableOrchestrationContext ctx)
+        public static async Task Throw([OrchestrationTrigger] DurableOrchestrationContext ctx)
         {
             string message = ctx.GetInput<string>();
             if (string.IsNullOrEmpty(message) || message.Contains("null"))
@@ -115,14 +115,22 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             await ctx.CallFunctionAsync(nameof(TestActivities.Throw), message);
         }
 
+        public static async Task OrchestratorGreeting([OrchestrationTrigger] DurableOrchestrationContext ctx)
+        {
+            string message = ctx.GetInput<string>();
+
+            // This throw happens in the implementation of an orchestrator.
+            await ctx.CallOrchestratorAsync(nameof(TestOrchestrations.SayHelloWithActivity), message);
+        }
+
         public static async Task OrchestratorThrowWithRetry([OrchestrationTrigger] DurableOrchestrationContext ctx)
         {
             string message = ctx.GetInput<string>();
 
             RetryOptions options = new RetryOptions(TimeSpan.FromSeconds(5), 3);
 
-            // This throw happens in the implementation of an activity.
-            await ctx.CallFunctionWithRetryAsync(nameof(TestOrchestrations.OrchestratorThrow), options, message);
+            // This throw happens in the implementation of an orchestrator.
+            await ctx.CallOrchestratorWithRetryAsync(nameof(TestOrchestrations.Throw), options, message);
         }
 
         public static async Task OrchestratorWithRetry_NullRetryOptions([OrchestrationTrigger] DurableOrchestrationContext ctx)
@@ -131,8 +139,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
             RetryOptions options = null;
 
-            // This throw happens in the implementation of an activity.
-            await ctx.CallFunctionWithRetryAsync(nameof(TestOrchestrations.OrchestratorThrow), options, message);
+            // This throw happens in the implementation of an orchestrator.
+            await ctx.CallOrchestratorWithRetryAsync(nameof(TestOrchestrations.Throw), options, message);
         }
 
         public static async Task ActivityThrowWithRetry([OrchestrationTrigger] DurableOrchestrationContext ctx)
@@ -202,6 +210,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             // Using StartOrchestrationArgs to start an activity function because it's easier than creating a new type.
             var startArgs = ctx.GetInput<StartOrchestrationArgs>();
             var result = await ctx.CallFunctionAsync<object>(startArgs.FunctionName, startArgs.Input);
+            return result;
+        }
+
+        public static async Task<object> CallOrchestrator([OrchestrationTrigger] DurableOrchestrationContext ctx)
+        {
+            // Using StartOrchestrationArgs to start an orchestrator function because it's easier than creating a new type.
+            var startArgs = ctx.GetInput<StartOrchestrationArgs>();
+            var result = await ctx.CallOrchestratorAsync<object>(startArgs.FunctionName, startArgs.Input);
             return result;
         }
 

--- a/test/TestOrchestrations.cs
+++ b/test/TestOrchestrations.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         public static async Task<string> SayHelloWithActivity([OrchestrationTrigger] DurableOrchestrationContext ctx)
         {
             string input = ctx.GetInput<string>();
-            string output = await ctx.CallFunctionAsync<string>(nameof(TestActivities.Hello), input);
+            string output = await ctx.CallActivityAsync<string>(nameof(TestActivities.Hello), input);
             return output;
         }
 
@@ -27,7 +27,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             long result = 1;
             for (int i = 1; i <= n; i++)
             {
-                result = await ctx.CallFunctionAsync<int>(nameof(TestActivities.Multiply), new[] { result, i });
+                result = await ctx.CallActivityAsync<int>(nameof(TestActivities.Multiply), new[] { result, i });
             }
 
             return result;
@@ -36,12 +36,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         public static async Task<long> DiskUsage([OrchestrationTrigger] DurableOrchestrationContext ctx)
         {
             string directory = ctx.GetInput<string>();
-            string[] files = await ctx.CallFunctionAsync<string[]>(nameof(TestActivities.GetFileList), directory);
+            string[] files = await ctx.CallActivityAsync<string[]>(nameof(TestActivities.GetFileList), directory);
 
             var tasks = new Task<long>[files.Length];
             for (int i = 0; i < files.Length; i++)
             {
-                tasks[i] = ctx.CallFunctionAsync<long>(nameof(TestActivities.GetFileSize), files[i]);
+                tasks[i] = ctx.CallActivityAsync<long>(nameof(TestActivities.GetFileSize), files[i]);
             }
 
             await Task.WhenAll(tasks);
@@ -112,15 +112,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             }
 
             // This throw happens in the implementation of an activity.
-            await ctx.CallFunctionAsync(nameof(TestActivities.Throw), message);
+            await ctx.CallActivityAsync(nameof(TestActivities.Throw), message);
         }
 
         public static async Task OrchestratorGreeting([OrchestrationTrigger] DurableOrchestrationContext ctx)
         {
             string message = ctx.GetInput<string>();
 
-            // This throw happens in the implementation of an orchestrator.
-            await ctx.CallOrchestratorAsync(nameof(TestOrchestrations.SayHelloWithActivity), message);
+            await ctx.CallSubOrchestratorAsync(nameof(TestOrchestrations.SayHelloWithActivity), message);
         }
 
         public static async Task OrchestratorThrowWithRetry([OrchestrationTrigger] DurableOrchestrationContext ctx)
@@ -130,7 +129,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             RetryOptions options = new RetryOptions(TimeSpan.FromSeconds(5), 3);
 
             // This throw happens in the implementation of an orchestrator.
-            await ctx.CallOrchestratorWithRetryAsync(nameof(TestOrchestrations.Throw), options, message);
+            await ctx.CallSubOrchestratorWithRetryAsync(nameof(TestOrchestrations.Throw), options, message);
         }
 
         public static async Task OrchestratorWithRetry_NullRetryOptions([OrchestrationTrigger] DurableOrchestrationContext ctx)
@@ -140,7 +139,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             RetryOptions options = null;
 
             // This throw happens in the implementation of an orchestrator.
-            await ctx.CallOrchestratorWithRetryAsync(nameof(TestOrchestrations.Throw), options, message);
+            await ctx.CallSubOrchestratorWithRetryAsync(nameof(TestOrchestrations.Throw), options, message);
         }
 
         public static async Task ActivityThrowWithRetry([OrchestrationTrigger] DurableOrchestrationContext ctx)
@@ -155,7 +154,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             RetryOptions options = new RetryOptions(TimeSpan.FromSeconds(5), 3);
 
             // This throw happens in the implementation of an activity.
-            await ctx.CallFunctionWithRetryAsync(nameof(TestActivities.Throw), options, message);
+            await ctx.CallActivityWithRetryAsync(nameof(TestActivities.Throw), options, message);
         }
 
         public static async Task ActivityWithRetry_NullRetryOptions([OrchestrationTrigger] DurableOrchestrationContext ctx)
@@ -170,7 +169,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             RetryOptions options = null;
 
             // This throw happens in the implementation of an activity.
-            await ctx.CallFunctionWithRetryAsync(nameof(TestActivities.Throw), options, message);
+            await ctx.CallActivityWithRetryAsync(nameof(TestActivities.Throw), options, message);
         }
 
         public static async Task<int> TryCatchLoop([OrchestrationTrigger] DurableOrchestrationContext ctx)
@@ -182,7 +181,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             {
                 try
                 {
-                    await ctx.CallFunctionAsync(nameof(TestActivities.Throw), "Kah-BOOOOOM!!!");
+                    await ctx.CallActivityAsync(nameof(TestActivities.Throw), "Kah-BOOOOOM!!!");
                 }
                 catch
                 {
@@ -196,20 +195,20 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         // TODO: It's not currently possible to detect this failure except by examining logs.
         public static async Task IllegalAwait([OrchestrationTrigger] DurableOrchestrationContext ctx)
         {
-            await ctx.CallFunctionAsync(nameof(TestActivities.Hello), "Foo");
+            await ctx.CallActivityAsync(nameof(TestActivities.Hello), "Foo");
 
             // This is the illegal await
             await Task.Run(() => { });
 
             // This call should throw
-            await ctx.CallFunctionAsync(nameof(TestActivities.Hello), "Bar");
+            await ctx.CallActivityAsync(nameof(TestActivities.Hello), "Bar");
         }
 
         public static async Task<object> CallActivity([OrchestrationTrigger] DurableOrchestrationContext ctx)
         {
             // Using StartOrchestrationArgs to start an activity function because it's easier than creating a new type.
             var startArgs = ctx.GetInput<StartOrchestrationArgs>();
-            var result = await ctx.CallFunctionAsync<object>(startArgs.FunctionName, startArgs.Input);
+            var result = await ctx.CallActivityAsync<object>(startArgs.FunctionName, startArgs.Input);
             return result;
         }
 
@@ -217,7 +216,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         {
             // Using StartOrchestrationArgs to start an orchestrator function because it's easier than creating a new type.
             var startArgs = ctx.GetInput<StartOrchestrationArgs>();
-            var result = await ctx.CallOrchestratorAsync<object>(startArgs.FunctionName, startArgs.Input);
+            var result = await ctx.CallSubOrchestratorAsync<object>(startArgs.FunctionName, startArgs.Input);
             return result;
         }
 


### PR DESCRIPTION
Addressed issue https://github.com/Azure/azure-functions-durable-extension/issues/54

1. Added new API named `CallOrchestratorAsync` and `CallOrchestratorWithRetryAsync` to allow customers to call orchestrator function types.
2. Added/updated tests.