### PR TITLE
Flow exception details between orchestrator and activity functions

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/DurableOrchestrationContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableOrchestrationContext.cs
@@ -160,19 +160,14 @@ namespace Microsoft.Azure.WebJobs
             return this.serializedOutput;
         }
 
-        /// <summary>
-        /// Sets the JSON-serializeable status of the current orchestrator function.
-        /// </summary>
-        /// <remarks>
-        /// The <paramref name="customStatusObject"/> value is serialized to JSON and will be made available
-        /// to the orchestration status query APIs.
-        /// </remarks>
-        /// <param name="customStatusObject">The JSON-serializeable value to use as the orchestrator function's custom status.</param>
-        public void SetCustomStatus(object customStatusObject)
+        /// <inheritdoc />
+        public override void SetCustomStatus(object customStatusObject)
         {
             // Limit the custom status payload to 16 KB
-            const int MaxPayloadSizeInKB = 16 * 1024;
-            this.serializedCustomStatus = MessagePayloadDataConverter.Default.Serialize(customStatusObject, MaxPayloadSizeInKB);
+            const int MaxCustomStatusPayloadSizeInKB = 16;
+            this.serializedCustomStatus = MessagePayloadDataConverter.Default.Serialize(
+                customStatusObject,
+                MaxCustomStatusPayloadSizeInKB);
         }
 
         internal string GetSerializedCustomStatus()
@@ -381,10 +376,11 @@ namespace Microsoft.Azure.WebJobs
             {
                 exception = e;
                 string message = string.Format(
-                    "The {0} function '{1}' failed. See the function execution logs for details.",
+                    "The {0} function '{1}' failed: \"{2}\". See the function execution logs for additional details.",
                     functionType.ToString().ToLowerInvariant(),
-                    functionName);
-                throw new FunctionFailedException(message, e);
+                    functionName,
+                    e.InnerException?.Message);
+                throw new FunctionFailedException(message, e.InnerException);
             }
             catch (Exception e)
             {

--- a/src/WebJobs.Extensions.DurableTask/DurableOrchestrationContextBase.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableOrchestrationContextBase.cs
@@ -361,5 +361,15 @@ namespace Microsoft.Azure.WebJobs
         /// </summary>
         /// <param name="input">The JSON-serializeable data to re-initialize the instance with.</param>
         public abstract void ContinueAsNew(object input);
+
+        /// <summary>
+        /// Sets the JSON-serializeable status of the current orchestrator function.
+        /// </summary>
+        /// <remarks>
+        /// The <paramref name="customStatusObject"/> value is serialized to JSON and will be made available
+        /// to the orchestration status query APIs.
+        /// </remarks>
+        /// <param name="customStatusObject">The JSON-serializeable value to use as the orchestrator function's custom status.</param>
+        public abstract void SetCustomStatus(object customStatusObject);
     }
 }

--- a/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
@@ -488,6 +488,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     {
                         await this.orchestrationService.CreateIfNotExistsAsync();
                         await this.taskHubWorker.StartAsync();
+
+                        // Enable flowing exception information from activities
+                        // to the parent orchestration code.
+                        this.taskHubWorker.TaskActivityDispatcher.IncludeDetails = true;
+                        this.taskHubWorker.TaskOrchestrationDispatcher.IncludeDetails = true;
                         this.isTaskHubWorkerStarted = true;
                         return true;
                     }

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
@@ -224,7 +224,7 @@
         </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.MessagePayloadDataConverter.Serialize(System.Object)">
             <summary>
-            JSON-serializes the specified object. This method will throw if the maximum message payload size is exceeded.
+            JSON-serializes the specified object.
             </summary>
         </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.MessagePayloadDataConverter.Serialize(System.Object,System.Int32)">
@@ -465,14 +465,7 @@
             <param name="output">The JSON-serializeable value to use as the orchestrator function output.</param>
         </member>
         <member name="M:Microsoft.Azure.WebJobs.DurableOrchestrationContext.SetCustomStatus(System.Object)">
