### PR TITLE
Extended timeout to allow test to pass.

### DIFF
--- a/test/DurableTaskEndToEndTests.cs
+++ b/test/DurableTaskEndToEndTests.cs
@@ -376,9 +376,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                     tasks[i] = orchestrationStarter();
                 }
 
-                // The 100 orchestrations above (which each delay for 10 seconds) should all complete in less than 40 seconds.
+                // The 100 orchestrations above (which each delay for 10 seconds) should all complete in less than 70 seconds.
                 Task parallelOrchestrations = Task.WhenAll(tasks);
-                Task timeoutTask = Task.Delay(TimeSpan.FromSeconds(40));
+                Task timeoutTask = Task.Delay(TimeSpan.FromSeconds(70));
 
                 Task winner = await Task.WhenAny(parallelOrchestrations, timeoutTask);
                 Assert.Equal(parallelOrchestrations, winner);


### PR DESCRIPTION
Test is failing, possibly due to sluggish test environment.  Fixed test to pass by extending timeout.