### PR TITLE
APIs to enumerate all orchestration instances

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/DurableOrchestrationClientBase.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableOrchestrationClientBase.cs
@@ -2,7 +2,9 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Extensions.DurableTask;
 
@@ -176,5 +178,14 @@ namespace Microsoft.Azure.WebJobs
         /// <param name="showHistoryOutput">Boolean marker for including input and output in the execution history response.</param>
         /// <returns>Returns a task which completes when the status has been fetched.</returns>
         public abstract Task<DurableOrchestrationStatus> GetStatusAsync(string instanceId, bool showHistory, bool showHistoryOutput);
+
+        /// <summary>
+        /// Gets all the status of the orchestration instances.
+        /// </summary>
+        /// <param name="showHistory">Boolean marker for including execution history in the response.</param>
+        /// <param name="showHistoryOutput">Boolean marker for including input and output in the execution history response.</param>
+        /// <param name="cancellationToken">Cancel your request by this token</param>
+        /// <returns>Returns orchestration status for all instances.</returns>
+        public abstract Task<IList<DurableOrchestrationStatus>> GetStatusAsync(bool showHistory = false, bool showHistoryOutput = false, CancellationToken cancellationToken = default(CancellationToken));
     }
 }

--- a/src/WebJobs.Extensions.DurableTask/DurableOrchestrationClientBase.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableOrchestrationClientBase.cs
@@ -182,7 +182,7 @@ namespace Microsoft.Azure.WebJobs
         /// <summary>
         /// Gets all the status of the orchestration instances.
         /// </summary>
-        /// <param name="cancellationToken">Cancel your request by this token</param>
+        /// <param name="cancellationToken">Cancellation token that can be used to cancel the status query operation.</param>
         /// <returns>Returns orchestration status for all instances.</returns>
         public abstract Task<IList<DurableOrchestrationStatus>> GetStatusAsync(CancellationToken cancellationToken = default(CancellationToken));
     }

--- a/src/WebJobs.Extensions.DurableTask/DurableOrchestrationClientBase.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableOrchestrationClientBase.cs
@@ -182,10 +182,8 @@ namespace Microsoft.Azure.WebJobs
         /// <summary>
         /// Gets all the status of the orchestration instances.
         /// </summary>
-        /// <param name="showHistory">Boolean marker for including execution history in the response.</param>
-        /// <param name="showHistoryOutput">Boolean marker for including input and output in the execution history response.</param>
         /// <param name="cancellationToken">Cancel your request by this token</param>
         /// <returns>Returns orchestration status for all instances.</returns>
-        public abstract Task<IList<DurableOrchestrationStatus>> GetStatusAsync(bool showHistory = false, bool showHistoryOutput = false, CancellationToken cancellationToken = default(CancellationToken));
+        public abstract Task<IList<DurableOrchestrationStatus>> GetStatusAsync(CancellationToken cancellationToken = default(CancellationToken));
     }
 }

--- a/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
+++ b/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
@@ -123,7 +123,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 string instanceId = path.Substring(i);
                 if (request.Method == HttpMethod.Get)
                 {
-                        return await this.HandleGetStatusRequestAsync(request, instanceId);
+                    return await this.HandleGetStatusRequestAsync(request, instanceId);
                 }
             }
             else if (request.Method == HttpMethod.Post)

--- a/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
+++ b/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
@@ -107,7 +107,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             {
                 // Retrive All Status in case of the request URL ends e.g. /instances/
                 if (request.Method == HttpMethod.Get
-                    && path.IndexOf(InstancesControllerSegment.TrimEnd('/'), StringComparison.OrdinalIgnoreCase) >= 0)
+                    && path.Equals(InstancesControllerSegment.TrimEnd('/'), StringComparison.OrdinalIgnoreCase))
                 {
                     return await this.HandleGetStatusRequestAsync(request);
                 }

