### PR TITLE
Fix message size limit check to use UTF-16 to align with Azure Storage.

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/MessagePayloadDataConverter.cs
+++ b/src/WebJobs.Extensions.DurableTask/MessagePayloadDataConverter.cs
@@ -33,13 +33,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         {
             string serializedJson = base.Serialize(value);
 
-            // String payloads in Azure Storage are encoded in UTF-32.
-            int payloadSizeInKB = (int)(Encoding.UTF32.GetByteCount(serializedJson) / 1024.0);
+            // String payloads in Azure Storage are encoded in UTF-16.
+            int payloadSizeInKB = (int)(Encoding.Unicode.GetByteCount(serializedJson) / 1024.0);
             if (payloadSizeInKB > MaxPayloadSizeInKB)
             {
                 throw new ArgumentException(
                     string.Format(
-                        "The UTF-32 size of the JSON-serialized payload must not exceed 60 KB. The current payload size is {0:N0} KB.",
+                        "The UTF-16 size of the JSON-serialized payload must not exceed 60 KB. The current payload size is {0:N0} KB.",
                         payloadSizeInKB));
             }
 

--- a/test/DurableTaskEndToEndTests.cs
+++ b/test/DurableTaskEndToEndTests.cs
@@ -1068,14 +1068,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 var timeout = Debugger.IsAttached ? TimeSpan.FromMinutes(5) : TimeSpan.FromSeconds(30);
 
                 // The expected maximum payload size is 60 KB.
-                // Strings in Azure Storage are encoded in UTF-32, which is 4 bytes per character.
-                int stringLength = (61 * 1024) / 4;
+                // Strings in Azure Storage are encoded in UTF-16, which is 2 bytes per character.
+                int stringLength = (61 * 1024) / 2;
 
                 var client = await host.StartOrchestratorAsync(orchestrator, stringLength, this.output);
                 var status = await client.WaitForCompletionAsync(timeout, this.output);
 
                 Assert.Equal(OrchestrationRuntimeStatus.Failed, status?.RuntimeStatus);
-                Assert.True(status?.Output.ToString().Contains("The UTF-32 size of the JSON-serialized payload must not exceed 60 KB"));
+                Assert.True(status?.Output.ToString().Contains("The UTF-16 size of the JSON-serialized payload must not exceed 60 KB"));
 
                 await host.StopAsync();
             }
@@ -1093,8 +1093,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 var timeout = Debugger.IsAttached ? TimeSpan.FromMinutes(5) : TimeSpan.FromSeconds(30);
 
                 // The expected maximum payload size is 60 KB.
-                // Strings in Azure Storage are encoded in UTF-32, which is 4 bytes per character.
-                int stringLength = (61 * 1024) / 4;
+                // Strings in Azure Storage are encoded in UTF-16, which is 2 bytes per character.
+                int stringLength = (61 * 1024) / 2;
                 var input = new StartOrchestrationArgs
                 {
                     FunctionName = nameof(TestActivities.BigReturnValue),
@@ -1108,7 +1108,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
                 // Activity function exception details are not captured in the orchestrator output:
                 // https://github.com/Azure/azure-functions-durable-extension/issues/84
-                ////Assert.True(status?.Output.ToString().Contains("The UTF-32 size of the JSON-serialized payload must not exceed 60 KB"));
+                ////Assert.True(status?.Output.ToString().Contains("The UTF-16 size of the JSON-serialized payload must not exceed 60 KB"));
                 Assert.StartsWith($"The activity function '{input.FunctionName}' failed.", (string)status?.Output);
 
                 await host.StopAsync();


### PR DESCRIPTION
This fix addresses the issue https://github.com/Azure/azure-functions-durable-extension/issues/189