### PR TITLE
Enable opting-out of the StartNewAsync polling

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/DurableOrchestrationClient.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableOrchestrationClient.cs
@@ -69,17 +69,20 @@ namespace Microsoft.Azure.WebJobs
                 functionType: FunctionType.Orchestrator,
                 isReplay: false);
 
-            DurableOrchestrationStatus status = await this.GetStatusAsync(instance.InstanceId);
-            Stopwatch stopwatch = Stopwatch.StartNew();
-            while ((status == null || status.RuntimeStatus == OrchestrationRuntimeStatus.Pending) && stopwatch.Elapsed < TimeSpan.FromSeconds(30))
+            if (!this.config.DisableStartInstancePolling)
             {
-                await Task.Delay(200);
-                status = await this.GetStatusAsync(instance.InstanceId);
-            }
+                DurableOrchestrationStatus status = await this.GetStatusAsync(instance.InstanceId);
+                Stopwatch stopwatch = Stopwatch.StartNew();
+                while ((status == null || status.RuntimeStatus == OrchestrationRuntimeStatus.Pending) && stopwatch.Elapsed < TimeSpan.FromSeconds(30))
+                {
+                    await Task.Delay(200);
+                    status = await this.GetStatusAsync(instance.InstanceId);
+                }
 
-            if (status == null || status.RuntimeStatus == OrchestrationRuntimeStatus.Pending)
-            {
-                throw new TimeoutException($"Timeout expired while waiting for the new instance to start. This can happen if the task hub is overloaded or if the orchestration host failed to process the start message. Please check the orchestration logs to see whether an internal failure may have occurred. Instance ID: {instance.InstanceId}");
+                if (status == null || status.RuntimeStatus == OrchestrationRuntimeStatus.Pending)
+                {
+                    throw new TimeoutException($"Timeout expired while waiting for the new instance to start. This can happen if the task hub is overloaded or if the orchestration host failed to process the start message. Please check the orchestration logs to see whether an internal failure may have occurred. Instance ID: {instance.InstanceId}");
+                }
             }
 
             return instance.InstanceId;

--- a/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
@@ -154,6 +154,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// </value>
         public bool DisableHttpManagementApis { get; set; }
 
+        /// <summary>
+        /// Gets or sets a value which controls whether the polling behavior of
+        /// <see cref="DurableOrchestrationClient.StartNewAsync"/> is disabled.
+        /// </summary>
+        /// <remarks>
+        /// This is a temporary setting and will be removed in future versions.
+        /// </remarks>
+        /// <value><c>true</c> to disable polling; <c>false</c> otherwise.</value>
+        public bool DisableStartInstancePolling { get; set; }
+
         internal EndToEndTraceHelper TraceHelper => this.traceHelper;
 
         /// <summary>

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
@@ -136,6 +136,16 @@
             <c>true</c> to disable the instance management HTTP APIs; otherwise <c>false</c>.
             </value>
         </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.DisableStartInstancePolling">
+            <summary>
+            Gets or sets a value which controls whether the polling behavior of
+            <see cref="M:Microsoft.Azure.WebJobs.DurableOrchestrationClient.StartNewAsync(System.String,System.String,System.Object)"/> is disabled.
+            </summary>
+            <remarks>
+            This is a temporary setting and will be removed in future versions.
+            </remarks>
+            <value><c>true</c> to disable polling; <c>false</c> otherwise.</value>
+        </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.Microsoft#Azure#WebJobs#Host#Config#IExtensionConfigProvider#Initialize(Microsoft.Azure.WebJobs.Host.Config.ExtensionConfigContext)">
             <summary>
             Internal initialization call from the WebJobs host.

--- a/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
+++ b/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
@@ -5,9 +5,9 @@
     <AssemblyName>Microsoft.Azure.WebJobs.Extensions.DurableTask</AssemblyName>
     <RootNamespace>Microsoft.Azure.WebJobs.Extensions.DurableTask</RootNamespace>
     <DocumentationFile>Microsoft.Azure.WebJobs.Extensions.DurableTask.xml</DocumentationFile>
-    <AssemblyVersion>1.2.0.0</AssemblyVersion>
-    <FileVersion>1.2.0.0</FileVersion>
-    <Version>1.2.0-beta3</Version>
+    <AssemblyVersion>1.2.1.0</AssemblyVersion>
+    <FileVersion>1.2.1.0</FileVersion>
+    <Version>1.2.1-beta3</Version>
     <Company>Microsoft Corporation</Company>
   </PropertyGroup>
 


### PR DESCRIPTION
This is a temporary fix that addresses https://github.com/Azure/azure-functions-durable-extension/issues/177, which was a problem that was introduced in beta3. A more permanent fix will be added later.

To disable the polling in StartNewAsync, simply update the host.json file as follows:

```json
{
  "durableTask": {
    "disableStartInstancePolling": true
  }
}
```