### PR TITLE
Adding ordering to App Insights Events

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/EndToEndTraceHelper.cs
+++ b/src/WebJobs.Extensions.DurableTask/EndToEndTraceHelper.cs
@@ -76,8 +76,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 IsReplay: isReplay);
 
             this.logger.LogInformation(
-                "{instanceId}: Function '{functionName} ({functionType})', version '{version}' scheduled. Reason: {reason}. IsReplay: {isReplay}. State: {state}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}.",
-                instanceId, functionName, functionType, version, reason, isReplay, FunctionState.Scheduled, hubName, LocalAppName, LocalSlotName, ExtensionVersion);
+                "{instanceId}: Function '{functionName} ({functionType})', version '{version}' scheduled. Reason: {reason}. IsReplay: {isReplay}. State: {state}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}. SequenceNumber: {sequenceNumber}.",
+                instanceId, functionName, functionType, version, reason, isReplay, FunctionState.Scheduled, hubName, LocalAppName, LocalSlotName, ExtensionVersion, DateTime.UtcNow.Ticks);
             this.appTraceWriter.Info(
                 $"{instanceId}: Function '{functionName} ({functionType})', version '{version}' scheduled. Reason: {reason}. IsReplay: {isReplay}. State: {FunctionState.Scheduled}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {ExtensionVersion}.");
         }
@@ -104,8 +104,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 IsReplay: isReplay);
 
             this.logger.LogInformation(
-                "{instanceId}: Function '{functionName} ({functionType})', version '{version}' started. IsReplay: {isReplay}. Input: {input}. State: {state}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}.",
-                instanceId, functionName, functionType, version, isReplay, input, FunctionState.Started, hubName, LocalAppName, LocalSlotName, ExtensionVersion);
+                "{instanceId}: Function '{functionName} ({functionType})', version '{version}' started. IsReplay: {isReplay}. Input: {input}. State: {state}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}. SequenceNumber: {sequenceNumber}.",
+                instanceId, functionName, functionType, version, isReplay, input, FunctionState.Started, hubName, LocalAppName, LocalSlotName, ExtensionVersion, DateTime.UtcNow.Ticks);
             this.appTraceWriter.Info(
                 $"{instanceId}: Function '{functionName} ({functionType})', version '{version}' started. IsReplay: {isReplay}. Input: {input}. State: {FunctionState.Started}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {ExtensionVersion}.");
         }
@@ -131,8 +131,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 IsReplay: isReplay);
 
             this.logger.LogInformation(
-                "{instanceId}: Function '{functionName} ({functionType})', version '{version}' awaited. IsReplay: {isReplay}. State: {state}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}.",
-                instanceId, functionName, functionType, version, isReplay, FunctionState.Awaited, hubName, LocalAppName, LocalSlotName, ExtensionVersion);
+                "{instanceId}: Function '{functionName} ({functionType})', version '{version}' awaited. IsReplay: {isReplay}. State: {state}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}. SequenceNumber: {sequenceNumber}.",
+                instanceId, functionName, functionType, version, isReplay, FunctionState.Awaited, hubName, LocalAppName, LocalSlotName, ExtensionVersion, DateTime.UtcNow.Ticks);
             this.appTraceWriter.Info(
                 $"{instanceId}: Function '{functionName} ({functionType})', version '{version}' awaited. IsReplay: {isReplay}. State: {FunctionState.Awaited}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {ExtensionVersion}.");
         }
