### PR TITLE
StyleCop

### DIFF
--- a/.stylecop/GlobalSuppressions.cs
+++ b/.stylecop/GlobalSuppressions.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+// This file is used by Code Analysis to maintain SuppressMessage
+// attributes that are applied to this project.
+// Project-level suppressions either have no target or are given
+// a specific target and scoped to a namespace, type, member, etc.
+
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1623:Property summary documentation should match accessors", Justification = "In some cases we would rather prefix descriptions with 'Optional'")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1642:Constructor summary documentation should begin with standard text", Justification = "Not enforcing")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.LayoutRules", "SA1502:Element should not be on a single line", Justification = "This is more concise")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.LayoutRules", "SA1512:Single-line comments should not be followed by blank line", Justification = "Disagree with this rule")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.OrderingRules", "SA1202:Elements should be ordered by access", Justification = "Logical method grouping for improved top-down readability is prefered")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.OrderingRules", "SA1204:Static elements should appear before instance elements", Justification = "Logical method grouping for improved top-down readability is prefered")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.ReadabilityRules", "SA1108:Block statements should not contain embedded comments", Justification = "Embedded comments have their usefulness")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.ReadabilityRules", "SA1118:Parameter should not span multiple lines", Justification = "Multiline parameters are useful for readability in cases like anonymous type initializers")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.ReadabilityRules", "SA1122:Use string.Empty for empty strings", Justification = "string.Empty is too verbose in some cases")]

--- a/.stylecop/stylecop.json
+++ b/.stylecop/stylecop.json
@@ -1,0 +1,21 @@
+﻿{
+  "$schema": "https://raw.githubusercontent.com/DotNetAnalyzers/StyleCopAnalyzers/master/StyleCop.Analyzers/StyleCop.Analyzers/Settings/stylecop.schema.json",
+  "settings": {
+
+    "orderingRules": {
+      "systemUsingDirectivesFirst": true,
+      "usingDirectivesPlacement": "outsideNamespace"
+    },
+
+    "documentationRules": {
+      "companyName": ".NET Foundation",
+      "copyrightText": "Copyright (c) {companyName}. All rights reserved.\nLicensed under the {licenseName} License. See {licenseFile} in the project root for license information.",
+      "documentInternalElements": false,
+      "variables": {
+        "licenseName": "MIT",
+        "licenseFile": "LICENSE"
+      },
+      "xmlHeader": false
+    }
+  }
+}

--- a/WebJobs.Extensions.DurableTask.sln
+++ b/WebJobs.Extensions.DurableTask.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26621.2
+VisualStudioVersion = 15.0.27004.2010
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WebJobs.Extensions.DurableTask", "src\WebJobs.Extensions.DurableTask\WebJobs.Extensions.DurableTask.csproj", "{51790AFE-5B8E-4795-9EA3-D2B15D04B5AC}"
 EndProject

--- a/src/WebJobs.Extensions.DurableTask/ActivityTriggerAttribute.cs
+++ b/src/WebJobs.Extensions.DurableTask/ActivityTriggerAttribute.cs
@@ -1,10 +1,9 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the MIT License. See License.txt in the project root for license information.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
 using System.Diagnostics;
 using Microsoft.Azure.WebJobs.Description;
-using Microsoft.Azure.WebJobs.Extensions.DurableTask;
 
 namespace Microsoft.Azure.WebJobs
 {

--- a/src/WebJobs.Extensions.DurableTask/AssemblyInfo.cs
+++ b/src/WebJobs.Extensions.DurableTask/AssemblyInfo.cs
@@ -1,5 +1,5 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the MIT License. See License.txt in the project root for license information.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System.Runtime.CompilerServices;
 

--- a/src/WebJobs.Extensions.DurableTask/AsyncLock.cs
+++ b/src/WebJobs.Extensions.DurableTask/AsyncLock.cs
@@ -1,5 +1,5 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the MIT License. See License.txt in the project root for license information.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
 using System.Threading;

--- a/src/WebJobs.Extensions.DurableTask/Bindings/ActivityTriggerAttributeBindingProvider.cs
+++ b/src/WebJobs.Extensions.DurableTask/Bindings/ActivityTriggerAttributeBindingProvider.cs
@@ -1,5 +1,5 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the MIT License. See License.txt in the project root for license information.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
 using System.Collections.Generic;
@@ -106,7 +106,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 else
                 {
                     // Try using the converter manager
+#pragma warning disable CS0618 // Type or member is obsolete
                     IConverterManager cm = this.parent.extensionContext.Config.ConverterManager;
+#pragma warning restore CS0618 // Type or member is obsolete
                     MethodInfo getConverterMethod = cm.GetType().GetMethod(nameof(cm.GetConverter));
                     getConverterMethod = getConverterMethod.MakeGenericMethod(
                         typeof(DurableActivityContext),
@@ -134,7 +136,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 }
 
                 var inputValueProvider = new ObjectValueProvider(
-                    convertedValue, 
+                    convertedValue,
                     this.parameterInfo.ParameterType);
 
                 var bindingData = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase)
@@ -172,7 +174,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
             public static void RegisterBindingRules(JobHostConfiguration hostConfig)
             {
+#pragma warning disable CS0618 // Type or member is obsolete
                 IConverterManager cm = hostConfig.ConverterManager;
+#pragma warning restore CS0618 // Type or member is obsolete
                 cm.AddConverter<DurableActivityContext, string>(ActivityContextToString);
                 cm.AddConverter<DurableActivityContext, JObject>(ActivityContextToJObject);
             }

--- a/src/WebJobs.Extensions.DurableTask/Bindings/BindingHelper.cs
+++ b/src/WebJobs.Extensions.DurableTask/Bindings/BindingHelper.cs
@@ -1,17 +1,13 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the MIT License. See License.txt in the project root for license information.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System;
-using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
-using DurableTask.AzureStorage;
-using Microsoft.Azure.WebJobs.Host;
 using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 {
-    internal class BindingHelper 
+    internal class BindingHelper
     {
         private readonly DurableTaskExtension config;
         private readonly EndToEndTraceHelper traceHelper;

--- a/src/WebJobs.Extensions.DurableTask/Bindings/ObjectValueProvider.cs
+++ b/src/WebJobs.Extensions.DurableTask/Bindings/ObjectValueProvider.cs
@@ -1,5 +1,5 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the MIT License. See License.txt in the project root for license information.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
 using System.Threading.Tasks;

--- a/src/WebJobs.Extensions.DurableTask/Bindings/OrchestrationTriggerAttributeBindingProvider.cs
+++ b/src/WebJobs.Extensions.DurableTask/Bindings/OrchestrationTriggerAttributeBindingProvider.cs
@@ -1,10 +1,9 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the MIT License. See License.txt in the project root for license information.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
 using System.Collections.Generic;
 using System.Reflection;
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Host.Bindings;
 using Microsoft.Azure.WebJobs.Host.Config;
@@ -96,7 +95,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 return Task.FromResult<ITriggerData>(triggerData);
             }
 
-            [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Reliability", "CA2000:Dispose objects before losing scope")]
+            [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Reliability", "CA2000:Dispose objects before losing scope", Justification = "The caller is responsible for disposing")]
             public Task<IListener> CreateListenerAsync(ListenerFactoryContext context)
             {
                 if (context == null)

--- a/src/WebJobs.Extensions.DurableTask/DurableActivityContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableActivityContext.cs
@@ -1,5 +1,5 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the MIT License. See License.txt in the project root for license information.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
 using Microsoft.Azure.WebJobs.Extensions.DurableTask;

--- a/src/WebJobs.Extensions.DurableTask/DurableOrchestrationClient.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableOrchestrationClient.cs
@@ -1,5 +1,5 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the MIT License. See License.txt in the project root for license information.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
 using System.Net.Http;
@@ -38,7 +38,7 @@ namespace Microsoft.Azure.WebJobs
         }
 
         /// <summary>
-        /// Creates an HTTP response for checking the status of the specified instance. 
+        /// Creates an HTTP response for checking the status of the specified instance.
         /// </summary>
         /// <param name="request">The HTTP request that triggered the current function.</param>
         /// <param name="instanceId">The unique ID of the instance to check.</param>
@@ -49,11 +49,11 @@ namespace Microsoft.Azure.WebJobs
         }
 
         /// <summary>
-        /// Creates an HTTP response for checking the status of the specified instance supporting synchronous response as well. 
+        /// Creates an HTTP response for checking the status of the specified instance supporting synchronous response as well.
         /// </summary>
         /// <param name="request">The HTTP request that triggered the current function.</param>
         /// <param name="instanceId">The unique ID of the instance to check.</param>
-        /// <param name="timeout">Total allowed timeout for output from the durable function. The default value is 10 seconds.</param>		
+        /// <param name="timeout">Total allowed timeout for output from the durable function. The default value is 10 seconds.</param>
         /// <param name="retryInterval">The timeout between checks for output from the durable function. The default value is 1 second.</param>
         /// <returns>An HTTP response which may include a 202 and location header or a 200 with the durable function output in the response body.</returns>
         public async Task<HttpResponseMessage> WaitForCompletionOrCreateCheckStatusResponseAsync(HttpRequestMessage request, string instanceId, TimeSpan? timeout, TimeSpan? retryInterval)
@@ -111,7 +111,7 @@ namespace Microsoft.Azure.WebJobs
         /// <param name="eventName">The name of the event.</param>
         /// <param name="eventData">The JSON-serializeable data associated with the event.</param>
         /// <returns>A task that completes when the event notification message has been enqueued.</returns>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1030:UseEventsWhereAppropriate")]
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1030:UseEventsWhereAppropriate", Justification = "An event is not appropriate in this case")]
         public async Task RaiseEventAsync(string instanceId, string eventName, object eventData)
         {
             if (string.IsNullOrEmpty(eventName))
@@ -178,7 +178,7 @@ namespace Microsoft.Azure.WebJobs
                 LastUpdatedTime = state.LastUpdatedTime,
                 RuntimeStatus = (OrchestrationRuntimeStatus)state.OrchestrationStatus,
                 Input = ParseToJToken(state.Input),
-                Output = ParseToJToken(state.Output)
+                Output = ParseToJToken(state.Output),
             };
         }
 

--- a/src/WebJobs.Extensions.DurableTask/DurableOrchestrationContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableOrchestrationContext.cs
@@ -1,5 +1,5 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the MIT License. See License.txt in the project root for license information.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
 using System.Collections.Generic;
@@ -22,7 +22,7 @@ namespace Microsoft.Azure.WebJobs
         private const string DefaultVersion = "";
         private const int MaxTimerDurationInDays = 6;
 
-        private readonly Dictionary<string, object> pendingExternalEvents = 
+        private readonly Dictionary<string, object> pendingExternalEvents =
             new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
 
         private readonly DurableTaskExtension config;
@@ -62,7 +62,7 @@ namespace Microsoft.Azure.WebJobs
         /// Gets the current date/time in a way that is safe for use by orchestrator functions.
         /// </summary>
         /// <remarks>
-        /// This date/time value is derived from the orchestration history. It always returns the same value 
+        /// This date/time value is derived from the orchestration history. It always returns the same value
         /// at specific points in the orchestrator function code, making it deterministic and safe for replay.
         /// </remarks>
         /// <value>The orchestration's current date/time in UTC.</value>
@@ -475,7 +475,7 @@ namespace Microsoft.Azure.WebJobs
         /// Creates a durable timer which expires at a specified time.
         /// </summary>
         /// <remarks>
-        /// All durable timers created using this method must either expire or be cancelled 
+        /// All durable timers created using this method must either expire or be cancelled
         /// using the <paramref name="cancelToken"/> before the orchestrator function completes.
         /// Otherwise the underlying framework will keep the instance alive until the timer expires.
         /// </remarks>
@@ -491,7 +491,7 @@ namespace Microsoft.Azure.WebJobs
         /// Creates a durable timer which expires at a specified time.
         /// </summary>
         /// <remarks>
-        /// All durable timers created using this method must either expire or be cancelled 
+        /// All durable timers created using this method must either expire or be cancelled
         /// using the <paramref name="cancelToken"/> before the orchestrator function completes.
         /// Otherwise the underlying framework will keep the instance alive until the timer expires.
         /// </remarks>
@@ -603,9 +603,13 @@ namespace Microsoft.Azure.WebJobs
                     }
                     else
                     {
-                        callTask = this.innerContext.ScheduleWithRetry<TResult>(functionName, version,
-                            retryOptions.GetRetryOptions(), input);
+                        callTask = this.innerContext.ScheduleWithRetry<TResult>(
+                            functionName,
+                            version,
+                            retryOptions.GetRetryOptions(),
+                            input);
                     }
+
                     break;
                 case FunctionType.Orchestrator:
                     if (retryOptions == null)
@@ -625,6 +629,7 @@ namespace Microsoft.Azure.WebJobs
                             retryOptions.GetRetryOptions(),
                             input);
                     }
+
                     break;
                 default:
                     throw new InvalidOperationException($"Unexpected function type '{functionType}'.");