--- a/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
+++ b/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
@@ -162,10 +162,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             HttpRequestMessage request)
         {
             DurableOrchestrationClientBase client = this.GetClient(request);
-            var status = await client.GetStatusAsync();
+            IList<DurableOrchestrationStatus> statusForAllInstances = await client.GetStatusAsync();
 
-            var results = new List<StatusResponsePayload>(status.Count);
-            foreach (var state in status)
+            var results = new List<StatusResponsePayload>(statusForAllInstances.Count);
+            foreach (var state in statusForAllInstances)
             {
                 results.Add(this.ConvertFrom(state));
             }

--- a/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
+++ b/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
@@ -105,6 +105,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             int i = path.IndexOf(InstancesControllerSegment, StringComparison.OrdinalIgnoreCase);
             if (i < 0)
             {
+                // Retrive All Status in case of the request URL ends e.g. /instances/
+                if (request.Method == HttpMethod.Get
+                    && path.IndexOf(InstancesControllerSegment.TrimEnd('/'), StringComparison.OrdinalIgnoreCase) >= 0)
+                {
+                    return await this.HandleGetStatusRequestAsync(request);
+                }
+
                 return request.CreateResponse(HttpStatusCode.NotFound);
             }
 
@@ -116,14 +123,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 string instanceId = path.Substring(i);
                 if (request.Method == HttpMethod.Get)
                 {
-                    if (instanceId == string.Empty)
-                    {
-                        return await this.HandleGetStatusRequestAsync(request);
-                    }
-                    else
-                    {
                         return await this.HandleGetStatusRequestAsync(request, instanceId);
-                    }
                 }
             }
             else if (request.Method == HttpMethod.Post)
