### PR TITLE
Fix: MessagePayloadDataConverter can't deserialize to string

### DIFF
--- a/samples/javascript/E3_GetIsClear/function.json
+++ b/samples/javascript/E3_GetIsClear/function.json
@@ -1,0 +1,10 @@
+{
+  "bindings": [
+    {
+      "name": "location",
+      "type": "activityTrigger",
+      "direction": "in"
+    }
+  ],
+  "disabled": false
+}

--- a/samples/javascript/E3_GetIsClear/index.js
+++ b/samples/javascript/E3_GetIsClear/index.js
@@ -1,0 +1,37 @@
+const request = require("request");
+
+const clearWeatherConditions = ['Overcast', 'Clear', 'Partly Cloudy', 'Mostly Cloudy', 'Scattered Clouds'];
+
+module.exports = function (context, location) {
+    getCurrentConditions(location)
+        .then(function (data) {
+            const isClear = clearWeatherConditions.includes(data.weather);
+            context.done(null, isClear);
+        })
+        .catch(function (err) {
+            context.log(`E3_GetIsClear encountered an error: ${err}`);
+            context.done(err);
+        });
+};
+
+function getCurrentConditions(location) {
+    return new Promise(function (resolve, reject) {
+        const options = {
+            url: `https://api.wunderground.com/api/${process.env["WeatherUndergroundApiKey"]}/conditions/q/${location.state}/${location.city}.json`,
+            method: 'GET',
+            json: true
+        };
+        request(options, function (err, res, body) {
+            if (err) {
+                reject(err);
+            }
+            if (body.error) {
+                reject(body.error);
+            }
+            if (body.response.error) {
+                reject(body.response.error);
+            }
+            resolve(body.current_observation);
+        });
+    });
+}

--- a/samples/javascript/E3_Monitor/function.json
+++ b/samples/javascript/E3_Monitor/function.json
@@ -1,0 +1,10 @@
+{
+  "bindings": [
+    {
+      "name": "context",
+      "type": "orchestrationTrigger",
+      "direction": "in"
+    }
+  ],
+  "disabled": false
+}

--- a/samples/javascript/E3_Monitor/index.js
+++ b/samples/javascript/E3_Monitor/index.js
@@ -1,0 +1,51 @@
+const df = require("durable-functions");
+const moment = require('moment');
+
+module.exports = df(function*(context) {
+    const input = context.df.getInput();
+    context.log("Received monitor request. location: " + (input ? input.location : undefined)
+        + ". phone: " + (input ? input.phone : undefined) + ".");
+
+    verifyRequest(input);
+
+    const endTime = moment.utc(context.df.currentUtcDateTime).add(6, 'h');
+    context.log("Instantiating monitor for " + input.location.city + ", " + input.location.state
+        + ". Expires: " + (endTime) + "."); // tostring in JavaScript?
+
+    while (moment.utc(context.df.currentUtcDateTime).isBefore(endTime)) {
+        // Check the weather
+        context.log("Checking current weather conditions for " + input.location.city + ", "
+            + input.location.state + " at " + context.df.currentUtcDateTime + ".");
+        const isClear = yield context.df.callActivityAsync("E3_GetIsClear", input.location);
+
+        if (isClear) {
+            // It's not raining! Or snowing. Or misting. Tell our user to take advantage of it.
+            context.log("Detected clear weather for " + input.location.city + ", "
+                + input.location.state + ". Notifying " + input.phone + ".");
+
+                yield context.df.callActivityAsync("E3_SendGoodWeatherAlert", input.phone);
+                break;
+        } else {
+            // Wait for the next checkpoint
+            var nextCheckpoint = moment.utc(context.df.currentUtcDateTime).add(30, 's');
+            context.log("Next check for " + input.location.city + ", " + input.location.state
+                + " at " + nextCheckpoint.toString());
+
+            yield context.df.createTimer(nextCheckpoint.toDate());   // accomodate cancellation tokens
+        }
+    }
+
+    context.log("Monitor expiring.");
+});
+
+function verifyRequest(request) {
+    if (!request) {
+        throw new Error("An input object is required.");
+    }
+    if (!request.location) {
+        throw new Error("A location input is required.");
+    }
+    if (!request.phone) {
+        throw new Error("A phone number input is required.");
+    }
+}

--- a/samples/javascript/E3_SendGoodWeatherAlert/function.json
+++ b/samples/javascript/E3_SendGoodWeatherAlert/function.json
@@ -1,0 +1,18 @@
+{
+    "bindings": [
+      {
+        "name": "phoneNumber",
+        "type": "activityTrigger",
+        "direction": "in"
+      },
+      {
+        "type": "twilioSms",
+        "name": "message",
+        "from": "%TwilioPhoneNumber%",
+        "accountSidSetting": "TwilioAccountSid",
+        "authTokenSetting": "TwilioAuthToken",
+        "direction": "out"
+      }
+    ],
+    "disabled": false
+  }

--- a/samples/javascript/E3_SendGoodWeatherAlert/index.js
+++ b/samples/javascript/E3_SendGoodWeatherAlert/index.js
@@ -1,0 +1,8 @@
+module.exports = function(context, phoneNumber) {
+    context.bindings.message = {
+        body: `The weather's clear outside! Go take a walk!`,
+        to: phoneNumber
+    };
+
+    context.done();
+};

