### PR TITLE
Functions V2 Compatibility Update

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/DurableActivityContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableActivityContext.cs
@@ -82,15 +82,27 @@ namespace Microsoft.Azure.WebJobs
                 return default(T);
             }
 
+            return (T)this.GetInput(typeof(T));
+        }
+
+        internal object GetInput(Type destinationType)
+        {
+            if (this.serializedInput == null)
+            {
+                return destinationType.IsValueType ?
+                    Activator.CreateInstance(destinationType) :
+                    null;
+            }
+
             JToken jToken = this.GetInputAsJson();
             var value = jToken as JValue;
             if (value != null)
             {
-                return value.ToObject<T>();
+                return value.ToObject(destinationType);
             }
 
             string serializedValue = jToken.ToString(Formatting.None);
-            return MessagePayloadDataConverter.Default.Deserialize<T>(serializedValue);
+            return MessagePayloadDataConverter.Default.Deserialize(serializedValue, destinationType);
         }
 
         internal string GetSerializedOutput()

--- a/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
@@ -15,6 +15,7 @@ using DurableTask.Core.Middleware;
 using Microsoft.Azure.WebJobs.Host;
 using Microsoft.Azure.WebJobs.Host.Config;
 using Microsoft.Azure.WebJobs.Host.Executors;
+using Microsoft.Extensions.Logging;
 using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
@@ -28,6 +29,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         INameVersionObjectManager<TaskOrchestration>,
         INameVersionObjectManager<TaskActivity>
     {
+        private const string LoggerCategoryName = "Host.Triggers.DurableTask";
+
         /// <summary>
         /// The default task hub name to use when not explicitly configured.
         /// </summary>
@@ -178,9 +181,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
             // Register the trigger bindings
             JobHostConfiguration hostConfig = context.Config;
+            ILogger logger = context.Config.LoggerFactory.CreateLogger(LoggerCategoryName);
 
-            this.traceHelper = new EndToEndTraceHelper(hostConfig, context.Trace);
-            this.httpApiHandler = new HttpApiHandler(this, context.Trace);
+            this.traceHelper = new EndToEndTraceHelper(hostConfig, logger);
+            this.httpApiHandler = new HttpApiHandler(this, logger);
 
             // Register the non-trigger bindings, which have a different model.
             var bindings = new BindingHelper(this, this.traceHelper);
@@ -279,6 +283,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 new TriggeredFunctionData
                 {
                     TriggerValue = context,
+
+#pragma warning disable CS0618 // Approved for use by this extension
                     InvokeHandler = userCodeInvoker =>
                     {
                         // 2. Configure the shim with the inner invoker to execute the user code.
@@ -287,6 +293,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                         // 3. Move to the next stage of the DTFx pipeline to trigger the orchestrator shim.
                         return next();
                     },
+#pragma warning restore CS0618
                 },
                 CancellationToken.None);
 

--- a/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
@@ -15,6 +15,7 @@ using DurableTask.Core.Middleware;
 using Microsoft.Azure.WebJobs.Host;
 using Microsoft.Azure.WebJobs.Host.Config;
 using Microsoft.Azure.WebJobs.Host.Executors;
+using Microsoft.Azure.WebJobs.Logging;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json.Linq;
 