@@ -160,8 +160,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 IsReplay: isReplay);
 
             this.logger.LogInformation(
-                "{instanceId}: Function '{functionName} ({functionType})', version '{version}' is waiting for input. Reason: {reason}. IsReplay: {isReplay}. State: {state}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}.",
-                instanceId, functionName, functionType, version, reason, isReplay, FunctionState.Listening, hubName, LocalAppName, LocalSlotName, ExtensionVersion);
+                "{instanceId}: Function '{functionName} ({functionType})', version '{version}' is waiting for input. Reason: {reason}. IsReplay: {isReplay}. State: {state}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}. SequenceNumber: {sequenceNumber}.",
+                instanceId, functionName, functionType, version, reason, isReplay, FunctionState.Listening, hubName, LocalAppName, LocalSlotName, ExtensionVersion, DateTime.UtcNow.Ticks);
             this.appTraceWriter.Info(
                 $"{instanceId}: Function '{functionName} ({functionType})', version '{version}' is waiting for input. Reason: {reason}. IsReplay: {isReplay}. State: {FunctionState.Listening}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}.  ExtensionVersion: {ExtensionVersion}.");
         }
@@ -190,8 +190,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 IsReplay: isReplay);
 
             this.logger.LogInformation(
-                "{instanceId}: Function '{functionName} ({functionType})', version '{version}' completed. ContinuedAsNew: {continuedAsNew}. IsReplay: {isReplay}. Output: {output}. State: {state}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}.",
-                instanceId, functionName, functionType, version, continuedAsNew, isReplay, output, FunctionState.Completed, hubName, LocalAppName, LocalSlotName, ExtensionVersion);
+                "{instanceId}: Function '{functionName} ({functionType})', version '{version}' completed. ContinuedAsNew: {continuedAsNew}. IsReplay: {isReplay}. Output: {output}. State: {state}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}. SequenceNumber: {sequenceNumber}.",
+                instanceId, functionName, functionType, version, continuedAsNew, isReplay, output, FunctionState.Completed, hubName, LocalAppName, LocalSlotName, ExtensionVersion, DateTime.UtcNow.Ticks);
             this.appTraceWriter.Info(
                 $"{instanceId}: Function '{functionName} ({functionType})', version '{version}' completed. ContinuedAsNew: {continuedAsNew}. IsReplay: {isReplay}. Output: {output}. State: {FunctionState.Completed}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {ExtensionVersion}.");
         }
@@ -218,8 +218,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 IsReplay: false);
 
             this.logger.LogWarning(
-                "{instanceId}: Function '{functionName} ({functionType})', version '{version}' was terminated. Reason: {reason}. State: {state}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}.",
-                instanceId, functionName, functionType, version, reason, FunctionState.Terminated, hubName, LocalAppName, LocalSlotName, ExtensionVersion);
+                "{instanceId}: Function '{functionName} ({functionType})', version '{version}' was terminated. Reason: {reason}. State: {state}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}. SequenceNumber: {sequenceNumber}.",
+                instanceId, functionName, functionType, version, reason, FunctionState.Terminated, hubName, LocalAppName, LocalSlotName, ExtensionVersion, DateTime.UtcNow.Ticks);
             this.appTraceWriter.Info(
                 $"{instanceId}: Function '{functionName} ({functionType})', version '{version}' was terminated. Reason: {reason}. State: {FunctionState.Terminated}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {ExtensionVersion}.");
         }
@@ -237,8 +237,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 instanceId, reason, functionType.ToString(), ExtensionVersion, IsReplay: false);
 
             this.logger.LogError(
-                "{instanceId}: Function '{functionName} ({functionType})', version '{version}' failed with an error. Reason: {reason}. IsReplay: {isReplay}. State: {state}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}.",
-                instanceId, functionName, functionType, version, reason, isReplay, FunctionState.Failed, hubName, LocalAppName, LocalSlotName, ExtensionVersion);
+                "{instanceId}: Function '{functionName} ({functionType})', version '{version}' failed with an error. Reason: {reason}. IsReplay: {isReplay}. State: {state}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}. SequenceNumber: {sequenceNumber}.",
+                instanceId, functionName, functionType, version, reason, isReplay, FunctionState.Failed, hubName, LocalAppName, LocalSlotName, ExtensionVersion, DateTime.UtcNow.Ticks);
             this.appTraceWriter.Info(
                 $"{instanceId}: Function '{functionName} ({functionType})', version '{version}' failed with an error. Reason: {reason}. IsReplay: {isReplay}. State: {FunctionState.Failed}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {ExtensionVersion}.");
         }
