### PR TITLE
Change custom Event Grid eventType property from an int to a string

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/LifeCycleNotificationHelper.cs
+++ b/src/WebJobs.Extensions.DurableTask/LifeCycleNotificationHelper.cs
@@ -210,7 +210,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                         FunctionName = functionName,
                         InstanceId = instanceId,
                         Reason = reason,
-                        EventType = orchestrationRuntimeStatus,
+                        RuntimeStatus = $"{orchestrationRuntimeStatus}",
                     },
                     DataVersion = "1.0",
                 },
@@ -233,8 +233,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             [JsonProperty(PropertyName = "reason")]
             public string Reason { get; set; }
 
-            [JsonProperty(PropertyName = "eventType")]
-            public OrchestrationRuntimeStatus EventType { get; set; }
+            [JsonProperty(PropertyName = "runtimeStatus")]
+            public string RuntimeStatus { get; set; }
         }
 
         private class EventGridEvent

--- a/src/WebJobs.Extensions.DurableTask/LifeCycleNotificationHelper.cs
+++ b/src/WebJobs.Extensions.DurableTask/LifeCycleNotificationHelper.cs
@@ -210,7 +210,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                         FunctionName = functionName,
                         InstanceId = instanceId,
                         Reason = reason,
-                        RuntimeStatus = $"{orchestrationRuntimeStatus}",
+                        RuntimeStatus = orchestrationRuntimeStatus.ToString(),
                     },
                     DataVersion = "1.0",
                 },

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
@@ -138,7 +138,7 @@
             </summary>
             <remarks>
             <para>Extended sessions can improve the performance of orchestrator functions by allowing them to skip
-            replays when new messages and received within short periods of time.</para>
+            replays when new messages are received within short periods of time.</para>
             <para>Note that orchestrator functions which are extended this way will continue to count against the
             <see cref="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.MaxConcurrentOrchestratorFunctions"/> limit. To avoid starvation, only half of the maximum
             number of allowed concurrent orchestrator functions can be concurrently extended at any given time.

--- a/test/DurableTaskLifeCycleNotificationTest.cs
+++ b/test/DurableTaskLifeCycleNotificationTest.cs
@@ -81,13 +81,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                         {
                             Assert.Equal("durable/orchestrator/Running", (string)o.subject);
                             Assert.Equal("orchestratorEvent", (string)o.eventType);
-                            Assert.Equal(0, (int)o.data.eventType);
+                            Assert.Equal("Running", (string)o.data.runtimeStatus);
                         }
                         else if (callCount == 1)
                         {
                             Assert.Equal("durable/orchestrator/Completed", (string)o.subject);
                             Assert.Equal("orchestratorEvent", (string)o.eventType);
-                            Assert.Equal(1, (int?)o.data.eventType);
+                            Assert.Equal("Completed", (string)o.data.runtimeStatus);
                         }
                         else
                         {
@@ -162,13 +162,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                         {
                             Assert.Equal("durable/orchestrator/Running", (string)o.subject);
                             Assert.Equal("orchestratorEvent", (string)o.eventType);
-                            Assert.Equal(0, (int)o.data.eventType);
+                            Assert.Equal("Running", (string)o.data.runtimeStatus);
                         }
                         else if (callCount == 1)
                         {
                             Assert.Equal("durable/orchestrator/Failed", (string)o.subject);
                             Assert.Equal("orchestratorEvent", (string)o.eventType);
-                            Assert.Equal(3, (int?)o.data.eventType);
+                            Assert.Equal("Failed", (string)o.data.runtimeStatus);
                         }
                         else
                         {
@@ -243,13 +243,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                         {
                             Assert.Equal("durable/orchestrator/Running", (string)o.subject);
                             Assert.Equal("orchestratorEvent", (string)o.eventType);
-                            Assert.Equal(0, (int)o.data.eventType);
+                            Assert.Equal("Running", (string)o.data.runtimeStatus);
                         }
                         else if (callCount == 1)
                         {
                             Assert.Equal("durable/orchestrator/Terminated", (string)o.subject);
                             Assert.Equal("orchestratorEvent", (string)o.eventType);
-                            Assert.Equal(5, (int?)o.data.eventType);
+                            Assert.Equal("Terminated", (string)o.data.runtimeStatus);
                         }
                         else
                         {
@@ -330,13 +330,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                         {
                             Assert.Equal("durable/orchestrator/Running", (string)o.subject);
                             Assert.Equal("orchestratorEvent", (string)o.eventType);
-                            Assert.Equal(0, (int)o.data.eventType);
+                            Assert.Equal("Running", (string)o.data.runtimeStatus);
                         }
                         else if (callCount == 1)
                         {
                             Assert.Equal("durable/orchestrator/Completed", (string)o.subject);
                             Assert.Equal("orchestratorEvent", (string)o.eventType);
-                            Assert.Equal(1, (int?)o.data.eventType);
+                            Assert.Equal("Completed", (string)o.data.runtimeStatus);
                         }
                         else
                         {


### PR DESCRIPTION
This pull request is for the https://github.com/Azure/azure-functions-durable-extension/issues/285 . 

I change EventGridPayload eventType -> runtimeStatus. 

Here is an example of the current paylod:

```
[
  {
    "id": "aeafd489-ee98-4b2e-b77f-2aac2594b4b2",
    "topic": null,
    "subject": "durable/orchestrator/Running",
    "data": {
      "hubName": "DFHub",
      "functionName": "Counter",
      "instanceId": "13b602a9d2914d7c981016acbee0b941",
      "reason": "",
      "eventType": 0
    },
    "eventType": "orchestratorEvent",
    "eventTime": "2018-04-29T04:41:43.5299974Z",
    "metadataVersion": null,
    "dataVersion": "1.0"
  }
]
```

This pull request change it like this. 

```
[
  {
    "id": "aeafd489-ee98-4b2e-b77f-2aac2594b4b2",
    "topic": null,
    "subject": "durable/orchestrator/Running",
    "data": {
      "hubName": "DFHub",
      "functionName": "Counter",
      "instanceId": "13b602a9d2914d7c981016acbee0b941",
      "reason": "",
      "runtimeStatus": "Running"
    },
    "eventType": "orchestratorEvent",
    "eventTime": "2018-04-29T04:41:43.5299974Z",
    "metadataVersion": null,
    "dataVersion": "1.0"
  }
]
```
@cgillum , However, I have local unit testing problem. Please Full CI for this pull request. 
I tested in my environment, the all tests related this change is all pass. However, some test fails for Timeout.  (Obviously, it is not related this change). 

Failed Tests are

* DurableTaskEndToEndTests
* HandledActivityException
* OrchestrationConcurrency
* TimerCancellation

Please have a look. 
 
