### PR TITLE
Support cross-language return values for orchestration triggers

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/OrchestrationClientAttribute.cs
+++ b/src/WebJobs.Extensions.DurableTask/OrchestrationClientAttribute.cs
@@ -1,9 +1,9 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using Microsoft.Azure.WebJobs.Description;
 using System;
 using System.Diagnostics;
+using Microsoft.Azure.WebJobs.Description;
 
 namespace Microsoft.Azure.WebJobs
 {

--- a/src/WebJobs.Extensions.DurableTask/OrchestrationClientAttribute.cs
+++ b/src/WebJobs.Extensions.DurableTask/OrchestrationClientAttribute.cs
@@ -12,11 +12,7 @@ namespace Microsoft.Azure.WebJobs
     /// </summary>
     [AttributeUsage(AttributeTargets.Parameter)]
     [DebuggerDisplay("TaskHub={TaskHub}, ConnectionName={ConnectionName}")]
-#if NETSTANDARD2_0
-    [Binding(TriggerHandlesReturnValue = false)]
-#else
     [Binding]
-#endif
     public sealed class OrchestrationClientAttribute : Attribute, IEquatable<OrchestrationClientAttribute>
     {
         /// <summary>

--- a/src/WebJobs.Extensions.DurableTask/OrchestrationClientAttribute.cs
+++ b/src/WebJobs.Extensions.DurableTask/OrchestrationClientAttribute.cs
@@ -1,10 +1,9 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using Microsoft.Azure.WebJobs.Description;
 using System;
 using System.Diagnostics;
-using Microsoft.Azure.WebJobs.Description;
-using Microsoft.Azure.WebJobs.Extensions.DurableTask;
 
 namespace Microsoft.Azure.WebJobs
 {
@@ -13,7 +12,11 @@ namespace Microsoft.Azure.WebJobs
     /// </summary>
     [AttributeUsage(AttributeTargets.Parameter)]
     [DebuggerDisplay("TaskHub={TaskHub}, ConnectionName={ConnectionName}")]
+#if NETSTANDARD2_0
+    [Binding(TriggerHandlesReturnValue = false)]
+#else
     [Binding]
+#endif
     public sealed class OrchestrationClientAttribute : Attribute, IEquatable<OrchestrationClientAttribute>
     {
         /// <summary>

--- a/src/WebJobs.Extensions.DurableTask/OrchestrationTriggerAttribute.cs
+++ b/src/WebJobs.Extensions.DurableTask/OrchestrationTriggerAttribute.cs
@@ -1,9 +1,9 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using Microsoft.Azure.WebJobs.Description;
 using System;
 using System.Diagnostics;
-using Microsoft.Azure.WebJobs.Description;
 
 namespace Microsoft.Azure.WebJobs
 {
@@ -12,7 +12,11 @@ namespace Microsoft.Azure.WebJobs
     /// </summary>
     [AttributeUsage(AttributeTargets.Parameter)]
     [DebuggerDisplay("{Orchestration} ({Version})")]
+#if NETSTANDARD2_0
+    [Binding(TriggerHandlesReturnValue = false)]
+#else
     [Binding]
+#endif
     public sealed class OrchestrationTriggerAttribute : Attribute
     {
         /// <summary>

--- a/src/WebJobs.Extensions.DurableTask/OrchestrationTriggerAttribute.cs
+++ b/src/WebJobs.Extensions.DurableTask/OrchestrationTriggerAttribute.cs
@@ -1,9 +1,9 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using Microsoft.Azure.WebJobs.Description;
 using System;
 using System.Diagnostics;
+using Microsoft.Azure.WebJobs.Description;
 
 namespace Microsoft.Azure.WebJobs
 {
@@ -13,7 +13,7 @@ namespace Microsoft.Azure.WebJobs
     [AttributeUsage(AttributeTargets.Parameter)]
     [DebuggerDisplay("{Orchestration} ({Version})")]
 #if NETSTANDARD2_0
-    [Binding(TriggerHandlesReturnValue = false)]
+    [Binding(TriggerHandlesReturnValue = true)]
 #else
     [Binding]
 #endif


### PR DESCRIPTION
This seems like it'll fix #120 