@@ -268,8 +268,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 IsReplay: isReplay);
 
             this.logger.LogInformation(
-                "{instanceId}: Function '{functionName} ({functionType})', version '{version}' received a '{eventName}' event. State: {state}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}.",
-                instanceId, functionName, functionType, version, eventName, FunctionState.ExternalEventRaised, hubName, LocalAppName, LocalSlotName, ExtensionVersion);
+                "{instanceId}: Function '{functionName} ({functionType})', version '{version}' received a '{eventName}' event. State: {state}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}. SequenceNumber: {sequenceNumber}.",
+                instanceId, functionName, functionType, version, eventName, FunctionState.ExternalEventRaised, hubName, LocalAppName, LocalSlotName, ExtensionVersion, DateTime.UtcNow.Ticks);
             this.appTraceWriter.Info(
                 $"{instanceId}: Function '{functionName} ({functionType})', version '{version}' received a '{eventName}' event. State: {FunctionState.ExternalEventRaised}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {ExtensionVersion}.");
         }
@@ -299,8 +299,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 IsReplay: isReplay);
 
             this.logger.LogInformation(
-                "{instanceId}: Function '{functionName} ({functionType})', version '{version}' was resumed by a timer scheduled for '{expirationTime}'. IsReplay: {isReplay}. State: {state}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}.",
-                instanceId, functionName, functionType, version, expirationTimeString, isReplay, FunctionState.TimerExpired, hubName, LocalAppName, LocalSlotName, ExtensionVersion);
+                "{instanceId}: Function '{functionName} ({functionType})', version '{version}' was resumed by a timer scheduled for '{expirationTime}'. IsReplay: {isReplay}. State: {state}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}. SequenceNumber: {sequenceNumber}.",
+                instanceId, functionName, functionType, version, expirationTimeString, isReplay, FunctionState.TimerExpired, hubName, LocalAppName, LocalSlotName, ExtensionVersion, DateTime.UtcNow.Ticks);
             this.appTraceWriter.Info(
                 $"{instanceId}: Function '{functionName} ({functionType})', version '{version}' was resumed by a timer scheduled for '{expirationTimeString}'. IsReplay: {isReplay}. State: {FunctionState.TimerExpired}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {ExtensionVersion}.");
         }


### PR DESCRIPTION
Hello @cgillum ,

May I ask you to take look on this first attempt to implement this issue - https://github.com/Azure/azure-functions-durable-extension/issues/71

It is possible that I am missing some of the edge cases or additional logic, but I tested with the samples project and then by running the following query against Application Insights:

```sql
let targetInstanceId = "33681f657c0141288fd1c0712dfe5e4a";
let start = datetime(2018-03-23T08:00:00);
traces
| where timestamp > start and timestamp < start + 50m
| where customDimensions.Category == "Host.Triggers.DurableTask"
| extend functionName = customDimensions["prop__functionName"]
| extend instanceId = customDimensions["prop__instanceId"]
| extend state = customDimensions["prop__state"]
| extend isReplay = tobool(tolower(customDimensions["prop__isReplay"]))
| extend sequenceNumber = tolong(customDimensions["prop__sequenceNumber"]) 
| where isReplay == false
| where instanceId == targetInstanceId
| sort by sequenceNumber asc
| project timestamp, functionName, state, instanceId, sequenceNumber, appName = cloud_RoleName
```

I got this output:

![image](https://user-images.githubusercontent.com/4756800/37818980-46ea39cc-2ebf-11e8-8ed5-2a0459490bf7.png)

Let me know if this is acceptable approach.

I am looking forward for your feedback and review comments.

Thank you! 