-            <summary>
-            Sets the JSON-serializeable status of the current orchestrator function.
-            </summary>
-            <remarks>
-            The <paramref name="customStatusObject"/> value is serialized to JSON and will be made available
-            to the orchestration status query APIs.
-            </remarks>
-            <param name="customStatusObject">The JSON-serializeable value to use as the orchestrator function's custom status.</param>
+            <inheritdoc />
         </member>
         <member name="M:Microsoft.Azure.WebJobs.DurableOrchestrationContext.CallActivityAsync``1(System.String,System.Object)">
             <inheritdoc />
@@ -822,6 +815,16 @@
             Restarts the orchestration and its history.
             </summary>
             <param name="input">The JSON-serializeable data to re-initialize the instance with.</param>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.DurableOrchestrationContextBase.SetCustomStatus(System.Object)">
+            <summary>
+            Sets the JSON-serializeable status of the current orchestrator function.
+            </summary>
+            <remarks>
+            The <paramref name="customStatusObject"/> value is serialized to JSON and will be made available
+            to the orchestration status query APIs.
+            </remarks>
+            <param name="customStatusObject">The JSON-serializeable value to use as the orchestrator function's custom status.</param>
         </member>
         <member name="T:Microsoft.Azure.WebJobs.DurableOrchestrationStatus">
             <summary>

--- a/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
+++ b/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="DurableTask.AzureStorage" Version="1.1.4-beta" />
+    <PackageReference Include="DurableTask.AzureStorage" Version="1.1.6-beta" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(Configuration)' == 'Debug'">

--- a/test/DurableTaskEndToEndTests.cs
+++ b/test/DurableTaskEndToEndTests.cs
@@ -825,7 +825,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
                 Assert.Equal(OrchestrationRuntimeStatus.Failed, status?.RuntimeStatus);
 
-                string output = status.Output.ToString();
+                string output = status.Output.ToString().Replace(Environment.NewLine, " ");
                 this.output.WriteLine($"Orchestration output string: {output}");
                 Assert.StartsWith(
                     $"Orchestrator function '{orchestratorFunctionNames[0]}' failed: Value cannot be null. Parameter name: retryOptions",
@@ -939,8 +939,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 var status = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(40), this.output);
 
                 Assert.Equal(OrchestrationRuntimeStatus.Failed, status?.RuntimeStatus);
-                Assert.True(status?.Output.ToString().Contains("Value cannot be null."));
-                Assert.True(status?.Output.ToString().Contains("Parameter name: retryOptions"));
+
+                string output = (string)status?.Output;
+                this.output.WriteLine($"Orchestration output string: {output}");
+                Assert.True(output.Contains(orchestratorFunctionName));
+                Assert.True(output.Contains("Value cannot be null."));
+                Assert.True(output.Contains("Parameter name: retryOptions"));
 
                 await host.StopAsync();
             }
@@ -980,7 +984,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             };
 
             const string activityFunctionName = "UnregisteredActivity";
-            string errorMessage = $"The function '{activityFunctionName}' doesn't exist, is disabled, or is not an activity function";
+            string errorMessage = $"Orchestrator function '{orchestratorFunctionNames[0]}' failed: The function '{activityFunctionName}' doesn't exist, is disabled, or is not an activity function";
 
             using (JobHost host = TestHelpers.GetJobHost(this.loggerFactory, nameof(this.Orchestration_OnUnregisteredActivity)))
             {

--- a/test/DurableTaskEndToEndTests.cs
+++ b/test/DurableTaskEndToEndTests.cs
@@ -566,7 +566,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         {
             string[] orchestratorFunctionNames =
             {
-                nameof(TestOrchestrations.Throw),
+                nameof(TestOrchestrations.ThrowOrchestrator),
             };
 
             using (JobHost host = TestHelpers.GetJobHost(this.loggerFactory, nameof(this.UnhandledOrchestrationException)))
@@ -578,7 +578,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 var status = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(10), this.output);
 
                 Assert.Equal(OrchestrationRuntimeStatus.Failed, status?.RuntimeStatus);
-                Assert.True(status?.Output.ToString().Contains("Value cannot be null"));
+
+                string output = status.Output.ToString();
+                this.output.WriteLine($"Orchestration output string: {output}");
+                Assert.StartsWith($"Orchestrator function '{orchestratorFunctionNames[0]}' failed: Value cannot be null.", output);
 
                 await host.StopAsync();
             }