--- a/samples/javascript/E4_SendSmsChallenge/function.json
+++ b/samples/javascript/E4_SendSmsChallenge/function.json
@@ -1,0 +1,18 @@
+{
+  "bindings": [
+    {
+      "name": "phoneNumber",
+      "type": "activityTrigger",
+      "direction": "in"
+    },
+    {
+      "type": "twilioSms",
+      "name": "message",
+      "from": "%TwilioPhoneNumber%",
+      "accountSidSetting": "TwilioAccountSid",
+      "authTokenSetting": "TwilioAuthToken",
+      "direction": "out"
+    }
+  ],
+  "disabled": false
+}

--- a/samples/javascript/E4_SendSmsChallenge/index.js
+++ b/samples/javascript/E4_SendSmsChallenge/index.js
@@ -1,0 +1,17 @@
+const seedrandom = require("seedrandom");
+const uuidv1 = require("uuid/v1");
+
+module.exports = function (context, phoneNumber) {
+    // Get a random number generator with a random seed (not time-based)
+    const rand = seedrandom(uuidv1());
+    const challengeCode = Math.floor(rand() * 10000);
+
+    context.log(`Sending verification code ${challengeCode} to ${phoneNumber}.`);
+
+    context.bindings.message = {
+        body: `Your verification code is ${challengeCode.toPrecision(4)}`,
+        to: phoneNumber
+    };
+
+    context.done(null, challengeCode);
+};

--- a/samples/javascript/E4_SmsPhoneVerification/function.json
+++ b/samples/javascript/E4_SmsPhoneVerification/function.json
@@ -1,0 +1,10 @@
+{
+  "bindings": [
+    {
+      "name": "context",
+      "type": "orchestrationTrigger",
+      "direction": "in"
+    }
+  ],
+  "disabled": false
+}

--- a/samples/javascript/E4_SmsPhoneVerification/index.js
+++ b/samples/javascript/E4_SmsPhoneVerification/index.js
@@ -1,0 +1,40 @@
+const df = require("durable-functions");
+const moment = require('moment');
+
+module.exports = df(function*(context) {
+    const phoneNumber = context.df.getInput();
+    if (!phoneNumber) {
+        throw "A phone number input is required.";
+    }
+
+    const challengeCode = yield context.df.callActivityAsync("E4_SendSmsChallenge", phoneNumber);
+
+    // The user has 90 seconds to respond with the code they received in the SMS message.
+    const expiration = moment.utc(context.df.currentUtcDateTime).add(90, 's');
+    const timeoutTask = context.df.createTimer(expiration.toDate());
+
+    let authorized = false;
+    for (let i = 0; i <= 3; i++) {
+        const challengeResponseTask = context.df.waitForExternalEvent("SmsChallengeResponse");
+
+        const winner = yield context.df.Task.any([challengeResponseTask, timeoutTask]);
+
+        if (winner === challengeResponseTask) {
+            // We got back a response! Compare it to the challenge code.
+            if (challengeResponseTask.result === challengeCode) {
+                authorized = true;
+                break;
+            }
+        } else {
+            // Timeout expired
+            break;
+        }
+    }
+
+    if (!timeoutTask.isCompleted) {
+        // All pending timers must be complete or canceled before the function exits.
+        timeoutTask.cancel();
+    }
+
+    return authorized;
+});

--- a/samples/javascript/package-lock.json
+++ b/samples/javascript/package-lock.json
@@ -570,6 +570,11 @@
       "resolved": "https://registry.npmjs.org/sax/-/sax-0.5.8.tgz",
       "integrity": "sha1-1HLbIo6zMcJQaw6MFVJK25OdEsE="
     },
+    "seedrandom": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-2.4.3.tgz",
+      "integrity": "sha1-JDhQTa0zkXMUv/GKxNeU8W1qrsw="
+    },
     "set-immediate-shim": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",

--- a/samples/javascript/package.json
+++ b/samples/javascript/package.json
@@ -6,6 +6,7 @@
         "durable-functions": "^0.0.3",
         "moment": "^2.22.1",
         "readdirp": "^2.1.0",
+        "seedrandom": "^2.4.3",
         "uuid": "^3.2.1"
     }
 }

--- a/src/WebJobs.Extensions.DurableTask/MessagePayloadDataConverter.cs
+++ b/src/WebJobs.Extensions.DurableTask/MessagePayloadDataConverter.cs
@@ -69,5 +69,21 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
             return serializedJson;
         }
+
+        /// <summary>
+        /// JSON-deserializes the specified string to the specified object type.
+        /// </summary>
+        public override object Deserialize(string data, Type objectType)
+        {
+            // Deserializing to a string throws an exception.
+            if (objectType.Equals(typeof(string)))
+            {
+                return data;
+            }
+            else
+            {
+                return base.Deserialize(data, objectType);
+            }
+        }
     }
 }


### PR DESCRIPTION
Due to Json.NET's JsonSerializer class throwing an exception when presented with stringified JSON and a target type of string.

Knock-on effect of bindings for out of proc functions being strings, not JObjects. (Did we ever figure that out?) This was keeping JavaScript activity functions from successfully binding to JSON data.