### PR TITLE
Support for binding expressions in activity functions

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/DurableActivityContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableActivityContext.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Azure.WebJobs
         private readonly string instanceId;
         private readonly string serializedInput;
 
+        private JToken parsedJsonInput;
         private string serializedOutput;
 
         internal DurableActivityContext(string instanceId, string serializedInput)
@@ -55,11 +56,7 @@ namespace Microsoft.Azure.WebJobs
         /// </returns>
         public JToken GetInputAsJson()
         {
-            if (this.serializedInput == null)
-            {
-                return null;
-            }
-            else
+            if (this.serializedInput != null && this.parsedJsonInput == null)
             {
                 JArray array = JArray.Parse(this.serializedInput);
                 if (array?.Count != 1)
@@ -67,9 +64,10 @@ namespace Microsoft.Azure.WebJobs
                     throw new ArgumentException("The serialized input is expected to be a JSON array with one element.");
                 }
 
-                JToken token = array[0];
-                return token;
+                this.parsedJsonInput = array[0];
             }
+
+            return this.parsedJsonInput;
         }
 
         /// <summary>

--- a/test/BindingTests.cs
+++ b/test/BindingTests.cs
@@ -4,8 +4,11 @@
 using System;
 using System.Diagnostics;
 using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Host;
 using Microsoft.Azure.WebJobs.Host.TestCommon;
 using Microsoft.Extensions.Logging;
+using Microsoft.WindowsAzure.Storage;
+using Microsoft.WindowsAzure.Storage.Blob;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -96,6 +99,115 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 // The function echos back the input value
                 Assert.Equal(OrchestrationRuntimeStatus.Completed, status?.RuntimeStatus);
                 Assert.Equal((double)startArgs.Input, status?.Output);
