### PR TITLE
Adding support for setting partition count in host.json

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
@@ -71,6 +71,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         public int ControlQueueBatchSize { get; set; } = 20;
 
         /// <summary>
+        /// Gets or sets the partition count for the control queue.
+        /// </summary>
+        /// <value>A positive integer between 1 and 16. The default value is <c>4</c>.</value>
+        public int PartitionCount { get; set; } = 4;
+
+        /// <summary>
         /// Gets or sets the visibility timeout of dequeued control queue messages.
         /// </summary>
         /// <value>
@@ -352,6 +358,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             {
                 StorageConnectionString = resolvedStorageConnectionString,
                 TaskHubName = taskHubNameOverride ?? this.HubName,
+                PartitionCount = this.PartitionCount,
                 ControlQueueVisibilityTimeout = this.ControlQueueVisibilityTimeout,
                 WorkItemQueueVisibilityTimeout = this.WorkItemQueueVisibilityTimeout,
                 MaxConcurrentTaskOrchestrationWorkItems = this.MaxConcurrentTaskOrchestrationWorkItems,

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
@@ -52,6 +52,12 @@
             </summary>
             <value>A positive integer configured by the host. The default value is <c>20</c>.</value>
         </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.PartitionCount">
+            <summary>
+            Gets or sets the partition count for the control queue.
+            </summary>
+            <value>A positive integer between 1 and 16. The default value is <c>4</c>.</value>
+        </member>
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.ControlQueueVisibilityTimeout">
             <summary>
             Gets or sets the visibility timeout of dequeued control queue messages.


### PR DESCRIPTION
The default number of partitions for the control queue is 4. Customers will now be able to configure the partition count in the **host.json** file.

This is done to address https://github.com/Azure/azure-functions-durable-extension/issues/73

## Verification Steps:

1. Open the `VSSample.sln` provided in [docs](https://docs.microsoft.com/en-us/azure/azure-functions/durable-functions-install).

2. Add the `PartitionCount` property to the default the `host.json `file, e.g. set **PartitionCount** to 8

```
{
  "http": {
    "routePrefix": ""
  },
  "applicationInsights": {
    "sampling": {
      "isEnabled": false
    }
  },
  "durableTask": {
    "HubName": "SampleHubVS",
    "PartitionCount" : 8  
  }
}
```

3. Launch the function host and run the `E1_HelloSequence` function.

4. Verify that the storage queue has a **8** partitions instead of the default **4**.

![storagequeuepartitions](https://user-images.githubusercontent.com/14911331/35765482-647d8b7c-0879-11e8-8fa7-542d9058fd81.PNG)