@@ -783,7 +786,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 var status = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(50), this.output);
 
                 Assert.Equal(OrchestrationRuntimeStatus.Failed, status?.RuntimeStatus);
-                Assert.True(status?.Output.ToString().Contains("Value cannot be null"));
+
+                string output = status.Output.ToString();
+                this.output.WriteLine($"Orchestration output string: {output}");
+                Assert.StartsWith($"Orchestrator function '{orchestratorFunctionNames[0]}' failed: Orchestrator function 'ThrowOrchestrator' failed: Value cannot be null.", output);
 
                 await host.StopAsync();
             }
@@ -818,8 +824,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 var status = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(50), this.output);
 
                 Assert.Equal(OrchestrationRuntimeStatus.Failed, status?.RuntimeStatus);
-                Assert.True(status?.Output.ToString().Contains("Value cannot be null."));
-                Assert.True(status?.Output.ToString().Contains("Parameter name: retryOptions"));
+
+                string output = status.Output.ToString();
+                this.output.WriteLine($"Orchestration output string: {output}");
+                Assert.StartsWith(
+                    $"Orchestrator function '{orchestratorFunctionNames[0]}' failed: Value cannot be null. Parameter name: retryOptions",
+                    output);
 
                 await host.StopAsync();
             }
@@ -833,10 +843,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         {
             string[] orchestratorFunctionNames =
             {
-                nameof(TestOrchestrations.Throw),
+                nameof(TestOrchestrations.ThrowOrchestrator),
             };
 
-            string activityFunctionName = nameof(TestActivities.Throw);
+            string activityFunctionName = nameof(TestActivities.ThrowActivity);
 
             using (JobHost host = TestHelpers.GetJobHost(this.loggerFactory, nameof(this.UnhandledActivityException)))
             {
@@ -850,8 +860,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
                 Assert.Equal(OrchestrationRuntimeStatus.Failed, status?.RuntimeStatus);
 
-                // There aren't any exception details in the output: https://github.com/Azure/azure-functions-durable-extension/issues/84
-                Assert.StartsWith($"The activity function '{activityFunctionName}' failed.", (string)status?.Output);
+                string output = (string)status?.Output;
+                this.output.WriteLine($"Orchestration output string: {output}");
+                Assert.StartsWith(
+                    $"Orchestrator function '{orchestratorFunctionNames[0]}' failed: The activity function '{activityFunctionName}' failed: \"{message}\"",
+                    output);
 
                 await host.StopAsync();
             }
@@ -878,7 +891,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 nameof(TestOrchestrations.ActivityThrowWithRetry),
             };
 
-            string activityFunctionName = nameof(TestActivities.Throw);
+            string activityFunctionName = nameof(TestActivities.ThrowActivity);
 
             using (JobHost host = TestHelpers.GetJobHost(this.loggerFactory, nameof(this.UnhandledActivityExceptionWithRetry)))
             {
@@ -890,8 +903,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
                 Assert.Equal(OrchestrationRuntimeStatus.Failed, status?.RuntimeStatus);
 
-                // There aren't any exception details in the output: https://github.com/Azure/azure-functions-durable-extension/issues/84
-                Assert.StartsWith($"The activity function '{activityFunctionName}' failed.", (string)status?.Output);
+                string output = (string)status?.Output;
+                this.output.WriteLine($"Orchestration output string: {output}");
+                Assert.StartsWith(
+                    $"Orchestrator function '{orchestratorFunctionNames[0]}' failed: The activity function '{activityFunctionName}' failed: \"{message}\"",
+                    output);
 
                 await host.StopAsync();
             }