+
+                await host.StopAsync();
+            }
+        }
+
+        [Fact]
+        public async Task BindToBlobViaParameterName()
+        {
+            using (JobHost host = TestHelpers.GetJobHost(this.loggerFactory, nameof(this.ActivityTriggerAsNumber)))
+            {
+                await host.StartAsync();
+
+                string connectionString = AmbientConnectionStringProvider.Instance.GetConnectionString(ConnectionStringNames.Storage);
+                CloudStorageAccount account = CloudStorageAccount.Parse(connectionString);
+                this.output.WriteLine($"Using storage account: {account.Credentials.AccountName}");
+
+                // Blob and container names need to be kept in sync with the activity code.
+                const string OriginalBlobName = "MyBlob";
+                const string UpdatedBlobName = OriginalBlobName + "-archive";
+                const string ContainerName = "test";
+
+                CloudBlobClient blobClient = account.CreateCloudBlobClient();
+                CloudBlobContainer container = blobClient.GetContainerReference(ContainerName);
+                if (await container.CreateIfNotExistsAsync())
+                {
+                    this.output.WriteLine($"Created container '{container.Name}'.");
+                }
+
+                string randomData = Guid.NewGuid().ToString("N");
+
+                CloudBlockBlob blob = container.GetBlockBlobReference(OriginalBlobName);
+                await blob.UploadTextAsync(randomData);
+                this.output.WriteLine($"Uploaded text '{randomData}' to {blob.Name}.");
+
+                // Using StartOrchestrationArgs to start an activity function because it's easier than creating a new type.
+                var startArgs = new StartOrchestrationArgs();
+                startArgs.FunctionName = nameof(TestActivities.BindToBlobViaParameterName);
+                startArgs.Input = OriginalBlobName;
+
+                var timeout = Debugger.IsAttached ? TimeSpan.FromMinutes(5) : TimeSpan.FromSeconds(30);
+                var client = await host.StartOrchestratorAsync(nameof(TestOrchestrations.CallActivity), startArgs, this.output);
+                var status = await client.WaitForCompletionAsync(timeout, this.output);
+
+                Assert.Equal(OrchestrationRuntimeStatus.Completed, status?.RuntimeStatus);
+
+                CloudBlockBlob newBlob = container.GetBlockBlobReference(UpdatedBlobName);
+                string copiedData = await newBlob.DownloadTextAsync();
+                this.output.WriteLine($"Downloaded text '{copiedData}' from {newBlob.Name}.");
+
+                Assert.Equal(randomData, copiedData);
+
+                await host.StopAsync();
+            }
+        }
+
+        [Fact]
+        public async Task BindToBlobViaPOCO()
+        {
+            using (JobHost host = TestHelpers.GetJobHost(this.loggerFactory, nameof(this.ActivityTriggerAsNumber)))
+            {
+                await host.StartAsync();
+
+                string connectionString = AmbientConnectionStringProvider.Instance.GetConnectionString(ConnectionStringNames.Storage);
+                CloudStorageAccount account = CloudStorageAccount.Parse(connectionString);
+                this.output.WriteLine($"Using storage account: {account.Credentials.AccountName}");
+
+                // Blob and container names need to be kept in sync with the activity code.
+                var data = new
+                {
+                    InputPrefix = "Input",
+                    OutputPrefix = "Output",
+                    Suffix = 42,
+                };
+
+                const string ContainerName = "test";
+                string inputBlobName = $"{data.InputPrefix}-{data.Suffix}";
+                string outputBlobName = $"{data.OutputPrefix}-{data.Suffix}";
+
+                CloudBlobClient blobClient = account.CreateCloudBlobClient();
+                CloudBlobContainer container = blobClient.GetContainerReference(ContainerName);
+                if (await container.CreateIfNotExistsAsync())
+                {
+                    this.output.WriteLine($"Created container '{container.Name}'.");
+                }
+
+                string randomData = Guid.NewGuid().ToString("N");
+
+                this.output.WriteLine($"Creating blob named {outputBlobName}...");
+                CloudBlockBlob blob = container.GetBlockBlobReference(inputBlobName);
+                await blob.UploadTextAsync(randomData);
+                this.output.WriteLine($"Uploaded text '{randomData}' to {blob.Name}.");
+
+                // Using StartOrchestrationArgs to start an activity function because it's easier than creating a new type.
+                var startArgs = new StartOrchestrationArgs();
+                startArgs.FunctionName = nameof(TestActivities.BindToBlobViaJsonPayload);
+                startArgs.Input = data;
+
+                var timeout = Debugger.IsAttached ? TimeSpan.FromMinutes(5) : TimeSpan.FromSeconds(30);
+                var client = await host.StartOrchestratorAsync(nameof(TestOrchestrations.CallActivity), startArgs, this.output);
+                var status = await client.WaitForCompletionAsync(timeout, this.output);
+
+                Assert.Equal(OrchestrationRuntimeStatus.Completed, status?.RuntimeStatus);
+
+                this.output.WriteLine($"Searching for blob named {outputBlobName}...");
+                CloudBlockBlob newBlob = container.GetBlockBlobReference(outputBlobName);
+                string copiedData = await newBlob.DownloadTextAsync();
+                this.output.WriteLine($"Downloaded text '{copiedData}' from {newBlob.Name}.");
+
+                Assert.Equal(randomData, copiedData);
 
                 await host.StopAsync();
             }

--- a/test/TestActivities.cs
+++ b/test/TestActivities.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.IO;
+using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
@@ -65,6 +66,22 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         public static double BindToDouble([ActivityTrigger] double value)
         {
             return value;
+        }
+
+        public static async Task BindToBlobViaParameterName(
+            [ActivityTrigger] string name,
+            [Blob("test/{name}", FileAccess.Read)] Stream input,
+            [Blob("test/{name}-archive", FileAccess.Write)] Stream output)
+        {
+            await input.CopyToAsync(output);
+        }
+
+        public static async Task BindToBlobViaJsonPayload(
+            [ActivityTrigger] JObject ignored,
+            [Blob("test/{data.InputPrefix}-{data.Suffix}", FileAccess.Read)] Stream input,
+            [Blob("test/{data.OutputPrefix}-{data.Suffix}", FileAccess.Write)] Stream output)
+        {
+            await input.CopyToAsync(output);
         }
 
         public class PlainOldClrObject


### PR DESCRIPTION
This PR fixes #123 (enable binding expressions in activity functions. it allows the function author to bind to the name of the parameter or to one of the top-level fields in the activity payload.

### Example 1: Binding to the parameter name
This activity function takes a string argument (the name of a blob) and uses that value to bind to blob input and output bindings.

**Activity Function**
```csharp
public static async Task ArchiveBlob(
    [ActivityTrigger] string name,
    [Blob("test/{name}", FileAccess.Read)] Stream input,
    [Blob("test/{name}-archive", FileAccess.Write)] Stream output)
{
    await input.CopyToAsync(output);
}
```

**Orchestrator Function**
```csharp
public static async Task Orchestrator([OrchestrationTrigger] DurableOrchestrationContext ctx)
{
    string blobName = ctx.GetInput<string>();
    await ctx.CallActivityAsync("ArchiveBlob", blobName);
}
```

### Example 2: Binding to the activity data payload
This activity function takes a custom POCO argument (it could also be a JSON argument) and uses the data contents to bind to blob inputs and outputs. Note the use of `data` in the binding expression, which always acts as a reference to the activity argument data.

**Activity Function**
```csharp
public static async Task CopyBlob(
    [ActivityTrigger] JObject ignored,
    [Blob("test/{data.InputPrefix}-{data.Suffix}", FileAccess.Read)] Stream input,
    [Blob("test/{data.OutputPrefix}-{data.Suffix}", FileAccess.Write)] Stream output)
{
    await input.CopyToAsync(output);
}
```

**Orchestrator Function**
```csharp
public static async Task Orchestrator([OrchestrationTrigger] DurableOrchestrationContext ctx)
{
    var data = new
    {
        InputPrefix = "Input",
        OutputPrefix = "Output",
        Suffix = 42,
    };

    await ctx.CallActivityAsync("CopyBlob", data);
}
```

Both of these examples are verified in the new unit tests that are included in this PR.