@@ -668,7 +673,7 @@ namespace Microsoft.Azure.WebJobs
             {
                 if (exception != null && this.innerContext.IsReplaying)
                 {
-                    // If this were not a replay, then the activity function trigger would have already 
+                    // If this were not a replay, then the activity function trigger would have already
                     // emitted a FunctionFailed trace with the full exception details.
                     this.config.TraceHelper.FunctionFailed(
                         this.config.HubName,
@@ -683,7 +688,7 @@ namespace Microsoft.Azure.WebJobs
 
             if (this.innerContext.IsReplaying)
             {
-                // If this were not a replay, then the activity function trigger would have already 
+                // If this were not a replay, then the activity function trigger would have already
                 // emitted a FunctionCompleted trace with the actual output details.
                 this.config.TraceHelper.FunctionCompleted(
                     this.config.HubName,
@@ -698,7 +703,6 @@ namespace Microsoft.Azure.WebJobs
 
             return output;
         }
-
 
         internal void RaiseEvent(string name, string input)
         {
@@ -724,8 +728,8 @@ namespace Microsoft.Azure.WebJobs
                 throw new InvalidOperationException("The inner context has not been initialized.");
             }
 
-            // TODO: This should be considered best effort because it's possible that async work 
-            // was scheduled and the CLR decided to run it on the same thread. The only guaranteed 
+            // TODO: This should be considered best effort because it's possible that async work
+            // was scheduled and the CLR decided to run it on the same thread. The only guaranteed
             // way to detect cross-thread access is to do it in the Durable Task Framework directly.
             if (this.owningThreadId != -1 && this.owningThreadId != Thread.CurrentThread.ManagedThreadId)
             {

--- a/src/WebJobs.Extensions.DurableTask/DurableOrchestrationStatus.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableOrchestrationStatus.cs
@@ -1,5 +1,5 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the MIT License. See License.txt in the project root for license information.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
 using Newtonsoft.Json.Linq;

--- a/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
@@ -1,5 +1,5 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the MIT License. See License.txt in the project root for license information.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
 using System.Collections.Concurrent;
@@ -28,6 +28,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         INameVersionObjectManager<TaskOrchestration>,
         INameVersionObjectManager<TaskActivity>
     {
+        /// <summary>
+        /// The default task hub name to use when not explicitly configured.
+        /// </summary>
+        internal const string DefaultHubName = "DurableFunctionsHub";
+
         // Creating client objects is expensive, so we cache them when the attributes match.
         // Note that OrchestrationClientAttribute defines a custom equality comparer.
         private readonly ConcurrentDictionary<OrchestrationClientAttribute, DurableOrchestrationClient> cachedClients =
@@ -35,6 +40,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
         private readonly ConcurrentDictionary<FunctionName, ITriggeredFunctionExecutor> registeredOrchestrators =
             new ConcurrentDictionary<FunctionName, ITriggeredFunctionExecutor>();
+
         private readonly ConcurrentDictionary<FunctionName, ITriggeredFunctionExecutor> registeredActivities =
             new ConcurrentDictionary<FunctionName, ITriggeredFunctionExecutor>();
 
@@ -48,16 +54,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         private HttpApiHandler httpApiHandler;
 
         /// <summary>
-        /// The default task hub name to use when not explicitly configured.
-        /// </summary>
-        internal const string DefaultHubName = "DurableFunctionsHub";
-
-        /// <summary>
         /// Gets or sets default task hub name to be used by all <see cref="DurableOrchestrationClient"/>,
         /// <see cref="DurableOrchestrationContext"/>, and <see cref="DurableActivityContext"/> instances.
         /// </summary>
         /// <remarks>
-        /// A task hub is a logical grouping of storage resources. Alternate task hub names can be used to isolate 
+        /// A task hub is a logical grouping of storage resources. Alternate task hub names can be used to isolate
         /// multiple Durable Functions applications from each other, even if they are using the same storage backend.
         /// </remarks>
         /// <value>The name of the default task hub.</value>
@@ -111,7 +112,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         public string AzureStorageConnectionStringName { get; set; }
 
         /// <summary>
-        /// The notification URL for polling status of instances. 
+        /// Gets or sets the notification URL for polling status of instances.
         /// </summary>
         /// <value>
         /// A URL pointing to the hosted function app that responds to status polling requests.
@@ -124,7 +125,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// <remarks>
         /// The default behavior when tracing function execution events is to include the number of bytes in the serialized
         /// inputs and outputs for function calls. This provides minimal information about what the inputs and outputs look
-        /// like without bloating the logs or inadvertently exposing sensitive information to the logs. Setting 
+        /// like without bloating the logs or inadvertently exposing sensitive information to the logs. Setting
         /// <see cref="TraceInputsAndOutputs"/> to <c>true</c> will instead cause the default function logging to log
         /// the entire contents of function inputs and outputs.
         /// </remarks>
@@ -149,6 +150,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
         internal EndToEndTraceHelper TraceHelper => this.traceHelper;
 
+        /// <summary>
+        /// Internal initialization call from the WebJobs host.
+        /// </summary>
+        /// <param name="context">Extension context provided by WebJobs.</param>
         void IExtensionConfigProvider.Initialize(ExtensionConfigContext context)
         {
             ConfigureLoaderHooks();
@@ -167,7 +172,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             // For 202 support
             if (this.NotificationUrl == null)
             {
+#pragma warning disable CS0618 // Type or member is obsolete
                 this.NotificationUrl = context.GetWebhookHandler();
+#pragma warning restore CS0618 // Type or member is obsolete
             }
 
             // Note that the order of the rules is important
@@ -175,7 +182,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 .AddConverter<JObject, StartOrchestrationArgs>(bindings.JObjectToStartOrchestrationArgs);
 
             rule.BindToCollector<StartOrchestrationArgs>(bindings.CreateAsyncCollector);
-            rule.BindToInput<DurableOrchestrationClient>(GetClient);
+            rule.BindToInput<DurableOrchestrationClient>(this.GetClient);
 
             context.AddBindingRule<OrchestrationTriggerAttribute>()
                 .BindToTrigger(new OrchestrationTriggerAttributeBindingProvider(this, context, this.traceHelper));
@@ -189,22 +196,42 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             this.taskHubWorker.AddOrchestrationDispatcherMiddleware(this.OrchestrationMiddleware);
         }
 
+        /// <summary>
+        /// Called by the Durable Task Framework: Not used.
+        /// </summary>
+        /// <param name="creator">This parameter is not used.</param>
         void INameVersionObjectManager<TaskOrchestration>.Add(ObjectCreator<TaskOrchestration> creator)
         {
             throw new InvalidOperationException("Orchestrations should never be added explicitly.");
         }
 
+        /// <summary>
+        /// Called by the Durable Task Framework: Returns the specified <see cref="TaskOrchestration"/>.
+        /// </summary>
+        /// <param name="name">The name of the orchestration to return.</param>
+        /// <param name="version">The version of the orchestration to return.</param>
+        /// <returns>An orchestration shim that delegates execution to an orchestrator function.</returns>
         TaskOrchestration INameVersionObjectManager<TaskOrchestration>.GetObject(string name, string version)
         {
             var context = new DurableOrchestrationContext(this, name, version);
             return new TaskOrchestrationShim(this, context);
         }
 
+        /// <summary>
+        /// Called by the durable task framework: Not used.
+        /// </summary>
+        /// <param name="creator">This parameter is not used.</param>
         void INameVersionObjectManager<TaskActivity>.Add(ObjectCreator<TaskActivity> creator)
         {
             throw new InvalidOperationException("Activities should never be added explicitly.");
         }
 
+        /// <summary>
+        /// Called by the Durable Task Framework: Returns the specified <see cref="TaskActivity"/>.
+        /// </summary>
+        /// <param name="name">The name of the activity to return.</param>
+        /// <param name="version">The version of the activity to return.</param>
+        /// <returns>An activity shim that delegates execution to an activity function.</returns>
         TaskActivity INameVersionObjectManager<TaskActivity>.GetObject(string name, string version)
         {
             FunctionName activityFunction = new FunctionName(name, version);
@@ -243,7 +270,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
                         // 3. Move to the next stage of the DTFx pipeline to trigger the orchestrator shim.
                         return next();
-                    }
+                    },
                 },
                 CancellationToken.None);
 
@@ -258,7 +285,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             }
         }
 
-        // This is temporary until script loading 
+        // This is temporary until script loading
         private static void ConfigureLoaderHooks()
         {
             AppDomain.CurrentDomain.AssemblyResolve += ResolveAssembly;
@@ -282,7 +309,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             return null;
         }
 
-
+        /// <summary>
+        /// Gets a <see cref="DurableOrchestrationClient"/> using configuration from a <see cref="OrchestrationClientAttribute"/> instance.
+        /// </summary>
+        /// <param name="attribute">The attribute containing the client configuration parameters.</param>
+        /// <returns>Returns a <see cref="DurableOrchestrationClient"/> instance. The returned instance may be a cached instance.</returns>
         protected internal virtual DurableOrchestrationClient GetClient(OrchestrationClientAttribute attribute)
         {
             DurableOrchestrationClient client = this.cachedClients.GetOrAdd(
@@ -300,7 +331,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         internal AzureStorageOrchestrationServiceSettings GetOrchestrationServiceSettings(
                 OrchestrationClientAttribute attribute)
         {
-            return GetOrchestrationServiceSettings(
+            return this.GetOrchestrationServiceSettings(
                 connectionNameOverride: attribute.ConnectionName,
                 taskHubNameOverride: attribute.TaskHub);
         }
@@ -360,7 +391,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             if (!this.registeredOrchestrators.ContainsKey(functionName))
             {
                 throw new ArgumentException(
-                    string.Format("The function '{0}' doesn't exist, is disabled, or is not an orchestrator function. The following are the active orchestrator functions: {1}.",
+                    string.Format(
+                        "The function '{0}' doesn't exist, is disabled, or is not an orchestrator function. The following are the active orchestrator functions: {1}.",
                         functionName,
                         string.Join(", ", this.registeredOrchestrators.Keys)));
             }
@@ -459,7 +491,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             }
         }
 
-        // Get a response that will point to our webhook handler. 
+        // Get a response that will point to our webhook handler.
         internal HttpResponseMessage CreateCheckStatusResponse(
             HttpRequestMessage request,
             string instanceId,
@@ -473,8 +505,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             return this.httpApiHandler.CreateCheckStatusResponse(request, instanceId, attribute);
         }
 
-        // Get a response that will wait for response from the durable function for predefined period of time before 
-        // pointing to our webhook handler. 
+        // Get a response that will wait for response from the durable function for predefined period of time before
+        // pointing to our webhook handler.
         internal async Task<HttpResponseMessage> WaitForCompletionOrCreateCheckStatusResponseAsync(
             HttpRequestMessage request,
             string instanceId,
@@ -490,6 +522,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             return await this.httpApiHandler.WaitForCompletionOrCreateCheckStatusResponseAsync(request, instanceId, attribute, timeout, retryInterval);
         }
 
+        /// <inheritdoc/>
         Task<HttpResponseMessage> IAsyncConverter<HttpRequestMessage, HttpResponseMessage>.ConvertAsync(
             HttpRequestMessage request,
             CancellationToken cancellationToken)

--- a/src/WebJobs.Extensions.DurableTask/DurableTaskJobHostConfigurationExtensions.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskJobHostConfigurationExtensions.cs
@@ -1,5 +1,5 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the MIT License. See License.txt in the project root for license information.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
 using Microsoft.Azure.WebJobs.Host;
@@ -17,7 +17,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// </summary>
         /// <param name="hostConfig">Configuration settings of the current <c>JobHost</c> instance.</param>
         /// <param name="listenerConfig">Durable Functions configuration.</param>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1011:ConsiderPassingBaseTypesAsParameters")]
         public static void UseDurableTask(
             this JobHostConfiguration hostConfig,
             DurableTaskExtension listenerConfig)
@@ -31,7 +30,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             {
                 throw new ArgumentNullException(nameof(listenerConfig));
             }
-                        
+
             IExtensionRegistry extensions = hostConfig.GetService<IExtensionRegistry>();
             extensions.RegisterExtension<IExtensionConfigProvider>(listenerConfig);
         }

--- a/src/WebJobs.Extensions.DurableTask/EndToEndTraceHelper.cs
+++ b/src/WebJobs.Extensions.DurableTask/EndToEndTraceHelper.cs
@@ -1,5 +1,5 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the MIT License. See License.txt in the project root for license information.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
 using System.Diagnostics;
@@ -11,9 +11,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
     internal class EndToEndTraceHelper
     {
         private const string CategoryName = "Host.Triggers.DurableTask";
+
+        private static readonly string ExtensionVersion = FileVersionInfo.GetVersionInfo(typeof(DurableTaskExtension).Assembly.Location).FileVersion;
+
         private static string appName;
         private static string slotName;
-        private static readonly string ExtensionVersion = FileVersionInfo.GetVersionInfo(typeof(DurableTaskExtension).Assembly.Location).FileVersion;
 
         private readonly TraceWriter appTraceWriter;
         private readonly ILogger logger;
@@ -50,6 +52,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             }
         }
 
+#pragma warning disable SA1117 // Parameters should be on same line or separate lines
+
         public void FunctionScheduled(
             string hubName,
             string functionName,
@@ -59,13 +63,21 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             FunctionType functionType,
             bool isReplay)
         {
-            EtwEventSource.Instance.FunctionScheduled(hubName, LocalAppName, LocalSlotName, functionName, version,
-                instanceId, reason, functionType.ToString(), ExtensionVersion, IsReplay: isReplay);
+            EtwEventSource.Instance.FunctionScheduled(
+                hubName,
+                LocalAppName,
+                LocalSlotName,
+                functionName,
+                version,
+                instanceId,
+                reason,
+                functionType.ToString(),
+                ExtensionVersion,
+                IsReplay: isReplay);
 
             this.logger.LogInformation(
                 "{instanceId}: Function '{functionName} ({functionType})', version '{version}' scheduled. Reason: {reason}. IsReplay: {isReplay}. State: {state}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}.",
-                instanceId, functionName, functionType, version, reason, isReplay, FunctionState.Scheduled, hubName,
-                LocalAppName, LocalSlotName, ExtensionVersion);
+                instanceId, functionName, functionType, version, reason, isReplay, FunctionState.Scheduled, hubName, LocalAppName, LocalSlotName, ExtensionVersion);
             this.appTraceWriter.Info(
                 $"{instanceId}: Function '{functionName} ({functionType})', version '{version}' scheduled. Reason: {reason}. IsReplay: {isReplay}. State: {FunctionState.Scheduled}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {ExtensionVersion}.");
         }
@@ -79,12 +91,21 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             FunctionType functionType,
             bool isReplay)
         {
-            EtwEventSource.Instance.FunctionStarting(hubName, LocalAppName, LocalSlotName, functionName, version,
-                instanceId, input, functionType.ToString(), ExtensionVersion, IsReplay: isReplay);
+            EtwEventSource.Instance.FunctionStarting(
+                hubName,
+                LocalAppName,
+                LocalSlotName,
+                functionName,
+                version,
+                instanceId,
+                input,
+                functionType.ToString(),
+                ExtensionVersion,
+                IsReplay: isReplay);
+
             this.logger.LogInformation(
                 "{instanceId}: Function '{functionName} ({functionType})', version '{version}' started. IsReplay: {isReplay}. Input: {input}. State: {state}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}.",
-                instanceId, functionName, functionType, version, isReplay, input, FunctionState.Started, hubName,
-                LocalAppName, LocalSlotName, ExtensionVersion);
+                instanceId, functionName, functionType, version, isReplay, input, FunctionState.Started, hubName, LocalAppName, LocalSlotName, ExtensionVersion);
             this.appTraceWriter.Info(
                 $"{instanceId}: Function '{functionName} ({functionType})', version '{version}' started. IsReplay: {isReplay}. Input: {input}. State: {FunctionState.Started}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {ExtensionVersion}.");
         }
@@ -98,12 +119,20 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         {
             FunctionType functionType = FunctionType.Orchestrator;
 
-            EtwEventSource.Instance.FunctionAwaited(hubName, LocalAppName, LocalSlotName, functionName, version,
-                instanceId, functionType.ToString(), ExtensionVersion, IsReplay: isReplay);
+            EtwEventSource.Instance.FunctionAwaited(
+                hubName,
+                LocalAppName,
+                LocalSlotName,
+                functionName,
+                version,
+                instanceId,
+                functionType.ToString(),
+                ExtensionVersion,
+                IsReplay: isReplay);
+
             this.logger.LogInformation(
                 "{instanceId}: Function '{functionName} ({functionType})', version '{version}' awaited. IsReplay: {isReplay}. State: {state}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}.",
-                instanceId, functionName, functionType, version, isReplay, FunctionState.Awaited, hubName,
-                LocalAppName, LocalSlotName, ExtensionVersion);
+                instanceId, functionName, functionType, version, isReplay, FunctionState.Awaited, hubName, LocalAppName, LocalSlotName, ExtensionVersion);
             this.appTraceWriter.Info(
                 $"{instanceId}: Function '{functionName} ({functionType})', version '{version}' awaited. IsReplay: {isReplay}. State: {FunctionState.Awaited}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {ExtensionVersion}.");
         }
@@ -118,13 +147,21 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         {
             FunctionType functionType = FunctionType.Orchestrator;
 
-            EtwEventSource.Instance.FunctionListening(hubName, LocalAppName, LocalSlotName, functionName, version,
-                instanceId, reason, functionType.ToString(), ExtensionVersion, IsReplay: isReplay);
+            EtwEventSource.Instance.FunctionListening(
+                hubName,
+                LocalAppName,
+                LocalSlotName,
+                functionName,
+                version,
+                instanceId,
+                reason,
+                functionType.ToString(),
+                ExtensionVersion,
+                IsReplay: isReplay);
 
             this.logger.LogInformation(
                 "{instanceId}: Function '{functionName} ({functionType})', version '{version}' is waiting for input. Reason: {reason}. IsReplay: {isReplay}. State: {state}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}.",
-                instanceId, functionName, functionType, version, reason, isReplay, FunctionState.Listening, hubName,
-                LocalAppName, LocalSlotName, ExtensionVersion);
+                instanceId, functionName, functionType, version, reason, isReplay, FunctionState.Listening, hubName, LocalAppName, LocalSlotName, ExtensionVersion);
             this.appTraceWriter.Info(
                 $"{instanceId}: Function '{functionName} ({functionType})', version '{version}' is waiting for input. Reason: {reason}. IsReplay: {isReplay}. State: {FunctionState.Listening}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}.  ExtensionVersion: {ExtensionVersion}.");
         }
@@ -139,13 +176,22 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             FunctionType functionType,
             bool isReplay)
         {
-            EtwEventSource.Instance.FunctionCompleted(hubName, LocalAppName, LocalSlotName, functionName, version,
-                instanceId, output, continuedAsNew, functionType.ToString(), ExtensionVersion, IsReplay: isReplay);
+            EtwEventSource.Instance.FunctionCompleted(
+                hubName,
+                LocalAppName,
+                LocalSlotName,
+                functionName,
+                version,
+                instanceId,
+                output,
+                continuedAsNew,
+                functionType.ToString(),
+                ExtensionVersion,
+                IsReplay: isReplay);
 
             this.logger.LogInformation(
                 "{instanceId}: Function '{functionName} ({functionType})', version '{version}' completed. ContinuedAsNew: {continuedAsNew}. IsReplay: {isReplay}. Output: {output}. State: {state}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}.",
-                instanceId, functionName, functionType, version, continuedAsNew, isReplay, output,
-                FunctionState.Completed, hubName, LocalAppName, LocalSlotName, ExtensionVersion);
+                instanceId, functionName, functionType, version, continuedAsNew, isReplay, output, FunctionState.Completed, hubName, LocalAppName, LocalSlotName, ExtensionVersion);
             this.appTraceWriter.Info(
                 $"{instanceId}: Function '{functionName} ({functionType})', version '{version}' completed. ContinuedAsNew: {continuedAsNew}. IsReplay: {isReplay}. Output: {output}. State: {FunctionState.Completed}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {ExtensionVersion}.");
         }
@@ -159,13 +205,21 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         {
             FunctionType functionType = FunctionType.Orchestrator;
 
-            EtwEventSource.Instance.FunctionTerminated(hubName, LocalAppName, LocalSlotName, functionName, version,
-                instanceId, reason, functionType.ToString(), ExtensionVersion, IsReplay: false);
+            EtwEventSource.Instance.FunctionTerminated(
+                hubName,
+                LocalAppName,
+                LocalSlotName,
+                functionName,
+                version,
+                instanceId,
+                reason,
+                functionType.ToString(),
+                ExtensionVersion,
+                IsReplay: false);
 
             this.logger.LogWarning(
                 "{instanceId}: Function '{functionName} ({functionType})', version '{version}' was terminated. Reason: {reason}. State: {state}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}.",
-                instanceId, functionName, functionType, version, reason, FunctionState.Terminated, hubName,
-                LocalAppName, LocalSlotName, ExtensionVersion);
+                instanceId, functionName, functionType, version, reason, FunctionState.Terminated, hubName, LocalAppName, LocalSlotName, ExtensionVersion);
             this.appTraceWriter.Info(
                 $"{instanceId}: Function '{functionName} ({functionType})', version '{version}' was terminated. Reason: {reason}. State: {FunctionState.Terminated}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {ExtensionVersion}.");
         }
@@ -184,8 +238,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
             this.logger.LogError(
                 "{instanceId}: Function '{functionName} ({functionType})', version '{version}' failed with an error. Reason: {reason}. IsReplay: {isReplay}. State: {state}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}.",
-                instanceId, functionName, functionType, version, reason, isReplay, FunctionState.Failed, hubName,
-                LocalAppName, LocalSlotName, ExtensionVersion);
+                instanceId, functionName, functionType, version, reason, isReplay, FunctionState.Failed, hubName, LocalAppName, LocalSlotName, ExtensionVersion);
             this.appTraceWriter.Info(
                 $"{instanceId}: Function '{functionName} ({functionType})', version '{version}' failed with an error. Reason: {reason}. IsReplay: {isReplay}. State: {FunctionState.Failed}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {ExtensionVersion}.");
         }
@@ -201,13 +254,22 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         {
             FunctionType functionType = FunctionType.Orchestrator;
 
-            EtwEventSource.Instance.ExternalEventRaised(hubName, LocalAppName, LocalSlotName, functionName, version,
-                instanceId, eventName, input, functionType.ToString(), ExtensionVersion, IsReplay: isReplay);
+            EtwEventSource.Instance.ExternalEventRaised(
+                hubName,
+                LocalAppName,
+                LocalSlotName,
+                functionName,
+                version,
+                instanceId,
+                eventName,
+                input,
+                functionType.ToString(),
+                ExtensionVersion,
+                IsReplay: isReplay);
 
             this.logger.LogInformation(
                 "{instanceId}: Function '{functionName} ({functionType})', version '{version}' received a '{eventName}' event. State: {state}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}.",
-                instanceId, functionName, functionType, version, eventName, FunctionState.ExternalEventRaised,
-                hubName, LocalAppName, LocalSlotName, ExtensionVersion);
+                instanceId, functionName, functionType, version, eventName, FunctionState.ExternalEventRaised, hubName, LocalAppName, LocalSlotName, ExtensionVersion);
             this.appTraceWriter.Info(
                 $"{instanceId}: Function '{functionName} ({functionType})', version '{version}' received a '{eventName}' event. State: {FunctionState.ExternalEventRaised}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {ExtensionVersion}.");
         }