@@ -980,8 +996,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 var status = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(30), this.output);
 
                 Assert.Equal(OrchestrationRuntimeStatus.Failed, status?.RuntimeStatus);
-
-                // There aren't any exception details in the output: https://github.com/Azure/azure-functions-durable-extension/issues/84
                 Assert.StartsWith(errorMessage, (string)status?.Output);
 
                 await host.StopAsync();

--- a/test/DurableTaskLifeCycleNotificationTest.cs
+++ b/test/DurableTaskLifeCycleNotificationTest.cs
@@ -128,7 +128,7 @@ namespace WebJobs.Extensions.DurableTask.Tests
         {
             string[] orchestratorFunctionNames =
             {
-                nameof(TestOrchestrations.Throw),
+                nameof(TestOrchestrations.ThrowOrchestrator),
             };
 
             var eventGridKeyValue = "testEventGridKey";

--- a/test/TestActivities.cs
+++ b/test/TestActivities.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             return info.Length;
         }
 
-        public static void Throw([ActivityTrigger] DurableActivityContext ctx)
+        public static void ThrowActivity([ActivityTrigger] DurableActivityContext ctx)
         {
             string message = ctx.GetInput<string>();
             throw new Exception(message);

--- a/test/TestHelpers.cs
+++ b/test/TestHelpers.cs
@@ -298,13 +298,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             {
                 $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' scheduled. Reason: NewInstance. IsReplay: False.",
                 $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' started. IsReplay: False. Input: \"Kah-BOOOOM!!!\"",
-                $"{messageId}: Function '{activityFunctionName} ({FunctionType.Activity})', version '' scheduled. Reason: Throw. IsReplay: False.",
+                $"{messageId}: Function '{activityFunctionName} ({FunctionType.Activity})', version '' scheduled. Reason: ThrowOrchestrator. IsReplay: False.",
                 $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' awaited. IsReplay: False.",
                 $"{messageId}: Function '{activityFunctionName} ({FunctionType.Activity})', version '' started. IsReplay: False. Input: [\"Kah-BOOOOM!!!\"]",
-                $"{messageId}: Function '{activityFunctionName} ({FunctionType.Activity})', version '' failed with an error. Reason: Microsoft.Azure.WebJobs.Host.FunctionInvocationException",
+                $"{messageId}: Function '{activityFunctionName} ({FunctionType.Activity})', version '' failed with an error. Reason: System.Exception: Kah-BOOOOM!!!",
                 $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' started. IsReplay: True. Input: \"Kah-BOOOOM!!!\"",
-                $"{messageId}: Function '{activityFunctionName} ({FunctionType.Activity})', version '' scheduled. Reason: Throw. IsReplay: True.",
-                $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' failed with an error. Reason: Microsoft.Azure.WebJobs.FunctionFailedException",
+                $"{messageId}: Function '{activityFunctionName} ({FunctionType.Activity})', version '' scheduled. Reason: ThrowOrchestrator. IsReplay: True.",
+                $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' failed with an error. Reason: Microsoft.Azure.WebJobs.FunctionFailedException: The activity function 'ThrowActivity' failed: \"Kah-BOOOOM!!!\"",
             };
 
             return list;
@@ -319,7 +319,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 $"{messageId}: Function '{activityFunctionName} ({FunctionType.Activity})', version '' scheduled. Reason: ActivityThrowWithRetry. IsReplay: False.",
                 $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' awaited. IsReplay: False.",
                 $"{messageId}: Function '{activityFunctionName} ({FunctionType.Activity})', version '' started. IsReplay: False. Input: [\"Kah-BOOOOM!!!\"]",
-                $"{messageId}: Function '{activityFunctionName} ({FunctionType.Activity})', version '' failed with an error. Reason: Microsoft.Azure.WebJobs.Host.FunctionInvocationException",
+                $"{messageId}: Function '{activityFunctionName} ({FunctionType.Activity})', version '' failed with an error. Reason: System.Exception: Kah-BOOOOM!!!",
                 $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' started. IsReplay: True. Input: \"Kah-BOOOOM!!!\"",
                 $"{messageId}: Function '{activityFunctionName} ({FunctionType.Activity})', version '' scheduled. Reason: ActivityThrowWithRetry. IsReplay: True.",
                 $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' awaited. IsReplay: False.",
@@ -327,7 +327,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 $"{messageId}: Function '{activityFunctionName} ({FunctionType.Activity})', version '' scheduled. Reason: ActivityThrowWithRetry. IsReplay: True.",
                 $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' awaited. IsReplay: False.",
                 $"{messageId}: Function '{activityFunctionName} ({FunctionType.Activity})', version '' started. IsReplay: False. Input: [\"Kah-BOOOOM!!!\"]",
-                $"{messageId}: Function '{activityFunctionName} ({FunctionType.Activity})', version '' failed with an error. Reason: Microsoft.Azure.WebJobs.Host.FunctionInvocationException",
+                $"{messageId}: Function '{activityFunctionName} ({FunctionType.Activity})', version '' failed with an error. Reason: System.Exception: Kah-BOOOOM!!!",
                 $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' started. IsReplay: True. Input: \"Kah-BOOOOM!!!\"",
                 $"{messageId}: Function '{activityFunctionName} ({FunctionType.Activity})', version '' scheduled. Reason: ActivityThrowWithRetry. IsReplay: True.",
                 $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' awaited. IsReplay: False.",
@@ -335,13 +335,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 $"{messageId}: Function '{activityFunctionName} ({FunctionType.Activity})', version '' scheduled. Reason: ActivityThrowWithRetry. IsReplay: True.",
                 $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' awaited. IsReplay: False.",
                 $"{messageId}: Function '{activityFunctionName} ({FunctionType.Activity})', version '' started. IsReplay: False. Input: [\"Kah-BOOOOM!!!\"]",
-                $"{messageId}: Function '{activityFunctionName} ({FunctionType.Activity})', version '' failed with an error. Reason: Microsoft.Azure.WebJobs.Host.FunctionInvocationException",
+                $"{messageId}: Function '{activityFunctionName} ({FunctionType.Activity})', version '' failed with an error. Reason: System.Exception: Kah-BOOOOM!!!",
                 $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' started. IsReplay: True. Input: \"Kah-BOOOOM!!!\"",
                 $"{messageId}: Function '{activityFunctionName} ({FunctionType.Activity})', version '' scheduled. Reason: ActivityThrowWithRetry. IsReplay: True.",
                 $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' awaited. IsReplay: False.",
                 $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' started. IsReplay: True. Input: \"Kah-BOOOOM!!!\"",
                 $"{messageId}: Function '{activityFunctionName} ({FunctionType.Activity})', version '' scheduled. Reason: ActivityThrowWithRetry. IsReplay: True.",
-                $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' failed with an error. Reason: Microsoft.Azure.WebJobs.FunctionFailedException",
+                $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})', version '' failed with an error. Reason: Microsoft.Azure.WebJobs.FunctionFailedException: The activity function 'ThrowActivity' failed: \"Kah-BOOOOM!!!\"",
             };
 
             return list;

