### PR TITLE
Expose parent orchestration instance id in a sub-orchestrator

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/DurableOrchestrationContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableOrchestrationContext.cs
@@ -53,6 +53,9 @@ namespace Microsoft.Azure.WebJobs
         /// <inheritdoc />
         public override string InstanceId => this.innerContext.OrchestrationInstance.InstanceId;
 
+        /// <inheritdoc cref="DurableOrchestrationClientBase" />
+        public new string ParentInstanceId { get; internal set; }
+
         /// <inheritdoc />
         public override DateTime CurrentUtcDateTime => this.innerContext.CurrentUtcDateTime;
 

--- a/src/WebJobs.Extensions.DurableTask/DurableOrchestrationContextBase.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableOrchestrationContextBase.cs
@@ -25,6 +25,18 @@ namespace Microsoft.Azure.WebJobs
         public abstract string InstanceId { get;  }
 
         /// <summary>
+        /// Gets the parent instance ID of the currently executing sub-orchestration.
+        /// </summary>
+        /// <remarks>
+        /// The parent instance ID is generated and fixed when the parent orchestrator function is scheduled. It can be either
+        /// auto-generated, in which case it is formatted as a GUID, or it can be user-specified with any format.
+        /// </remarks>
+        /// <value>
+        /// The ID of the parent orchestration of the current sub-orchestration instance. The value will be available only in sub-orchestrations.
+        /// </value>
+        public virtual string ParentInstanceId { get; }
+
+        /// <summary>
         /// Gets the current date/time in a way that is safe for use by orchestrator functions.
         /// </summary>
         /// <remarks>

--- a/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
@@ -276,6 +276,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             TaskOrchestrationShim shim = (TaskOrchestrationShim)dispatchContext.GetProperty<TaskOrchestration>();
             DurableOrchestrationContext context = shim.Context;
 
+            OrchestrationRuntimeState orchestrationRuntimeState = dispatchContext.GetProperty<OrchestrationRuntimeState>();
+
+            if (orchestrationRuntimeState.ParentInstance != null)
+            {
+                context.ParentInstanceId = orchestrationRuntimeState.ParentInstance.OrchestrationInstance.InstanceId;
+            }
+
             FunctionName orchestratorFunction = new FunctionName(context.Name, context.Version);
 
             ITriggeredFunctionExecutor executor;

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
@@ -430,6 +430,9 @@
         <member name="P:Microsoft.Azure.WebJobs.DurableOrchestrationContext.InstanceId">
             <inheritdoc />
         </member>
+        <member name="P:Microsoft.Azure.WebJobs.DurableOrchestrationContext.ParentInstanceId">
+            <inheritdoc cref="T:Microsoft.Azure.WebJobs.DurableOrchestrationClientBase" />
+        </member>
         <member name="P:Microsoft.Azure.WebJobs.DurableOrchestrationContext.CurrentUtcDateTime">
             <inheritdoc />
         </member>
@@ -503,6 +506,18 @@
             </remarks>
             <value>
             The ID of the current orchestration instance.
+            </value>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.DurableOrchestrationContextBase.ParentInstanceId">
+            <summary>
+            Gets the parent instance ID of the currently executing sub-orchestration.
+            </summary>
+            <remarks>
+            The parent instance ID is generated and fixed when the parent orchestrator function is scheduled. It can be either
+            auto-generated, in which case it is formatted as a GUID, or it can be user-specified with any format.
+            </remarks>
+            <value>
+            The ID of the parent orchestration of the current sub-orchestration instance. The value will be available only in sub-orchestrations.
             </value>
         </member>
         <member name="P:Microsoft.Azure.WebJobs.DurableOrchestrationContextBase.CurrentUtcDateTime">

--- a/test/TestOrchestrations.cs
+++ b/test/TestOrchestrations.cs
@@ -236,6 +236,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             return result;
         }
 
+        public static string ProvideParentInstanceId([OrchestrationTrigger] DurableOrchestrationContext ctx)
+        {
+            return ctx.ParentInstanceId;
+        }
+
         public static async Task<object> CallOrchestrator([OrchestrationTrigger] DurableOrchestrationContext ctx)
         {
             // Using StartOrchestrationArgs to start an orchestrator function because it's easier than creating a new type.


### PR DESCRIPTION
Hello @cgillum ,

May I ask you when you have time to check this implementation for exposing parent orchestrator instance id in the sub-orchestrator as specified here - [#246](https://github.com/Azure/azure-functions-durable-extension/issues/246).

Thank you!