@@ -238,10 +300,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
             this.logger.LogInformation(
                 "{instanceId}: Function '{functionName} ({functionType})', version '{version}' was resumed by a timer scheduled for '{expirationTime}'. IsReplay: {isReplay}. State: {state}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}.",
-                instanceId, functionName, functionType, version, expirationTimeString, isReplay, FunctionState.TimerExpired,
-                hubName, LocalAppName, LocalSlotName, ExtensionVersion);
+                instanceId, functionName, functionType, version, expirationTimeString, isReplay, FunctionState.TimerExpired, hubName, LocalAppName, LocalSlotName, ExtensionVersion);
             this.appTraceWriter.Info(
                 $"{instanceId}: Function '{functionName} ({functionType})', version '{version}' was resumed by a timer scheduled for '{expirationTimeString}'. IsReplay: {isReplay}. State: {FunctionState.TimerExpired}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {ExtensionVersion}.");
         }
+#pragma warning restore SA1117 // Parameters should be on same line or separate lines
     }
 }

--- a/src/WebJobs.Extensions.DurableTask/EtwEventSource.cs
+++ b/src/WebJobs.Extensions.DurableTask/EtwEventSource.cs
@@ -1,5 +1,5 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the MIT License. See License.txt in the project root for license information.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System.Diagnostics.Tracing;
 
@@ -11,11 +11,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
     [EventSource(Name = "WebJobs-Extensions-DurableTask")]
     internal sealed class EtwEventSource : EventSource
     {
-        public static EtwEventSource Instance = new EtwEventSource();
+        public static readonly EtwEventSource Instance = new EtwEventSource();
 
         // Private .ctor - callers should use the shared static instance.
         private EtwEventSource()
         { }
+
+#pragma warning disable SA1313 // Parameter names should begin with lower-case letter
 
         [Event(201, Level = EventLevel.Informational)]
         public void FunctionScheduled(
@@ -43,7 +45,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             string InstanceId,
             string Input,
             string FunctionType,
-            string ExtensionVersion, 
+            string ExtensionVersion,
             bool IsReplay)
         {
             this.WriteEvent(202, TaskHub, AppName, SlotName, FunctionName, Version ?? "", InstanceId, Input ?? "(null)", FunctionType, ExtensionVersion, IsReplay);
@@ -58,7 +60,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             string Version,
             string InstanceId,
             string FunctionType,
-            string ExtensionVersion, 
+            string ExtensionVersion,
             bool IsReplay)
         {
             this.WriteEvent(203, TaskHub, AppName, SlotName, FunctionName, Version ?? "", InstanceId, FunctionType, ExtensionVersion, IsReplay);
@@ -161,5 +163,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         {
             this.WriteEvent(209, TaskHub, AppName, SlotName, FunctionName, Version ?? "", InstanceId, Reason, FunctionType, ExtensionVersion, IsReplay);
         }
+#pragma warning restore SA1313 // Parameter names should begin with lower-case letter
     }
 }

--- a/src/WebJobs.Extensions.DurableTask/FunctionFailedException.cs
+++ b/src/WebJobs.Extensions.DurableTask/FunctionFailedException.cs
@@ -1,5 +1,5 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the MIT License. See License.txt in the project root for license information.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
 using System.Runtime.Serialization;

--- a/src/WebJobs.Extensions.DurableTask/FunctionName.cs
+++ b/src/WebJobs.Extensions.DurableTask/FunctionName.cs
@@ -1,5 +1,5 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the MIT License. See License.txt in the project root for license information.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
 

--- a/src/WebJobs.Extensions.DurableTask/FunctionState.cs
+++ b/src/WebJobs.Extensions.DurableTask/FunctionState.cs
@@ -1,5 +1,5 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the MIT License. See License.txt in the project root for license information.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 
 namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 {
@@ -13,6 +13,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         Terminated,
         Failed,
         ExternalEventRaised,
-        TimerExpired
+        TimerExpired,
     }
 }

--- a/src/WebJobs.Extensions.DurableTask/FunctionType.cs
+++ b/src/WebJobs.Extensions.DurableTask/FunctionType.cs
@@ -1,5 +1,5 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the MIT License. See License.txt in the project root for license information.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 
 namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 {
@@ -9,6 +9,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
     internal enum FunctionType
     {
         Activity,
-        Orchestrator
+        Orchestrator,
     }
 }

--- a/src/WebJobs.Extensions.DurableTask/HttpRequestMessageExtensions.cs
+++ b/src/WebJobs.Extensions.DurableTask/HttpRequestMessageExtensions.cs
@@ -1,5 +1,5 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the MIT License. See License.txt in the project root for license information.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
 using System.Collections.Specialized;
@@ -17,7 +17,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             return new HttpResponseMessage
             {
                 RequestMessage = request,
-                StatusCode = statusCode
+                StatusCode = statusCode,
             };
         }
 
@@ -27,7 +27,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             {
                 Content = new StringContent(JsonConvert.SerializeObject(value), Encoding.UTF8, "application/json"),
                 RequestMessage = request,
-                StatusCode = statusCode
+                StatusCode = statusCode,
             };
         }
 
@@ -39,7 +39,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             {
                 Content = new StringContent(JsonConvert.SerializeObject(error), Encoding.UTF8, "application/json"),
                 RequestMessage = request,
-                StatusCode = statusCode
+                StatusCode = statusCode,
             };
         }
 
@@ -50,14 +50,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 Message = message,
                 ExceptionMessage = e.Message,
                 ExceptionType = e.GetType().FullName,
-                StackTrace = e.StackTrace
+                StackTrace = e.StackTrace,
             };
 
             return new HttpResponseMessage
             {
                 Content = new StringContent(JsonConvert.SerializeObject(error), Encoding.UTF8, "application/json"),
                 RequestMessage = request,
-                StatusCode = statusCode
+                StatusCode = statusCode,
             };
         }
 
@@ -83,7 +83,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     if (ch == '=')
                     {
                         if (ti < 0)
+                        {
                             ti = i;
+                        }
                     }
                     else if (ch == separator) // e.g. '&' or ';'
                     {
@@ -94,8 +96,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 }
 
                 // extract the name / value pair
-                String name = null;
-                String value = null;
+                string name = null;
+                string value = null;
 
                 if (ti >= 0)
                 {
@@ -114,11 +116,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
                 // trailing '&'
                 if (i == l - 1 && s[i] == separator)
-                    values.Add(null, String.Empty);
+                {
+                    values.Add(null, string.Empty);
+                }
 
                 i++;
             }
-            
+
             return values;
         }
     }

--- a/src/WebJobs.Extensions.DurableTask/Listener/DurableTaskListener.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/DurableTaskListener.cs
@@ -1,5 +1,5 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the MIT License. See License.txt in the project root for license information.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
 using System.Threading;

--- a/src/WebJobs.Extensions.DurableTask/Listener/DurableTaskWorkerContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/DurableTaskWorkerContext.cs
@@ -1,5 +1,5 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the MIT License. See License.txt in the project root for license information.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System.Collections.Generic;
 using DurableTask.Core;

--- a/src/WebJobs.Extensions.DurableTask/Listener/TaskActivityShim.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/TaskActivityShim.cs
@@ -1,5 +1,5 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the MIT License. See License.txt in the project root for license information.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
 using System.Runtime.ExceptionServices;