--- a/test/TestOrchestrations.cs
+++ b/test/TestOrchestrations.cs
@@ -126,7 +126,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             }
         }
 
-        public static async Task Throw([OrchestrationTrigger] DurableOrchestrationContext ctx)
+        public static async Task ThrowOrchestrator([OrchestrationTrigger] DurableOrchestrationContext ctx)
         {
             string message = ctx.GetInput<string>();
             if (string.IsNullOrEmpty(message) || message.Contains("null"))
@@ -136,7 +136,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             }
 
             // This throw happens in the implementation of an activity.
-            await ctx.CallActivityAsync(nameof(TestActivities.Throw), message);
+            await ctx.CallActivityAsync(nameof(TestActivities.ThrowActivity), message);
         }
 
         public static async Task OrchestratorGreeting([OrchestrationTrigger] DurableOrchestrationContext ctx)
@@ -153,7 +153,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             RetryOptions options = new RetryOptions(TimeSpan.FromSeconds(5), 3);
 
             // This throw happens in the implementation of an orchestrator.
-            await ctx.CallSubOrchestratorWithRetryAsync(nameof(TestOrchestrations.Throw), options, message);
+            await ctx.CallSubOrchestratorWithRetryAsync(nameof(TestOrchestrations.ThrowOrchestrator), options, message);
         }
 
         public static async Task OrchestratorWithRetry_NullRetryOptions([OrchestrationTrigger] DurableOrchestrationContext ctx)