@@ -29,12 +30,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         INameVersionObjectManager<TaskOrchestration>,
         INameVersionObjectManager<TaskActivity>
     {
-        private const string LoggerCategoryName = "Host.Triggers.DurableTask";
-
         /// <summary>
         /// The default task hub name to use when not explicitly configured.
         /// </summary>
         internal const string DefaultHubName = "DurableFunctionsHub";
+
+        private static readonly string LoggerCategoryName = LogCategories.CreateTriggerCategory("DurableTask");
 
         // Creating client objects is expensive, so we cache them when the attributes match.
         // Note that OrchestrationClientAttribute defines a custom equality comparer.

--- a/src/WebJobs.Extensions.DurableTask/EndToEndTraceHelper.cs
+++ b/src/WebJobs.Extensions.DurableTask/EndToEndTraceHelper.cs
@@ -3,29 +3,24 @@
 
 using System;
 using System.Diagnostics;
-using Microsoft.Azure.WebJobs.Host;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 {
     internal class EndToEndTraceHelper
     {
-        private const string CategoryName = "Host.Triggers.DurableTask";
-
         private static readonly string ExtensionVersion = FileVersionInfo.GetVersionInfo(typeof(DurableTaskExtension).Assembly.Location).FileVersion;
 
         private static string appName;
         private static string slotName;
 
-        private long sequenceNumber;
-
-        private readonly TraceWriter appTraceWriter;
         private readonly ILogger logger;
 
-        public EndToEndTraceHelper(JobHostConfiguration config, TraceWriter traceWriter)
+        private long sequenceNumber;
+
+        public EndToEndTraceHelper(JobHostConfiguration config, ILogger logger)
         {
-            this.appTraceWriter = traceWriter;
-            this.logger = config.LoggerFactory?.CreateLogger(CategoryName);
+            this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
         public static string LocalAppName
@@ -80,8 +75,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             this.logger.LogInformation(
                 "{instanceId}: Function '{functionName} ({functionType})', version '{version}' scheduled. Reason: {reason}. IsReplay: {isReplay}. State: {state}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}. SequenceNumber: {sequenceNumber}.",
                 instanceId, functionName, functionType, version, reason, isReplay, FunctionState.Scheduled, hubName, LocalAppName, LocalSlotName, ExtensionVersion, this.sequenceNumber++);
-            this.appTraceWriter.Info(
-                $"{instanceId}: Function '{functionName} ({functionType})', version '{version}' scheduled. Reason: {reason}. IsReplay: {isReplay}. State: {FunctionState.Scheduled}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {ExtensionVersion}.");
         }
 
         public void FunctionStarting(
@@ -108,8 +101,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             this.logger.LogInformation(
                 "{instanceId}: Function '{functionName} ({functionType})', version '{version}' started. IsReplay: {isReplay}. Input: {input}. State: {state}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}. SequenceNumber: {sequenceNumber}.",
                 instanceId, functionName, functionType, version, isReplay, input, FunctionState.Started, hubName, LocalAppName, LocalSlotName, ExtensionVersion, this.sequenceNumber++);
-            this.appTraceWriter.Info(
-                $"{instanceId}: Function '{functionName} ({functionType})', version '{version}' started. IsReplay: {isReplay}. Input: {input}. State: {FunctionState.Started}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {ExtensionVersion}.");
         }
 
         public void FunctionAwaited(
@@ -135,8 +126,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             this.logger.LogInformation(
                 "{instanceId}: Function '{functionName} ({functionType})', version '{version}' awaited. IsReplay: {isReplay}. State: {state}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}. SequenceNumber: {sequenceNumber}.",
                 instanceId, functionName, functionType, version, isReplay, FunctionState.Awaited, hubName, LocalAppName, LocalSlotName, ExtensionVersion, this.sequenceNumber++);
-            this.appTraceWriter.Info(
-                $"{instanceId}: Function '{functionName} ({functionType})', version '{version}' awaited. IsReplay: {isReplay}. State: {FunctionState.Awaited}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {ExtensionVersion}.");
         }
 
         public void FunctionListening(
@@ -164,8 +153,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             this.logger.LogInformation(
                 "{instanceId}: Function '{functionName} ({functionType})', version '{version}' is waiting for input. Reason: {reason}. IsReplay: {isReplay}. State: {state}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}. SequenceNumber: {sequenceNumber}.",
                 instanceId, functionName, functionType, version, reason, isReplay, FunctionState.Listening, hubName, LocalAppName, LocalSlotName, ExtensionVersion, this.sequenceNumber++);
-            this.appTraceWriter.Info(
-                $"{instanceId}: Function '{functionName} ({functionType})', version '{version}' is waiting for input. Reason: {reason}. IsReplay: {isReplay}. State: {FunctionState.Listening}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}.  ExtensionVersion: {ExtensionVersion}.");
         }
 
         public void FunctionCompleted(
@@ -194,8 +181,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             this.logger.LogInformation(
                 "{instanceId}: Function '{functionName} ({functionType})', version '{version}' completed. ContinuedAsNew: {continuedAsNew}. IsReplay: {isReplay}. Output: {output}. State: {state}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}. SequenceNumber: {sequenceNumber}.",
                 instanceId, functionName, functionType, version, continuedAsNew, isReplay, output, FunctionState.Completed, hubName, LocalAppName, LocalSlotName, ExtensionVersion, this.sequenceNumber++);
-            this.appTraceWriter.Info(
-                $"{instanceId}: Function '{functionName} ({functionType})', version '{version}' completed. ContinuedAsNew: {continuedAsNew}. IsReplay: {isReplay}. Output: {output}. State: {FunctionState.Completed}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {ExtensionVersion}.");
         }
 
         public void FunctionTerminated(
@@ -222,8 +207,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             this.logger.LogWarning(
                 "{instanceId}: Function '{functionName} ({functionType})', version '{version}' was terminated. Reason: {reason}. State: {state}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}. SequenceNumber: {sequenceNumber}.",
                 instanceId, functionName, functionType, version, reason, FunctionState.Terminated, hubName, LocalAppName, LocalSlotName, ExtensionVersion, this.sequenceNumber++);
-            this.appTraceWriter.Info(
-                $"{instanceId}: Function '{functionName} ({functionType})', version '{version}' was terminated. Reason: {reason}. State: {FunctionState.Terminated}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {ExtensionVersion}.");
         }
 
         public void FunctionFailed(
@@ -241,8 +224,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             this.logger.LogError(
                 "{instanceId}: Function '{functionName} ({functionType})', version '{version}' failed with an error. Reason: {reason}. IsReplay: {isReplay}. State: {state}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}. SequenceNumber: {sequenceNumber}.",
                 instanceId, functionName, functionType, version, reason, isReplay, FunctionState.Failed, hubName, LocalAppName, LocalSlotName, ExtensionVersion, this.sequenceNumber++);
-            this.appTraceWriter.Info(
-                $"{instanceId}: Function '{functionName} ({functionType})', version '{version}' failed with an error. Reason: {reason}. IsReplay: {isReplay}. State: {FunctionState.Failed}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {ExtensionVersion}.");
         }
 
         public void ExternalEventRaised(
@@ -272,8 +253,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             this.logger.LogInformation(
                 "{instanceId}: Function '{functionName} ({functionType})', version '{version}' received a '{eventName}' event. State: {state}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}. SequenceNumber: {sequenceNumber}.",
                 instanceId, functionName, functionType, version, eventName, FunctionState.ExternalEventRaised, hubName, LocalAppName, LocalSlotName, ExtensionVersion, this.sequenceNumber++);
-            this.appTraceWriter.Info(
-                $"{instanceId}: Function '{functionName} ({functionType})', version '{version}' received a '{eventName}' event. State: {FunctionState.ExternalEventRaised}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {ExtensionVersion}.");
         }
 
         public void TimerExpired(
@@ -303,8 +282,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             this.logger.LogInformation(
                 "{instanceId}: Function '{functionName} ({functionType})', version '{version}' was resumed by a timer scheduled for '{expirationTime}'. IsReplay: {isReplay}. State: {state}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}. SequenceNumber: {sequenceNumber}.",
                 instanceId, functionName, functionType, version, expirationTimeString, isReplay, FunctionState.TimerExpired, hubName, LocalAppName, LocalSlotName, ExtensionVersion, this.sequenceNumber++);
-            this.appTraceWriter.Info(
-                $"{instanceId}: Function '{functionName} ({functionType})', version '{version}' was resumed by a timer scheduled for '{expirationTimeString}'. IsReplay: {isReplay}. State: {FunctionState.TimerExpired}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {ExtensionVersion}.");
         }
 #pragma warning restore SA1117 // Parameters should be on same line or separate lines
     }

--- a/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
+++ b/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
@@ -8,7 +8,7 @@ using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Threading.Tasks;
-using Microsoft.Azure.WebJobs.Host;
+using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
@@ -25,12 +25,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         private const string ShowHistoryOutputParameter = "showHistoryOutput";
 
         private readonly DurableTaskExtension config;
-        private readonly TraceWriter traceWriter;
+        private readonly ILogger logger;
 
-        public HttpApiHandler(DurableTaskExtension config, TraceWriter traceWriter)
+        public HttpApiHandler(DurableTaskExtension config, ILogger logger)
         {
             this.config = config;
-            this.traceWriter = traceWriter;
+            this.logger = logger;
         }
 
         internal HttpResponseMessage CreateCheckStatusResponse(
@@ -178,7 +178,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     location = null;
                     break;
                 default:
-                    this.traceWriter.Error($"Unknown runtime state '{status.RuntimeStatus}'.");
+                    this.logger.LogError($"Unknown runtime state '{status.RuntimeStatus}'.");
                     statusCode = HttpStatusCode.InternalServerError;
                     location = null;
                     break;

--- a/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
+++ b/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
@@ -20,11 +20,11 @@
   </ItemGroup>
   
   <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
-    <PackageReference Include="Microsoft.Azure.WebJobs" Version="2.1.0" />
+    <PackageReference Include="Microsoft.Azure.WebJobs" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.0-beta4" />
+    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.0-beta5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/WebJobs.Extensions.DurableTask.Tests.csproj
+++ b/test/WebJobs.Extensions.DurableTask.Tests.csproj
@@ -9,9 +9,8 @@
   <ItemGroup>
     <PackageReference Include="DurableTask.AzureStorage" Version="1.1.2-beta" />
     <PackageReference Include="FluentAssertions" Version="4.19.4" />
-    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.0-beta4" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" Version="3.0.0-beta4" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="1.1.1" />
+    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.0-beta5" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" Version="3.0.0-beta5" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="Moq" Version="4.7.145" />
     <PackageReference Include="xunit" Version="2.2.0" />


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-functions-durable-extension/issues/210. This is fairly urgent since durable functions on v2 is broken in production due to the recent beta5 breaking change roll-out.

Two main changes in this PR:

1. Replace all usage of `TraceWriter` with `ILogger`.
2. Remove all usage of converters in binding trigger providers.

It turns out that these changes actually make the code cleaner by simply removing unnecessary code.