@@ -28,7 +28,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         {
             this.config = config ?? throw new ArgumentNullException(nameof(config));
             this.executor = executor ?? throw new ArgumentNullException(nameof(executor));
-            
+
             if (string.IsNullOrEmpty(activityName))
             {
                 throw new ArgumentNullException(nameof(activityName));
@@ -78,7 +78,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
             string serializedOutput = inputContext.GetSerializedOutput();
             this.config.TraceHelper.FunctionCompleted(
-                config.HubName,
+                this.config.HubName,
                 this.activityName,
                 this.activityVersion,
                 instanceId,

--- a/src/WebJobs.Extensions.DurableTask/Listener/TaskOrchestrationShim.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/TaskOrchestrationShim.cs
@@ -1,5 +1,5 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the MIT License. See License.txt in the project root for license information.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
 using System.Threading.Tasks;
@@ -31,7 +31,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         {
             if (this.functionInvocationCallback != null)
             {
-                throw new InvalidOperationException($"{nameof(SetFunctionInvocationCallback)} must be called only once.");
+                throw new InvalidOperationException($"{nameof(this.SetFunctionInvocationCallback)} must be called only once.");
             }
 
             this.functionInvocationCallback = callback ?? throw new ArgumentNullException(nameof(callback));
@@ -41,7 +41,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         {
             if (this.functionInvocationCallback == null)
             {
-                throw new InvalidOperationException($"The {nameof(functionInvocationCallback)} has not been assigned!");
+                throw new InvalidOperationException($"The {nameof(this.functionInvocationCallback)} has not been assigned!");
             }
 
             this.context.AssignToCurrentThread();

--- a/src/WebJobs.Extensions.DurableTask/MessagePayloadDataConverter.cs
+++ b/src/WebJobs.Extensions.DurableTask/MessagePayloadDataConverter.cs
@@ -1,5 +1,5 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the MIT License. See License.txt in the project root for license information.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
 using System.Text;
@@ -16,7 +16,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         // We limit to 60 KB to leave room for metadata.
         private const int MaxPayloadSizeInKB = 60;
 
-        // The default JsonDataConverter for DTFx includes type information in JSON objects. This blows up when using Functions 
+        // The default JsonDataConverter for DTFx includes type information in JSON objects. This blows up when using Functions
         // because the type information generated from C# scripts cannot be understood by DTFx. For this reason, explicitly
         // configure the JsonDataConverter with default serializer settings, which don't include CLR type information.
         private static readonly JsonSerializerSettings SharedSettings = new JsonSerializerSettings();

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
@@ -1,0 +1,1038 @@
+<?xml version="1.0"?>
+<doc>
+    <assembly>
+        <name>Microsoft.Azure.WebJobs.Extensions.DurableTask</name>
+    </assembly>
+    <members>
+        <member name="T:Microsoft.Azure.WebJobs.ActivityTriggerAttribute">
+            <summary>
+            Trigger attribute used for durable activity functions.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.ActivityTriggerAttribute.Activity">
+            <summary>
+            Gets or sets the name of the activity function.
+            </summary>
+            <value>
+            The name of the activity function or <c>null</c> to use the function name.
+            </value>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.ActivityTriggerAttribute.Version">
+            <summary>
+            Gets or sets the version of the activity function.
+            </summary>
+            <value>
+            The version of the activity function.
+            </value>
+        </member>
+        <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension">
+            <summary>
+            Configuration for the Durable Functions extension.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.DefaultHubName">
+            <summary>
+            The default task hub name to use when not explicitly configured.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.HubName">
+            <summary>
+            Gets or sets default task hub name to be used by all <see cref="T:Microsoft.Azure.WebJobs.DurableOrchestrationClient"/>,
+            <see cref="T:Microsoft.Azure.WebJobs.DurableOrchestrationContext"/>, and <see cref="T:Microsoft.Azure.WebJobs.DurableActivityContext"/> instances.
+            </summary>
+            <remarks>
+            A task hub is a logical grouping of storage resources. Alternate task hub names can be used to isolate
+            multiple Durable Functions applications from each other, even if they are using the same storage backend.
+            </remarks>
+            <value>The name of the default task hub.</value>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.ControlQueueBatchSize">
+            <summary>
+            Gets or sets the number of messages to pull from the control queue at a time.
+            </summary>
+            <value>A positive integer configured by the host. The default value is <c>20</c>.</value>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.ControlQueueVisibilityTimeout">
+            <summary>
+            Gets or sets the visibility timeout of dequeued control queue messages.
+            </summary>
+            <value>
+            A <c>TimeSpan</c> configured by the host. The default is 5 minutes.
+            </value>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.WorkItemQueueVisibilityTimeout">
+            <summary>
+            Gets or sets the visibility timeout of dequeued work item queue messages.
+            </summary>
+            <value>
+            A <c>TimeSpan</c> configured by the host. The default is 5 minutes.
+            </value>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.MaxConcurrentTaskActivityWorkItems">
+            <summary>
+            Gets or sets the maximum number of work items that can be processed concurrently on a single node.
+            </summary>
+            <value>
+            A positive integer configured by the host. The default value is 10.
+            </value>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.MaxConcurrentTaskOrchestrationWorkItems">
+            <summary>
+            Gets or sets the maximum number of orchestrations that can be processed concurrently on a single node.
+            </summary>
+            <value>
+            A positive integer configured by the host. The default value is 100.
+            </value>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.AzureStorageConnectionStringName">
+            <summary>
+            Gets or sets the name of the Azure Storage connection string used to manage the underlying Azure Storage resources.
+            </summary>
+            <remarks>
+            If not specified, the default behavior is to use the standard `AzureWebJobsStorage` connection string for all storage usage.
+            </remarks>
+            <value>The name of a connection string that exists in the app's application settings.</value>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.NotificationUrl">
+            <summary>
+            Gets or sets the notification URL for polling status of instances.
+            </summary>
+            <value>
+            A URL pointing to the hosted function app that responds to status polling requests.
+            </value>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.TraceInputsAndOutputs">
+            <summary>
+            Gets or sets a value indicating whether to trace the inputs and outputs of function calls.
+            </summary>
+            <remarks>
+            The default behavior when tracing function execution events is to include the number of bytes in the serialized
+            inputs and outputs for function calls. This provides minimal information about what the inputs and outputs look
+            like without bloating the logs or inadvertently exposing sensitive information to the logs. Setting
+            <see cref="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.TraceInputsAndOutputs"/> to <c>true</c> will instead cause the default function logging to log
+            the entire contents of function inputs and outputs.
+            </remarks>
+            <value>
+            <c>true</c> to trace the raw values of inputs and outputs; otherwise <c>false</c>.
+            </value>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.DisableHttpManagementApis">
+            <summary>
+            Gets or sets a value indicating whether to expose HTTP APIs for managing orchestration instances.
+            </summary>
+            <remarks>
+            Orchestration instances can be managed using HTTP APIs implemented by the Durable Functions extension.
+            This includes checking status, raising events, and terminating instances. These APIs do not require
+            any authentication and therefore the instance IDs for these URLs should not be shared externally.
+            These APIs are enabled by default but can be disabled by setting this property to <c>true</c>.
+            </remarks>
+            <value>
+            <c>true</c> to disable the instance management HTTP APIs; otherwise <c>false</c>.
+            </value>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.Microsoft#Azure#WebJobs#Host#Config#IExtensionConfigProvider#Initialize(Microsoft.Azure.WebJobs.Host.Config.ExtensionConfigContext)">
+            <summary>
+            Internal initialization call from the WebJobs host.
+            </summary>
+            <param name="context">Extension context provided by WebJobs.</param>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.DurableTask#Core#INameVersionObjectManager{DurableTask#Core#TaskOrchestration}#Add(DurableTask.Core.ObjectCreator{DurableTask.Core.TaskOrchestration})">
+            <summary>
+            Called by the Durable Task Framework: Not used.
+            </summary>
+            <param name="creator">This parameter is not used.</param>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.DurableTask#Core#INameVersionObjectManager{DurableTask#Core#TaskOrchestration}#GetObject(System.String,System.String)">
+            <summary>
+            Called by the Durable Task Framework: Returns the specified <see cref="T:DurableTask.Core.TaskOrchestration"/>.
+            </summary>
+            <param name="name">The name of the orchestration to return.</param>
+            <param name="version">The version of the orchestration to return.</param>
+            <returns>An orchestration shim that delegates execution to an orchestrator function.</returns>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.DurableTask#Core#INameVersionObjectManager{DurableTask#Core#TaskActivity}#Add(DurableTask.Core.ObjectCreator{DurableTask.Core.TaskActivity})">
+            <summary>
+            Called by the durable task framework: Not used.
+            </summary>
+            <param name="creator">This parameter is not used.</param>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.DurableTask#Core#INameVersionObjectManager{DurableTask#Core#TaskActivity}#GetObject(System.String,System.String)">
+            <summary>
+            Called by the Durable Task Framework: Returns the specified <see cref="T:DurableTask.Core.TaskActivity"/>.
+            </summary>
+            <param name="name">The name of the activity to return.</param>
+            <param name="version">The version of the activity to return.</param>
+            <returns>An activity shim that delegates execution to an activity function.</returns>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.GetClient(Microsoft.Azure.WebJobs.OrchestrationClientAttribute)">
+            <summary>
+            Gets a <see cref="T:Microsoft.Azure.WebJobs.DurableOrchestrationClient"/> using configuration from a <see cref="T:Microsoft.Azure.WebJobs.OrchestrationClientAttribute"/> instance.
+            </summary>
+            <param name="attribute">The attribute containing the client configuration parameters.</param>
+            <returns>Returns a <see cref="T:Microsoft.Azure.WebJobs.DurableOrchestrationClient"/> instance. The returned instance may be a cached instance.</returns>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.Microsoft#Azure#WebJobs#IAsyncConverter{System#Net#Http#HttpRequestMessage,System#Net#Http#HttpResponseMessage}#ConvertAsync(System.Net.Http.HttpRequestMessage,System.Threading.CancellationToken)">
+            <inheritdoc/>
+        </member>
+        <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskJobHostConfigurationExtensions">
+            <summary>
+            Extension for registering a Durable Functions configuration with <c>JobHostConfiguration</c>.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskJobHostConfigurationExtensions.UseDurableTask(Microsoft.Azure.WebJobs.JobHostConfiguration,Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension)">
+            <summary>
+            Enable running durable orchestrations implemented as functions.
+            </summary>
+            <param name="hostConfig">Configuration settings of the current <c>JobHost</c> instance.</param>
+            <param name="listenerConfig">Durable Functions configuration.</param>
+        </member>
+        <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.EtwEventSource">
+            <summary>
+            ETW Event Provider for the WebJobs.Extensions.DurableTask extension.
+            </summary>
+        </member>
+        <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.FunctionType">
+            <summary>
+            The type of a function.
+            </summary>
+        </member>
+        <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.TaskActivityShim">
+            <summary>
+            Task activity implementation which delegates the implementation to a function.
+            </summary>
+        </member>
+        <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.TaskOrchestrationShim">
+            <summary>
+            Task orchestration implementation which delegates the orchestration implementation to a function.
+            </summary>
+        </member>
+        <member name="T:Microsoft.Azure.WebJobs.DurableActivityContext">
+            <summary>
+            Parameter data for activity bindings that are scheduled by their parent orchestrations.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.DurableActivityContext.InstanceId">
+            <summary>
+            Gets the instance ID of the currently executing orchestration.
+            </summary>
+            <remarks>
+            The instance ID is generated and fixed when the parent orchestrator function is scheduled. It can be either
+            auto-generated, in which case it is formatted as a GUID, or it can be user-specified with any format.
+            </remarks>
+            <value>
+            The ID of the current orchestration instance.
+            </value>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.DurableActivityContext.GetRawInput">
+            <summary>
+            Returns the input of the task activity in its raw JSON string value.
+            </summary>
+            <returns>
+            The raw JSON-formatted activity input as a string value.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.DurableActivityContext.GetInputAsJson">
+            <summary>
+            Gets the input of the current activity function instance as a <c>JToken</c>.
+            </summary>
+            <returns>
+            The parsed <c>JToken</c> representation of the activity input.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.DurableActivityContext.GetInput``1">
+            <summary>
+            Gets the input of the current activity function as a deserialized value.
+            </summary>
+            <typeparam name="T">Any data contract type that matches the JSON input.</typeparam>
+            <returns>The deserialized input value.</returns>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.DurableActivityContext.SetOutput(System.Object)">
+            <summary>
+            Sets the JSON-serializeable output of the activity function.
+            </summary>
+            <remarks>
+            If this method is not called explicitly, the return value of the activity function is used as the output.
+            </remarks>
+            <param name="output">
+            The JSON-serializeable value to use as the activity function output.
+            </param>
+        </member>
+        <member name="T:Microsoft.Azure.WebJobs.DurableOrchestrationClient">
+            <summary>
+            Client for starting, querying, terminating, and raising events to new or existing orchestration instances.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.DurableOrchestrationClient.CreateCheckStatusResponse(System.Net.Http.HttpRequestMessage,System.String)">
+            <summary>
+            Creates an HTTP response for checking the status of the specified instance.
+            </summary>
+            <param name="request">The HTTP request that triggered the current function.</param>
+            <param name="instanceId">The unique ID of the instance to check.</param>
+            <returns>An HTTP response which may include a 202 and location header.</returns>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.DurableOrchestrationClient.WaitForCompletionOrCreateCheckStatusResponseAsync(System.Net.Http.HttpRequestMessage,System.String,System.Nullable{System.TimeSpan},System.Nullable{System.TimeSpan})">
+            <summary>
+            Creates an HTTP response for checking the status of the specified instance supporting synchronous response as well.
+            </summary>
+            <param name="request">The HTTP request that triggered the current function.</param>
+            <param name="instanceId">The unique ID of the instance to check.</param>
+            <param name="timeout">Total allowed timeout for output from the durable function. The default value is 10 seconds.</param>
+            <param name="retryInterval">The timeout between checks for output from the durable function. The default value is 1 second.</param>
+            <returns>An HTTP response which may include a 202 and location header or a 200 with the durable function output in the response body.</returns>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.DurableOrchestrationClient.StartNewAsync(System.String,System.Object)">
+            <summary>
+            Starts a new execution of the specified orchestrator function.
+            </summary>
+            <param name="orchestratorFunctionName">The name of the orchestrator function to start.</param>
+            <param name="input">JSON-serializeable input value for the orchestrator function.</param>
+            <returns>A task that completes when the start message is enqueued.</returns>
+            <exception cref="T:System.ArgumentException">
+            The specified function does not exist, is disabled, or is not an orchestrator function.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.DurableOrchestrationClient.StartNewAsync(System.String,System.String,System.Object)">
+            <summary>
+            Starts a new execution of the specified orchestrator function.
+            </summary>
+            <param name="orchestratorFunctionName">The name of the orchestrator function to start.</param>
+            <param name="instanceId">A unique ID to use for the new orchestration instance.</param>
+            <param name="input">JSON-serializeable input value for the orchestrator function.</param>
+            <returns>A task that completes when the start message is enqueued.</returns>
+            <exception cref="T:System.ArgumentException">
+            The specified function does not exist, is disabled, or is not an orchestrator function.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.DurableOrchestrationClient.RaiseEventAsync(System.String,System.String,System.Object)">
+            <summary>
+            Sends an event notification message to a running orchestration instance.
+            </summary>
+            <param name="instanceId">The ID of the orchestration instance that will handle the event.</param>
+            <param name="eventName">The name of the event.</param>
+            <param name="eventData">The JSON-serializeable data associated with the event.</param>
+            <returns>A task that completes when the event notification message has been enqueued.</returns>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.DurableOrchestrationClient.TerminateAsync(System.String,System.String)">
+            <summary>
+            Terminates a running orchestration instance.
+            </summary>
+            <param name="instanceId">The ID of the orchestration instance to terminate.</param>
+            <param name="reason">The reason for terminating the orchestration instance.</param>
+            <returns>A task that completes when the terminate message is enqueued.</returns>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.DurableOrchestrationClient.GetStatusAsync(System.String)">
+            <summary>
+            Gets the status of the specified orchestration instance.
+            </summary>
+            <param name="instanceId">The ID of the orchestration instance to query.</param>
+            <returns>Returns a task which completes when the status has been fetched.</returns>
+        </member>
+        <member name="T:Microsoft.Azure.WebJobs.DurableOrchestrationContext">
+            <summary>
+            Parameter data for orchestration bindings that can be used to schedule function-based activities.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.DurableOrchestrationContext.InstanceId">
+            <summary>
+            Gets the instance ID of the currently executing orchestration.
+            </summary>
+            <remarks>
+            The instance ID is generated and fixed when the orchestrator function is scheduled. It can be either
+            auto-generated, in which case it is formatted as a GUID, or it can be user-specified with any format.
+            </remarks>
+            <value>
+            The ID of the current orchestration instance.
+            </value>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.DurableOrchestrationContext.CurrentUtcDateTime">
+            <summary>
+            Gets the current date/time in a way that is safe for use by orchestrator functions.
+            </summary>
+            <remarks>
+            This date/time value is derived from the orchestration history. It always returns the same value
+            at specific points in the orchestrator function code, making it deterministic and safe for replay.
+            </remarks>
+            <value>The orchestration's current date/time in UTC.</value>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.DurableOrchestrationContext.IsReplaying">
+            <summary>
+            Gets a value indicating whether the orchestrator function is currently replaying itself.
+            </summary>
+            <remarks>
+            This property is useful when there is logic that needs to run only when the orchestrator function
+            is *not* replaying. For example, certain types of application logging may become too noisy when duplicated
+            as part of orchestrator function replay. The orchestrator code could check to see whether the function is
+            being replayed and then issue the log statements when this value is <c>false</c>.
+            </remarks>
+            <value>
+            <c>true</c> if the orchestrator function is currently being replayed; otherwise <c>false</c>.
+            </value>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.DurableOrchestrationContext.GetRawInput">
+            <summary>
+            Returns the orchestrator function input as a raw JSON string value.
+            </summary>
+            <returns>
+            The raw JSON-formatted orchestrator function input.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.DurableOrchestrationContext.GetInputAsJson">
+            <summary>
+            Gets the input of the current orchestrator function instance as a <c>JToken</c>.
+            </summary>
+            <returns>
+            The parsed <c>JToken</c> representation of the orchestrator function input.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.DurableOrchestrationContext.GetInput``1">
+            <summary>
+            Gets the input of the current orchestrator function as a deserialized value.
+            </summary>
+            <typeparam name="T">Any data contract type that matches the JSON input.</typeparam>
+            <returns>The deserialized input value.</returns>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.DurableOrchestrationContext.SetOutput(System.Object)">
+            <summary>
+            Sets the JSON-serializeable output of the current orchestrator function.
+            </summary>
+            <remarks>
+            If this method is not called explicitly, the return value of the orchestrator function is used as the output.
+            </remarks>
+            <param name="output">The JSON-serializeable value to use as the orchestrator function output.</param>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.DurableOrchestrationContext.CallActivityAsync(System.String,System.Object)">
+            <summary>
+            Schedules an activity function named <paramref name="functionName"/> for execution.
+            </summary>
+            <param name="functionName">The name of the activity function to call.</param>
+            <param name="input">The JSON-serializeable input to pass to the activity function.</param>
+            <returns>A durable task that completes when the called function completes or fails.</returns>
+            <exception cref="T:System.ArgumentException">
+            The specified function does not exist, is disabled, or is not an orchestrator function.
+            </exception>
+            <exception cref="T:System.InvalidOperationException">
+            The current thread is different than the thread which started the orchestrator execution.
+            </exception>
+            <exception cref="T:Microsoft.Azure.WebJobs.FunctionFailedException">
+            The activity function failed with an unhandled exception.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.DurableOrchestrationContext.CallActivityWithRetryAsync(System.String,Microsoft.Azure.WebJobs.RetryOptions,System.Object)">
+            <summary>
+            Schedules an activity function named <paramref name="functionName"/> for execution with retry options.
+            </summary>
+            <param name="functionName">The name of the activity function to call.</param>
+            <param name="retryOptions">The retry option for the activity function.</param>
+            <param name="input">The JSON-serializeable input to pass to the activity function.</param>
+            <returns>A durable task that completes when the called activity function completes or fails.</returns>
+            <exception cref="T:System.ArgumentNullException">
+            The retry option object is null.
+            </exception>
+            <exception cref="T:System.ArgumentException">
+            The specified function does not exist, is disabled, or is not an orchestrator function.
+            </exception>
+            <exception cref="T:System.InvalidOperationException">
+            The current thread is different than the thread which started the orchestrator execution.
+            </exception>
+            <exception cref="T:Microsoft.Azure.WebJobs.FunctionFailedException">
+            The activity function failed with an unhandled exception.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.DurableOrchestrationContext.CallActivityAsync``1(System.String,System.Object)">
+            <summary>
+            Schedules an activity function named <paramref name="functionName"/> for execution.
+            </summary>
+            <typeparam name="TResult">The return type of the scheduled activity function.</typeparam>
+            <param name="functionName">The name of the activity function to call.</param>
+            <param name="input">The JSON-serializeable input to pass to the activity function.</param>
+            <returns>A durable task that completes when the called activity function completes or fails.</returns>
+            <exception cref="T:System.ArgumentException">
+            The specified function does not exist, is disabled, or is not an orchestrator function.
+            </exception>
+            <exception cref="T:System.InvalidOperationException">
+            The current thread is different than the thread which started the orchestrator execution.
+            </exception>
+            <exception cref="T:Microsoft.Azure.WebJobs.FunctionFailedException">
+            The activity function failed with an unhandled exception.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.DurableOrchestrationContext.CallActivityWithRetryAsync``1(System.String,Microsoft.Azure.WebJobs.RetryOptions,System.Object)">
+            <summary>
+            Schedules an activity function named <paramref name="functionName"/> for execution with retry options.
+            </summary>
+            <typeparam name="TResult">The return type of the scheduled activity function.</typeparam>
+            <param name="functionName">The name of the activity function to call.</param>
+            <param name="retryOptions">The retry option for the activity function.</param>
+            <param name="input">The JSON-serializeable input to pass to the activity function.</param>
+            <returns>A durable task that completes when the called activity function completes or fails.</returns>
+            <exception cref="T:System.ArgumentNullException">
+            The retry option object is null.
+            </exception>
+            <exception cref="T:System.ArgumentException">
+            The specified function does not exist, is disabled, or is not an orchestrator function.
+            </exception>
+            <exception cref="T:System.InvalidOperationException">
+            The current thread is different than the thread which started the orchestrator execution.
+            </exception>
+            <exception cref="T:Microsoft.Azure.WebJobs.FunctionFailedException">
+            The activity function failed with an unhandled exception.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.DurableOrchestrationContext.CallSubOrchestratorAsync(System.String,System.Object)">
+            <summary>
+            Schedules an orchestrator function named <paramref name="functionName"/> for execution.
+            </summary>
+            <param name="functionName">The name of the orchestrator function to call.</param>
+            <param name="input">The JSON-serializeable input to pass to the orchestrator function.</param>
+            <returns>A durable task that completes when the called orchestrator function completes or fails.</returns>
+            <exception cref="T:System.ArgumentException">
+            The specified function does not exist, is disabled, or is not an orchestrator function.
+            </exception>
+            <exception cref="T:System.InvalidOperationException">
+            The current thread is different than the thread which started the orchestrator execution.
+            </exception>
+            <exception cref="T:Microsoft.Azure.WebJobs.FunctionFailedException">
+            The activity function failed with an unhandled exception.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.DurableOrchestrationContext.CallSubOrchestratorAsync(System.String,System.String,System.Object)">
+            <summary>
+            Schedules an orchestrator function named <paramref name="functionName"/> for execution.
+            </summary>
+            <param name="functionName">The name of the orchestrator function to call.</param>
+            <param name="instanceId">A unique ID to use for the sub-orchestration instance.</param>
+            <param name="input">The JSON-serializeable input to pass to the orchestrator function.</param>
+            <returns>A durable task that completes when the called orchestrator function completes or fails.</returns>
+            <exception cref="T:System.ArgumentException">
+            The specified function does not exist, is disabled, or is not an orchestrator function.
+            </exception>
+            <exception cref="T:System.InvalidOperationException">
+            The current thread is different than the thread which started the orchestrator execution.
+            </exception>
+            <exception cref="T:Microsoft.Azure.WebJobs.FunctionFailedException">
+            The activity function failed with an unhandled exception.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.DurableOrchestrationContext.CallSubOrchestratorAsync``1(System.String,System.Object)">
+            <summary>
+            Schedules an orchestration function named <paramref name="functionName"/> for execution.
+            </summary>
+            <typeparam name="TResult">The return type of the scheduled orchestrator function.</typeparam>
+            <param name="functionName">The name of the orchestrator function to call.</param>
+            <param name="input">The JSON-serializeable input to pass to the orchestrator function.</param>
+            <returns>A durable task that completes when the called orchestrator function completes or fails.</returns>
+            <exception cref="T:System.ArgumentException">
+            The specified function does not exist, is disabled, or is not an orchestrator function.
+            </exception>
+            <exception cref="T:System.InvalidOperationException">
+            The current thread is different than the thread which started the orchestrator execution.
+            </exception>
+            <exception cref="T:Microsoft.Azure.WebJobs.FunctionFailedException">
+            The activity function failed with an unhandled exception.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.DurableOrchestrationContext.CallSubOrchestratorAsync``1(System.String,System.String,System.Object)">
+            <summary>
+            Schedules an orchestration function named <paramref name="functionName"/> for execution.
+            </summary>
+            <typeparam name="TResult">The return type of the scheduled orchestrator function.</typeparam>
+            <param name="functionName">The name of the orchestrator function to call.</param>
+            <param name="instanceId">A unique ID to use for the sub-orchestration instance.</param>
+            <param name="input">The JSON-serializeable input to pass to the orchestrator function.</param>
+            <returns>A durable task that completes when the called orchestrator function completes or fails.</returns>
+            <exception cref="T:System.ArgumentException">
+            The specified function does not exist, is disabled, or is not an orchestrator function.
+            </exception>
+            <exception cref="T:System.InvalidOperationException">
+            The current thread is different than the thread which started the orchestrator execution.
+            </exception>
+            <exception cref="T:Microsoft.Azure.WebJobs.FunctionFailedException">
+            The activity function failed with an unhandled exception.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.DurableOrchestrationContext.CallSubOrchestratorWithRetryAsync(System.String,Microsoft.Azure.WebJobs.RetryOptions,System.Object)">
+            <summary>
+            Schedules an orchestrator function named <paramref name="functionName"/> for execution with retry options.
+            </summary>
+            <param name="functionName">The name of the orchestrator function to call.</param>
+            <param name="retryOptions">The retry option for the orchestrator function.</param>
+            <param name="input">The JSON-serializeable input to pass to the orchestrator function.</param>
+            <returns>A durable task that completes when the called orchestrator function completes or fails.</returns>
+            <exception cref="T:System.ArgumentNullException">
+            The retry option object is null.
+            </exception>
+            <exception cref="T:System.ArgumentException">
+            The specified function does not exist, is disabled, or is not an orchestrator function.
+            </exception>
+            <exception cref="T:System.InvalidOperationException">
+            The current thread is different than the thread which started the orchestrator execution.
+            </exception>
+            <exception cref="T:Microsoft.Azure.WebJobs.FunctionFailedException">
+            The activity function failed with an unhandled exception.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.DurableOrchestrationContext.CallSubOrchestratorWithRetryAsync(System.String,Microsoft.Azure.WebJobs.RetryOptions,System.String,System.Object)">
+            <summary>
+            Schedules an orchestrator function named <paramref name="functionName"/> for execution with retry options.
+            </summary>
+            <param name="functionName">The name of the orchestrator function to call.</param>
+            <param name="retryOptions">The retry option for the orchestrator function.</param>
+            <param name="instanceId">A unique ID to use for the sub-orchestration instance.</param>
+            <param name="input">The JSON-serializeable input to pass to the orchestrator function.</param>
+            <returns>A durable task that completes when the called orchestrator function completes or fails.</returns>
+            <exception cref="T:System.ArgumentNullException">
+            The retry option object is null.
+            </exception>
+            <exception cref="T:System.ArgumentException">
+            The specified function does not exist, is disabled, or is not an orchestrator function.
+            </exception>
+            <exception cref="T:System.InvalidOperationException">
+            The current thread is different than the thread which started the orchestrator execution.
+            </exception>
+            <exception cref="T:Microsoft.Azure.WebJobs.FunctionFailedException">
+            The activity function failed with an unhandled exception.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.DurableOrchestrationContext.CallSubOrchestratorWithRetryAsync``1(System.String,Microsoft.Azure.WebJobs.RetryOptions,System.Object)">
+            <summary>
+            Schedules an orchestrator function named <paramref name="functionName"/> for execution with retry options.
+            </summary>
+            <typeparam name="TResult">The return type of the scheduled orchestrator function.</typeparam>
+            <param name="functionName">The name of the orchestrator function to call.</param>
+            <param name="retryOptions">The retry option for the orchestrator function.</param>
+            <param name="input">The JSON-serializeable input to pass to the orchestrator function.</param>
+            <returns>A durable task that completes when the called orchestrator function completes or fails.</returns>
+            <exception cref="T:System.ArgumentNullException">
+            The retry option object is null.
+            </exception>
+            <exception cref="T:System.ArgumentException">
+            The specified function does not exist, is disabled, or is not an orchestrator function.
+            </exception>
+            <exception cref="T:System.InvalidOperationException">
+            The current thread is different than the thread which started the orchestrator execution.
+            </exception>
+            <exception cref="T:Microsoft.Azure.WebJobs.FunctionFailedException">
+            The activity function failed with an unhandled exception.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.DurableOrchestrationContext.CallSubOrchestratorWithRetryAsync``1(System.String,Microsoft.Azure.WebJobs.RetryOptions,System.String,System.Object)">
+            <summary>
+            Schedules an orchestrator function named <paramref name="functionName"/> for execution with retry options.
+            </summary>
+            <typeparam name="TResult">The return type of the scheduled orchestrator function.</typeparam>
+            <param name="functionName">The name of the orchestrator function to call.</param>
+            <param name="retryOptions">The retry option for the orchestrator function.</param>
+            <param name="instanceId">A unique ID to use for the sub-orchestration instance.</param>
+            <param name="input">The JSON-serializeable input to pass to the orchestrator function.</param>
+            <returns>A durable task that completes when the called orchestrator function completes or fails.</returns>
+            <exception cref="T:System.ArgumentNullException">
+            The retry option object is null.
+            </exception>
+            <exception cref="T:System.ArgumentException">
+            The specified function does not exist, is disabled, or is not an orchestrator function.
+            </exception>
+            <exception cref="T:System.InvalidOperationException">
+            The current thread is different than the thread which started the orchestrator execution.
+            </exception>
+            <exception cref="T:Microsoft.Azure.WebJobs.FunctionFailedException">
+            The activity function failed with an unhandled exception.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.DurableOrchestrationContext.CreateTimer(System.DateTime,System.Threading.CancellationToken)">
+            <summary>
+            Creates a durable timer which expires at a specified time.
+            </summary>
+            <remarks>
+            All durable timers created using this method must either expire or be cancelled
+            using the <paramref name="cancelToken"/> before the orchestrator function completes.
+            Otherwise the underlying framework will keep the instance alive until the timer expires.
+            </remarks>
+            <param name="fireAt">The time at which the timer should expire.</param>
+            <param name="cancelToken">The <c>CancellationToken</c> to use for cancelling the timer.</param>
+            <returns>A durable task that completes when the durable timer expires.</returns>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.DurableOrchestrationContext.CreateTimer``1(System.DateTime,``0,System.Threading.CancellationToken)">
+            <summary>
+            Creates a durable timer which expires at a specified time.
+            </summary>
+            <remarks>
+            All durable timers created using this method must either expire or be cancelled
+            using the <paramref name="cancelToken"/> before the orchestrator function completes.
+            Otherwise the underlying framework will keep the instance alive until the timer expires.
+            </remarks>
+            <typeparam name="T">The type of <paramref name="state"/>.</typeparam>
+            <param name="fireAt">The time at which the timer should expire.</param>
+            <param name="state">Any state to be preserved by the timer.</param>
+            <param name="cancelToken">The <c>CancellationToken</c> to use for cancelling the timer.</param>
+            <returns>A durable task that completes when the durable timer expires.</returns>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.DurableOrchestrationContext.WaitForExternalEvent``1(System.String)">
+            <summary>
+            Waits asynchronously for an event to be raised with name <paramref name="name"/> and returns the event data.
+            </summary>
+            <param name="name">The name of the event to wait for.</param>
+            <typeparam name="T">Any serializeable type that represents the JSON event payload.</typeparam>
+            <returns>A durable task that completes when the external event is received.</returns>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.DurableOrchestrationContext.ContinueAsNew(System.Object)">
+            <summary>
+            Restarts the orchestration and its history.
+            </summary>
+            <param name="input">The JSON-serializeable data to re-initialize the instance with.</param>
+        </member>
+        <member name="T:Microsoft.Azure.WebJobs.DurableOrchestrationStatus">
+            <summary>
+            Represents the status of a durable orchestration instance.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.DurableOrchestrationStatus.Name">
+            <summary>
+            Gets the name of the queried orchestrator function.
+            </summary>
+            <value>
+            The orchestrator function name.
+            </value>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.DurableOrchestrationStatus.InstanceId">
+            <summary>
+            Gets the ID of the queried orchestration instance.
+            </summary>
+            <remarks>
+            The instance ID is generated and fixed when the orchestrator function is scheduled. It can be either
+            auto-generated, in which case it is formatted as a GUID, or it can be user-specified with any format.
+            </remarks>
+            <value>
+            The ID of the queried instance.
+            </value>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.DurableOrchestrationStatus.CreatedTime">
+            <summary>
+            Gets the time at which the queried orchestration instance was created.
+            </summary>
+            <value>
+            The creation time in UTC.
+            </value>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.DurableOrchestrationStatus.LastUpdatedTime">
+            <summary>
+            Gets the time at which the queried orchestration instance last updated its execution history.
+            </summary>
+            <value>
+            The last-updated time in UTC.
+            </value>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.DurableOrchestrationStatus.Input">
+            <summary>
+            Gets the input of the queried orchestrator function instance.
+            </summary>
+            <value>
+            The input as a <c>JToken</c> or <c>null</c> if no input was provided.
+            </value>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.DurableOrchestrationStatus.Output">
+            <summary>
+            Gets the output of the queried orchestration instance.
+            </summary>
+            <value>
+            The output as a <c>JToken</c> object or <c>null</c> if it has not yet completed.
+            </value>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.DurableOrchestrationStatus.RuntimeStatus">
+            <summary>
+            Gets the runtime status of the queried orchestration instance.
+            </summary>
+            <value>
+            Expected values include `Running`, `Pending`, `Failed`, `Canceled`, `Terminated`, `Completed`.
+            </value>
+        </member>
+        <member name="T:Microsoft.Azure.WebJobs.FunctionFailedException">
+            <summary>
+            The exception that is thrown when a sub-orchestrator or activity function fails
+            with an error.
+            </summary>
+        </member>
+        <member name="T:Microsoft.Azure.WebJobs.FunctionName">
+            <summary>
+            The name of a durable function, which includes its version (if any).
+            </summary>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.FunctionName.#ctor(System.String,System.String)">
+            <summary>
+            Initializes a new instance of the <see cref="T:Microsoft.Azure.WebJobs.FunctionName"/> struct.
+            </summary>
+            <param name="name">The name of the function.</param>
+            <param name="version">The version of the function.</param>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.FunctionName.Name">
+            <summary>
+            Gets the name of the function without the version.
+            </summary>
+            <value>
+            The name of the activity function without the version.
+            </value>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.FunctionName.Version">
+            <summary>
+            Gets the version of the function.
+            </summary>
+            <value>
+            The version of the function or <c>null</c> if no version information was specified.
+            </value>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.FunctionName.op_Equality(Microsoft.Azure.WebJobs.FunctionName,Microsoft.Azure.WebJobs.FunctionName)">
+            <summary>
+            Compares two <see cref="T:Microsoft.Azure.WebJobs.FunctionName"/> objects for equality.
+            </summary>
+            <param name="a">The first <see cref="T:Microsoft.Azure.WebJobs.FunctionName"/> to compare.</param>
+            <param name="b">The second <see cref="T:Microsoft.Azure.WebJobs.FunctionName"/> to compare.</param>
+            <returns><c>true</c> if the two <see cref="T:Microsoft.Azure.WebJobs.FunctionName"/> objects are equal; otherwise <c>false</c>.</returns>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.FunctionName.op_Inequality(Microsoft.Azure.WebJobs.FunctionName,Microsoft.Azure.WebJobs.FunctionName)">
+            <summary>
+            Compares two <see cref="T:Microsoft.Azure.WebJobs.FunctionName"/> objects for inequality.
+            </summary>
+            <param name="a">The first <see cref="T:Microsoft.Azure.WebJobs.FunctionName"/> to compare.</param>
+            <param name="b">The second <see cref="T:Microsoft.Azure.WebJobs.FunctionName"/> to compare.</param>
+            <returns><c>true</c> if the two <see cref="T:Microsoft.Azure.WebJobs.FunctionName"/> objects are not equal; otherwise <c>false</c>.</returns>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.FunctionName.Equals(Microsoft.Azure.WebJobs.FunctionName)">
+            <summary>
+            Gets a value indicating whether to <see cref="T:Microsoft.Azure.WebJobs.FunctionName"/> objects
+            are equal using value semantics.
+            </summary>
+            <param name="other">The other object to compare to.</param>
+            <returns><c>true</c> if the two objects are equal using value semantics; otherwise <c>false</c>.</returns>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.FunctionName.Equals(System.Object)">
+            <summary>
+            Gets a value indicating whether to <see cref="T:Microsoft.Azure.WebJobs.FunctionName"/> objects
+            are equal using value semantics.
+            </summary>
+            <param name="other">The other object to compare to.</param>
+            <returns><c>true</c> if the two objects are equal using value semantics; otherwise <c>false</c>.</returns>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.FunctionName.GetHashCode">
+            <summary>
+            Calculates a hash code value for the current <see cref="T:Microsoft.Azure.WebJobs.FunctionName"/> instance.
+            </summary>
+            <returns>A 32-bit hash code value.</returns>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.FunctionName.ToString">
+            <summary>
+            Gets the string value of the current <see cref="T:Microsoft.Azure.WebJobs.FunctionName"/> instance.
+            </summary>
+            <returns>The name and optional version of the current <see cref="T:Microsoft.Azure.WebJobs.FunctionName"/> instance.</returns>
+        </member>
+        <member name="T:Microsoft.Azure.WebJobs.OrchestrationClientAttribute">
+            <summary>
+            Attribute used to bind a function parameter to a Durable Functions client object.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.OrchestrationClientAttribute.TaskHub">
+            <summary>
+            Optional. Gets or sets the name of the task hub to be operated on.
+            </summary>
+            <value>The task hub used by this binding.</value>
+            <remarks>
+            The default behavior is to use the task hub name specified in <see cref="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.HubName"/>.
+            If no value exists there, then a default value will be used.
+            </remarks>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.OrchestrationClientAttribute.ConnectionName">
+            <summary>
+            Optional. Gets or sets the name of the Azure Storage connection string used by this binding.
+            </summary>
+            <value>The name of a connection string that exists in the app's application settings.</value>
+            <remarks>
+            The default behavior is to use the value specified in
+            <see cref="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.AzureStorageConnectionStringName"/>. If no value exists there, then
+            the default behavior is to use the standard `AzureWebJobsStorage` connection string for all storage usage.
+            </remarks>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.OrchestrationClientAttribute.GetHashCode">
+            <summary>
+            Returns a hash code for this attribute.
+            </summary>
+            <returns>A hash code for this attribute.</returns>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.OrchestrationClientAttribute.Equals(System.Object)">
+            <summary>
+            Compares two <see cref="T:Microsoft.Azure.WebJobs.OrchestrationClientAttribute"/> instances for value equality.
+            </summary>
+            <param name="obj">The <see cref="T:Microsoft.Azure.WebJobs.OrchestrationClientAttribute"/> object to compare with.</param>
+            <returns><c>true</c> if the two attributes have the same configuration; otherwise <c>false</c>.</returns>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.OrchestrationClientAttribute.Equals(Microsoft.Azure.WebJobs.OrchestrationClientAttribute)">
+            <summary>
+            Compares two <see cref="T:Microsoft.Azure.WebJobs.OrchestrationClientAttribute"/> instances for value equality.
+            </summary>
+            <param name="other">The <see cref="T:Microsoft.Azure.WebJobs.OrchestrationClientAttribute"/> object to compare with.</param>
+            <returns><c>true</c> if the two attributes have the same configuration; otherwise <c>false</c>.</returns>
+        </member>
+        <member name="T:Microsoft.Azure.WebJobs.OrchestrationRuntimeStatus">
+            <summary>
+            Represents the possible runtime execution status values for an orchestration instance.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Azure.WebJobs.OrchestrationRuntimeStatus.Running">
+            <summary>
+            The orchestration is running (it may be actively running or waiting for input).
+            </summary>
+        </member>
+        <member name="F:Microsoft.Azure.WebJobs.OrchestrationRuntimeStatus.Completed">
+            <summary>
+            The orchestration ran to completion.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Azure.WebJobs.OrchestrationRuntimeStatus.ContinuedAsNew">
+            <summary>
+            The orchestration completed with ContinueAsNew as is in the process of restarting.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Azure.WebJobs.OrchestrationRuntimeStatus.Failed">
+            <summary>
+            The orchestration failed with an error.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Azure.WebJobs.OrchestrationRuntimeStatus.Canceled">
+            <summary>
+            The orchestration was gracefully canceled.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Azure.WebJobs.OrchestrationRuntimeStatus.Terminated">
+            <summary>
+            The orchestration was abruptly terminated via an API call.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Azure.WebJobs.OrchestrationRuntimeStatus.Pending">
+            <summary>
+            The orchestration was scheduled but is not yet active.
+            </summary>
+        </member>
+        <member name="T:Microsoft.Azure.WebJobs.OrchestrationTriggerAttribute">
+            <summary>
+            Trigger attribute used for durable orchestrator functions.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.OrchestrationTriggerAttribute.Orchestration">
+            <summary>
+            Gets or sets the name of the orchestrator function.
+            </summary>
+            <value>
+            The name of the orchestrator function or <c>null</c> to use the function name.
+            </value>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.OrchestrationTriggerAttribute.Version">
+            <summary>
+            Gets or sets the version of the orchestrator function.
+            </summary>
+            <value>
+            The version of the orchestrator function.
+            </value>
+        </member>
+        <member name="T:Microsoft.Azure.WebJobs.RetryOptions">
+            <summary>
+                Contains retry policies that can be passed as parameters to various operations
+            </summary>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.RetryOptions.#ctor(System.TimeSpan,System.Int32)">
+            <summary>
+            Creates a new instance RetryOptions with the supplied first retry and max attempts
+            </summary>
+            <param name="firstRetryInterval">Timespan to wait for the first retry</param>
+            <param name="maxNumberOfAttempts">Max number of attempts to retry</param>
+            <exception cref="T:System.ArgumentException">
+            The TimeSpan value must be greater than TimeSpan.Zero.
+            </exception>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.RetryOptions.FirstRetryInterval">
+            <summary>
+            Gets or sets the first retry interval
+            </summary>
+            <value>
+            The TimeSpan to wait for the first retries
+            </value>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.RetryOptions.MaxRetryInterval">
+            <summary>
+            Gets or sets the max retry interval
+            </summary>
+            <value>
+            The TimeSpan of the max retry interval, defaults to TimeSpan.MaxValue
+            </value>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.RetryOptions.BackoffCoefficient">
+            <summary>
+            Gets or sets the backoff coefficient
+            </summary>
+            <value>
+            The backoff coefficient used to determine rate of increase of backoff, defaults to 1.
+            </value>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.RetryOptions.RetryTimeout">
+            <summary>
+            Gets or sets the timeout for retries
+            </summary>
+            <value>
+            The TimeSpan timeout for retries, defaults to TimeSpan.MaxValue
+            </value>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.RetryOptions.MaxNumberOfAttempts">
+            <summary>
+            Gets or sets the max number of attempts
+            </summary>
+            <value>
+            The maximum number of retry attempts
+            </value>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.RetryOptions.Handle">
+            <summary>
+            Gets or sets a Func to call on exception to determine if retries should proceed
+            </summary>
+            <value>
+            The Func to handle exception to determie if retries should proceed
+            </value>
+        </member>
+        <member name="T:Microsoft.Azure.WebJobs.StartOrchestrationArgs">
+            <summary>
+            Parameters for starting a new instance of an orchestration.
+            </summary>
+            <remarks>
+            This class is primarily intended for use with <c>IAsyncCollector&lt;T&gt;</c>.
+            </remarks>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.StartOrchestrationArgs.#ctor(System.String,System.Object)">
+            <summary>
+            Initializes a new instance of the <see cref="T:Microsoft.Azure.WebJobs.StartOrchestrationArgs"/> class.
+            </summary>
+            <param name="functionName">The name of the orchestrator function to start.</param>
+            <param name="input">The JSON-serializeable input for the orchestrator function.</param>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.StartOrchestrationArgs.#ctor">
+            <summary>
+            Initializes a new instance of the <see cref="T:Microsoft.Azure.WebJobs.StartOrchestrationArgs"/> class.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.StartOrchestrationArgs.FunctionName">
+            <summary>
+            Gets or sets the name of the orchestrator function to start.
+            </summary>
+            <value>The name of the orchestrator function to start.</value>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.StartOrchestrationArgs.InstanceId">
+            <summary>
+            Gets or sets the instance ID to assign to the started orchestration.
+            </summary>
+            <remarks>
+            If this property value is null (the default), then a randomly generated instance ID will be assigned automatically.
+            </remarks>
+            <value>The instance ID to assign.</value>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.StartOrchestrationArgs.Input">
+            <summary>
+            Gets or sets the JSON-serializeable input data for the orchestrator function.
+            </summary>
+            <value>JSON-serializeable input value for the orchestrator function.</value>
+        </member>
+    </members>
+</doc>

--- a/src/WebJobs.Extensions.DurableTask/OrchestrationClientAttribute.cs
+++ b/src/WebJobs.Extensions.DurableTask/OrchestrationClientAttribute.cs
@@ -1,5 +1,5 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the MIT License. See License.txt in the project root for license information.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
 using System.Diagnostics;
@@ -31,7 +31,7 @@ namespace Microsoft.Azure.WebJobs
         /// </summary>
         /// <value>The name of a connection string that exists in the app's application settings.</value>
         /// <remarks>
-        /// The default behavior is to use the value specified in 
+        /// The default behavior is to use the value specified in
         /// <see cref="DurableTaskExtension.AzureStorageConnectionStringName"/>. If no value exists there, then
         /// the default behavior is to use the standard `AzureWebJobsStorage` connection string for all storage usage.
         /// </remarks>

--- a/src/WebJobs.Extensions.DurableTask/OrchestrationRuntimeStatus.cs
+++ b/src/WebJobs.Extensions.DurableTask/OrchestrationRuntimeStatus.cs
@@ -1,10 +1,11 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the MIT License. See License.txt in the project root for license information.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 
 namespace Microsoft.Azure.WebJobs
 {
     // Must be kept consistent with DurableTask.Core.OrchestrationStatus:
     // https://github.com/Azure/durabletask/blob/master/src/DurableTask.Core/OrchestrationStatus.cs
+
     /// <summary>
     /// Represents the possible runtime execution status values for an orchestration instance.
     /// </summary>
@@ -43,6 +44,6 @@ namespace Microsoft.Azure.WebJobs
         /// <summary>
         /// The orchestration was scheduled but is not yet active.
         /// </summary>
-        Pending = 6
+        Pending = 6,
     }
 }

--- a/src/WebJobs.Extensions.DurableTask/OrchestrationTriggerAttribute.cs
+++ b/src/WebJobs.Extensions.DurableTask/OrchestrationTriggerAttribute.cs
@@ -1,5 +1,5 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the MIT License. See License.txt in the project root for license information.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
 using System.Diagnostics;

--- a/src/WebJobs.Extensions.DurableTask/RetryOptions.cs
+++ b/src/WebJobs.Extensions.DurableTask/RetryOptions.cs
@@ -1,5 +1,5 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the MIT License. See License.txt in the project root for license information.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
 using DurableTaskCore = DurableTask.Core;
@@ -23,7 +23,7 @@ namespace Microsoft.Azure.WebJobs
         /// </exception>
         public RetryOptions(TimeSpan firstRetryInterval, int maxNumberOfAttempts)
         {
-            retryOptions = new DurableTaskCore.RetryOptions(firstRetryInterval, maxNumberOfAttempts);
+            this.retryOptions = new DurableTaskCore.RetryOptions(firstRetryInterval, maxNumberOfAttempts);
         }
 
         /// <summary>
@@ -49,7 +49,6 @@ namespace Microsoft.Azure.WebJobs
             get { return this.retryOptions.MaxRetryInterval; }
             set { this.retryOptions.MaxRetryInterval = value; }
         }
-
 
         /// <summary>
         /// Gets or sets the backoff coefficient

--- a/src/WebJobs.Extensions.DurableTask/StartOrchestrationArgs.cs
+++ b/src/WebJobs.Extensions.DurableTask/StartOrchestrationArgs.cs
@@ -1,5 +1,5 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the MIT License. See License.txt in the project root for license information.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 
 namespace Microsoft.Azure.WebJobs
 {

--- a/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
+++ b/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <AssemblyName>Microsoft.Azure.WebJobs.Extensions.DurableTask</AssemblyName>
     <RootNamespace>Microsoft.Azure.WebJobs.Extensions.DurableTask</RootNamespace>
+    <DocumentationFile>Microsoft.Azure.WebJobs.Extensions.DurableTask.xml</DocumentationFile>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
     <FileVersion>1.1.0.0</FileVersion>
     <Version>1.1.0-beta2</Version>
@@ -12,6 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="DurableTask.AzureStorage" Version="1.1.1-beta" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta004" />
   </ItemGroup>
   
   <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
@@ -21,7 +23,12 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.0-beta4" />
   </ItemGroup>
-  
+
+  <ItemGroup>
+    <AdditionalFiles Include="..\..\.stylecop\stylecop.json" />
+    <Compile Include="..\..\.stylecop\GlobalSuppressions.cs" Link="GlobalSuppressions.cs" />
+  </ItemGroup>
+
   <!-- NuGet Publishing Metadata -->
   <PropertyGroup>
     <Title>Azure Functions Durable Task Extension</Title>

--- a/test/BindingTests.cs
+++ b/test/BindingTests.cs
@@ -1,5 +1,5 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the MIT License. See License.txt in the project root for license information.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
 using System.Diagnostics;
@@ -21,15 +21,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         public BindingTests(ITestOutputHelper output)
         {
             this.output = output;
-            loggerProvider = new TestLoggerProvider();
-            loggerFactory = new LoggerFactory();
-            loggerFactory.AddProvider(loggerProvider);
+            this.loggerProvider = new TestLoggerProvider();
+            this.loggerFactory = new LoggerFactory();
+            this.loggerFactory.AddProvider(this.loggerProvider);
         }
 
         [Fact]
         public async Task ActivityTriggerAsJObject()
         {
-            using (JobHost host = TestHelpers.GetJobHost(loggerFactory, nameof(ActivityTriggerAsJObject)))
+            using (JobHost host = TestHelpers.GetJobHost(this.loggerFactory, nameof(this.ActivityTriggerAsJObject)))
             {
                 await host.StartAsync();
 
@@ -54,7 +54,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         [Fact]
         public async Task ActivityTriggerAsPOCO()
         {
-            using (JobHost host = TestHelpers.GetJobHost(loggerFactory, nameof(ActivityTriggerAsPOCO)))
+            using (JobHost host = TestHelpers.GetJobHost(this.loggerFactory, nameof(this.ActivityTriggerAsPOCO)))
             {
                 await host.StartAsync();
 
@@ -77,11 +77,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             }
         }
 
-
         [Fact]
         public async Task ActivityTriggerAsNumber()
         {
-            using (JobHost host = TestHelpers.GetJobHost(loggerFactory, nameof(ActivityTriggerAsNumber)))
+            using (JobHost host = TestHelpers.GetJobHost(this.loggerFactory, nameof(this.ActivityTriggerAsNumber)))
             {
                 await host.StartAsync();
 

--- a/test/DurableOrchestrationClientMock.cs
+++ b/test/DurableOrchestrationClientMock.cs
@@ -1,5 +1,5 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the MIT License. See License.txt in the project root for license information.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
 using System.Threading.Tasks;
@@ -9,15 +9,16 @@ using Microsoft.Azure.WebJobs.Extensions.DurableTask;
 
 namespace WebJobs.Extensions.DurableTask.Tests
 {
-    public class DurableOrchestrationClientMock : DurableOrchestrationClient
+    internal class DurableOrchestrationClientMock : DurableOrchestrationClient
     {
-        internal DurableOrchestrationClientMock(IOrchestrationServiceClient serviceClient, DurableTaskExtension config, OrchestrationClientAttribute attribute, EndToEndTraceHelper traceHelper) : base(serviceClient, config, attribute, traceHelper)
+        internal DurableOrchestrationClientMock(IOrchestrationServiceClient serviceClient, DurableTaskExtension config, OrchestrationClientAttribute attribute, EndToEndTraceHelper traceHelper)
+            : base(serviceClient, config, attribute, traceHelper)
         {
         }
 
         public int Counter { get; set; }
 
-        public override async Task<DurableOrchestrationStatus> GetStatusAsync(string instanceId)
+        public override Task<DurableOrchestrationStatus> GetStatusAsync(string instanceId)
         {
             var runtimeStatus = OrchestrationRuntimeStatus.Running;
             switch (instanceId)
@@ -26,14 +27,15 @@ namespace WebJobs.Extensions.DurableTask.Tests
                     runtimeStatus = OrchestrationRuntimeStatus.Completed;
                     break;
                 case TestConstants.InstanceIdIterations:
-                    if (Counter < 3)
+                    if (this.Counter < 3)
                     {
-                        Counter++;
+                        this.Counter++;
                     }
                     else
                     {
                         runtimeStatus = OrchestrationRuntimeStatus.Completed;
                     }
+
                     break;
 
                 case TestConstants.InstanceIdFailed:
@@ -47,7 +49,8 @@ namespace WebJobs.Extensions.DurableTask.Tests
                     runtimeStatus = OrchestrationRuntimeStatus.Canceled;
                     break;
             }
-            return new DurableOrchestrationStatus
+
+            return Task.FromResult(new DurableOrchestrationStatus
             {
                 Name = "Sample Test",
                 InstanceId = instanceId,
@@ -55,8 +58,8 @@ namespace WebJobs.Extensions.DurableTask.Tests
                 LastUpdatedTime = DateTime.Now,
                 RuntimeStatus = runtimeStatus,
                 Input = "",
-                Output = "Hello Tokyo!"
-            };
+                Output = "Hello Tokyo!",
+            });
         }
     }
 }

--- a/test/DurableTaskEndToEndTests.cs
+++ b/test/DurableTaskEndToEndTests.cs
@@ -1,5 +1,5 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the MIT License. See License.txt in the project root for license information.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
 using System.Collections.Generic;
@@ -25,7 +25,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         private readonly TestLoggerProvider loggerProvider;
         private readonly bool useTestLogger;
 
-        private readonly string instrumentationKey = Environment.GetEnvironmentVariable("APPINSIGHTS_INSTRUMENTATIONKEY");
+        private static readonly string InstrumentationKey = Environment.GetEnvironmentVariable("APPINSIGHTS_INSTRUMENTATIONKEY");
 
         public DurableTaskEndToEndTests(ITestOutputHelper output)
         {
@@ -34,26 +34,26 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             // Set to false to manually verify log entries in Application Insights but tests with TestHelpers.AssertLogMessageSequence will be skipped
             this.useTestLogger = true;
 
-            loggerProvider = new TestLoggerProvider();
-            loggerFactory = new LoggerFactory();
+            this.loggerProvider = new TestLoggerProvider();
+            this.loggerFactory = new LoggerFactory();
 
-            if (useTestLogger)
+            if (this.useTestLogger)
             {
-                loggerFactory.AddProvider(loggerProvider);
+                this.loggerFactory.AddProvider(this.loggerProvider);
             }
             else
             {
-                if (!string.IsNullOrEmpty(instrumentationKey))
+                if (!string.IsNullOrEmpty(InstrumentationKey))
                 {
                     var filter = new LogCategoryFilter
                     {
-                        DefaultLevel = LogLevel.Debug
+                        DefaultLevel = LogLevel.Debug,
                     };
 
                     filter.CategoryLevels[TestHelpers.LogCategory] = LogLevel.Debug;
 
-                    loggerFactory = new LoggerFactory()
-                        .AddApplicationInsights(instrumentationKey, filter.Filter);
+                    this.loggerFactory = new LoggerFactory()
+                        .AddApplicationInsights(InstrumentationKey, filter.Filter);
                 }
             }
         }
@@ -66,10 +66,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         {
             string[] orchestratorFunctionNames =
             {
-                nameof(TestOrchestrations.SayHelloInline)
+                nameof(TestOrchestrations.SayHelloInline),
             };
 
-            using (JobHost host = TestHelpers.GetJobHost(this.loggerFactory, nameof(HelloWorldOrchestration_Inline)))
+            using (JobHost host = TestHelpers.GetJobHost(this.loggerFactory, nameof(this.HelloWorldOrchestration_Inline)))
             {
                 await host.StartAsync();
 
@@ -85,8 +85,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
             if (this.useTestLogger)
             {
-                TestHelpers.AssertLogMessageSequence(loggerProvider, "HelloWorldOrchestration_Inline",
-                    orchestratorFunctionNames);
+                TestHelpers.AssertLogMessageSequence(this.loggerProvider, "HelloWorldOrchestration_Inline", orchestratorFunctionNames);
             }
         }
 
@@ -98,11 +97,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         {
             string[] orchestratorFunctionNames =
             {
-                nameof(TestOrchestrations.SayHelloWithActivity)
+                nameof(TestOrchestrations.SayHelloWithActivity),
             };
+
             string activityFunctionName = nameof(TestActivities.Hello);
 
-            using (JobHost host = TestHelpers.GetJobHost(this.loggerFactory, nameof(HelloWorldOrchestration_Activity)))
+            using (JobHost host = TestHelpers.GetJobHost(this.loggerFactory, nameof(this.HelloWorldOrchestration_Activity)))
             {
                 await host.StartAsync();
 
@@ -118,8 +118,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
             if (this.useTestLogger)
             {
-                TestHelpers.AssertLogMessageSequence(loggerProvider, "HelloWorldOrchestration_Activity",
-                    orchestratorFunctionNames, activityFunctionName);
+                TestHelpers.AssertLogMessageSequence(
+                    this.loggerProvider,
+                    "HelloWorldOrchestration_Activity",
+                    orchestratorFunctionNames,
+                    activityFunctionName);
             }
         }
 
@@ -129,7 +132,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         [Fact]
         public async Task SequentialOrchestration()
         {
-            using (JobHost host = TestHelpers.GetJobHost(this.loggerFactory, nameof(SequentialOrchestration)))
+            using (JobHost host = TestHelpers.GetJobHost(this.loggerFactory, nameof(this.SequentialOrchestration)))
             {
                 await host.StartAsync();
 
@@ -146,21 +149,20 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             // Assert log entry count
             if (this.useTestLogger)
             {
-                var logger = loggerProvider.CreatedLoggers.Single(l => l.Category == TestHelpers.LogCategory);
+                var logger = this.loggerProvider.CreatedLoggers.Single(l => l.Category == TestHelpers.LogCategory);
                 var logMessages = logger.LogMessages.ToList();
                 Assert.Equal(153, logMessages.Count);
             }
         }
-        
-        
+
         /// <summary>
-        /// End-to-end test which validates parallel function execution by enumerating all files in the current directory 
+        /// End-to-end test which validates parallel function execution by enumerating all files in the current directory
         /// in parallel and getting the sum total of all file sizes.
         /// </summary>
         [Fact]
         public async Task ParallelOrchestration()
         {
-            using (JobHost host = TestHelpers.GetJobHost(this.loggerFactory, nameof(ParallelOrchestration)))
+            using (JobHost host = TestHelpers.GetJobHost(this.loggerFactory, nameof(this.ParallelOrchestration)))
             {
                 await host.StartAsync();
 
@@ -175,20 +177,18 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             }
         }
 
-
         /// <summary>
         /// End-to-end test which validates the ContinueAsNew functionality by implementing a counter actor pattern.
         /// </summary>
         [Fact]
         public async Task ActorOrchestration()
         {
-            using (JobHost host = TestHelpers.GetJobHost(this.loggerFactory, nameof(ActorOrchestration)))
+            using (JobHost host = TestHelpers.GetJobHost(this.loggerFactory, nameof(this.ActorOrchestration)))
             {
                 await host.StartAsync();
 
                 int initialValue = 0;
-                var client = await host.StartOrchestratorAsync(nameof(TestOrchestrations.Counter), initialValue,
-                    this.output);
+                var client = await host.StartOrchestratorAsync(nameof(TestOrchestrations.Counter), initialValue, this.output);
 
                 // Need to wait for the instance to start before sending events to it.
                 // TODO: This requirement may not be ideal and should be revisited.
@@ -222,7 +222,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 status = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(10), this.output);
 
                 Assert.Equal(OrchestrationRuntimeStatus.Completed, status?.RuntimeStatus);
-                Assert.Equal(3, (int) status?.Output);
+                Assert.Equal(3, (int)status?.Output);
 
                 // When using ContinueAsNew, the original input is discarded and replaced with the most recent state.
                 Assert.NotEqual(initialValue, status?.Input);
@@ -232,7 +232,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
             if (this.useTestLogger)
             {
-                var logger = loggerProvider.CreatedLoggers.Single(l => l.Category == TestHelpers.LogCategory);
+                var logger = this.loggerProvider.CreatedLoggers.Single(l => l.Category == TestHelpers.LogCategory);
                 var logMessages = logger.LogMessages.ToList();
                 Assert.Equal(49, logMessages.Count);
             }
@@ -246,10 +246,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         {
             string[] orchestratorFunctionNames =
             {
-                nameof(TestOrchestrations.Counter)
+                nameof(TestOrchestrations.Counter),
             };
-            
-            using (JobHost host = TestHelpers.GetJobHost(this.loggerFactory, nameof(TerminateOrchestration)))
+
+            using (JobHost host = TestHelpers.GetJobHost(this.loggerFactory, nameof(this.TerminateOrchestration)))
             {
                 await host.StartAsync();
 
@@ -273,8 +273,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
             if (this.useTestLogger)
             {
-                TestHelpers.AssertLogMessageSequence(loggerProvider, "TerminateOrchestration",
-                    orchestratorFunctionNames);
+                TestHelpers.AssertLogMessageSequence(this.loggerProvider, "TerminateOrchestration", orchestratorFunctionNames);
             }
         }
 
@@ -286,10 +285,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         {
             string[] orchestratorFunctionNames =
             {
-                nameof(TestOrchestrations.Approval)
+                nameof(TestOrchestrations.Approval),
             };
 
-            using (JobHost host = TestHelpers.GetJobHost(this.loggerFactory, nameof(TimerCancellation)))
+            using (JobHost host = TestHelpers.GetJobHost(this.loggerFactory, nameof(this.TimerCancellation)))
             {
                 await host.StartAsync();
 
@@ -311,7 +310,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
             if (this.useTestLogger)
             {
-                TestHelpers.AssertLogMessageSequence(loggerProvider, "TimerCancellation", orchestratorFunctionNames);
+                TestHelpers.AssertLogMessageSequence(this.loggerProvider, "TimerCancellation", orchestratorFunctionNames);
             }
         }
 
@@ -323,9 +322,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         {
             string[] orchestratorFunctionNames =
             {
-                nameof(TestOrchestrations.Approval)
+                nameof(TestOrchestrations.Approval),
             };
-            using (JobHost host = TestHelpers.GetJobHost(this.loggerFactory, nameof(TimerExpiration)))
+
+            using (JobHost host = TestHelpers.GetJobHost(this.loggerFactory, nameof(this.TimerExpiration)))
             {
                 await host.StartAsync();
 
@@ -348,7 +348,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
             if (this.useTestLogger)
             {
-                TestHelpers.AssertLogMessageSequence(loggerProvider, "TimerExpiration", orchestratorFunctionNames);
+                TestHelpers.AssertLogMessageSequence(this.loggerProvider, "TimerExpiration", orchestratorFunctionNames);
             }
         }
 
@@ -358,11 +358,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         [Fact]
         public async Task OrchestrationConcurrency()
         {
-            using (JobHost host = TestHelpers.GetJobHost(this.loggerFactory, nameof(OrchestrationConcurrency)))
+            using (JobHost host = TestHelpers.GetJobHost(this.loggerFactory, nameof(this.OrchestrationConcurrency)))
             {
                 await host.StartAsync();
 
-                Func<Task> orchestrationStarter = async delegate()
+                Func<Task> orchestrationStarter = async () =>
                 {
                     var timeout = TimeSpan.FromSeconds(10);
                     var client = await host.StartOrchestratorAsync(nameof(TestOrchestrations.Approval), timeout, this.output);
@@ -395,7 +395,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         [Fact]
         public async Task HandledActivityException()
         {
-            using (JobHost host = TestHelpers.GetJobHost(this.loggerFactory, nameof(HandledActivityException)))
+            using (JobHost host = TestHelpers.GetJobHost(this.loggerFactory, nameof(this.HandledActivityException)))
             {
                 await host.StartAsync();
 
@@ -418,10 +418,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         {
             string[] orchestratorFunctionNames =
             {
-                nameof(TestOrchestrations.Throw)
+                nameof(TestOrchestrations.Throw),
             };
 
-            using (JobHost host = TestHelpers.GetJobHost(this.loggerFactory, nameof(UnhandledOrchestrationException)))
+            using (JobHost host = TestHelpers.GetJobHost(this.loggerFactory, nameof(this.UnhandledOrchestrationException)))
             {
                 await host.StartAsync();
 
@@ -437,8 +437,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
             if (this.useTestLogger)
             {
-                TestHelpers.AssertLogMessageSequence(loggerProvider, "UnhandledOrchestrationException",
-                    orchestratorFunctionNames);
+                TestHelpers.AssertLogMessageSequence(this.loggerProvider, "UnhandledOrchestrationException", orchestratorFunctionNames);
             }
         }
 
@@ -451,12 +450,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             string[] orchestratorFunctionNames =
             {
                 nameof(TestOrchestrations.OrchestratorGreeting),
-                nameof(TestOrchestrations.SayHelloWithActivity)
+                nameof(TestOrchestrations.SayHelloWithActivity),
             };
 
             string activityFunctionName = nameof(TestActivities.Hello);
 
-            using (JobHost host = TestHelpers.GetJobHost(this.loggerFactory, nameof(Orchestration_Activity)))
+            using (JobHost host = TestHelpers.GetJobHost(this.loggerFactory, nameof(this.Orchestration_Activity)))
             {
                 await host.StartAsync();
 
@@ -473,8 +472,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
             if (this.useTestLogger)
             {
-                TestHelpers.AssertLogMessageSequence(loggerProvider, "Orchestration_Activity",
-                    orchestratorFunctionNames, activityFunctionName);
+                TestHelpers.AssertLogMessageSequence(
+                    this.loggerProvider,
+                    "Orchestration_Activity",
+                    orchestratorFunctionNames,
+                    activityFunctionName);
             }
         }
 
@@ -484,7 +486,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         [Fact]
         public async Task SubOrchestration_ComplexType()
         {
-            const string TaskHub = nameof(SubOrchestration_ComplexType);
+            const string TaskHub = nameof(this.SubOrchestration_ComplexType);
             using (JobHost host = TestHelpers.GetJobHost(this.loggerFactory, TaskHub))
             {
                 await host.StartAsync();
@@ -544,11 +546,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         {
             string[] orchestratorFunctionNames =
             {
-                nameof(TestOrchestrations.OrchestratorThrowWithRetry)
+                nameof(TestOrchestrations.OrchestratorThrowWithRetry),
             };
 
             using (JobHost host =
-                TestHelpers.GetJobHost(loggerFactory, nameof(UnhandledOrchestrationExceptionWithRetry)))
+                TestHelpers.GetJobHost(this.loggerFactory, nameof(this.UnhandledOrchestrationExceptionWithRetry)))
             {
                 await host.StartAsync();
 
@@ -564,7 +566,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
             if (this.useTestLogger)
             {
-                TestHelpers.UnhandledOrchesterationExceptionWithRetry_AssertLogMessageSequence(loggerProvider, "UnhandledOrchestrationExceptionWithRetry",
+                TestHelpers.UnhandledOrchesterationExceptionWithRetry_AssertLogMessageSequence(
+                    this.loggerProvider,
+                    "UnhandledOrchestrationExceptionWithRetry",
                     orchestratorFunctionNames);
             }
         }
@@ -577,10 +581,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         {
             string[] orchestratorFunctionNames =
             {
-                nameof(TestOrchestrations.OrchestratorWithRetry_NullRetryOptions)
+                nameof(TestOrchestrations.OrchestratorWithRetry_NullRetryOptions),
             };
 
-            using (JobHost host = TestHelpers.GetJobHost(loggerFactory, nameof(OrchestrationWithRetry_NullRetryOptions)))
+            using (JobHost host = TestHelpers.GetJobHost(this.loggerFactory, nameof(this.OrchestrationWithRetry_NullRetryOptions)))
             {
                 await host.StartAsync();
 
@@ -604,11 +608,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         {
             string[] orchestratorFunctionNames =
             {
-                nameof(TestOrchestrations.Throw)
+                nameof(TestOrchestrations.Throw),
             };
+
             string activityFunctionName = nameof(TestActivities.Throw);
 
-            using (JobHost host = TestHelpers.GetJobHost(this.loggerFactory, nameof(UnhandledActivityException)))
+            using (JobHost host = TestHelpers.GetJobHost(this.loggerFactory, nameof(this.UnhandledActivityException)))
             {
                 await host.StartAsync();
 
@@ -628,8 +633,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
             if (this.useTestLogger)
             {
-                TestHelpers.AssertLogMessageSequence(loggerProvider, "UnhandledActivityException",
-                    orchestratorFunctionNames, activityFunctionName);
+                TestHelpers.AssertLogMessageSequence(
+                    this.loggerProvider,
+                    "UnhandledActivityException",
+                    orchestratorFunctionNames,
+                    activityFunctionName);
             }
         }
 
@@ -641,11 +649,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         {
             string[] orchestratorFunctionNames =
             {
-                nameof(TestOrchestrations.ActivityThrowWithRetry)
+                nameof(TestOrchestrations.ActivityThrowWithRetry),
             };
+
             string activityFunctionName = nameof(TestActivities.Throw);
 
-            using (JobHost host = TestHelpers.GetJobHost(loggerFactory, nameof(UnhandledActivityExceptionWithRetry)))
+            using (JobHost host = TestHelpers.GetJobHost(this.loggerFactory, nameof(this.UnhandledActivityExceptionWithRetry)))
             {
                 await host.StartAsync();
 
@@ -663,8 +672,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
             if (this.useTestLogger)
             {
-                TestHelpers.AssertLogMessageSequence(loggerProvider, "UnhandledActivityExceptionWithRetry",
-                    orchestratorFunctionNames, activityFunctionName);
+                TestHelpers.AssertLogMessageSequence(
+                    this.loggerProvider,
+                    "UnhandledActivityExceptionWithRetry",
+                    orchestratorFunctionNames,
+                    activityFunctionName);
             }
         }
 
@@ -674,7 +686,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         [Fact]
         public async Task ActivityWithRetry_NullRetryOptions()
         {
-            using (JobHost host = TestHelpers.GetJobHost(loggerFactory, nameof(ActivityWithRetry_NullRetryOptions)))
+            using (JobHost host = TestHelpers.GetJobHost(this.loggerFactory, nameof(this.ActivityWithRetry_NullRetryOptions)))
             {
                 await host.StartAsync();
 
@@ -700,12 +712,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             const string activityFunctionName = "UnregisteredOrchestrator";
             string errorMessage = $"The function '{activityFunctionName}' doesn't exist, is disabled, or is not an orchestrator function";
 
-            using (JobHost host = TestHelpers.GetJobHost(this.loggerFactory, nameof(StartOrchestration_OnUnregisteredOrchestrator)))
+            using (JobHost host = TestHelpers.GetJobHost(this.loggerFactory, nameof(this.StartOrchestration_OnUnregisteredOrchestrator)))
             {
                 await host.StartAsync();
 
                 Exception ex = await Assert.ThrowsAsync<FunctionInvocationException>(async () => await host.StartOrchestratorAsync("UnregisteredOrchestrator", "Unregistered", this.output));
-                
+
                 Assert.NotNull(ex.InnerException);
                 Assert.Contains(errorMessage, ex.InnerException?.ToString());
 
@@ -721,19 +733,20 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         {
             string[] orchestratorFunctionNames =
             {
-                nameof(TestOrchestrations.CallActivity)
+                nameof(TestOrchestrations.CallActivity),
             };
+
             const string activityFunctionName = "UnregisteredActivity";
             string errorMessage = $"The function '{activityFunctionName}' doesn't exist, is disabled, or is not an activity function";
 
-            using (JobHost host = TestHelpers.GetJobHost(this.loggerFactory, nameof(Orchestration_OnUnregisteredActivity)))
+            using (JobHost host = TestHelpers.GetJobHost(this.loggerFactory, nameof(this.Orchestration_OnUnregisteredActivity)))
             {
                 await host.StartAsync();
 
                 var startArgs = new StartOrchestrationArgs
                 {
                     FunctionName = activityFunctionName,
-                    Input = new {Foo = "Bar"}
+                    Input = new { Foo = "Bar" },
                 };
 
                 var client = await host.StartOrchestratorAsync(orchestratorFunctionNames[0], startArgs, this.output);
@@ -749,7 +762,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
             if (this.useTestLogger)
             {
-                TestHelpers.AssertLogMessageSequence(loggerProvider, "Orchestration_OnUnregisteredActivity",
+                TestHelpers.AssertLogMessageSequence(
+                    this.loggerProvider,
+                    "Orchestration_OnUnregisteredActivity",
                     orchestratorFunctionNames);
             }
         }
@@ -765,20 +780,21 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             string[] orchestratorFunctionNames =
             {
                 nameof(TestOrchestrations.CallOrchestrator),
-                validOrchestratorName
+                validOrchestratorName,
             };
+
             string activityFunctionName = nameof(TestActivities.Hello);
 
             var input = new { Foo = greetingName };
             var inputJson = JsonConvert.SerializeObject(input);
-            using (JobHost host = TestHelpers.GetJobHost(this.loggerFactory, nameof(Orchestration_OnValidOrchestrator)))
+            using (JobHost host = TestHelpers.GetJobHost(this.loggerFactory, nameof(this.Orchestration_OnValidOrchestrator)))
             {
                 await host.StartAsync();
 
                 var startArgs = new StartOrchestrationArgs
                 {
                     FunctionName = orchestratorFunctionNames[1],
-                    Input = inputJson
+                    Input = inputJson,
                 };
 
                 // Function type call chain: 'CallActivity' (orchestrator) -> 'SayHelloWithActivity' (orchestrator) -> 'Hello' (activity)
@@ -797,8 +813,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
                 if (this.useTestLogger)
                 {
-                    TestHelpers.AssertLogMessageSequence(loggerProvider, "Orchestration_OnValidOrchestrator",
-                        orchestratorFunctionNames, activityFunctionName);
+                    TestHelpers.AssertLogMessageSequence(
+                        this.loggerProvider,
+                        "Orchestration_OnValidOrchestrator",
+                        orchestratorFunctionNames,
+                        activityFunctionName);
                 }
             }
         }
@@ -806,7 +825,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         [Fact]
         public async Task ThrowExceptionOnLongTimer()
         {
-            using (JobHost host = TestHelpers.GetJobHost(this.loggerFactory, nameof(Orchestration_OnValidOrchestrator)))
+            using (JobHost host = TestHelpers.GetJobHost(this.loggerFactory, nameof(this.Orchestration_OnValidOrchestrator)))
             {
                 await host.StartAsync();
 
@@ -834,19 +853,19 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             string[] orchestratorFunctionNames =
             {
                 nameof(TestOrchestrations.CallOrchestrator),
-                unregisteredOrchestrator
+                unregisteredOrchestrator,
             };
-            
+
             string errorMessage = $"The function '{unregisteredOrchestrator}' doesn't exist, is disabled, or is not an orchestrator function";
 
-            using (JobHost host = TestHelpers.GetJobHost(this.loggerFactory, nameof(Orchestration_OnUnregisteredActivity)))
+            using (JobHost host = TestHelpers.GetJobHost(this.loggerFactory, nameof(this.Orchestration_OnUnregisteredActivity)))
             {
                 await host.StartAsync();
 
                 var startArgs = new StartOrchestrationArgs
                 {
                     FunctionName = unregisteredOrchestrator,
-                    Input = new { Foo = "Bar" }
+                    Input = new { Foo = "Bar" },
                 };
 
                 var client = await host.StartOrchestratorAsync(orchestratorFunctionNames[0], startArgs, this.output);
@@ -860,7 +879,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
             if (this.useTestLogger)
             {
-                TestHelpers.AssertLogMessageSequence(loggerProvider, "Orchestration_OnUnregisteredOrchestrator",
+                TestHelpers.AssertLogMessageSequence(
+                    this.loggerProvider,
+                    "Orchestration_OnUnregisteredOrchestrator",
                     orchestratorFunctionNames);
             }
         }
@@ -868,7 +889,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         [Fact]
         public async Task BigReturnValue_Orchestrator()
         {
-            string taskHub = nameof(BigReturnValue_Orchestrator);
+            string taskHub = nameof(this.BigReturnValue_Orchestrator);
             using (JobHost host = TestHelpers.GetJobHost(this.loggerFactory, taskHub))
             {
                 await host.StartAsync();
@@ -893,7 +914,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         [Fact]
         public async Task BigReturnValue_Activity()
         {
-            string taskHub = nameof(BigReturnValue_Activity);
+            string taskHub = nameof(this.BigReturnValue_Activity);
             using (JobHost host = TestHelpers.GetJobHost(this.loggerFactory, taskHub))
             {
                 await host.StartAsync();
@@ -907,7 +928,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 var input = new StartOrchestrationArgs
                 {
                     FunctionName = nameof(TestActivities.BigReturnValue),
-                    Input = stringLength
+                    Input = stringLength,
                 };
 
                 var client = await host.StartOrchestratorAsync(orchestrator, input, this.output);
@@ -927,7 +948,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         [Fact]
         public async Task RaiseEventToSubOrchestration()
         {
-            string taskHub = nameof(RaiseEventToSubOrchestration);
+            string taskHub = nameof(this.RaiseEventToSubOrchestration);
             using (JobHost host = TestHelpers.GetJobHost(this.loggerFactory, taskHub))
             {
                 await host.StartAsync();
@@ -939,7 +960,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 {
                     FunctionName = nameof(TestOrchestrations.Approval),
                     InstanceId = "SubOrchestration-" + Guid.NewGuid().ToString("N"),
-                    Input = TimeSpan.FromMinutes(5)
+                    Input = TimeSpan.FromMinutes(5),
                 };
 
                 var client = await host.StartOrchestratorAsync(orchestrator, input, this.output);
@@ -959,8 +980,18 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         }
 
         [DataContract]
-        class ComplexType
+        private class ComplexType
         {
+            [DataContract]
+            public enum CustomEnum
+            {
+                [EnumMember]
+                Value1,
+
+                [EnumMember]
+                Value2,
+            }
+
             [DataMember]
             public int A { get; set; }
 
@@ -982,16 +1013,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 [DataMember]
                 public TimeSpan F { get; set; }
             }
-
-            [DataContract]
-            public enum CustomEnum
-            {
-                [EnumMember]
-                Value1,
-                [EnumMember]
-                Value2
-            }
         }
     }
 }
-

--- a/test/DurableTaskExtensionMock.cs
+++ b/test/DurableTaskExtensionMock.cs
@@ -1,10 +1,10 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the MIT License. See License.txt in the project root for license information.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using Moq;
 using DurableTask.Core;
 using Microsoft.Azure.WebJobs;
 using Microsoft.Azure.WebJobs.Extensions.DurableTask;
+using Moq;
 
 namespace WebJobs.Extensions.DurableTask.Tests
 {
@@ -12,7 +12,6 @@ namespace WebJobs.Extensions.DurableTask.Tests
     {
         protected internal override DurableOrchestrationClient GetClient(OrchestrationClientAttribute attribute)
         {
-
             var orchestrationServiceClientMock = new Mock<IOrchestrationServiceClient>();
             return new DurableOrchestrationClientMock(orchestrationServiceClientMock.Object, this, null, null);
         }

--- a/test/DurableTaskHostExtensions.cs
+++ b/test/DurableTaskHostExtensions.cs
@@ -1,5 +1,5 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the MIT License. See License.txt in the project root for license information.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
 using System.Collections.Generic;
@@ -9,7 +9,7 @@ using Xunit.Abstractions;
 
 namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 {
-    public static class DurableTaskHostExtensions
+    internal static class DurableTaskHostExtensions
     {
         public static async Task<TestOrchestratorClient> StartOrchestratorAsync(
             this JobHost host,
@@ -62,7 +62,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             }
         }
 
-        class ExplicitTypeLocator : ITypeLocator
+        private class ExplicitTypeLocator : ITypeLocator
         {
             private readonly IReadOnlyList<Type> types;
 

--- a/test/HttpApiHandlerTests.cs
+++ b/test/HttpApiHandlerTests.cs
@@ -1,5 +1,5 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the MIT License. See License.txt in the project root for license information.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
 using System.Diagnostics;
@@ -31,13 +31,13 @@ namespace WebJobs.Extensions.DurableTask.Tests
             var ex = await Assert.ThrowsAsync<ArgumentException>(() => httpApiHandler.WaitForCompletionOrCreateCheckStatusResponseAsync(
                 new HttpRequestMessage
                 {
-                    RequestUri = new Uri(TestConstants.RequestUri)
-                }, 
-                TestConstants.InstanceId, 
+                    RequestUri = new Uri(TestConstants.RequestUri),
+                },
+                TestConstants.InstanceId,
                 new OrchestrationClientAttribute
                 {
                     TaskHub = TestConstants.TaskHub,
-                    ConnectionName = TestConstants.ConnectionName
+                    ConnectionName = TestConstants.ConnectionName,
                 },
                 TimeSpan.FromSeconds(0),
                 TimeSpan.FromSeconds(100)));
@@ -51,23 +51,26 @@ namespace WebJobs.Extensions.DurableTask.Tests
             var httpResponseMessage = httpApiHandler.CreateCheckStatusResponse(
                 new HttpRequestMessage
                 {
-                    RequestUri = new Uri(TestConstants.RequestUri)
-                }, 
-                TestConstants.InstanceId, 
+                    RequestUri = new Uri(TestConstants.RequestUri),
+                },
+                TestConstants.InstanceId,
                 new OrchestrationClientAttribute
                 {
                     TaskHub = TestConstants.TaskHub,
-                    ConnectionName = TestConstants.ConnectionName
+                    ConnectionName = TestConstants.ConnectionName,
                 });
             Assert.Equal(httpResponseMessage.StatusCode, HttpStatusCode.Accepted);
             var content = await httpResponseMessage.Content.ReadAsStringAsync();
             var status = JsonConvert.DeserializeObject<JObject>(content);
             Assert.Equal(status["id"], TestConstants.InstanceId);
-            Assert.Equal(status["statusQueryGetUri"], 
+            Assert.Equal(
+                status["statusQueryGetUri"],
                 "http://localhost:7071/admin/extensions/DurableTaskExtension/instances/7b59154ae666471993659902ed0ba742?taskHub=SampleHubVS&connection=Storage&code=mykey");
-            Assert.Equal(status["sendEventPostUri"], 
+            Assert.Equal(
+                status["sendEventPostUri"],
                 "http://localhost:7071/admin/extensions/DurableTaskExtension/instances/7b59154ae666471993659902ed0ba742/raiseEvent/{eventName}?taskHub=SampleHubVS&connection=Storage&code=mykey");
-            Assert.Equal(status["terminatePostUri"], 
+            Assert.Equal(
+                status["terminatePostUri"],
                 "http://localhost:7071/admin/extensions/DurableTaskExtension/instances/7b59154ae666471993659902ed0ba742/terminate?reason={text}&taskHub=SampleHubVS&connection=Storage&code=mykey");
         }
 
@@ -80,13 +83,13 @@ namespace WebJobs.Extensions.DurableTask.Tests
             var httpResponseMessage = await httpApiHandler.WaitForCompletionOrCreateCheckStatusResponseAsync(
                 new HttpRequestMessage
                 {
-                    RequestUri = new Uri(TestConstants.RequestUri)
-                }, 
-                TestConstants.RandomInstanceId, 
+                    RequestUri = new Uri(TestConstants.RequestUri),
+                },
+                TestConstants.RandomInstanceId,
                 new OrchestrationClientAttribute
                 {
                     TaskHub = TestConstants.TaskHub,
-                    ConnectionName = TestConstants.ConnectionName
+                    ConnectionName = TestConstants.ConnectionName,
                 },
                 TimeSpan.FromSeconds(100),
                 TimeSpan.FromSeconds(10));
@@ -95,11 +98,14 @@ namespace WebJobs.Extensions.DurableTask.Tests
             var content = await httpResponseMessage.Content.ReadAsStringAsync();
             var status = JsonConvert.DeserializeObject<JObject>(content);
             Assert.Equal(status["id"], TestConstants.RandomInstanceId);
-            Assert.Equal(status["statusQueryGetUri"], 
+            Assert.Equal(
+                status["statusQueryGetUri"],
                 "http://localhost:7071/admin/extensions/DurableTaskExtension/instances/9b59154ae666471993659902ed0ba749?taskHub=SampleHubVS&connection=Storage&code=mykey");
-            Assert.Equal(status["sendEventPostUri"], 
+            Assert.Equal(
+                status["sendEventPostUri"],
                 "http://localhost:7071/admin/extensions/DurableTaskExtension/instances/9b59154ae666471993659902ed0ba749/raiseEvent/{eventName}?taskHub=SampleHubVS&connection=Storage&code=mykey");
-            Assert.Equal(status["terminatePostUri"], 
+            Assert.Equal(
+                status["terminatePostUri"],
                 "http://localhost:7071/admin/extensions/DurableTaskExtension/instances/9b59154ae666471993659902ed0ba749/terminate?reason={text}&taskHub=SampleHubVS&connection=Storage&code=mykey");
             Assert.True(stopWatch.Elapsed > TimeSpan.FromSeconds(30));
         }
@@ -111,13 +117,13 @@ namespace WebJobs.Extensions.DurableTask.Tests
             var httpResponseMessage = await httpApiHandler.WaitForCompletionOrCreateCheckStatusResponseAsync(
                 new HttpRequestMessage
                 {
-                    RequestUri = new Uri(TestConstants.RequestUri)
-                }, 
-                TestConstants.IntanceIdFactComplete, 
+                    RequestUri = new Uri(TestConstants.RequestUri),
+                },
+                TestConstants.IntanceIdFactComplete,
                 new OrchestrationClientAttribute
                 {
                     TaskHub = TestConstants.TaskHub,
-                    ConnectionName = TestConstants.ConnectionName
+                    ConnectionName = TestConstants.ConnectionName,
                 },
                 TimeSpan.FromSeconds(100),
                 TimeSpan.FromSeconds(10));
@@ -127,7 +133,6 @@ namespace WebJobs.Extensions.DurableTask.Tests
             Assert.Equal(value, "Hello Tokyo!");
         }
 
-
         [Fact]
         public async Task WaitForCompletionOrCreateCheckStatusResponseAsync_Returns_HTTP_200_Response_After_Few_Iterations()
         {
@@ -136,13 +141,13 @@ namespace WebJobs.Extensions.DurableTask.Tests
             var httpResponseMessage = await httpApiHandler.WaitForCompletionOrCreateCheckStatusResponseAsync(
                 new HttpRequestMessage
                 {
-                    RequestUri = new Uri(TestConstants.RequestUri)
-                }, 
-                TestConstants.InstanceIdIterations, 
+                    RequestUri = new Uri(TestConstants.RequestUri),
+                },
+                TestConstants.InstanceIdIterations,
                 new OrchestrationClientAttribute
                 {
                     TaskHub = TestConstants.TaskHub,
-                    ConnectionName = TestConstants.ConnectionName
+                    ConnectionName = TestConstants.ConnectionName,
                 },
                 TimeSpan.FromSeconds(30),
                 TimeSpan.FromSeconds(8));
@@ -157,19 +162,19 @@ namespace WebJobs.Extensions.DurableTask.Tests
         [Fact]
         public async Task WaitForCompletionOrCreateCheckStatusResponseAsync_Returns_Defaults_When_Runtime_Status_is_Failed()
         {
-            await CheckRuntimeStatus(TestConstants.InstanceIdFailed, OrchestrationRuntimeStatus.Failed);
+            await this.CheckRuntimeStatus(TestConstants.InstanceIdFailed, OrchestrationRuntimeStatus.Failed);
         }
 
         [Fact]
         public async Task WaitForCompletionOrCreateCheckStatusResponseAsync_Returns_Defaults_When_Runtime_Status_is_Terminated()
         {
-            await CheckRuntimeStatus(TestConstants.InstanceIdTerminated, OrchestrationRuntimeStatus.Terminated);
+            await this.CheckRuntimeStatus(TestConstants.InstanceIdTerminated, OrchestrationRuntimeStatus.Terminated);
         }
 
         [Fact]
         public async Task WaitForCompletionOrCreateCheckStatusResponseAsync_Returns_Defaults_When_Runtime_Status_is_Canceled()
         {
-            await CheckRuntimeStatus(TestConstants.InstanceIdCanceled, OrchestrationRuntimeStatus.Canceled);
+            await this.CheckRuntimeStatus(TestConstants.InstanceIdCanceled, OrchestrationRuntimeStatus.Canceled);
         }
 
         private async Task CheckRuntimeStatus(string instanceId, OrchestrationRuntimeStatus runtimeStatus)
@@ -178,13 +183,13 @@ namespace WebJobs.Extensions.DurableTask.Tests
             var httpResponseMessage = await httpApiHandler.WaitForCompletionOrCreateCheckStatusResponseAsync(
                 new HttpRequestMessage
                 {
-                    RequestUri = new Uri(TestConstants.RequestUri)
-                }, 
-                instanceId, 
+                    RequestUri = new Uri(TestConstants.RequestUri),
+                },
+                instanceId,
                 new OrchestrationClientAttribute
                 {
                     TaskHub = TestConstants.TaskHub,
-                    ConnectionName = TestConstants.ConnectionName
+                    ConnectionName = TestConstants.ConnectionName,
                 },
                 TimeSpan.FromSeconds(30),
                 TimeSpan.FromSeconds(8));

--- a/test/LogMessage.cs
+++ b/test/LogMessage.cs
@@ -1,5 +1,5 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the MIT License. See License.txt in the project root for license information.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
 using System.Collections.Generic;
@@ -7,12 +7,16 @@ using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 {
-    public class LogMessage
+    internal class LogMessage
     {
         public LogLevel Level { get; set; }
+
         public EventId EventId { get; set; }
+
         public IEnumerable<KeyValuePair<string, object>> State { get; set; }
+
         public Exception Exception { get; set; }
+
         public string FormattedMessage { get; set; }
 
         public string Category { get; set; }

--- a/test/TestActivities.cs
+++ b/test/TestActivities.cs
@@ -1,9 +1,9 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the MIT License. See License.txt in the project root for license information.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using Newtonsoft.Json.Linq;
 using System;
 using System.IO;
+using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 {

--- a/test/TestConstants.cs
+++ b/test/TestConstants.cs
@@ -1,5 +1,5 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the MIT License. See License.txt in the project root for license information.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 
 namespace WebJobs.Extensions.DurableTask.Tests
 {

--- a/test/TestHelpers.cs
+++ b/test/TestHelpers.cs
@@ -1,5 +1,5 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the MIT License. See License.txt in the project root for license information.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
 using System.Collections.Generic;
@@ -21,7 +21,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             config.UseDurableTask(new DurableTaskExtension
             {
                 HubName = taskHub.Replace("_", ""),
-                TraceInputsAndOutputs = true
+                TraceInputsAndOutputs = true,
             });
 
             // Performance is *significantly* worse when dashboard logging is enabled, at least
@@ -35,8 +35,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             return host;
         }
 
-        public static void AssertLogMessageSequence(TestLoggerProvider loggerProvider, string testName,
-            string[] orchestratorFunctionNames, string activityFunctionName = null)
+        public static void AssertLogMessageSequence(
+            TestLoggerProvider loggerProvider,
+            string testName,
+            string[] orchestratorFunctionNames,
+            string activityFunctionName = null)
         {
             List<string> messageIds;
             string timeStamp;
@@ -49,8 +52,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             AssertLogMessages(expectedLogMessages, actualLogMessages);
         }
 
-        public static void UnhandledOrchesterationExceptionWithRetry_AssertLogMessageSequence(TestLoggerProvider loggerProvider, string testName,
-            string[] orchestratorFunctionNames, string activityFunctionName = null)
+        public static void UnhandledOrchesterationExceptionWithRetry_AssertLogMessageSequence(
+            TestLoggerProvider loggerProvider,
+            string testName,
+            string[] orchestratorFunctionNames,
+            string activityFunctionName = null)
         {
             List<string> messageIds;
             string timeStamp;
@@ -63,14 +69,17 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             Assert.Equal(4, exceptionCount);
         }
 
-        private static List<LogMessage> GetLogMessages(TestLoggerProvider loggerProvider, string testName, out List<string> messageIds,
+        private static List<LogMessage> GetLogMessages(
+            TestLoggerProvider loggerProvider,
+            string testName,
+            out List<string> messageIds,
             out string timeStamp)
         {
             var logger = loggerProvider.CreatedLoggers.Single(l => l.Category == LogCategory);
             var logMessages = logger.LogMessages.ToList();
             messageIds = new List<string>()
             {
-                GetMessageId(logMessages[0].FormattedMessage)
+                GetMessageId(logMessages[0].FormattedMessage),
             };
 
             timeStamp = string.Empty;
@@ -146,6 +155,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 Assert.StartsWith(expected[i], actual[i]);
             }
         }
+
         private static List<string> GetLogs_HelloWorldOrchestration_Inline(string messageId, string[] functionNames)
         {
             var list = new List<string>()
@@ -187,7 +197,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' was terminated. Reason: sayōnara",
                 $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' started. IsReplay: True. Input: 0",
                 $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' is waiting for input. Reason: WaitForExternalEvent:operation. IsReplay: True.",
-                $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' awaited. IsReplay: False."
+                $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' awaited. IsReplay: False.",
             };
 
             return list;
@@ -207,7 +217,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' is waiting for input. Reason: WaitForExternalEvent:approval. IsReplay: True.",
                 $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' is waiting for input. Reason: CreateTimer:{timerTimestamp}. IsReplay: True.",
                 $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' received a 'approval' event.",
-                $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' completed. ContinuedAsNew: False. IsReplay: False. Output: \"Approved\""
+                $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' completed. ContinuedAsNew: False. IsReplay: False. Output: \"Approved\"",
             };
 
             return list;

--- a/test/TestLogger.cs
+++ b/test/TestLogger.cs
@@ -1,5 +1,5 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the MIT License. See License.txt in the project root for license information.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
 using System.Collections.Generic;
@@ -7,19 +7,19 @@ using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 {
-    public class TestLogger : ILogger
+    internal class TestLogger : ILogger
     {
         private readonly Func<string, LogLevel, bool> filter;
 
-        public string Category { get; private set; }
-
-        public IList<LogMessage> LogMessages = new List<LogMessage>();
-
         public TestLogger(string category, Func<string, LogLevel, bool> filter = null)
         {
-            Category = category;
+            this.Category = category;
             this.filter = filter;
         }
+
+        public string Category { get; private set; }
+
+        public IList<LogMessage> LogMessages { get; } = new List<LogMessage>();
 
         public IDisposable BeginScope<TState>(TState state)
         {
@@ -28,24 +28,24 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
         public bool IsEnabled(LogLevel logLevel)
         {
-            return filter?.Invoke(Category, logLevel) ?? true;
+            return this.filter?.Invoke(this.Category, logLevel) ?? true;
         }
 
         public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
         {
-            if (!IsEnabled(logLevel))
+            if (!this.IsEnabled(logLevel))
             {
                 return;
             }
 
-            LogMessages.Add(new LogMessage
+            this.LogMessages.Add(new LogMessage
             {
                 Level = logLevel,
                 EventId = eventId,
                 State = state as IEnumerable<KeyValuePair<string, object>>,
                 Exception = exception,
                 FormattedMessage = formatter(state, exception),
-                Category = Category
+                Category = this.Category,
             });
         }
     }

--- a/test/TestLoggerProvider.cs
+++ b/test/TestLoggerProvider.cs
@@ -1,5 +1,5 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the MIT License. See License.txt in the project root for license information.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
 using System.Collections.Generic;
@@ -10,27 +10,27 @@ using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Azure.WebJobs.Host.TestCommon
 {
-    public class TestLoggerProvider : ILoggerProvider
+    internal class TestLoggerProvider : ILoggerProvider
     {
         private readonly Func<string, LogLevel, bool> filter;
-
-        public IList<TestLogger> CreatedLoggers = new List<TestLogger>();
 
         public TestLoggerProvider(Func<string, LogLevel, bool> filter = null)
         {
             this.filter = filter ?? new LogCategoryFilter().Filter;
         }
 
+        public IList<TestLogger> CreatedLoggers { get; } = new List<TestLogger>();
+
         public ILogger CreateLogger(string categoryName)
         {
-            var logger = new TestLogger(categoryName, filter);
-            CreatedLoggers.Add(logger);
+            var logger = new TestLogger(categoryName, this.filter);
+            this.CreatedLoggers.Add(logger);
             return logger;
         }
 
         public IEnumerable<LogMessage> GetAllLogMessages()
         {
-            return CreatedLoggers.SelectMany(l => l.LogMessages);
+            return this.CreatedLoggers.SelectMany(l => l.LogMessages);
         }
 
         public void Dispose()

--- a/test/TestOrchestrations.cs
+++ b/test/TestOrchestrations.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;

--- a/test/TestOrchestratorClient.cs
+++ b/test/TestOrchestratorClient.cs
@@ -1,5 +1,5 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the MIT License. See License.txt in the project root for license information.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
 using System.Diagnostics;
@@ -9,7 +9,7 @@ using Xunit.Abstractions;
 
 namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 {
-    public class TestOrchestratorClient
+    internal class TestOrchestratorClient
     {
         private readonly DurableOrchestrationClient innerClient;
         private readonly string functionName;
@@ -52,15 +52,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             return status;
         }
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1030:UseEventsWhereAppropriate")]
         public async Task RaiseEventAsync(string eventName, object eventData)
         {
-            await this.innerClient.RaiseEventAsync(instanceId, eventName, eventData);
+            await this.innerClient.RaiseEventAsync(this.instanceId, eventName, eventData);
         }
 
         public async Task TerminateAsync(string reason)
         {
-            await this.innerClient.TerminateAsync(instanceId, reason);
+            await this.innerClient.TerminateAsync(this.instanceId, reason);
         }
 
         public async Task<DurableOrchestrationStatus> WaitForStartupAsync(TimeSpan timeout, ITestOutputHelper output)
@@ -76,8 +75,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 }
 
                 await Task.Delay(TimeSpan.FromSeconds(1));
-
-            } while (sw.Elapsed < timeout);
+            }
+            while (sw.Elapsed < timeout);
 
             throw new TimeoutException($"Durable function '{this.functionName}' with instance ID '{this.instanceId}' failed to start.");
         }
@@ -97,8 +96,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 }
 
                 await Task.Delay(TimeSpan.FromSeconds(1));
-
-            } while (sw.Elapsed < timeout);
+            }
+            while (sw.Elapsed < timeout);
 
             throw new TimeoutException($"Durable function '{this.functionName}' with instance ID '{this.instanceId}' failed to complete.");
         }

--- a/test/WebJobs.Extensions.DurableTask.Tests.csproj
+++ b/test/WebJobs.Extensions.DurableTask.Tests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
     <Company>Microsoft Corporation</Company>
+    <NoWarn>SA0001;SA1600;SA1615</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
@@ -14,16 +15,22 @@
     <PackageReference Include="Moq" Version="4.7.145" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta004" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\src\WebJobs.Extensions.DurableTask\WebJobs.Extensions.DurableTask.csproj" />
+    <ProjectReference Include="$(SolutionDir)\src\WebJobs.Extensions.DurableTask\WebJobs.Extensions.DurableTask.csproj" />
   </ItemGroup>
 
   <ItemGroup>
     <None Update="xunit.runner.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <AdditionalFiles Include="$(SolutionDir)\.stylecop\stylecop.json" Link="stylecop.json" />
+    <Compile Include="$(SolutionDir)\.stylecop\GlobalSuppressions.cs" Link="GlobalSuppressions.cs" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Because this is an open source project and we have a variety of contributers with different coding styles, I thought it would be a good to introduce StyleCop to help enforce some basic consistency guidelines.

For now, all rules are warnings, but we could escalate them to errors later. Even better if we can simply gate PRs by ensuring they don't contain any warnings so that contributers don't have to fix StyleCop warnings until they are ready to do so.

I'm using the new "Analyzers" feature of Visual Studio, which is apparently the new way to do StyleCop. Hopefully it will work well for us.