@@ -163,7 +163,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             RetryOptions options = null;
 
             // This throw happens in the implementation of an orchestrator.
-            await ctx.CallSubOrchestratorWithRetryAsync(nameof(TestOrchestrations.Throw), options, message);
+            await ctx.CallSubOrchestratorWithRetryAsync(nameof(TestOrchestrations.ThrowOrchestrator), options, message);
         }
 
         public static async Task ActivityThrowWithRetry([OrchestrationTrigger] DurableOrchestrationContext ctx)
@@ -178,7 +178,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             RetryOptions options = new RetryOptions(TimeSpan.FromSeconds(5), 3);
 
             // This throw happens in the implementation of an activity.
-            await ctx.CallActivityWithRetryAsync(nameof(TestActivities.Throw), options, message);
+            await ctx.CallActivityWithRetryAsync(nameof(TestActivities.ThrowActivity), options, message);
         }
 
         public static async Task ActivityWithRetry_NullRetryOptions([OrchestrationTrigger] DurableOrchestrationContext ctx)
@@ -193,7 +193,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             RetryOptions options = null;
 
             // This throw happens in the implementation of an activity.
-            await ctx.CallActivityWithRetryAsync(nameof(TestActivities.Throw), options, message);
+            await ctx.CallActivityWithRetryAsync(nameof(TestActivities.ThrowActivity), options, message);
         }
 
         public static async Task<int> TryCatchLoop([OrchestrationTrigger] DurableOrchestrationContext ctx)
@@ -205,7 +205,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             {
                 try
                 {
-                    await ctx.CallActivityAsync(nameof(TestActivities.Throw), "Kah-BOOOOOM!!!");
+                    await ctx.CallActivityAsync(nameof(TestActivities.ThrowActivity), "Kah-BOOOOOM!!!");
                 }
                 catch (FunctionFailedException)
                 {

--- a/test/WebJobs.Extensions.DurableTask.Tests.csproj
+++ b/test/WebJobs.Extensions.DurableTask.Tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="DurableTask.AzureStorage" Version="1.1.4-beta" />
+    <PackageReference Include="DurableTask.AzureStorage" Version="1.1.6-beta" />
     <PackageReference Include="FluentAssertions" Version="4.19.4" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.0-beta5" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" Version="3.0.0-beta5" />


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-functions-durable-extension/issues/84. The new behavior is that activity and sub-orchestrator functions will continue to throw `FunctionFailedException`, but the `InnerException` will now contain the details of the original exception.

This required taking a new version of **DurableTask.Core**, which has fixes for https://github.com/Azure/azure-functions-durable-extension/issues/146 as well.