@@ -251,6 +251,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         {
             return new StatusResponsePayload
             {
+                InstanceId = status.InstanceId,
                 RuntimeStatus = status.RuntimeStatus.ToString(),
                 Input = status.Input,
                 CustomStatus = status.CustomStatus,

--- a/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
+++ b/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
@@ -161,23 +161,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         private async Task<HttpResponseMessage> HandleGetStatusRequestAsync(
             HttpRequestMessage request)
         {
-            try
-            {
-                DurableOrchestrationClientBase client = this.GetClient(request);
-                var status = await client.GetStatusAsync();
+            DurableOrchestrationClientBase client = this.GetClient(request);
+            var status = await client.GetStatusAsync();
 
-                var results = new List<StatusResponsePayload>(status.Count);
-                foreach (var state in status)
-                {
-                    results.Add(this.ConvertFrom(state));
-                }
-
-                return request.CreateResponse(HttpStatusCode.OK, results);
-            }
-            catch (Exception e)
+            var results = new List<StatusResponsePayload>(status.Count);
+            foreach (var state in status)
             {
-                return request.CreateErrorResponse(HttpStatusCode.InternalServerError, "Internal Server Error", e);
+                results.Add(this.ConvertFrom(state));
             }
+
+            return request.CreateResponse(HttpStatusCode.OK, results);
         }
 
         private async Task<HttpResponseMessage> HandleGetStatusRequestAsync(

--- a/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
+++ b/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
@@ -106,9 +106,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             if (i < 0)
             {
                 // Retrive All Status in case of the request URL ends e.g. /instances/
-                int indexOfSegment = request.RequestUri.AbsolutePath.TrimEnd('/').IndexOf(InstancesControllerSegment.TrimEnd('/'), StringComparison.OrdinalIgnoreCase);
                 if (request.Method == HttpMethod.Get
-                    && string.Equals(path?.Substring(indexOfSegment), InstancesControllerSegment.TrimEnd('/'), StringComparison.OrdinalIgnoreCase))
+                    && path.EndsWith(InstancesControllerSegment.TrimEnd('/'), StringComparison.OrdinalIgnoreCase))
                 {
                     return await this.HandleGetStatusRequestAsync(request);
                 }

--- a/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
+++ b/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
@@ -106,8 +106,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             if (i < 0)
             {
                 // Retrive All Status in case of the request URL ends e.g. /instances/
+                int indexOfSegment = request.RequestUri.AbsolutePath.TrimEnd('/').IndexOf(InstancesControllerSegment.TrimEnd('/'), StringComparison.OrdinalIgnoreCase);
                 if (request.Method == HttpMethod.Get
-                    && path.Equals(InstancesControllerSegment.TrimEnd('/'), StringComparison.OrdinalIgnoreCase))
+                    && string.Equals(path?.Substring(indexOfSegment), InstancesControllerSegment.TrimEnd('/'), StringComparison.OrdinalIgnoreCase))
                 {
                     return await this.HandleGetStatusRequestAsync(request);
                 }

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
@@ -307,6 +307,11 @@
             Response for Orchestration Status Query.
             </summary>
         </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.StatusResponsePayload.InstanceId">
+            <summary>
+            InstanceId.
+            </summary>
+        </member>
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.StatusResponsePayload.RuntimeStatus">
             <summary>
             Runtime status.
@@ -420,6 +425,9 @@
             <inheritdoc />
         </member>
         <member name="M:Microsoft.Azure.WebJobs.DurableOrchestrationClient.GetStatusAsync(System.String,System.Boolean,System.Boolean)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.DurableOrchestrationClient.GetStatusAsync(System.Threading.CancellationToken)">
             <inheritdoc />
         </member>
         <member name="T:Microsoft.Azure.WebJobs.DurableOrchestrationClientBase">
@@ -558,6 +566,13 @@
             <param name="showHistory">Boolean marker for including execution history in the response.</param>
             <param name="showHistoryOutput">Boolean marker for including input and output in the execution history response.</param>
             <returns>Returns a task which completes when the status has been fetched.</returns>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.DurableOrchestrationClientBase.GetStatusAsync(System.Threading.CancellationToken)">
+            <summary>
+            Gets all the status of the orchestration instances.
+            </summary>
+            <param name="cancellationToken">Cancellation token that can be used to cancel the status query operation.</param>
+            <returns>Returns orchestration status for all instances.</returns>
         </member>
         <member name="T:Microsoft.Azure.WebJobs.DurableOrchestrationContext">
             <summary>

--- a/src/WebJobs.Extensions.DurableTask/StatusResponsePayload.cs
+++ b/src/WebJobs.Extensions.DurableTask/StatusResponsePayload.cs
@@ -13,6 +13,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
     internal class StatusResponsePayload
     {
         /// <summary>
+        /// InstanceId.
+        /// </summary>
+        [DataMember(Name = "instanceId")]
+        public JToken InstanceId { get; set; }
+
+        /// <summary>
         /// Runtime status.
         /// </summary>
         [DataMember(Name = "runtimeStatus")]

--- a/src/WebJobs.Extensions.DurableTask/StatusResponsePayload.cs
+++ b/src/WebJobs.Extensions.DurableTask/StatusResponsePayload.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// InstanceId.
         /// </summary>
         [DataMember(Name = "instanceId")]
-        public JToken InstanceId { get; set; }
+        public string InstanceId { get; set; }
 
         /// <summary>
         /// Runtime status.

--- a/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
+++ b/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
@@ -11,10 +11,6 @@
     <Company>Microsoft Corporation</Company>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="DurableTask.AzureStorage" Version="1.2.2" />
-  </ItemGroup>
-
   <ItemGroup Condition="'$(Configuration)' == 'Debug'">
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta006" />
   </ItemGroup>
@@ -30,6 +26,11 @@
   <ItemGroup>
     <AdditionalFiles Include="..\..\.stylecop\stylecop.json" />
     <Compile Include="..\..\.stylecop\GlobalSuppressions.cs" Link="GlobalSuppressions.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="DurableTask.AzureStorage" Version="1.2.2" />
+    <PackageReference Include="DurableTask.Core" Version="2.0.0.5" />
   </ItemGroup>
 
   <!-- NuGet Publishing Metadata -->

--- a/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
+++ b/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
@@ -29,7 +29,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="DurableTask.AzureStorage" Version="1.2.2" />
+    <PackageReference Include="DurableTask.AzureStorage" Version="1.2.3" />
+    <PackageReference Include="DurableTask.Core" Version="2.0.0.6" />
   </ItemGroup>
 
   <!-- NuGet Publishing Metadata -->

--- a/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
+++ b/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
@@ -30,7 +30,6 @@
 
   <ItemGroup>
     <PackageReference Include="DurableTask.AzureStorage" Version="1.2.3" />
-    <PackageReference Include="DurableTask.Core" Version="2.0.0.6" />
   </ItemGroup>
 
   <!-- NuGet Publishing Metadata -->

--- a/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
+++ b/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
@@ -30,7 +30,6 @@
 
   <ItemGroup>
     <PackageReference Include="DurableTask.AzureStorage" Version="1.2.2" />
-    <PackageReference Include="DurableTask.Core" Version="2.0.0.5" />
   </ItemGroup>
 
   <!-- NuGet Publishing Metadata -->

--- a/test/HttpApiHandlerTests.cs
+++ b/test/HttpApiHandlerTests.cs
@@ -2,9 +2,11 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Net;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 using Moq;
 using Newtonsoft.Json;
@@ -268,6 +270,46 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             var content = await httpResponseMessage.Content.ReadAsStringAsync();
             var response = JsonConvert.DeserializeObject<JObject>(content);
             Assert.Equal(response["runtimeStatus"], runtimeStatus.ToString());
+        }
+        [Fact]
+        public async Task GetAllStatus_is_Success()
+        {
+
+            var list = (IList<DurableOrchestrationStatus>)new List<DurableOrchestrationStatus>
+                     {
+                         new DurableOrchestrationStatus
+                         {
+                             InstanceId = "01",
+                             RuntimeStatus = OrchestrationRuntimeStatus.Running
+                         },
+                         new DurableOrchestrationStatus
+                         {
+                             InstanceId = "02",
+                             RuntimeStatus = OrchestrationRuntimeStatus.Completed
+                         },
+                     };
+
+            var clientMock = new Mock<DurableOrchestrationClientBase>();
+            clientMock
+                .Setup(x => x.GetStatusAsync(It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(list));
+            var httpApiHandler = new ExtendedHttpApiHandler(clientMock.Object);
+
+            var getStatusRequestUriBuilder = new UriBuilder(TestConstants.NotificationUrl);
+            getStatusRequestUriBuilder.Path += $"/Instances/";
+
+            var responseMessage = await httpApiHandler.HandleRequestAsync(
+                new HttpRequestMessage
+                {
+                    Method = HttpMethod.Get,
+                    RequestUri = getStatusRequestUriBuilder.Uri,
+                });
+            var actual = JsonConvert.DeserializeObject<IList<StatusResponsePayload>>(await responseMessage.Content.ReadAsStringAsync());
+
+            Assert.Equal("01", actual[0].InstanceId);
+            Assert.Equal("Running", actual[0].RuntimeStatus);
+            Assert.Equal("02", actual[1].InstanceId);
+            Assert.Equal("Completed", actual[1].RuntimeStatus);
         }
 
         [Fact]

--- a/test/HttpApiHandlerTests.cs
+++ b/test/HttpApiHandlerTests.cs
@@ -304,6 +304,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                     Method = HttpMethod.Get,
                     RequestUri = getStatusRequestUriBuilder.Uri,
                 });
+            Assert.Equal(HttpStatusCode.OK, responseMessage.StatusCode);
             var actual = JsonConvert.DeserializeObject<IList<StatusResponsePayload>>(await responseMessage.Content.ReadAsStringAsync());
 
             Assert.Equal("01", actual[0].InstanceId);

--- a/test/WebJobs.Extensions.DurableTask.Tests.csproj
+++ b/test/WebJobs.Extensions.DurableTask.Tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="DurableTask.AzureStorage" Version="1.2.2" />
+    <PackageReference Include="DurableTask.AzureStorage" Version="1.2.3" />
     <PackageReference Include="FluentAssertions" Version="4.19.4" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.0-beta5" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" Version="3.0.0-beta5" />

--- a/test/WebJobs.Extensions.DurableTask.Tests.csproj
+++ b/test/WebJobs.Extensions.DurableTask.Tests.csproj
@@ -33,8 +33,4 @@
     <Compile Include="$(SolutionDir)\.stylecop\GlobalSuppressions.cs" Link="GlobalSuppressions.cs" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
-  </ItemGroup>
-
 </Project>

--- a/test/WebJobs.Extensions.DurableTask.Tests.csproj
+++ b/test/WebJobs.Extensions.DurableTask.Tests.csproj
@@ -33,4 +33,8 @@
     <Compile Include="$(SolutionDir)\.stylecop\GlobalSuppressions.cs" Link="GlobalSuppressions.cs" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
Hi @cgillum 

I start this pull request to start conversation. 
This pull request is for this issue. 

https://github.com/Azure/azure-functions-durable-extension/issues/316

Also, related this pull request for DurableTask

https://github.com/Azure/durabletask/pull/187

# NOTE

If you do CI for this pull request, currently it must fail.   This fix need the code change of the durable task pull request. I write a code with the nuget packages of DurableTask.AzureStorage (2.0.0.5) I don't include  csproj file since it is changed to load local file.

I have some questions for you. 

* Should I change the version of the DurableTaskStorage? or leave it to you?
* For writing test, we need to add method to the DurableOrchestrationClientMock.cs. However, it is just mplement DurableOrchestrationClientBase. As we discuss, currently, I use cast for avoiding change of DurableTask.Core. I can't change the mock. Should I leave test? then implement after change the TaskHubClient? 

Anyway, this is the first steps. :) Please review this before go deep. :)