### PR TITLE
Returing 500 Http Status code on Orchestrator failure

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
+++ b/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
@@ -169,8 +169,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     location = request.RequestUri;
                     break;
 
-                // The orchestration is not running - return 202 w/out Location header
+                // The orchestration has failed - return 500 w/out Location header
                 case OrchestrationRuntimeStatus.Failed:
+                    statusCode = HttpStatusCode.InternalServerError;
+                    location = null;
+                    break;
+
+                // The orchestration is not running - return 200 w/out Location header
                 case OrchestrationRuntimeStatus.Canceled:
                 case OrchestrationRuntimeStatus.Terminated:
                 case OrchestrationRuntimeStatus.Completed:

--- a/test/HttpApiHandlerTests.cs
+++ b/test/HttpApiHandlerTests.cs
@@ -163,7 +163,7 @@ namespace WebJobs.Extensions.DurableTask.Tests
         [Fact]
         public async Task WaitForCompletionOrCreateCheckStatusResponseAsync_Returns_Defaults_When_Runtime_Status_is_Failed()
         {
-            await this.CheckRuntimeStatus(TestConstants.InstanceIdFailed, OrchestrationRuntimeStatus.Failed);
+            await this.CheckRuntimeStatus(TestConstants.InstanceIdFailed, OrchestrationRuntimeStatus.Failed, HttpStatusCode.InternalServerError);
         }
 
         [Fact]
@@ -178,7 +178,7 @@ namespace WebJobs.Extensions.DurableTask.Tests
             await this.CheckRuntimeStatus(TestConstants.InstanceIdCanceled, OrchestrationRuntimeStatus.Canceled);
         }
 
-        private async Task CheckRuntimeStatus(string instanceId, OrchestrationRuntimeStatus runtimeStatus)
+        private async Task CheckRuntimeStatus(string instanceId, OrchestrationRuntimeStatus runtimeStatus, HttpStatusCode httpStatusCode = HttpStatusCode.OK)
         {
             var httpApiHandler = new HttpApiHandler(new DurableTaskExtensionMock() { NotificationUrl = new Uri(TestConstants.NotificationUrl) }, null);
             var httpResponseMessage = await httpApiHandler.WaitForCompletionOrCreateCheckStatusResponseAsync(
@@ -194,7 +194,7 @@ namespace WebJobs.Extensions.DurableTask.Tests
                 },
                 TimeSpan.FromSeconds(30),
                 TimeSpan.FromSeconds(8));
-            Assert.Equal(httpResponseMessage.StatusCode, HttpStatusCode.OK);
+            Assert.Equal(httpResponseMessage.StatusCode, httpStatusCode);
             var content = await httpResponseMessage.Content.ReadAsStringAsync();
             var response = JsonConvert.DeserializeObject<JObject>(content);
             Assert.Equal(response["runtimeStatus"], runtimeStatus.ToString());


### PR DESCRIPTION
Hello @cgillum,

I started to think how we can implement this issue - [154](https://github.com/Azure/azure-functions-durable-extension/issues/154).

May I ask you when you have time to review the proposed changes and let me know if the current approach is correct?

Thank you! 
