### PR TITLE
Fix isOutOfProc detection logic to work with DurableOrchestrationContextBase

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/Bindings/OrchestrationTriggerAttributeBindingProvider.cs
+++ b/src/WebJobs.Extensions.DurableTask/Bindings/OrchestrationTriggerAttributeBindingProvider.cs
@@ -136,7 +136,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     throw new ArgumentNullException(nameof(context));
                 }
 
-                var isOutOfProc = this.parameterInfo.ParameterType != typeof(DurableOrchestrationContext);
+                // The current assumption is that in-proc (.NET) apps always use
+                // DurableOrchestrationContextBase or some derivative. Non-.NET apps
+                // which cannot use these types are therefore assumed to be "out-of-proc".
+                // We may need to revisit this assumption when Functions v2 adds support
+                // for "out-of-proc" .NET.
+                var isOutOfProc = !typeof(DurableOrchestrationContextBase).IsAssignableFrom(this.parameterInfo.ParameterType);
                 this.config.RegisterOrchestrator(this.orchestratorName, new OrchestratorInfo(context.Executor, isOutOfProc));
 
                 var listener = new DurableTaskListener(


### PR DESCRIPTION
The C# **E1_HelloSequence** sample silently hangs when run with the latest code from **dev**. Further investigation revealed that this is due to the `isOutOfProc` check.

The problem is that **E1_HelloSequence** uses `DurableOrchestrationContextBase` instead of `DurableOrchestrationContext`. The `isOutOfProc` logic only checked for `DurableOrchestrationContext` as the orchestration argument type, so it incorrectly thought the C# **E1_HelloSequence** orchestrator function was out-of-proc.  This resulted in a hang because the shim was blocking on `Task.Result`, which never completes by-design for in-proc orchestrations.

The fix is to make `isOutOfProc` aware of `DurableOrchestrationContextBase`.