### PR TITLE
Fix for HTTP Race condition on Cold Start

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/Bindings/ActivityTriggerAttributeBindingProvider.cs
+++ b/src/WebJobs.Extensions.DurableTask/Bindings/ActivityTriggerAttributeBindingProvider.cs
@@ -159,6 +159,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     throw new ArgumentNullException(nameof(context));
                 }
 
+                this.parent.durableTaskConfig.RegisterActivity(this.activityName, context.Executor);
+
                 var listener = new DurableTaskListener(
                     this.parent.durableTaskConfig,
                     this.activityName,

--- a/src/WebJobs.Extensions.DurableTask/Bindings/OrchestrationTriggerAttributeBindingProvider.cs
+++ b/src/WebJobs.Extensions.DurableTask/Bindings/OrchestrationTriggerAttributeBindingProvider.cs
@@ -103,6 +103,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     throw new ArgumentNullException(nameof(context));
                 }
 
+               this.config.RegisterOrchestrator(this.orchestratorName, context.Executor);
+
                 var listener = new DurableTaskListener(
                     this.config,
                     this.orchestratorName,

--- a/src/WebJobs.Extensions.DurableTask/Listener/DurableTaskListener.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/DurableTaskListener.cs
@@ -36,15 +36,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
         public Task StartAsync(CancellationToken cancellationToken)
         {
-            if (this.isOrchestrator)
-            {
-                this.config.RegisterOrchestrator(this.functionName, this.executor);
-            }
-            else
-            {
-                this.config.RegisterActivity(this.functionName, this.executor);
-            }
-
             return this.config.StartTaskHubWorkerIfNotStartedAsync();
         }
 


### PR DESCRIPTION
Hello @cgillum ,

May I ask you to review when you have time this initial commit for HTTP Race Condition on Cold Start as described here - https://github.com/Azure/azure-functions-durable-extension/issues/205 ?

I decided to call  `RegisterOrchestrator(FunctionName orchestratorFunction, ITriggeredFunctionExecutor executor)` inside `CreateListenerAsync` (in  `ActivityTriggerBinding.CreateListenerAsync` and  `OrchestrationTriggerBinding.CreateListenerAsync` ) because there I have access to the `ListenerFactoryContext` which will give me the `ITriggeredFunctionExecutor Executor`. I did not see a way to get access to the Executor in `TryCreateAsync` methods without changing the dependencies for the class. 

Let me know if this is an acceptable approach or I need to change the direction.

Thank you! 