### PR TITLE
add comment with copyright & license information

### DIFF
--- a/samples/precompiled/HttpSyncStart.cs
+++ b/samples/precompiled/HttpSyncStart.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
 using System;
 using System.Linq;
 using System.Net.Http;

--- a/samples/precompiled/HttpSyncStart.cs
+++ b/samples/precompiled/HttpSyncStart.cs
@@ -1,5 +1,5 @@
 // Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the MIT License. See License.txt in the project root for license information.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
 using System.Linq;


### PR DESCRIPTION
All the other .cs files had the copyright & license at the top of the file. Please reject if the omission was intentional.