### PR TITLE
Update samples and auto-generated API docs for v1.5.0

### DIFF
--- a/docs/api/Microsoft.Azure.WebJobs.ActivityTriggerAttribute.html
+++ b/docs/api/Microsoft.Azure.WebJobs.ActivityTriggerAttribute.html
@@ -12,7 +12,7 @@
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Class ActivityTriggerAttribute
    ">
-    <meta name="generator" content="docfx 2.35.4.0">
+    <meta name="generator" content="docfx 2.36.2.0">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <link rel="stylesheet" href="../styles/docfx.vendor.css">

--- a/docs/api/Microsoft.Azure.WebJobs.DurableActivityContext.html
+++ b/docs/api/Microsoft.Azure.WebJobs.DurableActivityContext.html
@@ -12,7 +12,7 @@
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Class DurableActivityContext
    ">
-    <meta name="generator" content="docfx 2.35.4.0">
+    <meta name="generator" content="docfx 2.36.2.0">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <link rel="stylesheet" href="../styles/docfx.vendor.css">
@@ -119,7 +119,7 @@
     <a href="https://github.com/Azure/azure-functions-durable-extension/new/master/apiSpec/new?filename=Microsoft_Azure_WebJobs_DurableActivityContext_InstanceId.md&amp;value=---%0Auid%3A%20Microsoft.Azure.WebJobs.DurableActivityContext.InstanceId%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableActivityContext.cs/#L38">View Source</a>
+    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableActivityContext.cs/#L39">View Source</a>
   </span>
   <a id="Microsoft_Azure_WebJobs_DurableActivityContext_InstanceId_" data-uid="Microsoft.Azure.WebJobs.DurableActivityContext.InstanceId*"></a>
   <h4 id="Microsoft_Azure_WebJobs_DurableActivityContext_InstanceId" data-uid="Microsoft.Azure.WebJobs.DurableActivityContext.InstanceId">InstanceId</h4>
@@ -157,7 +157,7 @@ auto-generated, in which case it is formatted as a GUID, or it can be an arbitra
     <a href="https://github.com/Azure/azure-functions-durable-extension/new/master/apiSpec/new?filename=Microsoft_Azure_WebJobs_DurableActivityContext_GetInput__1.md&amp;value=---%0Auid%3A%20Microsoft.Azure.WebJobs.DurableActivityContext.GetInput%60%601%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableActivityContext.cs/#L78">View Source</a>
+    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableActivityContext.cs/#L79">View Source</a>
   </span>
   <a id="Microsoft_Azure_WebJobs_DurableActivityContext_GetInput_" data-uid="Microsoft.Azure.WebJobs.DurableActivityContext.GetInput*"></a>
   <h4 id="Microsoft_Azure_WebJobs_DurableActivityContext_GetInput__1" data-uid="Microsoft.Azure.WebJobs.DurableActivityContext.GetInput``1">GetInput&lt;T&gt;()</h4>
@@ -211,7 +211,7 @@ auto-generated, in which case it is formatted as a GUID, or it can be an arbitra
                     <a href="https://github.com/Azure/azure-functions-durable-extension/new/master/apiSpec/new?filename=Microsoft_Azure_WebJobs_DurableActivityContext.md&amp;value=---%0Auid%3A%20Microsoft.Azure.WebJobs.DurableActivityContext%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
                   </li>
                   <li>
-                    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableActivityContext.cs/#L14" class="contribution-link">View Source</a>
+                    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableActivityContext.cs/#L15" class="contribution-link">View Source</a>
                   </li>
                 </ul>
               </div>

--- a/docs/api/Microsoft.Azure.WebJobs.DurableOrchestrationClient.html
+++ b/docs/api/Microsoft.Azure.WebJobs.DurableOrchestrationClient.html
@@ -12,7 +12,7 @@
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Class DurableOrchestrationClient
    ">
-    <meta name="generator" content="docfx 2.35.4.0">
+    <meta name="generator" content="docfx 2.36.2.0">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <link rel="stylesheet" href="../styles/docfx.vendor.css">
@@ -135,7 +135,7 @@
     <a href="https://github.com/Azure/azure-functions-durable-extension/new/master/apiSpec/new?filename=Microsoft_Azure_WebJobs_DurableOrchestrationClient_TaskHubName.md&amp;value=---%0Auid%3A%20Microsoft.Azure.WebJobs.DurableOrchestrationClient.TaskHubName%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableOrchestrationClient.cs/#L46">View Source</a>
+    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableOrchestrationClient.cs/#L48">View Source</a>
   </span>
   <a id="Microsoft_Azure_WebJobs_DurableOrchestrationClient_TaskHubName_" data-uid="Microsoft.Azure.WebJobs.DurableOrchestrationClient.TaskHubName*"></a>
   <h4 id="Microsoft_Azure_WebJobs_DurableOrchestrationClient_TaskHubName" data-uid="Microsoft.Azure.WebJobs.DurableOrchestrationClient.TaskHubName">TaskHubName</h4>
@@ -171,7 +171,7 @@
     <a href="https://github.com/Azure/azure-functions-durable-extension/new/master/apiSpec/new?filename=Microsoft_Azure_WebJobs_DurableOrchestrationClient_CreateCheckStatusResponse_System_Net_Http_HttpRequestMessage_System_String_.md&amp;value=---%0Auid%3A%20Microsoft.Azure.WebJobs.DurableOrchestrationClient.CreateCheckStatusResponse(System.Net.Http.HttpRequestMessage%2CSystem.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableOrchestrationClient.cs/#L49">View Source</a>
+    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableOrchestrationClient.cs/#L51">View Source</a>
   </span>
   <a id="Microsoft_Azure_WebJobs_DurableOrchestrationClient_CreateCheckStatusResponse_" data-uid="Microsoft.Azure.WebJobs.DurableOrchestrationClient.CreateCheckStatusResponse*"></a>
   <h4 id="Microsoft_Azure_WebJobs_DurableOrchestrationClient_CreateCheckStatusResponse_System_Net_Http_HttpRequestMessage_System_String_" data-uid="Microsoft.Azure.WebJobs.DurableOrchestrationClient.CreateCheckStatusResponse(System.Net.Http.HttpRequestMessage,System.String)">CreateCheckStatusResponse(HttpRequestMessage, String)</h4>
@@ -231,10 +231,62 @@ terminate the orchestration.</p>
 </div>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
+    <a href="https://github.com/Azure/azure-functions-durable-extension/new/master/apiSpec/new?filename=Microsoft_Azure_WebJobs_DurableOrchestrationClient_CreateHttpManagementPayload_System_String_.md&amp;value=---%0Auid%3A%20Microsoft.Azure.WebJobs.DurableOrchestrationClient.CreateHttpManagementPayload(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableOrchestrationClient.cs/#L57">View Source</a>
+  </span>
+  <a id="Microsoft_Azure_WebJobs_DurableOrchestrationClient_CreateHttpManagementPayload_" data-uid="Microsoft.Azure.WebJobs.DurableOrchestrationClient.CreateHttpManagementPayload*"></a>
+  <h4 id="Microsoft_Azure_WebJobs_DurableOrchestrationClient_CreateHttpManagementPayload_System_String_" data-uid="Microsoft.Azure.WebJobs.DurableOrchestrationClient.CreateHttpManagementPayload(System.String)">CreateHttpManagementPayload(String)</h4>
+  <div class="markdown level1 summary"><p>Creates a <a class="xref" href="Microsoft.Azure.WebJobs.Extensions.DurableTask.HttpManagementPayload.html">HttpManagementPayload</a> object that contains status, terminate and send external event HTTP endpoints.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public override HttpManagementPayload CreateHttpManagementPayload(string instanceId)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><span class="xref">System.String</span></td>
+        <td><span class="parametername">instanceId</span></td>
+        <td><p>The ID of the orchestration instance to check.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="Microsoft.Azure.WebJobs.Extensions.DurableTask.HttpManagementPayload.html">HttpManagementPayload</a></td>
+        <td><p>Instance of the <a class="xref" href="Microsoft.Azure.WebJobs.Extensions.DurableTask.HttpManagementPayload.html">HttpManagementPayload</a> class.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="overrides">Overrides</h5>
+  <div><a class="xref" href="Microsoft.Azure.WebJobs.DurableOrchestrationClientBase.html#Microsoft_Azure_WebJobs_DurableOrchestrationClientBase_CreateHttpManagementPayload_System_String_">DurableOrchestrationClientBase.CreateHttpManagementPayload(String)</a></div>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
     <a href="https://github.com/Azure/azure-functions-durable-extension/new/master/apiSpec/new?filename=Microsoft_Azure_WebJobs_DurableOrchestrationClient_GetStatusAsync_System_String_System_Boolean_System_Boolean_.md&amp;value=---%0Auid%3A%20Microsoft.Azure.WebJobs.DurableOrchestrationClient.GetStatusAsync(System.String%2CSystem.Boolean%2CSystem.Boolean)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableOrchestrationClient.cs/#L141">View Source</a>
+    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableOrchestrationClient.cs/#L149">View Source</a>
   </span>
   <a id="Microsoft_Azure_WebJobs_DurableOrchestrationClient_GetStatusAsync_" data-uid="Microsoft.Azure.WebJobs.DurableOrchestrationClient.GetStatusAsync*"></a>
   <h4 id="Microsoft_Azure_WebJobs_DurableOrchestrationClient_GetStatusAsync_System_String_System_Boolean_System_Boolean_" data-uid="Microsoft.Azure.WebJobs.DurableOrchestrationClient.GetStatusAsync(System.String,System.Boolean,System.Boolean)">GetStatusAsync(String, Boolean, Boolean)</h4>
@@ -295,10 +347,62 @@ terminate the orchestration.</p>
   <div><a class="xref" href="Microsoft.Azure.WebJobs.DurableOrchestrationClientBase.html#Microsoft_Azure_WebJobs_DurableOrchestrationClientBase_GetStatusAsync_System_String_System_Boolean_System_Boolean_">DurableOrchestrationClientBase.GetStatusAsync(String, Boolean, Boolean)</a></div>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
+    <a href="https://github.com/Azure/azure-functions-durable-extension/new/master/apiSpec/new?filename=Microsoft_Azure_WebJobs_DurableOrchestrationClient_GetStatusAsync_System_Threading_CancellationToken_.md&amp;value=---%0Auid%3A%20Microsoft.Azure.WebJobs.DurableOrchestrationClient.GetStatusAsync(System.Threading.CancellationToken)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableOrchestrationClient.cs/#L161">View Source</a>
+  </span>
+  <a id="Microsoft_Azure_WebJobs_DurableOrchestrationClient_GetStatusAsync_" data-uid="Microsoft.Azure.WebJobs.DurableOrchestrationClient.GetStatusAsync*"></a>
+  <h4 id="Microsoft_Azure_WebJobs_DurableOrchestrationClient_GetStatusAsync_System_Threading_CancellationToken_" data-uid="Microsoft.Azure.WebJobs.DurableOrchestrationClient.GetStatusAsync(System.Threading.CancellationToken)">GetStatusAsync(CancellationToken)</h4>
+  <div class="markdown level1 summary"><p>Gets all the status of the orchestration instances.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public override Task&lt;IList&lt;DurableOrchestrationStatus&gt;&gt; GetStatusAsync(CancellationToken cancellationToken = default(CancellationToken))</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><span class="xref">System.Threading.CancellationToken</span></td>
+        <td><span class="parametername">cancellationToken</span></td>
+        <td><p>Cancellation token that can be used to cancel the status query operation.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><span class="xref">System.Threading.Tasks.Task</span>&lt;<span class="xref">System.Collections.Generic.IList</span>&lt;<a class="xref" href="Microsoft.Azure.WebJobs.DurableOrchestrationStatus.html">DurableOrchestrationStatus</a>&gt;&gt;</td>
+        <td><p>Returns orchestration status for all instances.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="overrides">Overrides</h5>
+  <div><a class="xref" href="Microsoft.Azure.WebJobs.DurableOrchestrationClientBase.html#Microsoft_Azure_WebJobs_DurableOrchestrationClientBase_GetStatusAsync_System_Threading_CancellationToken_">DurableOrchestrationClientBase.GetStatusAsync(CancellationToken)</a></div>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
     <a href="https://github.com/Azure/azure-functions-durable-extension/new/master/apiSpec/new?filename=Microsoft_Azure_WebJobs_DurableOrchestrationClient_RaiseEventAsync_System_String_System_String_System_Object_.md&amp;value=---%0Auid%3A%20Microsoft.Azure.WebJobs.DurableOrchestrationClient.RaiseEventAsync(System.String%2CSystem.String%2CSystem.Object)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableOrchestrationClient.cs/#L100">View Source</a>
+    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableOrchestrationClient.cs/#L108">View Source</a>
   </span>
   <a id="Microsoft_Azure_WebJobs_DurableOrchestrationClient_RaiseEventAsync_" data-uid="Microsoft.Azure.WebJobs.DurableOrchestrationClient.RaiseEventAsync*"></a>
   <h4 id="Microsoft_Azure_WebJobs_DurableOrchestrationClient_RaiseEventAsync_System_String_System_String_System_Object_" data-uid="Microsoft.Azure.WebJobs.DurableOrchestrationClient.RaiseEventAsync(System.String,System.String,System.Object)">RaiseEventAsync(String, String, Object)</h4>
@@ -371,7 +475,7 @@ If the specified instance is not found or not running, this operation will have 
     <a href="https://github.com/Azure/azure-functions-durable-extension/new/master/apiSpec/new?filename=Microsoft_Azure_WebJobs_DurableOrchestrationClient_StartNewAsync_System_String_System_String_System_Object_.md&amp;value=---%0Auid%3A%20Microsoft.Azure.WebJobs.DurableOrchestrationClient.StartNewAsync(System.String%2CSystem.String%2CSystem.Object)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableOrchestrationClient.cs/#L70">View Source</a>
+    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableOrchestrationClient.cs/#L78">View Source</a>
   </span>
   <a id="Microsoft_Azure_WebJobs_DurableOrchestrationClient_StartNewAsync_" data-uid="Microsoft.Azure.WebJobs.DurableOrchestrationClient.StartNewAsync*"></a>
   <h4 id="Microsoft_Azure_WebJobs_DurableOrchestrationClient_StartNewAsync_System_String_System_String_System_Object_" data-uid="Microsoft.Azure.WebJobs.DurableOrchestrationClient.StartNewAsync(System.String,System.String,System.Object)">StartNewAsync(String, String, Object)</h4>
@@ -455,7 +559,7 @@ will be silently replaced by this new instance.</p>
     <a href="https://github.com/Azure/azure-functions-durable-extension/new/master/apiSpec/new?filename=Microsoft_Azure_WebJobs_DurableOrchestrationClient_TerminateAsync_System_String_System_String_.md&amp;value=---%0Auid%3A%20Microsoft.Azure.WebJobs.DurableOrchestrationClient.TerminateAsync(System.String%2CSystem.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableOrchestrationClient.cs/#L127">View Source</a>
+    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableOrchestrationClient.cs/#L135">View Source</a>
   </span>
   <a id="Microsoft_Azure_WebJobs_DurableOrchestrationClient_TerminateAsync_" data-uid="Microsoft.Azure.WebJobs.DurableOrchestrationClient.TerminateAsync*"></a>
   <h4 id="Microsoft_Azure_WebJobs_DurableOrchestrationClient_TerminateAsync_System_String_System_String_" data-uid="Microsoft.Azure.WebJobs.DurableOrchestrationClient.TerminateAsync(System.String,System.String)">TerminateAsync(String, String)</h4>
@@ -517,7 +621,7 @@ or sub-orchestrations that were started by the current orchestration instance.</
     <a href="https://github.com/Azure/azure-functions-durable-extension/new/master/apiSpec/new?filename=Microsoft_Azure_WebJobs_DurableOrchestrationClient_WaitForCompletionOrCreateCheckStatusResponseAsync_System_Net_Http_HttpRequestMessage_System_String_System_TimeSpan_System_TimeSpan_.md&amp;value=---%0Auid%3A%20Microsoft.Azure.WebJobs.DurableOrchestrationClient.WaitForCompletionOrCreateCheckStatusResponseAsync(System.Net.Http.HttpRequestMessage%2CSystem.String%2CSystem.TimeSpan%2CSystem.TimeSpan)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableOrchestrationClient.cs/#L55">View Source</a>
+    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableOrchestrationClient.cs/#L63">View Source</a>
   </span>
   <a id="Microsoft_Azure_WebJobs_DurableOrchestrationClient_WaitForCompletionOrCreateCheckStatusResponseAsync_" data-uid="Microsoft.Azure.WebJobs.DurableOrchestrationClient.WaitForCompletionOrCreateCheckStatusResponseAsync*"></a>
   <h4 id="Microsoft_Azure_WebJobs_DurableOrchestrationClient_WaitForCompletionOrCreateCheckStatusResponseAsync_System_Net_Http_HttpRequestMessage_System_String_System_TimeSpan_System_TimeSpan_" data-uid="Microsoft.Azure.WebJobs.DurableOrchestrationClient.WaitForCompletionOrCreateCheckStatusResponseAsync(System.Net.Http.HttpRequestMessage,System.String,System.TimeSpan,System.TimeSpan)">WaitForCompletionOrCreateCheckStatusResponseAsync(HttpRequestMessage, String, TimeSpan, TimeSpan)</h4>
@@ -600,7 +704,7 @@ complete within the specified timeout, then the HTTP response will be identical 
                     <a href="https://github.com/Azure/azure-functions-durable-extension/new/master/apiSpec/new?filename=Microsoft_Azure_WebJobs_DurableOrchestrationClient.md&amp;value=---%0Auid%3A%20Microsoft.Azure.WebJobs.DurableOrchestrationClient%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
                   </li>
                   <li>
-                    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableOrchestrationClient.cs/#L19" class="contribution-link">View Source</a>
+                    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableOrchestrationClient.cs/#L21" class="contribution-link">View Source</a>
                   </li>
                 </ul>
               </div>

--- a/docs/api/Microsoft.Azure.WebJobs.DurableOrchestrationClientBase.html
+++ b/docs/api/Microsoft.Azure.WebJobs.DurableOrchestrationClientBase.html
@@ -12,7 +12,7 @@
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Class DurableOrchestrationClientBase
    ">
-    <meta name="generator" content="docfx 2.35.4.0">
+    <meta name="generator" content="docfx 2.36.2.0">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <link rel="stylesheet" href="../styles/docfx.vendor.css">
@@ -74,7 +74,7 @@
   
   <h1 id="Microsoft_Azure_WebJobs_DurableOrchestrationClientBase" data-uid="Microsoft.Azure.WebJobs.DurableOrchestrationClientBase" class="text-break">Class DurableOrchestrationClientBase
   </h1>
-  <div class="markdown level0 summary"><p>Abstract class for <a class="xref" href="Microsoft.Azure.WebJobs.DurableOrchestrationClient.html">DurableOrchestrationClient</a></p>
+  <div class="markdown level0 summary"><p>Abstract base class for <a class="xref" href="Microsoft.Azure.WebJobs.DurableOrchestrationClient.html">DurableOrchestrationClient</a>.</p>
 </div>
   <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
@@ -120,7 +120,7 @@
     <a href="https://github.com/Azure/azure-functions-durable-extension/new/master/apiSpec/new?filename=Microsoft_Azure_WebJobs_DurableOrchestrationClientBase_TaskHubName.md&amp;value=---%0Auid%3A%20Microsoft.Azure.WebJobs.DurableOrchestrationClientBase.TaskHubName%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableOrchestrationClientBase.cs/#L21">View Source</a>
+    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableOrchestrationClientBase.cs/#L24">View Source</a>
   </span>
   <a id="Microsoft_Azure_WebJobs_DurableOrchestrationClientBase_TaskHubName_" data-uid="Microsoft.Azure.WebJobs.DurableOrchestrationClientBase.TaskHubName*"></a>
   <h4 id="Microsoft_Azure_WebJobs_DurableOrchestrationClientBase_TaskHubName" data-uid="Microsoft.Azure.WebJobs.DurableOrchestrationClientBase.TaskHubName">TaskHubName</h4>
@@ -154,7 +154,7 @@
     <a href="https://github.com/Azure/azure-functions-durable-extension/new/master/apiSpec/new?filename=Microsoft_Azure_WebJobs_DurableOrchestrationClientBase_CreateCheckStatusResponse_System_Net_Http_HttpRequestMessage_System_String_.md&amp;value=---%0Auid%3A%20Microsoft.Azure.WebJobs.DurableOrchestrationClientBase.CreateCheckStatusResponse(System.Net.Http.HttpRequestMessage%2CSystem.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableOrchestrationClientBase.cs/#L34">View Source</a>
+    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableOrchestrationClientBase.cs/#L37">View Source</a>
   </span>
   <a id="Microsoft_Azure_WebJobs_DurableOrchestrationClientBase_CreateCheckStatusResponse_" data-uid="Microsoft.Azure.WebJobs.DurableOrchestrationClientBase.CreateCheckStatusResponse*"></a>
   <h4 id="Microsoft_Azure_WebJobs_DurableOrchestrationClientBase_CreateCheckStatusResponse_System_Net_Http_HttpRequestMessage_System_String_" data-uid="Microsoft.Azure.WebJobs.DurableOrchestrationClientBase.CreateCheckStatusResponse(System.Net.Http.HttpRequestMessage,System.String)">CreateCheckStatusResponse(HttpRequestMessage, String)</h4>
@@ -212,10 +212,60 @@ terminate the orchestration.</p>
 </div>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
+    <a href="https://github.com/Azure/azure-functions-durable-extension/new/master/apiSpec/new?filename=Microsoft_Azure_WebJobs_DurableOrchestrationClientBase_CreateHttpManagementPayload_System_String_.md&amp;value=---%0Auid%3A%20Microsoft.Azure.WebJobs.DurableOrchestrationClientBase.CreateHttpManagementPayload(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableOrchestrationClientBase.cs/#L44">View Source</a>
+  </span>
+  <a id="Microsoft_Azure_WebJobs_DurableOrchestrationClientBase_CreateHttpManagementPayload_" data-uid="Microsoft.Azure.WebJobs.DurableOrchestrationClientBase.CreateHttpManagementPayload*"></a>
+  <h4 id="Microsoft_Azure_WebJobs_DurableOrchestrationClientBase_CreateHttpManagementPayload_System_String_" data-uid="Microsoft.Azure.WebJobs.DurableOrchestrationClientBase.CreateHttpManagementPayload(System.String)">CreateHttpManagementPayload(String)</h4>
+  <div class="markdown level1 summary"><p>Creates a <a class="xref" href="Microsoft.Azure.WebJobs.Extensions.DurableTask.HttpManagementPayload.html">HttpManagementPayload</a> object that contains status, terminate and send external event HTTP endpoints.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public abstract HttpManagementPayload CreateHttpManagementPayload(string instanceId)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><span class="xref">System.String</span></td>
+        <td><span class="parametername">instanceId</span></td>
+        <td><p>The ID of the orchestration instance to check.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="Microsoft.Azure.WebJobs.Extensions.DurableTask.HttpManagementPayload.html">HttpManagementPayload</a></td>
+        <td><p>Instance of the <a class="xref" href="Microsoft.Azure.WebJobs.Extensions.DurableTask.HttpManagementPayload.html">HttpManagementPayload</a> class.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
     <a href="https://github.com/Azure/azure-functions-durable-extension/new/master/apiSpec/new?filename=Microsoft_Azure_WebJobs_DurableOrchestrationClientBase_GetStatusAsync_System_String_.md&amp;value=---%0Auid%3A%20Microsoft.Azure.WebJobs.DurableOrchestrationClientBase.GetStatusAsync(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableOrchestrationClientBase.cs/#L147">View Source</a>
+    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableOrchestrationClientBase.cs/#L182">View Source</a>
   </span>
   <a id="Microsoft_Azure_WebJobs_DurableOrchestrationClientBase_GetStatusAsync_" data-uid="Microsoft.Azure.WebJobs.DurableOrchestrationClientBase.GetStatusAsync*"></a>
   <h4 id="Microsoft_Azure_WebJobs_DurableOrchestrationClientBase_GetStatusAsync_System_String_" data-uid="Microsoft.Azure.WebJobs.DurableOrchestrationClientBase.GetStatusAsync(System.String)">GetStatusAsync(String)</h4>
@@ -265,7 +315,7 @@ terminate the orchestration.</p>
     <a href="https://github.com/Azure/azure-functions-durable-extension/new/master/apiSpec/new?filename=Microsoft_Azure_WebJobs_DurableOrchestrationClientBase_GetStatusAsync_System_String_System_Boolean_.md&amp;value=---%0Auid%3A%20Microsoft.Azure.WebJobs.DurableOrchestrationClientBase.GetStatusAsync(System.String%2CSystem.Boolean)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableOrchestrationClientBase.cs/#L158">View Source</a>
+    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableOrchestrationClientBase.cs/#L193">View Source</a>
   </span>
   <a id="Microsoft_Azure_WebJobs_DurableOrchestrationClientBase_GetStatusAsync_" data-uid="Microsoft.Azure.WebJobs.DurableOrchestrationClientBase.GetStatusAsync*"></a>
   <h4 id="Microsoft_Azure_WebJobs_DurableOrchestrationClientBase_GetStatusAsync_System_String_System_Boolean_" data-uid="Microsoft.Azure.WebJobs.DurableOrchestrationClientBase.GetStatusAsync(System.String,System.Boolean)">GetStatusAsync(String, Boolean)</h4>
@@ -321,7 +371,7 @@ terminate the orchestration.</p>
     <a href="https://github.com/Azure/azure-functions-durable-extension/new/master/apiSpec/new?filename=Microsoft_Azure_WebJobs_DurableOrchestrationClientBase_GetStatusAsync_System_String_System_Boolean_System_Boolean_.md&amp;value=---%0Auid%3A%20Microsoft.Azure.WebJobs.DurableOrchestrationClientBase.GetStatusAsync(System.String%2CSystem.Boolean%2CSystem.Boolean)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableOrchestrationClientBase.cs/#L170">View Source</a>
+    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableOrchestrationClientBase.cs/#L205">View Source</a>
   </span>
   <a id="Microsoft_Azure_WebJobs_DurableOrchestrationClientBase_GetStatusAsync_" data-uid="Microsoft.Azure.WebJobs.DurableOrchestrationClientBase.GetStatusAsync*"></a>
   <h4 id="Microsoft_Azure_WebJobs_DurableOrchestrationClientBase_GetStatusAsync_System_String_System_Boolean_System_Boolean_" data-uid="Microsoft.Azure.WebJobs.DurableOrchestrationClientBase.GetStatusAsync(System.String,System.Boolean,System.Boolean)">GetStatusAsync(String, Boolean, Boolean)</h4>
@@ -380,10 +430,60 @@ terminate the orchestration.</p>
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
+    <a href="https://github.com/Azure/azure-functions-durable-extension/new/master/apiSpec/new?filename=Microsoft_Azure_WebJobs_DurableOrchestrationClientBase_GetStatusAsync_System_Threading_CancellationToken_.md&amp;value=---%0Auid%3A%20Microsoft.Azure.WebJobs.DurableOrchestrationClientBase.GetStatusAsync(System.Threading.CancellationToken)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableOrchestrationClientBase.cs/#L212">View Source</a>
+  </span>
+  <a id="Microsoft_Azure_WebJobs_DurableOrchestrationClientBase_GetStatusAsync_" data-uid="Microsoft.Azure.WebJobs.DurableOrchestrationClientBase.GetStatusAsync*"></a>
+  <h4 id="Microsoft_Azure_WebJobs_DurableOrchestrationClientBase_GetStatusAsync_System_Threading_CancellationToken_" data-uid="Microsoft.Azure.WebJobs.DurableOrchestrationClientBase.GetStatusAsync(System.Threading.CancellationToken)">GetStatusAsync(CancellationToken)</h4>
+  <div class="markdown level1 summary"><p>Gets all the status of the orchestration instances.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public abstract Task&lt;IList&lt;DurableOrchestrationStatus&gt;&gt; GetStatusAsync(CancellationToken cancellationToken = default(CancellationToken))</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><span class="xref">System.Threading.CancellationToken</span></td>
+        <td><span class="parametername">cancellationToken</span></td>
+        <td><p>Cancellation token that can be used to cancel the status query operation.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><span class="xref">System.Threading.Tasks.Task</span>&lt;<span class="xref">System.Collections.Generic.IList</span>&lt;<a class="xref" href="Microsoft.Azure.WebJobs.DurableOrchestrationStatus.html">DurableOrchestrationStatus</a>&gt;&gt;</td>
+        <td><p>Returns orchestration status for all instances.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
     <a href="https://github.com/Azure/azure-functions-durable-extension/new/master/apiSpec/new?filename=Microsoft_Azure_WebJobs_DurableOrchestrationClientBase_RaiseEventAsync_System_String_System_String_System_Object_.md&amp;value=---%0Auid%3A%20Microsoft.Azure.WebJobs.DurableOrchestrationClientBase.RaiseEventAsync(System.String%2CSystem.String%2CSystem.Object)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableOrchestrationClientBase.cs/#L127">View Source</a>
+    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableOrchestrationClientBase.cs/#L162">View Source</a>
   </span>
   <a id="Microsoft_Azure_WebJobs_DurableOrchestrationClientBase_RaiseEventAsync_" data-uid="Microsoft.Azure.WebJobs.DurableOrchestrationClientBase.RaiseEventAsync*"></a>
   <h4 id="Microsoft_Azure_WebJobs_DurableOrchestrationClientBase_RaiseEventAsync_System_String_System_String_System_Object_" data-uid="Microsoft.Azure.WebJobs.DurableOrchestrationClientBase.RaiseEventAsync(System.String,System.String,System.Object)">RaiseEventAsync(String, String, Object)</h4>
@@ -454,7 +554,7 @@ If the specified instance is not found or not running, this operation will have 
     <a href="https://github.com/Azure/azure-functions-durable-extension/new/master/apiSpec/new?filename=Microsoft_Azure_WebJobs_DurableOrchestrationClientBase_StartNewAsync_System_String_System_Object_.md&amp;value=---%0Auid%3A%20Microsoft.Azure.WebJobs.DurableOrchestrationClientBase.StartNewAsync(System.String%2CSystem.Object)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableOrchestrationClientBase.cs/#L90">View Source</a>
+    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableOrchestrationClientBase.cs/#L125">View Source</a>
   </span>
   <a id="Microsoft_Azure_WebJobs_DurableOrchestrationClientBase_StartNewAsync_" data-uid="Microsoft.Azure.WebJobs.DurableOrchestrationClientBase.StartNewAsync*"></a>
   <h4 id="Microsoft_Azure_WebJobs_DurableOrchestrationClientBase_StartNewAsync_System_String_System_Object_" data-uid="Microsoft.Azure.WebJobs.DurableOrchestrationClientBase.StartNewAsync(System.String,System.Object)">StartNewAsync(String, Object)</h4>
@@ -526,7 +626,7 @@ If the specified instance is not found or not running, this operation will have 
     <a href="https://github.com/Azure/azure-functions-durable-extension/new/master/apiSpec/new?filename=Microsoft_Azure_WebJobs_DurableOrchestrationClientBase_StartNewAsync_System_String_System_String_System_Object_.md&amp;value=---%0Auid%3A%20Microsoft.Azure.WebJobs.DurableOrchestrationClientBase.StartNewAsync(System.String%2CSystem.String%2CSystem.Object)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableOrchestrationClientBase.cs/#L109">View Source</a>
+    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableOrchestrationClientBase.cs/#L144">View Source</a>
   </span>
   <a id="Microsoft_Azure_WebJobs_DurableOrchestrationClientBase_StartNewAsync_" data-uid="Microsoft.Azure.WebJobs.DurableOrchestrationClientBase.StartNewAsync*"></a>
   <h4 id="Microsoft_Azure_WebJobs_DurableOrchestrationClientBase_StartNewAsync_System_String_System_String_System_Object_" data-uid="Microsoft.Azure.WebJobs.DurableOrchestrationClientBase.StartNewAsync(System.String,System.String,System.Object)">StartNewAsync(String, String, Object)</h4>
@@ -608,7 +708,7 @@ will be silently replaced by this new instance.</p>
     <a href="https://github.com/Azure/azure-functions-durable-extension/new/master/apiSpec/new?filename=Microsoft_Azure_WebJobs_DurableOrchestrationClientBase_TerminateAsync_System_String_System_String_.md&amp;value=---%0Auid%3A%20Microsoft.Azure.WebJobs.DurableOrchestrationClientBase.TerminateAsync(System.String%2CSystem.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableOrchestrationClientBase.cs/#L140">View Source</a>
+    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableOrchestrationClientBase.cs/#L175">View Source</a>
   </span>
   <a id="Microsoft_Azure_WebJobs_DurableOrchestrationClientBase_TerminateAsync_" data-uid="Microsoft.Azure.WebJobs.DurableOrchestrationClientBase.TerminateAsync*"></a>
   <h4 id="Microsoft_Azure_WebJobs_DurableOrchestrationClientBase_TerminateAsync_System_String_System_String_" data-uid="Microsoft.Azure.WebJobs.DurableOrchestrationClientBase.TerminateAsync(System.String,System.String)">TerminateAsync(String, String)</h4>
@@ -668,11 +768,13 @@ or sub-orchestrations that were started by the current orchestration instance.</
     <a href="https://github.com/Azure/azure-functions-durable-extension/new/master/apiSpec/new?filename=Microsoft_Azure_WebJobs_DurableOrchestrationClientBase_WaitForCompletionOrCreateCheckStatusResponseAsync_System_Net_Http_HttpRequestMessage_System_String_.md&amp;value=---%0Auid%3A%20Microsoft.Azure.WebJobs.DurableOrchestrationClientBase.WaitForCompletionOrCreateCheckStatusResponseAsync(System.Net.Http.HttpRequestMessage%2CSystem.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableOrchestrationClientBase.cs/#L37">View Source</a>
+    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableOrchestrationClientBase.cs/#L59">View Source</a>
   </span>
   <a id="Microsoft_Azure_WebJobs_DurableOrchestrationClientBase_WaitForCompletionOrCreateCheckStatusResponseAsync_" data-uid="Microsoft.Azure.WebJobs.DurableOrchestrationClientBase.WaitForCompletionOrCreateCheckStatusResponseAsync*"></a>
   <h4 id="Microsoft_Azure_WebJobs_DurableOrchestrationClientBase_WaitForCompletionOrCreateCheckStatusResponseAsync_System_Net_Http_HttpRequestMessage_System_String_" data-uid="Microsoft.Azure.WebJobs.DurableOrchestrationClientBase.WaitForCompletionOrCreateCheckStatusResponseAsync(System.Net.Http.HttpRequestMessage,System.String)">WaitForCompletionOrCreateCheckStatusResponseAsync(HttpRequestMessage, String)</h4>
-  <div class="markdown level1 summary"></div>
+  <div class="markdown level1 summary"><p>Creates an HTTP response which either contains a payload of management URLs for a non-completed instance
+or contains the payload containing the output of the completed orchestration.</p>
+</div>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
@@ -691,12 +793,14 @@ or sub-orchestrations that were started by the current orchestration instance.</
       <tr>
         <td><span class="xref">System.Net.Http.HttpRequestMessage</span></td>
         <td><span class="parametername">request</span></td>
-        <td></td>
+        <td><p>The HTTP request that triggered the current function.</p>
+</td>
       </tr>
       <tr>
         <td><span class="xref">System.String</span></td>
         <td><span class="parametername">instanceId</span></td>
-        <td></td>
+        <td><p>The unique ID of the instance to check.</p>
+</td>
       </tr>
     </tbody>
   </table>
@@ -711,20 +815,29 @@ or sub-orchestrations that were started by the current orchestration instance.</
     <tbody>
       <tr>
         <td><span class="xref">System.Threading.Tasks.Task</span>&lt;<span class="xref">System.Net.Http.HttpResponseMessage</span>&gt;</td>
-        <td></td>
+        <td><p>An HTTP response which may include a 202 and location header or a 200 with the durable function output in the response body.</p>
+</td>
       </tr>
     </tbody>
   </table>
+  <h5 id="Microsoft_Azure_WebJobs_DurableOrchestrationClientBase_WaitForCompletionOrCreateCheckStatusResponseAsync_System_Net_Http_HttpRequestMessage_System_String__remarks">Remarks</h5>
+  <div class="markdown level1 remarks"><p>If the orchestration instance completes within the default 10 second timeout, then the HTTP response payload will
+contain the output of the orchestration instance formatted as JSON. However, if the orchestration does not
+complete within this timeout, then the HTTP response will be identical to that of the
+<a class="xref" href="Microsoft.Azure.WebJobs.DurableOrchestrationClientBase.html#Microsoft_Azure_WebJobs_DurableOrchestrationClientBase_CreateCheckStatusResponse_System_Net_Http_HttpRequestMessage_System_String_">CreateCheckStatusResponse(HttpRequestMessage, String)</a> API.</p>
+</div>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
     <a href="https://github.com/Azure/azure-functions-durable-extension/new/master/apiSpec/new?filename=Microsoft_Azure_WebJobs_DurableOrchestrationClientBase_WaitForCompletionOrCreateCheckStatusResponseAsync_System_Net_Http_HttpRequestMessage_System_String_System_TimeSpan_.md&amp;value=---%0Auid%3A%20Microsoft.Azure.WebJobs.DurableOrchestrationClientBase.WaitForCompletionOrCreateCheckStatusResponseAsync(System.Net.Http.HttpRequestMessage%2CSystem.String%2CSystem.TimeSpan)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableOrchestrationClientBase.cs/#L48">View Source</a>
+    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableOrchestrationClientBase.cs/#L83">View Source</a>
   </span>
   <a id="Microsoft_Azure_WebJobs_DurableOrchestrationClientBase_WaitForCompletionOrCreateCheckStatusResponseAsync_" data-uid="Microsoft.Azure.WebJobs.DurableOrchestrationClientBase.WaitForCompletionOrCreateCheckStatusResponseAsync*"></a>
   <h4 id="Microsoft_Azure_WebJobs_DurableOrchestrationClientBase_WaitForCompletionOrCreateCheckStatusResponseAsync_System_Net_Http_HttpRequestMessage_System_String_System_TimeSpan_" data-uid="Microsoft.Azure.WebJobs.DurableOrchestrationClientBase.WaitForCompletionOrCreateCheckStatusResponseAsync(System.Net.Http.HttpRequestMessage,System.String,System.TimeSpan)">WaitForCompletionOrCreateCheckStatusResponseAsync(HttpRequestMessage, String, TimeSpan)</h4>
-  <div class="markdown level1 summary"></div>
+  <div class="markdown level1 summary"><p>Creates an HTTP response which either contains a payload of management URLs for a non-completed instance
+or contains the payload containing the output of the completed orchestration.</p>
+</div>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
@@ -743,17 +856,20 @@ or sub-orchestrations that were started by the current orchestration instance.</
       <tr>
         <td><span class="xref">System.Net.Http.HttpRequestMessage</span></td>
         <td><span class="parametername">request</span></td>
-        <td></td>
+        <td><p>The HTTP request that triggered the current function.</p>
+</td>
       </tr>
       <tr>
         <td><span class="xref">System.String</span></td>
         <td><span class="parametername">instanceId</span></td>
-        <td></td>
+        <td><p>The unique ID of the instance to check.</p>
+</td>
       </tr>
       <tr>
         <td><span class="xref">System.TimeSpan</span></td>
         <td><span class="parametername">timeout</span></td>
-        <td></td>
+        <td><p>Total allowed timeout for output from the durable function. The default value is 10 seconds.</p>
+</td>
       </tr>
     </tbody>
   </table>
@@ -768,16 +884,23 @@ or sub-orchestrations that were started by the current orchestration instance.</
     <tbody>
       <tr>
         <td><span class="xref">System.Threading.Tasks.Task</span>&lt;<span class="xref">System.Net.Http.HttpResponseMessage</span>&gt;</td>
-        <td></td>
+        <td><p>An HTTP response which may include a 202 and location header or a 200 with the durable function output in the response body.</p>
+</td>
       </tr>
     </tbody>
   </table>
+  <h5 id="Microsoft_Azure_WebJobs_DurableOrchestrationClientBase_WaitForCompletionOrCreateCheckStatusResponseAsync_System_Net_Http_HttpRequestMessage_System_String_System_TimeSpan__remarks">Remarks</h5>
+  <div class="markdown level1 remarks"><p>If the orchestration instance completes within the specified timeout, then the HTTP response payload will
+contain the output of the orchestration instance formatted as JSON. However, if the orchestration does not
+complete within the specified timeout, then the HTTP response will be identical to that of the
+<a class="xref" href="Microsoft.Azure.WebJobs.DurableOrchestrationClientBase.html#Microsoft_Azure_WebJobs_DurableOrchestrationClientBase_CreateCheckStatusResponse_System_Net_Http_HttpRequestMessage_System_String_">CreateCheckStatusResponse(HttpRequestMessage, String)</a> API.</p>
+</div>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
     <a href="https://github.com/Azure/azure-functions-durable-extension/new/master/apiSpec/new?filename=Microsoft_Azure_WebJobs_DurableOrchestrationClientBase_WaitForCompletionOrCreateCheckStatusResponseAsync_System_Net_Http_HttpRequestMessage_System_String_System_TimeSpan_System_TimeSpan_.md&amp;value=---%0Auid%3A%20Microsoft.Azure.WebJobs.DurableOrchestrationClientBase.WaitForCompletionOrCreateCheckStatusResponseAsync(System.Net.Http.HttpRequestMessage%2CSystem.String%2CSystem.TimeSpan%2CSystem.TimeSpan)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableOrchestrationClientBase.cs/#L75">View Source</a>
+    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableOrchestrationClientBase.cs/#L110">View Source</a>
   </span>
   <a id="Microsoft_Azure_WebJobs_DurableOrchestrationClientBase_WaitForCompletionOrCreateCheckStatusResponseAsync_" data-uid="Microsoft.Azure.WebJobs.DurableOrchestrationClientBase.WaitForCompletionOrCreateCheckStatusResponseAsync*"></a>
   <h4 id="Microsoft_Azure_WebJobs_DurableOrchestrationClientBase_WaitForCompletionOrCreateCheckStatusResponseAsync_System_Net_Http_HttpRequestMessage_System_String_System_TimeSpan_System_TimeSpan_" data-uid="Microsoft.Azure.WebJobs.DurableOrchestrationClientBase.WaitForCompletionOrCreateCheckStatusResponseAsync(System.Net.Http.HttpRequestMessage,System.String,System.TimeSpan,System.TimeSpan)">WaitForCompletionOrCreateCheckStatusResponseAsync(HttpRequestMessage, String, TimeSpan, TimeSpan)</h4>
@@ -858,7 +981,7 @@ complete within the specified timeout, then the HTTP response will be identical 
                     <a href="https://github.com/Azure/azure-functions-durable-extension/new/master/apiSpec/new?filename=Microsoft_Azure_WebJobs_DurableOrchestrationClientBase.md&amp;value=---%0Auid%3A%20Microsoft.Azure.WebJobs.DurableOrchestrationClientBase%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
                   </li>
                   <li>
-                    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableOrchestrationClientBase.cs/#L13" class="contribution-link">View Source</a>
+                    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableOrchestrationClientBase.cs/#L16" class="contribution-link">View Source</a>
                   </li>
                 </ul>
               </div>

--- a/docs/api/Microsoft.Azure.WebJobs.DurableOrchestrationContext.html
+++ b/docs/api/Microsoft.Azure.WebJobs.DurableOrchestrationContext.html
@@ -12,7 +12,7 @@
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Class DurableOrchestrationContext
    ">
-    <meta name="generator" content="docfx 2.35.4.0">
+    <meta name="generator" content="docfx 2.36.2.0">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <link rel="stylesheet" href="../styles/docfx.vendor.css">
@@ -913,7 +913,7 @@ Otherwise the underlying framework will keep the instance alive until the timer 
   <div><a class="xref" href="Microsoft.Azure.WebJobs.DurableOrchestrationContextBase.html#Microsoft_Azure_WebJobs_DurableOrchestrationContextBase_SetCustomStatus_System_Object_">DurableOrchestrationContextBase.SetCustomStatus(Object)</a></div>
   <h5 id="Microsoft_Azure_WebJobs_DurableOrchestrationContext_SetCustomStatus_System_Object__remarks">Remarks</h5>
   <div class="markdown level1 remarks"><p>The <code data-dev-comment-type="paramref" class="paramref">customStatusObject</code> value is serialized to JSON and will
-be made available to the orchestration status query APIs. The serialized JSON 
+be made available to the orchestration status query APIs. The serialized JSON
 value must not exceed 16 KB of UTF-16 encoded text.</p>
 </div>
   <span class="small pull-right mobile-hide">

--- a/docs/api/Microsoft.Azure.WebJobs.DurableOrchestrationContextBase.html
+++ b/docs/api/Microsoft.Azure.WebJobs.DurableOrchestrationContextBase.html
@@ -12,7 +12,7 @@
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Class DurableOrchestrationContextBase
    ">
-    <meta name="generator" content="docfx 2.35.4.0">
+    <meta name="generator" content="docfx 2.36.2.0">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <link rel="stylesheet" href="../styles/docfx.vendor.css">
@@ -120,7 +120,7 @@
     <a href="https://github.com/Azure/azure-functions-durable-extension/new/master/apiSpec/new?filename=Microsoft_Azure_WebJobs_DurableOrchestrationContextBase_CurrentUtcDateTime.md&amp;value=---%0Auid%3A%20Microsoft.Azure.WebJobs.DurableOrchestrationContextBase.CurrentUtcDateTime%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableOrchestrationContextBase.cs/#L47">View Source</a>
+    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableOrchestrationContextBase.cs/#L48">View Source</a>
   </span>
   <a id="Microsoft_Azure_WebJobs_DurableOrchestrationContextBase_CurrentUtcDateTime_" data-uid="Microsoft.Azure.WebJobs.DurableOrchestrationContextBase.CurrentUtcDateTime*"></a>
   <h4 id="Microsoft_Azure_WebJobs_DurableOrchestrationContextBase_CurrentUtcDateTime" data-uid="Microsoft.Azure.WebJobs.DurableOrchestrationContextBase.CurrentUtcDateTime">CurrentUtcDateTime</h4>
@@ -156,7 +156,7 @@ at specific points in the orchestrator function code, making it deterministic an
     <a href="https://github.com/Azure/azure-functions-durable-extension/new/master/apiSpec/new?filename=Microsoft_Azure_WebJobs_DurableOrchestrationContextBase_InstanceId.md&amp;value=---%0Auid%3A%20Microsoft.Azure.WebJobs.DurableOrchestrationContextBase.InstanceId%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableOrchestrationContextBase.cs/#L25">View Source</a>
+    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableOrchestrationContextBase.cs/#L26">View Source</a>
   </span>
   <a id="Microsoft_Azure_WebJobs_DurableOrchestrationContextBase_InstanceId_" data-uid="Microsoft.Azure.WebJobs.DurableOrchestrationContextBase.InstanceId*"></a>
   <h4 id="Microsoft_Azure_WebJobs_DurableOrchestrationContextBase_InstanceId" data-uid="Microsoft.Azure.WebJobs.DurableOrchestrationContextBase.InstanceId">InstanceId</h4>
@@ -192,7 +192,7 @@ auto-generated, in which case it is formatted as a GUID, or it can be user-speci
     <a href="https://github.com/Azure/azure-functions-durable-extension/new/master/apiSpec/new?filename=Microsoft_Azure_WebJobs_DurableOrchestrationContextBase_IsReplaying.md&amp;value=---%0Auid%3A%20Microsoft.Azure.WebJobs.DurableOrchestrationContextBase.IsReplaying%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableOrchestrationContextBase.cs/#L61">View Source</a>
+    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableOrchestrationContextBase.cs/#L62">View Source</a>
   </span>
   <a id="Microsoft_Azure_WebJobs_DurableOrchestrationContextBase_IsReplaying_" data-uid="Microsoft.Azure.WebJobs.DurableOrchestrationContextBase.IsReplaying*"></a>
   <h4 id="Microsoft_Azure_WebJobs_DurableOrchestrationContextBase_IsReplaying" data-uid="Microsoft.Azure.WebJobs.DurableOrchestrationContextBase.IsReplaying">IsReplaying</h4>
@@ -230,7 +230,7 @@ being replayed and then issue the log statements when this value is <code>false<
     <a href="https://github.com/Azure/azure-functions-durable-extension/new/master/apiSpec/new?filename=Microsoft_Azure_WebJobs_DurableOrchestrationContextBase_ParentInstanceId.md&amp;value=---%0Auid%3A%20Microsoft.Azure.WebJobs.DurableOrchestrationContextBase.ParentInstanceId%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableOrchestrationContextBase.cs/#L37">View Source</a>
+    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableOrchestrationContextBase.cs/#L38">View Source</a>
   </span>
   <a id="Microsoft_Azure_WebJobs_DurableOrchestrationContextBase_ParentInstanceId_" data-uid="Microsoft.Azure.WebJobs.DurableOrchestrationContextBase.ParentInstanceId*"></a>
   <h4 id="Microsoft_Azure_WebJobs_DurableOrchestrationContextBase_ParentInstanceId" data-uid="Microsoft.Azure.WebJobs.DurableOrchestrationContextBase.ParentInstanceId">ParentInstanceId</h4>
@@ -268,7 +268,7 @@ auto-generated, in which case it is formatted as a GUID, or it can be user-speci
     <a href="https://github.com/Azure/azure-functions-durable-extension/new/master/apiSpec/new?filename=Microsoft_Azure_WebJobs_DurableOrchestrationContextBase_CallActivityAsync_System_String_System_Object_.md&amp;value=---%0Auid%3A%20Microsoft.Azure.WebJobs.DurableOrchestrationContextBase.CallActivityAsync(System.String%2CSystem.Object)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableOrchestrationContextBase.cs/#L85">View Source</a>
+    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableOrchestrationContextBase.cs/#L86">View Source</a>
   </span>
   <a id="Microsoft_Azure_WebJobs_DurableOrchestrationContextBase_CallActivityAsync_" data-uid="Microsoft.Azure.WebJobs.DurableOrchestrationContextBase.CallActivityAsync*"></a>
   <h4 id="Microsoft_Azure_WebJobs_DurableOrchestrationContextBase_CallActivityAsync_System_String_System_Object_" data-uid="Microsoft.Azure.WebJobs.DurableOrchestrationContextBase.CallActivityAsync(System.String,System.Object)">CallActivityAsync(String, Object)</h4>
@@ -350,7 +350,7 @@ auto-generated, in which case it is formatted as a GUID, or it can be user-speci
     <a href="https://github.com/Azure/azure-functions-durable-extension/new/master/apiSpec/new?filename=Microsoft_Azure_WebJobs_DurableOrchestrationContextBase_CallActivityAsync__1_System_String_System_Object_.md&amp;value=---%0Auid%3A%20Microsoft.Azure.WebJobs.DurableOrchestrationContextBase.CallActivityAsync%60%601(System.String%2CSystem.Object)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableOrchestrationContextBase.cs/#L130">View Source</a>
+    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableOrchestrationContextBase.cs/#L131">View Source</a>
   </span>
   <a id="Microsoft_Azure_WebJobs_DurableOrchestrationContextBase_CallActivityAsync_" data-uid="Microsoft.Azure.WebJobs.DurableOrchestrationContextBase.CallActivityAsync*"></a>
   <h4 id="Microsoft_Azure_WebJobs_DurableOrchestrationContextBase_CallActivityAsync__1_System_String_System_Object_" data-uid="Microsoft.Azure.WebJobs.DurableOrchestrationContextBase.CallActivityAsync``1(System.String,System.Object)">CallActivityAsync&lt;TResult&gt;(String, Object)</h4>
@@ -448,7 +448,7 @@ auto-generated, in which case it is formatted as a GUID, or it can be user-speci
     <a href="https://github.com/Azure/azure-functions-durable-extension/new/master/apiSpec/new?filename=Microsoft_Azure_WebJobs_DurableOrchestrationContextBase_CallActivityWithRetryAsync_System_String_Microsoft_Azure_WebJobs_RetryOptions_System_Object_.md&amp;value=---%0Auid%3A%20Microsoft.Azure.WebJobs.DurableOrchestrationContextBase.CallActivityWithRetryAsync(System.String%2CMicrosoft.Azure.WebJobs.RetryOptions%2CSystem.Object)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableOrchestrationContextBase.cs/#L109">View Source</a>
+    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableOrchestrationContextBase.cs/#L110">View Source</a>
   </span>
   <a id="Microsoft_Azure_WebJobs_DurableOrchestrationContextBase_CallActivityWithRetryAsync_" data-uid="Microsoft.Azure.WebJobs.DurableOrchestrationContextBase.CallActivityWithRetryAsync*"></a>
   <h4 id="Microsoft_Azure_WebJobs_DurableOrchestrationContextBase_CallActivityWithRetryAsync_System_String_Microsoft_Azure_WebJobs_RetryOptions_System_Object_" data-uid="Microsoft.Azure.WebJobs.DurableOrchestrationContextBase.CallActivityWithRetryAsync(System.String,Microsoft.Azure.WebJobs.RetryOptions,System.Object)">CallActivityWithRetryAsync(String, RetryOptions, Object)</h4>
@@ -541,7 +541,7 @@ auto-generated, in which case it is formatted as a GUID, or it can be user-speci
     <a href="https://github.com/Azure/azure-functions-durable-extension/new/master/apiSpec/new?filename=Microsoft_Azure_WebJobs_DurableOrchestrationContextBase_CallActivityWithRetryAsync__1_System_String_Microsoft_Azure_WebJobs_RetryOptions_System_Object_.md&amp;value=---%0Auid%3A%20Microsoft.Azure.WebJobs.DurableOrchestrationContextBase.CallActivityWithRetryAsync%60%601(System.String%2CMicrosoft.Azure.WebJobs.RetryOptions%2CSystem.Object)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableOrchestrationContextBase.cs/#L152">View Source</a>
+    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableOrchestrationContextBase.cs/#L153">View Source</a>
   </span>
   <a id="Microsoft_Azure_WebJobs_DurableOrchestrationContextBase_CallActivityWithRetryAsync_" data-uid="Microsoft.Azure.WebJobs.DurableOrchestrationContextBase.CallActivityWithRetryAsync*"></a>
   <h4 id="Microsoft_Azure_WebJobs_DurableOrchestrationContextBase_CallActivityWithRetryAsync__1_System_String_Microsoft_Azure_WebJobs_RetryOptions_System_Object_" data-uid="Microsoft.Azure.WebJobs.DurableOrchestrationContextBase.CallActivityWithRetryAsync``1(System.String,Microsoft.Azure.WebJobs.RetryOptions,System.Object)">CallActivityWithRetryAsync&lt;TResult&gt;(String, RetryOptions, Object)</h4>
@@ -650,7 +650,7 @@ auto-generated, in which case it is formatted as a GUID, or it can be user-speci
     <a href="https://github.com/Azure/azure-functions-durable-extension/new/master/apiSpec/new?filename=Microsoft_Azure_WebJobs_DurableOrchestrationContextBase_CallSubOrchestratorAsync_System_String_System_Object_.md&amp;value=---%0Auid%3A%20Microsoft.Azure.WebJobs.DurableOrchestrationContextBase.CallSubOrchestratorAsync(System.String%2CSystem.Object)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableOrchestrationContextBase.cs/#L169">View Source</a>
+    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableOrchestrationContextBase.cs/#L170">View Source</a>
   </span>
   <a id="Microsoft_Azure_WebJobs_DurableOrchestrationContextBase_CallSubOrchestratorAsync_" data-uid="Microsoft.Azure.WebJobs.DurableOrchestrationContextBase.CallSubOrchestratorAsync*"></a>
   <h4 id="Microsoft_Azure_WebJobs_DurableOrchestrationContextBase_CallSubOrchestratorAsync_System_String_System_Object_" data-uid="Microsoft.Azure.WebJobs.DurableOrchestrationContextBase.CallSubOrchestratorAsync(System.String,System.Object)">CallSubOrchestratorAsync(String, Object)</h4>
@@ -732,7 +732,7 @@ auto-generated, in which case it is formatted as a GUID, or it can be user-speci
     <a href="https://github.com/Azure/azure-functions-durable-extension/new/master/apiSpec/new?filename=Microsoft_Azure_WebJobs_DurableOrchestrationContextBase_CallSubOrchestratorAsync_System_String_System_String_System_Object_.md&amp;value=---%0Auid%3A%20Microsoft.Azure.WebJobs.DurableOrchestrationContextBase.CallSubOrchestratorAsync(System.String%2CSystem.String%2CSystem.Object)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableOrchestrationContextBase.cs/#L190">View Source</a>
+    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableOrchestrationContextBase.cs/#L191">View Source</a>
   </span>
   <a id="Microsoft_Azure_WebJobs_DurableOrchestrationContextBase_CallSubOrchestratorAsync_" data-uid="Microsoft.Azure.WebJobs.DurableOrchestrationContextBase.CallSubOrchestratorAsync*"></a>
   <h4 id="Microsoft_Azure_WebJobs_DurableOrchestrationContextBase_CallSubOrchestratorAsync_System_String_System_String_System_Object_" data-uid="Microsoft.Azure.WebJobs.DurableOrchestrationContextBase.CallSubOrchestratorAsync(System.String,System.String,System.Object)">CallSubOrchestratorAsync(String, String, Object)</h4>
@@ -820,7 +820,7 @@ auto-generated, in which case it is formatted as a GUID, or it can be user-speci
     <a href="https://github.com/Azure/azure-functions-durable-extension/new/master/apiSpec/new?filename=Microsoft_Azure_WebJobs_DurableOrchestrationContextBase_CallSubOrchestratorAsync__1_System_String_System_Object_.md&amp;value=---%0Auid%3A%20Microsoft.Azure.WebJobs.DurableOrchestrationContextBase.CallSubOrchestratorAsync%60%601(System.String%2CSystem.Object)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableOrchestrationContextBase.cs/#L211">View Source</a>
+    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableOrchestrationContextBase.cs/#L212">View Source</a>
   </span>
   <a id="Microsoft_Azure_WebJobs_DurableOrchestrationContextBase_CallSubOrchestratorAsync_" data-uid="Microsoft.Azure.WebJobs.DurableOrchestrationContextBase.CallSubOrchestratorAsync*"></a>
   <h4 id="Microsoft_Azure_WebJobs_DurableOrchestrationContextBase_CallSubOrchestratorAsync__1_System_String_System_Object_" data-uid="Microsoft.Azure.WebJobs.DurableOrchestrationContextBase.CallSubOrchestratorAsync``1(System.String,System.Object)">CallSubOrchestratorAsync&lt;TResult&gt;(String, Object)</h4>
@@ -918,7 +918,7 @@ auto-generated, in which case it is formatted as a GUID, or it can be user-speci
     <a href="https://github.com/Azure/azure-functions-durable-extension/new/master/apiSpec/new?filename=Microsoft_Azure_WebJobs_DurableOrchestrationContextBase_CallSubOrchestratorAsync__1_System_String_System_String_System_Object_.md&amp;value=---%0Auid%3A%20Microsoft.Azure.WebJobs.DurableOrchestrationContextBase.CallSubOrchestratorAsync%60%601(System.String%2CSystem.String%2CSystem.Object)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableOrchestrationContextBase.cs/#L233">View Source</a>
+    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableOrchestrationContextBase.cs/#L234">View Source</a>
   </span>
   <a id="Microsoft_Azure_WebJobs_DurableOrchestrationContextBase_CallSubOrchestratorAsync_" data-uid="Microsoft.Azure.WebJobs.DurableOrchestrationContextBase.CallSubOrchestratorAsync*"></a>
   <h4 id="Microsoft_Azure_WebJobs_DurableOrchestrationContextBase_CallSubOrchestratorAsync__1_System_String_System_String_System_Object_" data-uid="Microsoft.Azure.WebJobs.DurableOrchestrationContextBase.CallSubOrchestratorAsync``1(System.String,System.String,System.Object)">CallSubOrchestratorAsync&lt;TResult&gt;(String, String, Object)</h4>
@@ -1022,7 +1022,7 @@ auto-generated, in which case it is formatted as a GUID, or it can be user-speci
     <a href="https://github.com/Azure/azure-functions-durable-extension/new/master/apiSpec/new?filename=Microsoft_Azure_WebJobs_DurableOrchestrationContextBase_CallSubOrchestratorWithRetryAsync_System_String_Microsoft_Azure_WebJobs_RetryOptions_System_Object_.md&amp;value=---%0Auid%3A%20Microsoft.Azure.WebJobs.DurableOrchestrationContextBase.CallSubOrchestratorWithRetryAsync(System.String%2CMicrosoft.Azure.WebJobs.RetryOptions%2CSystem.Object)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableOrchestrationContextBase.cs/#L254">View Source</a>
+    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableOrchestrationContextBase.cs/#L255">View Source</a>
   </span>
   <a id="Microsoft_Azure_WebJobs_DurableOrchestrationContextBase_CallSubOrchestratorWithRetryAsync_" data-uid="Microsoft.Azure.WebJobs.DurableOrchestrationContextBase.CallSubOrchestratorWithRetryAsync*"></a>
   <h4 id="Microsoft_Azure_WebJobs_DurableOrchestrationContextBase_CallSubOrchestratorWithRetryAsync_System_String_Microsoft_Azure_WebJobs_RetryOptions_System_Object_" data-uid="Microsoft.Azure.WebJobs.DurableOrchestrationContextBase.CallSubOrchestratorWithRetryAsync(System.String,Microsoft.Azure.WebJobs.RetryOptions,System.Object)">CallSubOrchestratorWithRetryAsync(String, RetryOptions, Object)</h4>
@@ -1115,7 +1115,7 @@ auto-generated, in which case it is formatted as a GUID, or it can be user-speci
     <a href="https://github.com/Azure/azure-functions-durable-extension/new/master/apiSpec/new?filename=Microsoft_Azure_WebJobs_DurableOrchestrationContextBase_CallSubOrchestratorWithRetryAsync_System_String_Microsoft_Azure_WebJobs_RetryOptions_System_String_System_Object_.md&amp;value=---%0Auid%3A%20Microsoft.Azure.WebJobs.DurableOrchestrationContextBase.CallSubOrchestratorWithRetryAsync(System.String%2CMicrosoft.Azure.WebJobs.RetryOptions%2CSystem.String%2CSystem.Object)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableOrchestrationContextBase.cs/#L279">View Source</a>
+    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableOrchestrationContextBase.cs/#L280">View Source</a>
   </span>
   <a id="Microsoft_Azure_WebJobs_DurableOrchestrationContextBase_CallSubOrchestratorWithRetryAsync_" data-uid="Microsoft.Azure.WebJobs.DurableOrchestrationContextBase.CallSubOrchestratorWithRetryAsync*"></a>
   <h4 id="Microsoft_Azure_WebJobs_DurableOrchestrationContextBase_CallSubOrchestratorWithRetryAsync_System_String_Microsoft_Azure_WebJobs_RetryOptions_System_String_System_Object_" data-uid="Microsoft.Azure.WebJobs.DurableOrchestrationContextBase.CallSubOrchestratorWithRetryAsync(System.String,Microsoft.Azure.WebJobs.RetryOptions,System.String,System.Object)">CallSubOrchestratorWithRetryAsync(String, RetryOptions, String, Object)</h4>
@@ -1214,7 +1214,7 @@ auto-generated, in which case it is formatted as a GUID, or it can be user-speci
     <a href="https://github.com/Azure/azure-functions-durable-extension/new/master/apiSpec/new?filename=Microsoft_Azure_WebJobs_DurableOrchestrationContextBase_CallSubOrchestratorWithRetryAsync__1_System_String_Microsoft_Azure_WebJobs_RetryOptions_System_Object_.md&amp;value=---%0Auid%3A%20Microsoft.Azure.WebJobs.DurableOrchestrationContextBase.CallSubOrchestratorWithRetryAsync%60%601(System.String%2CMicrosoft.Azure.WebJobs.RetryOptions%2CSystem.Object)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableOrchestrationContextBase.cs/#L304">View Source</a>
+    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableOrchestrationContextBase.cs/#L305">View Source</a>
   </span>
   <a id="Microsoft_Azure_WebJobs_DurableOrchestrationContextBase_CallSubOrchestratorWithRetryAsync_" data-uid="Microsoft.Azure.WebJobs.DurableOrchestrationContextBase.CallSubOrchestratorWithRetryAsync*"></a>
   <h4 id="Microsoft_Azure_WebJobs_DurableOrchestrationContextBase_CallSubOrchestratorWithRetryAsync__1_System_String_Microsoft_Azure_WebJobs_RetryOptions_System_Object_" data-uid="Microsoft.Azure.WebJobs.DurableOrchestrationContextBase.CallSubOrchestratorWithRetryAsync``1(System.String,Microsoft.Azure.WebJobs.RetryOptions,System.Object)">CallSubOrchestratorWithRetryAsync&lt;TResult&gt;(String, RetryOptions, Object)</h4>
@@ -1323,7 +1323,7 @@ auto-generated, in which case it is formatted as a GUID, or it can be user-speci
     <a href="https://github.com/Azure/azure-functions-durable-extension/new/master/apiSpec/new?filename=Microsoft_Azure_WebJobs_DurableOrchestrationContextBase_CallSubOrchestratorWithRetryAsync__1_System_String_Microsoft_Azure_WebJobs_RetryOptions_System_String_System_Object_.md&amp;value=---%0Auid%3A%20Microsoft.Azure.WebJobs.DurableOrchestrationContextBase.CallSubOrchestratorWithRetryAsync%60%601(System.String%2CMicrosoft.Azure.WebJobs.RetryOptions%2CSystem.String%2CSystem.Object)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableOrchestrationContextBase.cs/#L330">View Source</a>
+    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableOrchestrationContextBase.cs/#L331">View Source</a>
   </span>
   <a id="Microsoft_Azure_WebJobs_DurableOrchestrationContextBase_CallSubOrchestratorWithRetryAsync_" data-uid="Microsoft.Azure.WebJobs.DurableOrchestrationContextBase.CallSubOrchestratorWithRetryAsync*"></a>
   <h4 id="Microsoft_Azure_WebJobs_DurableOrchestrationContextBase_CallSubOrchestratorWithRetryAsync__1_System_String_Microsoft_Azure_WebJobs_RetryOptions_System_String_System_Object_" data-uid="Microsoft.Azure.WebJobs.DurableOrchestrationContextBase.CallSubOrchestratorWithRetryAsync``1(System.String,Microsoft.Azure.WebJobs.RetryOptions,System.String,System.Object)">CallSubOrchestratorWithRetryAsync&lt;TResult&gt;(String, RetryOptions, String, Object)</h4>
@@ -1438,7 +1438,7 @@ auto-generated, in which case it is formatted as a GUID, or it can be user-speci
     <a href="https://github.com/Azure/azure-functions-durable-extension/new/master/apiSpec/new?filename=Microsoft_Azure_WebJobs_DurableOrchestrationContextBase_ContinueAsNew_System_Object_.md&amp;value=---%0Auid%3A%20Microsoft.Azure.WebJobs.DurableOrchestrationContextBase.ContinueAsNew(System.Object)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableOrchestrationContextBase.cs/#L386">View Source</a>
+    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableOrchestrationContextBase.cs/#L387">View Source</a>
   </span>
   <a id="Microsoft_Azure_WebJobs_DurableOrchestrationContextBase_ContinueAsNew_" data-uid="Microsoft.Azure.WebJobs.DurableOrchestrationContextBase.ContinueAsNew*"></a>
   <h4 id="Microsoft_Azure_WebJobs_DurableOrchestrationContextBase_ContinueAsNew_System_Object_" data-uid="Microsoft.Azure.WebJobs.DurableOrchestrationContextBase.ContinueAsNew(System.Object)">ContinueAsNew(Object)</h4>
@@ -1479,7 +1479,7 @@ instance restarts itself using this method.</p>
     <a href="https://github.com/Azure/azure-functions-durable-extension/new/master/apiSpec/new?filename=Microsoft_Azure_WebJobs_DurableOrchestrationContextBase_CreateTimer_System_DateTime_System_Threading_CancellationToken_.md&amp;value=---%0Auid%3A%20Microsoft.Azure.WebJobs.DurableOrchestrationContextBase.CreateTimer(System.DateTime%2CSystem.Threading.CancellationToken)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableOrchestrationContextBase.cs/#L343">View Source</a>
+    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableOrchestrationContextBase.cs/#L344">View Source</a>
   </span>
   <a id="Microsoft_Azure_WebJobs_DurableOrchestrationContextBase_CreateTimer_" data-uid="Microsoft.Azure.WebJobs.DurableOrchestrationContextBase.CreateTimer*"></a>
   <h4 id="Microsoft_Azure_WebJobs_DurableOrchestrationContextBase_CreateTimer_System_DateTime_System_Threading_CancellationToken_" data-uid="Microsoft.Azure.WebJobs.DurableOrchestrationContextBase.CreateTimer(System.DateTime,System.Threading.CancellationToken)">CreateTimer(DateTime, CancellationToken)</h4>
@@ -1540,7 +1540,7 @@ Otherwise the underlying framework will keep the instance alive until the timer 
     <a href="https://github.com/Azure/azure-functions-durable-extension/new/master/apiSpec/new?filename=Microsoft_Azure_WebJobs_DurableOrchestrationContextBase_CreateTimer__1_System_DateTime___0_System_Threading_CancellationToken_.md&amp;value=---%0Auid%3A%20Microsoft.Azure.WebJobs.DurableOrchestrationContextBase.CreateTimer%60%601(System.DateTime%2C%60%600%2CSystem.Threading.CancellationToken)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableOrchestrationContextBase.cs/#L361">View Source</a>
+    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableOrchestrationContextBase.cs/#L362">View Source</a>
   </span>
   <a id="Microsoft_Azure_WebJobs_DurableOrchestrationContextBase_CreateTimer_" data-uid="Microsoft.Azure.WebJobs.DurableOrchestrationContextBase.CreateTimer*"></a>
   <h4 id="Microsoft_Azure_WebJobs_DurableOrchestrationContextBase_CreateTimer__1_System_DateTime___0_System_Threading_CancellationToken_" data-uid="Microsoft.Azure.WebJobs.DurableOrchestrationContextBase.CreateTimer``1(System.DateTime,``0,System.Threading.CancellationToken)">CreateTimer&lt;T&gt;(DateTime, T, CancellationToken)</h4>
@@ -1623,7 +1623,7 @@ Otherwise the underlying framework will keep the instance alive until the timer 
     <a href="https://github.com/Azure/azure-functions-durable-extension/new/master/apiSpec/new?filename=Microsoft_Azure_WebJobs_DurableOrchestrationContextBase_GetInput__1.md&amp;value=---%0Auid%3A%20Microsoft.Azure.WebJobs.DurableOrchestrationContextBase.GetInput%60%601%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableOrchestrationContextBase.cs/#L68">View Source</a>
+    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableOrchestrationContextBase.cs/#L69">View Source</a>
   </span>
   <a id="Microsoft_Azure_WebJobs_DurableOrchestrationContextBase_GetInput_" data-uid="Microsoft.Azure.WebJobs.DurableOrchestrationContextBase.GetInput*"></a>
   <h4 id="Microsoft_Azure_WebJobs_DurableOrchestrationContextBase_GetInput__1" data-uid="Microsoft.Azure.WebJobs.DurableOrchestrationContextBase.GetInput``1">GetInput&lt;T&gt;()</h4>
@@ -1671,7 +1671,7 @@ Otherwise the underlying framework will keep the instance alive until the timer 
     <a href="https://github.com/Azure/azure-functions-durable-extension/new/master/apiSpec/new?filename=Microsoft_Azure_WebJobs_DurableOrchestrationContextBase_SetCustomStatus_System_Object_.md&amp;value=---%0Auid%3A%20Microsoft.Azure.WebJobs.DurableOrchestrationContextBase.SetCustomStatus(System.Object)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableOrchestrationContextBase.cs/#L397">View Source</a>
+    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableOrchestrationContextBase.cs/#L398">View Source</a>
   </span>
   <a id="Microsoft_Azure_WebJobs_DurableOrchestrationContextBase_SetCustomStatus_" data-uid="Microsoft.Azure.WebJobs.DurableOrchestrationContextBase.SetCustomStatus*"></a>
   <h4 id="Microsoft_Azure_WebJobs_DurableOrchestrationContextBase_SetCustomStatus_System_Object_" data-uid="Microsoft.Azure.WebJobs.DurableOrchestrationContextBase.SetCustomStatus(System.Object)">SetCustomStatus(Object)</h4>
@@ -1702,7 +1702,7 @@ Otherwise the underlying framework will keep the instance alive until the timer 
   </table>
   <h5 id="Microsoft_Azure_WebJobs_DurableOrchestrationContextBase_SetCustomStatus_System_Object__remarks">Remarks</h5>
   <div class="markdown level1 remarks"><p>The <code data-dev-comment-type="paramref" class="paramref">customStatusObject</code> value is serialized to JSON and will
-be made available to the orchestration status query APIs. The serialized JSON 
+be made available to the orchestration status query APIs. The serialized JSON
 value must not exceed 16 KB of UTF-16 encoded text.</p>
 </div>
   <span class="small pull-right mobile-hide">
@@ -1710,7 +1710,7 @@ value must not exceed 16 KB of UTF-16 encoded text.</p>
     <a href="https://github.com/Azure/azure-functions-durable-extension/new/master/apiSpec/new?filename=Microsoft_Azure_WebJobs_DurableOrchestrationContextBase_WaitForExternalEvent__1_System_String_.md&amp;value=---%0Auid%3A%20Microsoft.Azure.WebJobs.DurableOrchestrationContextBase.WaitForExternalEvent%60%601(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableOrchestrationContextBase.cs/#L373">View Source</a>
+    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableOrchestrationContextBase.cs/#L374">View Source</a>
   </span>
   <a id="Microsoft_Azure_WebJobs_DurableOrchestrationContextBase_WaitForExternalEvent_" data-uid="Microsoft.Azure.WebJobs.DurableOrchestrationContextBase.WaitForExternalEvent*"></a>
   <h4 id="Microsoft_Azure_WebJobs_DurableOrchestrationContextBase_WaitForExternalEvent__1_System_String_" data-uid="Microsoft.Azure.WebJobs.DurableOrchestrationContextBase.WaitForExternalEvent``1(System.String)">WaitForExternalEvent&lt;T&gt;(String)</h4>
@@ -1786,7 +1786,7 @@ value must not exceed 16 KB of UTF-16 encoded text.</p>
                     <a href="https://github.com/Azure/azure-functions-durable-extension/new/master/apiSpec/new?filename=Microsoft_Azure_WebJobs_DurableOrchestrationContextBase.md&amp;value=---%0Auid%3A%20Microsoft.Azure.WebJobs.DurableOrchestrationContextBase%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
                   </li>
                   <li>
-                    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableOrchestrationContextBase.cs/#L13" class="contribution-link">View Source</a>
+                    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableOrchestrationContextBase.cs/#L14" class="contribution-link">View Source</a>
                   </li>
                 </ul>
               </div>

--- a/docs/api/Microsoft.Azure.WebJobs.DurableOrchestrationStatus.html
+++ b/docs/api/Microsoft.Azure.WebJobs.DurableOrchestrationStatus.html
@@ -12,7 +12,7 @@
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Class DurableOrchestrationStatus
    ">
-    <meta name="generator" content="docfx 2.35.4.0">
+    <meta name="generator" content="docfx 2.36.2.0">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <link rel="stylesheet" href="../styles/docfx.vendor.css">

--- a/docs/api/Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.html
+++ b/docs/api/Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.html
@@ -12,7 +12,7 @@
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Class DurableTaskExtension
    ">
-    <meta name="generator" content="docfx 2.35.4.0">
+    <meta name="generator" content="docfx 2.36.2.0">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <link rel="stylesheet" href="../styles/docfx.vendor.css">
@@ -251,6 +251,102 @@ dispatcher is ready to process them.</p>
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
+    <a href="https://github.com/Azure/azure-functions-durable-extension/new/master/apiSpec/new?filename=Microsoft_Azure_WebJobs_Extensions_DurableTask_DurableTaskExtension_EventGridPublishRetryCount.md&amp;value=---%0Auid%3A%20Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.EventGridPublishRetryCount%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs/#L191">View Source</a>
+  </span>
+  <a id="Microsoft_Azure_WebJobs_Extensions_DurableTask_DurableTaskExtension_EventGridPublishRetryCount_" data-uid="Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.EventGridPublishRetryCount*"></a>
+  <h4 id="Microsoft_Azure_WebJobs_Extensions_DurableTask_DurableTaskExtension_EventGridPublishRetryCount" data-uid="Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.EventGridPublishRetryCount">EventGridPublishRetryCount</h4>
+  <div class="markdown level1 summary"><p>Gets or sets the Event Grid publish request retry count.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public int EventGridPublishRetryCount { get; set; }</code></pre>
+  </div>
+  <h5 class="propertyValue">Property Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><span class="xref">System.Int32</span></td>
+        <td><p>The number of retry attempts.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/Azure/azure-functions-durable-extension/new/master/apiSpec/new?filename=Microsoft_Azure_WebJobs_Extensions_DurableTask_DurableTaskExtension_EventGridPublishRetryHttpStatus.md&amp;value=---%0Auid%3A%20Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.EventGridPublishRetryHttpStatus%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs/#L203">View Source</a>
+  </span>
+  <a id="Microsoft_Azure_WebJobs_Extensions_DurableTask_DurableTaskExtension_EventGridPublishRetryHttpStatus_" data-uid="Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.EventGridPublishRetryHttpStatus*"></a>
+  <h4 id="Microsoft_Azure_WebJobs_Extensions_DurableTask_DurableTaskExtension_EventGridPublishRetryHttpStatus" data-uid="Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.EventGridPublishRetryHttpStatus">EventGridPublishRetryHttpStatus</h4>
+  <div class="markdown level1 summary"><p>Gets or sets the Event Grid publish request http status.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public int[] EventGridPublishRetryHttpStatus { get; set; }</code></pre>
+  </div>
+  <h5 class="propertyValue">Property Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><span class="xref">System.Int32</span>[]</td>
+        <td><p>A list of HTTP status codes, e.g. 400, 403.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/Azure/azure-functions-durable-extension/new/master/apiSpec/new?filename=Microsoft_Azure_WebJobs_Extensions_DurableTask_DurableTaskExtension_EventGridPublishRetryInterval.md&amp;value=---%0Auid%3A%20Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.EventGridPublishRetryInterval%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs/#L197">View Source</a>
+  </span>
+  <a id="Microsoft_Azure_WebJobs_Extensions_DurableTask_DurableTaskExtension_EventGridPublishRetryInterval_" data-uid="Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.EventGridPublishRetryInterval*"></a>
+  <h4 id="Microsoft_Azure_WebJobs_Extensions_DurableTask_DurableTaskExtension_EventGridPublishRetryInterval" data-uid="Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.EventGridPublishRetryInterval">EventGridPublishRetryInterval</h4>
+  <div class="markdown level1 summary"><p>Gets orsets the Event Grid publish request retry interval.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public TimeSpan EventGridPublishRetryInterval { get; set; }</code></pre>
+  </div>
+  <h5 class="propertyValue">Property Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><span class="xref">System.TimeSpan</span></td>
+        <td><p>A <span class="xref">System.TimeSpan</span> representing the retry interval. The default value is 5 minutes.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
     <a href="https://github.com/Azure/azure-functions-durable-extension/new/master/apiSpec/new?filename=Microsoft_Azure_WebJobs_Extensions_DurableTask_DurableTaskExtension_EventGridTopicEndpoint.md&amp;value=---%0Auid%3A%20Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.EventGridTopicEndpoint%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
@@ -292,7 +388,7 @@ https://{topic_name}.{region}.eventgrid.azure.net/api/events.</p>
     <a href="https://github.com/Azure/azure-functions-durable-extension/new/master/apiSpec/new?filename=Microsoft_Azure_WebJobs_Extensions_DurableTask_DurableTaskExtension_ExtendedSessionIdleTimeoutInSeconds.md&amp;value=---%0Auid%3A%20Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.ExtendedSessionIdleTimeoutInSeconds%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs/#L215">View Source</a>
+    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs/#L233">View Source</a>
   </span>
   <a id="Microsoft_Azure_WebJobs_Extensions_DurableTask_DurableTaskExtension_ExtendedSessionIdleTimeoutInSeconds_" data-uid="Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.ExtendedSessionIdleTimeoutInSeconds*"></a>
   <h4 id="Microsoft_Azure_WebJobs_Extensions_DurableTask_DurableTaskExtension_ExtendedSessionIdleTimeoutInSeconds" data-uid="Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.ExtendedSessionIdleTimeoutInSeconds">ExtendedSessionIdleTimeoutInSeconds</h4>
@@ -327,7 +423,7 @@ https://{topic_name}.{region}.eventgrid.azure.net/api/events.</p>
     <a href="https://github.com/Azure/azure-functions-durable-extension/new/master/apiSpec/new?filename=Microsoft_Azure_WebJobs_Extensions_DurableTask_DurableTaskExtension_ExtendedSessionsEnabled.md&amp;value=---%0Auid%3A%20Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.ExtendedSessionsEnabled%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs/#L204">View Source</a>
+    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs/#L222">View Source</a>
   </span>
   <a id="Microsoft_Azure_WebJobs_Extensions_DurableTask_DurableTaskExtension_ExtendedSessionsEnabled_" data-uid="Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.ExtendedSessionsEnabled*"></a>
   <h4 id="Microsoft_Azure_WebJobs_Extensions_DurableTask_DurableTaskExtension_ExtendedSessionsEnabled" data-uid="Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.ExtendedSessionsEnabled">ExtendedSessionsEnabled</h4>
@@ -401,6 +497,41 @@ ensure that the orchestrator code correctly obeys the idempotency rules.</p>
   <h5 id="Microsoft_Azure_WebJobs_Extensions_DurableTask_DurableTaskExtension_HubName_remarks">Remarks</h5>
   <div class="markdown level1 remarks"><p>A task hub is a logical grouping of storage resources. Alternate task hub names can be used to isolate
 multiple Durable Functions applications from each other, even if they are using the same storage backend.</p>
+</div>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/Azure/azure-functions-durable-extension/new/master/apiSpec/new?filename=Microsoft_Azure_WebJobs_Extensions_DurableTask_DurableTaskExtension_LogReplayEvents.md&amp;value=---%0Auid%3A%20Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.LogReplayEvents%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs/#L244">View Source</a>
+  </span>
+  <a id="Microsoft_Azure_WebJobs_Extensions_DurableTask_DurableTaskExtension_LogReplayEvents_" data-uid="Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.LogReplayEvents*"></a>
+  <h4 id="Microsoft_Azure_WebJobs_Extensions_DurableTask_DurableTaskExtension_LogReplayEvents" data-uid="Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.LogReplayEvents">LogReplayEvents</h4>
+  <div class="markdown level1 summary"><p>Gets or sets if logs for replay events need to be recorded.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public bool LogReplayEvents { get; set; }</code></pre>
+  </div>
+  <h5 class="propertyValue">Property Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><span class="xref">System.Boolean</span></td>
+        <td><p>Boolean value specifying if the replay events should be logged.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 id="Microsoft_Azure_WebJobs_Extensions_DurableTask_DurableTaskExtension_LogReplayEvents_remarks">Remarks</h5>
+  <div class="markdown level1 remarks"><p>The default value is false, which disables the logging of replay events.</p>
 </div>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
@@ -622,7 +753,7 @@ the entire contents of function inputs and outputs.</p>
     <a href="https://github.com/Azure/azure-functions-durable-extension/new/master/apiSpec/new?filename=Microsoft_Azure_WebJobs_Extensions_DurableTask_DurableTaskExtension_DeleteTaskHubAsync.md&amp;value=---%0Auid%3A%20Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.DeleteTaskHubAsync%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs/#L276">View Source</a>
+    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs/#L306">View Source</a>
   </span>
   <a id="Microsoft_Azure_WebJobs_Extensions_DurableTask_DurableTaskExtension_DeleteTaskHubAsync_" data-uid="Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.DeleteTaskHubAsync*"></a>
   <h4 id="Microsoft_Azure_WebJobs_Extensions_DurableTask_DurableTaskExtension_DeleteTaskHubAsync" data-uid="Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.DeleteTaskHubAsync">DeleteTaskHubAsync()</h4>
@@ -654,7 +785,7 @@ the entire contents of function inputs and outputs.</p>
     <a href="https://github.com/Azure/azure-functions-durable-extension/new/master/apiSpec/new?filename=Microsoft_Azure_WebJobs_Extensions_DurableTask_DurableTaskExtension_GetClient_Microsoft_Azure_WebJobs_OrchestrationClientAttribute_.md&amp;value=---%0Auid%3A%20Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.GetClient(Microsoft.Azure.WebJobs.OrchestrationClientAttribute)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs/#L413">View Source</a>
+    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs/#L443">View Source</a>
   </span>
   <a id="Microsoft_Azure_WebJobs_Extensions_DurableTask_DurableTaskExtension_GetClient_" data-uid="Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.GetClient*"></a>
   <h4 id="Microsoft_Azure_WebJobs_Extensions_DurableTask_DurableTaskExtension_GetClient_Microsoft_Azure_WebJobs_OrchestrationClientAttribute_" data-uid="Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.GetClient(Microsoft.Azure.WebJobs.OrchestrationClientAttribute)">GetClient(OrchestrationClientAttribute)</h4>
@@ -706,7 +837,7 @@ the entire contents of function inputs and outputs.</p>
     <a href="https://github.com/Azure/azure-functions-durable-extension/new/master/apiSpec/new?filename=Microsoft_Azure_WebJobs_Extensions_DurableTask_DurableTaskExtension_DurableTask_Core_INameVersionObjectManager_DurableTask_Core_TaskActivity__Add_DurableTask_Core_ObjectCreator_DurableTask_Core_TaskActivity__.md&amp;value=---%0Auid%3A%20Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.DurableTask%23Core%23INameVersionObjectManager%7BDurableTask%23Core%23TaskActivity%7D%23Add(DurableTask.Core.ObjectCreator%7BDurableTask.Core.TaskActivity%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs/#L306">View Source</a>
+    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs/#L336">View Source</a>
   </span>
   <a id="Microsoft_Azure_WebJobs_Extensions_DurableTask_DurableTaskExtension_DurableTask_Core_INameVersionObjectManager_DurableTask_Core_TaskActivity__Add_" data-uid="Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.DurableTask#Core#INameVersionObjectManager{DurableTask#Core#TaskActivity}#Add*"></a>
   <h4 id="Microsoft_Azure_WebJobs_Extensions_DurableTask_DurableTaskExtension_DurableTask_Core_INameVersionObjectManager_DurableTask_Core_TaskActivity__Add_DurableTask_Core_ObjectCreator_DurableTask_Core_TaskActivity__" data-uid="Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.DurableTask#Core#INameVersionObjectManager{DurableTask#Core#TaskActivity}#Add(DurableTask.Core.ObjectCreator{DurableTask.Core.TaskActivity})">INameVersionObjectManager&lt;TaskActivity&gt;.Add(ObjectCreator&lt;TaskActivity&gt;)</h4>
@@ -742,7 +873,7 @@ the entire contents of function inputs and outputs.</p>
     <a href="https://github.com/Azure/azure-functions-durable-extension/new/master/apiSpec/new?filename=Microsoft_Azure_WebJobs_Extensions_DurableTask_DurableTaskExtension_DurableTask_Core_INameVersionObjectManager_DurableTask_Core_TaskActivity__GetObject_System_String_System_String_.md&amp;value=---%0Auid%3A%20Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.DurableTask%23Core%23INameVersionObjectManager%7BDurableTask%23Core%23TaskActivity%7D%23GetObject(System.String%2CSystem.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs/#L317">View Source</a>
+    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs/#L347">View Source</a>
   </span>
   <a id="Microsoft_Azure_WebJobs_Extensions_DurableTask_DurableTaskExtension_DurableTask_Core_INameVersionObjectManager_DurableTask_Core_TaskActivity__GetObject_" data-uid="Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.DurableTask#Core#INameVersionObjectManager{DurableTask#Core#TaskActivity}#GetObject*"></a>
   <h4 id="Microsoft_Azure_WebJobs_Extensions_DurableTask_DurableTaskExtension_DurableTask_Core_INameVersionObjectManager_DurableTask_Core_TaskActivity__GetObject_System_String_System_String_" data-uid="Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.DurableTask#Core#INameVersionObjectManager{DurableTask#Core#TaskActivity}#GetObject(System.String,System.String)">INameVersionObjectManager&lt;TaskActivity&gt;.GetObject(String, String)</h4>
@@ -800,7 +931,7 @@ the entire contents of function inputs and outputs.</p>
     <a href="https://github.com/Azure/azure-functions-durable-extension/new/master/apiSpec/new?filename=Microsoft_Azure_WebJobs_Extensions_DurableTask_DurableTaskExtension_DurableTask_Core_INameVersionObjectManager_DurableTask_Core_TaskOrchestration__Add_DurableTask_Core_ObjectCreator_DurableTask_Core_TaskOrchestration__.md&amp;value=---%0Auid%3A%20Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.DurableTask%23Core%23INameVersionObjectManager%7BDurableTask%23Core%23TaskOrchestration%7D%23Add(DurableTask.Core.ObjectCreator%7BDurableTask.Core.TaskOrchestration%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs/#L285">View Source</a>
+    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs/#L315">View Source</a>
   </span>
   <a id="Microsoft_Azure_WebJobs_Extensions_DurableTask_DurableTaskExtension_DurableTask_Core_INameVersionObjectManager_DurableTask_Core_TaskOrchestration__Add_" data-uid="Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.DurableTask#Core#INameVersionObjectManager{DurableTask#Core#TaskOrchestration}#Add*"></a>
   <h4 id="Microsoft_Azure_WebJobs_Extensions_DurableTask_DurableTaskExtension_DurableTask_Core_INameVersionObjectManager_DurableTask_Core_TaskOrchestration__Add_DurableTask_Core_ObjectCreator_DurableTask_Core_TaskOrchestration__" data-uid="Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.DurableTask#Core#INameVersionObjectManager{DurableTask#Core#TaskOrchestration}#Add(DurableTask.Core.ObjectCreator{DurableTask.Core.TaskOrchestration})">INameVersionObjectManager&lt;TaskOrchestration&gt;.Add(ObjectCreator&lt;TaskOrchestration&gt;)</h4>
@@ -836,7 +967,7 @@ the entire contents of function inputs and outputs.</p>
     <a href="https://github.com/Azure/azure-functions-durable-extension/new/master/apiSpec/new?filename=Microsoft_Azure_WebJobs_Extensions_DurableTask_DurableTaskExtension_DurableTask_Core_INameVersionObjectManager_DurableTask_Core_TaskOrchestration__GetObject_System_String_System_String_.md&amp;value=---%0Auid%3A%20Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.DurableTask%23Core%23INameVersionObjectManager%7BDurableTask%23Core%23TaskOrchestration%7D%23GetObject(System.String%2CSystem.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs/#L296">View Source</a>
+    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs/#L326">View Source</a>
   </span>
   <a id="Microsoft_Azure_WebJobs_Extensions_DurableTask_DurableTaskExtension_DurableTask_Core_INameVersionObjectManager_DurableTask_Core_TaskOrchestration__GetObject_" data-uid="Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.DurableTask#Core#INameVersionObjectManager{DurableTask#Core#TaskOrchestration}#GetObject*"></a>
   <h4 id="Microsoft_Azure_WebJobs_Extensions_DurableTask_DurableTaskExtension_DurableTask_Core_INameVersionObjectManager_DurableTask_Core_TaskOrchestration__GetObject_System_String_System_String_" data-uid="Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.DurableTask#Core#INameVersionObjectManager{DurableTask#Core#TaskOrchestration}#GetObject(System.String,System.String)">INameVersionObjectManager&lt;TaskOrchestration&gt;.GetObject(String, String)</h4>
@@ -894,7 +1025,7 @@ the entire contents of function inputs and outputs.</p>
     <a href="https://github.com/Azure/azure-functions-durable-extension/new/master/apiSpec/new?filename=Microsoft_Azure_WebJobs_Extensions_DurableTask_DurableTaskExtension_Microsoft_Azure_WebJobs_Host_Config_IExtensionConfigProvider_Initialize_Microsoft_Azure_WebJobs_Host_Config_ExtensionConfigContext_.md&amp;value=---%0Auid%3A%20Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.Microsoft%23Azure%23WebJobs%23Host%23Config%23IExtensionConfigProvider%23Initialize(Microsoft.Azure.WebJobs.Host.Config.ExtensionConfigContext)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs/#L225">View Source</a>
+    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs/#L254">View Source</a>
   </span>
   <a id="Microsoft_Azure_WebJobs_Extensions_DurableTask_DurableTaskExtension_Microsoft_Azure_WebJobs_Host_Config_IExtensionConfigProvider_Initialize_" data-uid="Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.Microsoft#Azure#WebJobs#Host#Config#IExtensionConfigProvider#Initialize*"></a>
   <h4 id="Microsoft_Azure_WebJobs_Extensions_DurableTask_DurableTaskExtension_Microsoft_Azure_WebJobs_Host_Config_IExtensionConfigProvider_Initialize_Microsoft_Azure_WebJobs_Host_Config_ExtensionConfigContext_" data-uid="Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.Microsoft#Azure#WebJobs#Host#Config#IExtensionConfigProvider#Initialize(Microsoft.Azure.WebJobs.Host.Config.ExtensionConfigContext)">IExtensionConfigProvider.Initialize(ExtensionConfigContext)</h4>
@@ -930,7 +1061,7 @@ the entire contents of function inputs and outputs.</p>
     <a href="https://github.com/Azure/azure-functions-durable-extension/new/master/apiSpec/new?filename=Microsoft_Azure_WebJobs_Extensions_DurableTask_DurableTaskExtension_Microsoft_Azure_WebJobs_IAsyncConverter_System_Net_Http_HttpRequestMessage_System_Net_Http_HttpResponseMessage__ConvertAsync_System_Net_Http_HttpRequestMessage_System_Threading_CancellationToken_.md&amp;value=---%0Auid%3A%20Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.Microsoft%23Azure%23WebJobs%23IAsyncConverter%7BSystem%23Net%23Http%23HttpRequestMessage%2CSystem%23Net%23Http%23HttpResponseMessage%7D%23ConvertAsync(System.Net.Http.HttpRequestMessage%2CSystem.Threading.CancellationToken)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs/#L645">View Source</a>
+    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs/#L684">View Source</a>
   </span>
   <a id="Microsoft_Azure_WebJobs_Extensions_DurableTask_DurableTaskExtension_Microsoft_Azure_WebJobs_IAsyncConverter_System_Net_Http_HttpRequestMessage_System_Net_Http_HttpResponseMessage__ConvertAsync_" data-uid="Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.Microsoft#Azure#WebJobs#IAsyncConverter{System#Net#Http#HttpRequestMessage,System#Net#Http#HttpResponseMessage}#ConvertAsync*"></a>
   <h4 id="Microsoft_Azure_WebJobs_Extensions_DurableTask_DurableTaskExtension_Microsoft_Azure_WebJobs_IAsyncConverter_System_Net_Http_HttpRequestMessage_System_Net_Http_HttpResponseMessage__ConvertAsync_System_Net_Http_HttpRequestMessage_System_Threading_CancellationToken_" data-uid="Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.Microsoft#Azure#WebJobs#IAsyncConverter{System#Net#Http#HttpRequestMessage,System#Net#Http#HttpResponseMessage}#ConvertAsync(System.Net.Http.HttpRequestMessage,System.Threading.CancellationToken)">IAsyncConverter&lt;HttpRequestMessage, HttpResponseMessage&gt;.ConvertAsync(HttpRequestMessage, CancellationToken)</h4>

--- a/docs/api/Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskJobHostConfigurationExtensions.html
+++ b/docs/api/Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskJobHostConfigurationExtensions.html
@@ -12,7 +12,7 @@
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Class DurableTaskJobHostConfigurationExtensions
    ">
-    <meta name="generator" content="docfx 2.35.4.0">
+    <meta name="generator" content="docfx 2.36.2.0">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <link rel="stylesheet" href="../styles/docfx.vendor.css">

--- a/docs/api/Microsoft.Azure.WebJobs.Extensions.DurableTask.HttpManagementPayload.html
+++ b/docs/api/Microsoft.Azure.WebJobs.Extensions.DurableTask.HttpManagementPayload.html
@@ -1,0 +1,290 @@
+﻿<!DOCTYPE html>
+<!--[if IE]><![endif]-->
+<html>
+  
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <title>Class HttpManagementPayload
+   </title>
+    <!-- Prevent search engine web crawlers from indexing or crawling this page -->
+    <meta name="robots" content="none">
+    <meta name="viewport" content="width=device-width">
+    <meta name="title" content="Class HttpManagementPayload
+   ">
+    <meta name="generator" content="docfx 2.36.2.0">
+    
+    <link rel="shortcut icon" href="../favicon.ico">
+    <link rel="stylesheet" href="../styles/docfx.vendor.css">
+    <link rel="stylesheet" href="../styles/docfx.css">
+    <link rel="stylesheet" href="../styles/main.css">
+    <meta property="docfx:navrel" content="../toc.html">
+    <meta property="docfx:tocrel" content="toc.html">
+    
+    
+  </head>
+  <body data-spy="scroll" data-target="#affix">
+    <div id="wrapper">
+      <header>
+        
+        <nav id="autocollapse" class="navbar navbar-inverse ng-scope" role="navigation">
+          <div class="container">
+            <div class="navbar-header">
+              <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#navbar">
+                <span class="sr-only">Toggle navigation</span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+              </button>
+              
+              <a class="navbar-brand" href="../index.html">
+                <img id="logo" class="svg" src="../logo.svg" alt="">
+              </a>
+            </div>
+            <div class="collapse navbar-collapse" id="navbar">
+              <form class="navbar-form navbar-right" role="search" id="search">
+                <div class="form-group">
+                  <input type="text" class="form-control" id="search-query" placeholder="Search" autocomplete="off">
+                </div>
+              </form>
+            </div>
+          </div>
+        </nav>
+        
+        <div class="subnav navbar navbar-default">
+          <div class="container hide-when-search" id="breadcrumb">
+            <ul class="breadcrumb">
+              <li></li>
+            </ul>
+          </div>
+        </div>
+      </header>
+      <div role="main" class="container body-content hide-when-search">
+        
+        <div class="sidenav hide-when-search">
+          <a class="btn toc-toggle collapse" data-toggle="collapse" href="#sidetoggle" aria-expanded="false" aria-controls="sidetoggle">Show / Hide Table of Contents</a>
+          <div class="sidetoggle collapse" id="sidetoggle">
+            <div id="sidetoc"></div>
+          </div>
+        </div>
+        <div class="article row grid-right">
+          <div class="col-md-10">
+            <article class="content wrap" id="_content" data-uid="Microsoft.Azure.WebJobs.Extensions.DurableTask.HttpManagementPayload">
+  
+  
+  <h1 id="Microsoft_Azure_WebJobs_Extensions_DurableTask_HttpManagementPayload" data-uid="Microsoft.Azure.WebJobs.Extensions.DurableTask.HttpManagementPayload" class="text-break">Class HttpManagementPayload
+  </h1>
+  <div class="markdown level0 summary"><p>Data structure containing status, terminate and send external event HTTP endpoints.</p>
+</div>
+  <div class="markdown level0 conceptual"></div>
+  <div class="inheritance">
+    <h5>Inheritance</h5>
+    <div class="level0"><span class="xref">System.Object</span></div>
+    <div class="level1"><span class="xref">HttpManagementPayload</span></div>
+  </div>
+  <div class="inheritedMembers">
+    <h5>Inherited Members</h5>
+    <div>
+      <span class="xref">System.Object.Equals(System.Object)</span>
+    </div>
+    <div>
+      <span class="xref">System.Object.Equals(System.Object, System.Object)</span>
+    </div>
+    <div>
+      <span class="xref">System.Object.GetHashCode()</span>
+    </div>
+    <div>
+      <span class="xref">System.Object.GetType()</span>
+    </div>
+    <div>
+      <span class="xref">System.Object.MemberwiseClone()</span>
+    </div>
+    <div>
+      <span class="xref">System.Object.ReferenceEquals(System.Object, System.Object)</span>
+    </div>
+    <div>
+      <span class="xref">System.Object.ToString()</span>
+    </div>
+  </div>
+  <h6><strong>Namespace</strong>: <a class="xref" href="Microsoft.Azure.WebJobs.Extensions.DurableTask.html">Microsoft.Azure.WebJobs.Extensions.DurableTask</a></h6>
+  <h6><strong>Assembly</strong>: Microsoft.Azure.WebJobs.Extensions.DurableTask.dll</h6>
+  <h5 id="Microsoft_Azure_WebJobs_Extensions_DurableTask_HttpManagementPayload_syntax">Syntax</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public class HttpManagementPayload</code></pre>
+  </div>
+  <h3 id="properties">Properties
+  </h3>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/Azure/azure-functions-durable-extension/new/master/apiSpec/new?filename=Microsoft_Azure_WebJobs_Extensions_DurableTask_HttpManagementPayload_Id.md&amp;value=---%0Auid%3A%20Microsoft.Azure.WebJobs.Extensions.DurableTask.HttpManagementPayload.Id%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/HttpManagementPayload.cs/#L19">View Source</a>
+  </span>
+  <a id="Microsoft_Azure_WebJobs_Extensions_DurableTask_HttpManagementPayload_Id_" data-uid="Microsoft.Azure.WebJobs.Extensions.DurableTask.HttpManagementPayload.Id*"></a>
+  <h4 id="Microsoft_Azure_WebJobs_Extensions_DurableTask_HttpManagementPayload_Id" data-uid="Microsoft.Azure.WebJobs.Extensions.DurableTask.HttpManagementPayload.Id">Id</h4>
+  <div class="markdown level1 summary"><p>Gets the ID of the orchestration instance.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">[JsonProperty(&quot;id&quot;)]
+public string Id { get; }</code></pre>
+  </div>
+  <h5 class="propertyValue">Property Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><span class="xref">System.String</span></td>
+        <td><p>The ID of the orchestration instance.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/Azure/azure-functions-durable-extension/new/master/apiSpec/new?filename=Microsoft_Azure_WebJobs_Extensions_DurableTask_HttpManagementPayload_SendEventPostUri.md&amp;value=---%0Auid%3A%20Microsoft.Azure.WebJobs.Extensions.DurableTask.HttpManagementPayload.SendEventPostUri%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/HttpManagementPayload.cs/#L37">View Source</a>
+  </span>
+  <a id="Microsoft_Azure_WebJobs_Extensions_DurableTask_HttpManagementPayload_SendEventPostUri_" data-uid="Microsoft.Azure.WebJobs.Extensions.DurableTask.HttpManagementPayload.SendEventPostUri*"></a>
+  <h4 id="Microsoft_Azure_WebJobs_Extensions_DurableTask_HttpManagementPayload_SendEventPostUri" data-uid="Microsoft.Azure.WebJobs.Extensions.DurableTask.HttpManagementPayload.SendEventPostUri">SendEventPostUri</h4>
+  <div class="markdown level1 summary"><p>Gets the HTTP POST external event sending endpoint URL.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">[JsonProperty(&quot;sendEventPostUri&quot;)]
+public string SendEventPostUri { get; }</code></pre>
+  </div>
+  <h5 class="propertyValue">Property Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><span class="xref">System.String</span></td>
+        <td><p>The HTTP URL for posting external event notifications.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/Azure/azure-functions-durable-extension/new/master/apiSpec/new?filename=Microsoft_Azure_WebJobs_Extensions_DurableTask_HttpManagementPayload_StatusQueryGetUri.md&amp;value=---%0Auid%3A%20Microsoft.Azure.WebJobs.Extensions.DurableTask.HttpManagementPayload.StatusQueryGetUri%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/HttpManagementPayload.cs/#L28">View Source</a>
+  </span>
+  <a id="Microsoft_Azure_WebJobs_Extensions_DurableTask_HttpManagementPayload_StatusQueryGetUri_" data-uid="Microsoft.Azure.WebJobs.Extensions.DurableTask.HttpManagementPayload.StatusQueryGetUri*"></a>
+  <h4 id="Microsoft_Azure_WebJobs_Extensions_DurableTask_HttpManagementPayload_StatusQueryGetUri" data-uid="Microsoft.Azure.WebJobs.Extensions.DurableTask.HttpManagementPayload.StatusQueryGetUri">StatusQueryGetUri</h4>
+  <div class="markdown level1 summary"><p>Gets the HTTP GET status query endpoint URL.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">[JsonProperty(&quot;statusQueryGetUri&quot;)]
+public string StatusQueryGetUri { get; }</code></pre>
+  </div>
+  <h5 class="propertyValue">Property Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><span class="xref">System.String</span></td>
+        <td><p>The HTTP URL for fetching the instance status.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/Azure/azure-functions-durable-extension/new/master/apiSpec/new?filename=Microsoft_Azure_WebJobs_Extensions_DurableTask_HttpManagementPayload_TerminatePostUri.md&amp;value=---%0Auid%3A%20Microsoft.Azure.WebJobs.Extensions.DurableTask.HttpManagementPayload.TerminatePostUri%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/HttpManagementPayload.cs/#L46">View Source</a>
+  </span>
+  <a id="Microsoft_Azure_WebJobs_Extensions_DurableTask_HttpManagementPayload_TerminatePostUri_" data-uid="Microsoft.Azure.WebJobs.Extensions.DurableTask.HttpManagementPayload.TerminatePostUri*"></a>
+  <h4 id="Microsoft_Azure_WebJobs_Extensions_DurableTask_HttpManagementPayload_TerminatePostUri" data-uid="Microsoft.Azure.WebJobs.Extensions.DurableTask.HttpManagementPayload.TerminatePostUri">TerminatePostUri</h4>
+  <div class="markdown level1 summary"><p>Gets the HTTP POST instance termination endpoint.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">[JsonProperty(&quot;terminatePostUri&quot;)]
+public string TerminatePostUri { get; }</code></pre>
+  </div>
+  <h5 class="propertyValue">Property Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><span class="xref">System.String</span></td>
+        <td><p>The HTTP URL for posting instance termination commands.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+</article>
+          </div>
+          
+          <div class="hidden-sm col-md-2" role="complementary">
+            <div class="sideaffix">
+              <div class="contribution">
+                <ul class="nav">
+                  <li>
+                    <a href="https://github.com/Azure/azure-functions-durable-extension/new/master/apiSpec/new?filename=Microsoft_Azure_WebJobs_Extensions_DurableTask_HttpManagementPayload.md&amp;value=---%0Auid%3A%20Microsoft.Azure.WebJobs.Extensions.DurableTask.HttpManagementPayload%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
+                  </li>
+                  <li>
+                    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/HttpManagementPayload.cs/#L11" class="contribution-link">View Source</a>
+                  </li>
+                </ul>
+              </div>
+              <nav class="bs-docs-sidebar hidden-print hidden-xs hidden-sm affix" id="affix">
+              <!-- <p><a class="back-to-top" href="#top">Back to top</a><p> -->
+              </nav>
+            </div>
+          </div>
+        </div>
+      </div>
+      
+      <footer>
+        <div class="grad-bottom"></div>
+        <div class="footer">
+          <div class="container">
+            <span class="pull-right">
+              <a href="#top">Back to top</a>
+            </span>
+            Copyright © .NET Foundation
+            
+          </div>
+        </div>
+      </footer>
+    </div>
+    
+    <script type="text/javascript" src="../styles/docfx.vendor.js"></script>
+    <script type="text/javascript" src="../styles/docfx.js"></script>
+    <script type="text/javascript" src="../styles/main.js"></script>
+  </body>
+</html>

--- a/docs/api/Microsoft.Azure.WebJobs.Extensions.DurableTask.html
+++ b/docs/api/Microsoft.Azure.WebJobs.Extensions.DurableTask.html
@@ -12,7 +12,7 @@
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
    ">
-    <meta name="generator" content="docfx 2.35.4.0">
+    <meta name="generator" content="docfx 2.36.2.0">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <link rel="stylesheet" href="../styles/docfx.vendor.css">
@@ -83,6 +83,9 @@
 </section>
       <h4><a class="xref" href="Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskJobHostConfigurationExtensions.html">DurableTaskJobHostConfigurationExtensions</a></h4>
       <section><p>Extension for registering a Durable Functions configuration with <code>JobHostConfiguration</code>.</p>
+</section>
+      <h4><a class="xref" href="Microsoft.Azure.WebJobs.Extensions.DurableTask.HttpManagementPayload.html">HttpManagementPayload</a></h4>
+      <section><p>Data structure containing status, terminate and send external event HTTP endpoints.</p>
 </section>
 </article>
           </div>

--- a/docs/api/Microsoft.Azure.WebJobs.FunctionFailedException.html
+++ b/docs/api/Microsoft.Azure.WebJobs.FunctionFailedException.html
@@ -12,7 +12,7 @@
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Class FunctionFailedException
    ">
-    <meta name="generator" content="docfx 2.35.4.0">
+    <meta name="generator" content="docfx 2.36.2.0">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <link rel="stylesheet" href="../styles/docfx.vendor.css">

--- a/docs/api/Microsoft.Azure.WebJobs.HttpManagementPayload.html
+++ b/docs/api/Microsoft.Azure.WebJobs.HttpManagementPayload.html
@@ -1,0 +1,290 @@
+﻿<!DOCTYPE html>
+<!--[if IE]><![endif]-->
+<html>
+  
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <title>Class HttpManagementPayload
+   </title>
+    <!-- Prevent search engine web crawlers from indexing or crawling this page -->
+    <meta name="robots" content="none">
+    <meta name="viewport" content="width=device-width">
+    <meta name="title" content="Class HttpManagementPayload
+   ">
+    <meta name="generator" content="docfx 2.36.2.0">
+    
+    <link rel="shortcut icon" href="../favicon.ico">
+    <link rel="stylesheet" href="../styles/docfx.vendor.css">
+    <link rel="stylesheet" href="../styles/docfx.css">
+    <link rel="stylesheet" href="../styles/main.css">
+    <meta property="docfx:navrel" content="../toc.html">
+    <meta property="docfx:tocrel" content="toc.html">
+    
+    
+  </head>
+  <body data-spy="scroll" data-target="#affix">
+    <div id="wrapper">
+      <header>
+        
+        <nav id="autocollapse" class="navbar navbar-inverse ng-scope" role="navigation">
+          <div class="container">
+            <div class="navbar-header">
+              <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#navbar">
+                <span class="sr-only">Toggle navigation</span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+              </button>
+              
+              <a class="navbar-brand" href="../index.html">
+                <img id="logo" class="svg" src="../logo.svg" alt="">
+              </a>
+            </div>
+            <div class="collapse navbar-collapse" id="navbar">
+              <form class="navbar-form navbar-right" role="search" id="search">
+                <div class="form-group">
+                  <input type="text" class="form-control" id="search-query" placeholder="Search" autocomplete="off">
+                </div>
+              </form>
+            </div>
+          </div>
+        </nav>
+        
+        <div class="subnav navbar navbar-default">
+          <div class="container hide-when-search" id="breadcrumb">
+            <ul class="breadcrumb">
+              <li></li>
+            </ul>
+          </div>
+        </div>
+      </header>
+      <div role="main" class="container body-content hide-when-search">
+        
+        <div class="sidenav hide-when-search">
+          <a class="btn toc-toggle collapse" data-toggle="collapse" href="#sidetoggle" aria-expanded="false" aria-controls="sidetoggle">Show / Hide Table of Contents</a>
+          <div class="sidetoggle collapse" id="sidetoggle">
+            <div id="sidetoc"></div>
+          </div>
+        </div>
+        <div class="article row grid-right">
+          <div class="col-md-10">
+            <article class="content wrap" id="_content" data-uid="Microsoft.Azure.WebJobs.HttpManagementPayload">
+  
+  
+  <h1 id="Microsoft_Azure_WebJobs_HttpManagementPayload" data-uid="Microsoft.Azure.WebJobs.HttpManagementPayload" class="text-break">Class HttpManagementPayload
+  </h1>
+  <div class="markdown level0 summary"><p>Data structure containing status, terminate and send external event HTTP endpoints.</p>
+</div>
+  <div class="markdown level0 conceptual"></div>
+  <div class="inheritance">
+    <h5>Inheritance</h5>
+    <div class="level0"><span class="xref">System.Object</span></div>
+    <div class="level1"><span class="xref">HttpManagementPayload</span></div>
+  </div>
+  <div class="inheritedMembers">
+    <h5>Inherited Members</h5>
+    <div>
+      <span class="xref">System.Object.Equals(System.Object)</span>
+    </div>
+    <div>
+      <span class="xref">System.Object.Equals(System.Object, System.Object)</span>
+    </div>
+    <div>
+      <span class="xref">System.Object.GetHashCode()</span>
+    </div>
+    <div>
+      <span class="xref">System.Object.GetType()</span>
+    </div>
+    <div>
+      <span class="xref">System.Object.MemberwiseClone()</span>
+    </div>
+    <div>
+      <span class="xref">System.Object.ReferenceEquals(System.Object, System.Object)</span>
+    </div>
+    <div>
+      <span class="xref">System.Object.ToString()</span>
+    </div>
+  </div>
+  <h6><strong>Namespace</strong>: <a class="xref" href="Microsoft.Azure.WebJobs.html">Microsoft.Azure.WebJobs</a></h6>
+  <h6><strong>Assembly</strong>: Microsoft.Azure.WebJobs.Extensions.DurableTask.dll</h6>
+  <h5 id="Microsoft_Azure_WebJobs_HttpManagementPayload_syntax">Syntax</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public class HttpManagementPayload</code></pre>
+  </div>
+  <h3 id="properties">Properties
+  </h3>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/Azure/azure-functions-durable-extension/new/master/apiSpec/new?filename=Microsoft_Azure_WebJobs_HttpManagementPayload_Id.md&amp;value=---%0Auid%3A%20Microsoft.Azure.WebJobs.HttpManagementPayload.Id%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/HttpManagementPayload.cs/#L19">View Source</a>
+  </span>
+  <a id="Microsoft_Azure_WebJobs_HttpManagementPayload_Id_" data-uid="Microsoft.Azure.WebJobs.HttpManagementPayload.Id*"></a>
+  <h4 id="Microsoft_Azure_WebJobs_HttpManagementPayload_Id" data-uid="Microsoft.Azure.WebJobs.HttpManagementPayload.Id">Id</h4>
+  <div class="markdown level1 summary"><p>Gets the ID of the orchestration instance.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">[JsonProperty(&quot;id&quot;)]
+public string Id { get; }</code></pre>
+  </div>
+  <h5 class="propertyValue">Property Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><span class="xref">System.String</span></td>
+        <td><p>The ID of the orchestration instance.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/Azure/azure-functions-durable-extension/new/master/apiSpec/new?filename=Microsoft_Azure_WebJobs_HttpManagementPayload_SendEventPostUri.md&amp;value=---%0Auid%3A%20Microsoft.Azure.WebJobs.HttpManagementPayload.SendEventPostUri%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/HttpManagementPayload.cs/#L37">View Source</a>
+  </span>
+  <a id="Microsoft_Azure_WebJobs_HttpManagementPayload_SendEventPostUri_" data-uid="Microsoft.Azure.WebJobs.HttpManagementPayload.SendEventPostUri*"></a>
+  <h4 id="Microsoft_Azure_WebJobs_HttpManagementPayload_SendEventPostUri" data-uid="Microsoft.Azure.WebJobs.HttpManagementPayload.SendEventPostUri">SendEventPostUri</h4>
+  <div class="markdown level1 summary"><p>Gets the HTTP POST external event sending endpoint URL.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">[JsonProperty(&quot;sendEventPostUri&quot;)]
+public string SendEventPostUri { get; }</code></pre>
+  </div>
+  <h5 class="propertyValue">Property Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><span class="xref">System.String</span></td>
+        <td><p>The HTTP URL for posting external event notifications.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/Azure/azure-functions-durable-extension/new/master/apiSpec/new?filename=Microsoft_Azure_WebJobs_HttpManagementPayload_StatusQueryGetUri.md&amp;value=---%0Auid%3A%20Microsoft.Azure.WebJobs.HttpManagementPayload.StatusQueryGetUri%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/HttpManagementPayload.cs/#L28">View Source</a>
+  </span>
+  <a id="Microsoft_Azure_WebJobs_HttpManagementPayload_StatusQueryGetUri_" data-uid="Microsoft.Azure.WebJobs.HttpManagementPayload.StatusQueryGetUri*"></a>
+  <h4 id="Microsoft_Azure_WebJobs_HttpManagementPayload_StatusQueryGetUri" data-uid="Microsoft.Azure.WebJobs.HttpManagementPayload.StatusQueryGetUri">StatusQueryGetUri</h4>
+  <div class="markdown level1 summary"><p>Gets the HTTP GET status query endpoint URL.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">[JsonProperty(&quot;statusQueryGetUri&quot;)]
+public string StatusQueryGetUri { get; }</code></pre>
+  </div>
+  <h5 class="propertyValue">Property Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><span class="xref">System.String</span></td>
+        <td><p>The HTTP URL for fetching the instance status.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/Azure/azure-functions-durable-extension/new/master/apiSpec/new?filename=Microsoft_Azure_WebJobs_HttpManagementPayload_TerminatePostUri.md&amp;value=---%0Auid%3A%20Microsoft.Azure.WebJobs.HttpManagementPayload.TerminatePostUri%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/HttpManagementPayload.cs/#L46">View Source</a>
+  </span>
+  <a id="Microsoft_Azure_WebJobs_HttpManagementPayload_TerminatePostUri_" data-uid="Microsoft.Azure.WebJobs.HttpManagementPayload.TerminatePostUri*"></a>
+  <h4 id="Microsoft_Azure_WebJobs_HttpManagementPayload_TerminatePostUri" data-uid="Microsoft.Azure.WebJobs.HttpManagementPayload.TerminatePostUri">TerminatePostUri</h4>
+  <div class="markdown level1 summary"><p>Gets the HTTP POST instance termination endpoint.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">[JsonProperty(&quot;terminatePostUri&quot;)]
+public string TerminatePostUri { get; }</code></pre>
+  </div>
+  <h5 class="propertyValue">Property Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><span class="xref">System.String</span></td>
+        <td><p>The HTTP URL for posting instance termination commands.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+</article>
+          </div>
+          
+          <div class="hidden-sm col-md-2" role="complementary">
+            <div class="sideaffix">
+              <div class="contribution">
+                <ul class="nav">
+                  <li>
+                    <a href="https://github.com/Azure/azure-functions-durable-extension/new/master/apiSpec/new?filename=Microsoft_Azure_WebJobs_HttpManagementPayload.md&amp;value=---%0Auid%3A%20Microsoft.Azure.WebJobs.HttpManagementPayload%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
+                  </li>
+                  <li>
+                    <a href="https://github.com/Azure/azure-functions-durable-extension/blob/master/src/WebJobs.Extensions.DurableTask/HttpManagementPayload.cs/#L11" class="contribution-link">View Source</a>
+                  </li>
+                </ul>
+              </div>
+              <nav class="bs-docs-sidebar hidden-print hidden-xs hidden-sm affix" id="affix">
+              <!-- <p><a class="back-to-top" href="#top">Back to top</a><p> -->
+              </nav>
+            </div>
+          </div>
+        </div>
+      </div>
+      
+      <footer>
+        <div class="grad-bottom"></div>
+        <div class="footer">
+          <div class="container">
+            <span class="pull-right">
+              <a href="#top">Back to top</a>
+            </span>
+            Copyright © .NET Foundation
+            
+          </div>
+        </div>
+      </footer>
+    </div>
+    
+    <script type="text/javascript" src="../styles/docfx.vendor.js"></script>
+    <script type="text/javascript" src="../styles/docfx.js"></script>
+    <script type="text/javascript" src="../styles/main.js"></script>
+  </body>
+</html>

--- a/docs/api/Microsoft.Azure.WebJobs.OrchestrationClientAttribute.html
+++ b/docs/api/Microsoft.Azure.WebJobs.OrchestrationClientAttribute.html
@@ -12,7 +12,7 @@
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Class OrchestrationClientAttribute
    ">
-    <meta name="generator" content="docfx 2.35.4.0">
+    <meta name="generator" content="docfx 2.36.2.0">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <link rel="stylesheet" href="../styles/docfx.vendor.css">

--- a/docs/api/Microsoft.Azure.WebJobs.OrchestrationRuntimeStatus.html
+++ b/docs/api/Microsoft.Azure.WebJobs.OrchestrationRuntimeStatus.html
@@ -12,7 +12,7 @@
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Enum OrchestrationRuntimeStatus
    ">
-    <meta name="generator" content="docfx 2.35.4.0">
+    <meta name="generator" content="docfx 2.36.2.0">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <link rel="stylesheet" href="../styles/docfx.vendor.css">

--- a/docs/api/Microsoft.Azure.WebJobs.OrchestrationTriggerAttribute.html
+++ b/docs/api/Microsoft.Azure.WebJobs.OrchestrationTriggerAttribute.html
@@ -12,7 +12,7 @@
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Class OrchestrationTriggerAttribute
    ">
-    <meta name="generator" content="docfx 2.35.4.0">
+    <meta name="generator" content="docfx 2.36.2.0">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <link rel="stylesheet" href="../styles/docfx.vendor.css">

--- a/docs/api/Microsoft.Azure.WebJobs.RetryOptions.html
+++ b/docs/api/Microsoft.Azure.WebJobs.RetryOptions.html
@@ -12,7 +12,7 @@
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Class RetryOptions
    ">
-    <meta name="generator" content="docfx 2.35.4.0">
+    <meta name="generator" content="docfx 2.36.2.0">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <link rel="stylesheet" href="../styles/docfx.vendor.css">

--- a/docs/api/Microsoft.Azure.WebJobs.StartOrchestrationArgs.html
+++ b/docs/api/Microsoft.Azure.WebJobs.StartOrchestrationArgs.html
@@ -12,7 +12,7 @@
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Class StartOrchestrationArgs
    ">
-    <meta name="generator" content="docfx 2.35.4.0">
+    <meta name="generator" content="docfx 2.36.2.0">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <link rel="stylesheet" href="../styles/docfx.vendor.css">

--- a/docs/api/Microsoft.Azure.WebJobs.html
+++ b/docs/api/Microsoft.Azure.WebJobs.html
@@ -12,7 +12,7 @@
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Namespace Microsoft.Azure.WebJobs
    ">
-    <meta name="generator" content="docfx 2.35.4.0">
+    <meta name="generator" content="docfx 2.36.2.0">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <link rel="stylesheet" href="../styles/docfx.vendor.css">
@@ -88,7 +88,7 @@
       <section><p>Client for starting, querying, terminating, and raising events to orchestration instances.</p>
 </section>
       <h4><a class="xref" href="Microsoft.Azure.WebJobs.DurableOrchestrationClientBase.html">DurableOrchestrationClientBase</a></h4>
-      <section><p>Abstract class for <a class="xref" href="Microsoft.Azure.WebJobs.DurableOrchestrationClient.html">DurableOrchestrationClient</a></p>
+      <section><p>Abstract base class for <a class="xref" href="Microsoft.Azure.WebJobs.DurableOrchestrationClient.html">DurableOrchestrationClient</a>.</p>
 </section>
       <h4><a class="xref" href="Microsoft.Azure.WebJobs.DurableOrchestrationContext.html">DurableOrchestrationContext</a></h4>
       <section><p>Parameter data for orchestration bindings that can be used to schedule function-based activities.</p>

--- a/docs/api/toc.html
+++ b/docs/api/toc.html
@@ -10,7 +10,7 @@
     <meta name="robots" content="none">
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Table of Content ">
-    <meta name="generator" content="docfx 2.35.4.0">
+    <meta name="generator" content="docfx 2.36.2.0">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <link rel="stylesheet" href="../styles/docfx.vendor.css">
@@ -128,6 +128,9 @@
                   </li>
                   <li>
                     <a href="Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskJobHostConfigurationExtensions.html" name="" title="DurableTaskJobHostConfigurationExtensions">DurableTaskJobHostConfigurationExtensions</a>
+                  </li>
+                  <li>
+                    <a href="Microsoft.Azure.WebJobs.Extensions.DurableTask.HttpManagementPayload.html" name="" title="HttpManagementPayload">HttpManagementPayload</a>
                   </li>
                 </ul>  </li>
           </ul>      </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -10,7 +10,7 @@
     <meta name="robots" content="none">
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Durable Functions ">
-    <meta name="generator" content="docfx 2.35.4.0">
+    <meta name="generator" content="docfx 2.36.2.0">
     
     <link rel="shortcut icon" href="favicon.ico">
     <link rel="stylesheet" href="styles/docfx.vendor.css">

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -9,7 +9,7 @@
       "output": {
         ".html": {
           "relative_path": "api/Microsoft.Azure.WebJobs.ActivityTriggerAttribute.html",
-          "hash": "fydIIUbEssOa+a1oa2uxmQ=="
+          "hash": "YzcBN9qJX+IE7QP35Tenww=="
         }
       },
       "is_incremental": false,
@@ -21,7 +21,7 @@
       "output": {
         ".html": {
           "relative_path": "api/Microsoft.Azure.WebJobs.DurableActivityContext.html",
-          "hash": "EZNs0Q5KlicFI0xBg5OgVg=="
+          "hash": "8fe0wDGUPC9vS19Ql/JYoQ=="
         }
       },
       "is_incremental": false,
@@ -33,7 +33,7 @@
       "output": {
         ".html": {
           "relative_path": "api/Microsoft.Azure.WebJobs.DurableOrchestrationClient.html",
-          "hash": "KawisvtlAZZqIvmQr6tpog=="
+          "hash": "vIcZ2VuSXsR3lN/I8EDFFQ=="
         }
       },
       "is_incremental": false,
@@ -45,7 +45,7 @@
       "output": {
         ".html": {
           "relative_path": "api/Microsoft.Azure.WebJobs.DurableOrchestrationClientBase.html",
-          "hash": "kYoYkAUqywH9Kjc4ktFtTQ=="
+          "hash": "g7Ml680PZyhh3nUXQyl7ig=="
         }
       },
       "is_incremental": false,
@@ -57,7 +57,7 @@
       "output": {
         ".html": {
           "relative_path": "api/Microsoft.Azure.WebJobs.DurableOrchestrationContext.html",
-          "hash": "joFnL9RZNKFo8LNDTOXhFQ=="
+          "hash": "BAvt8cNms6bqeRht2XShwQ=="
         }
       },
       "is_incremental": false,
@@ -69,7 +69,7 @@
       "output": {
         ".html": {
           "relative_path": "api/Microsoft.Azure.WebJobs.DurableOrchestrationContextBase.html",
-          "hash": "uEvVx+DNrnxy13SMjyuPUg=="
+          "hash": "aJ2/nIwBNpzCLpmtC9UgJA=="
         }
       },
       "is_incremental": false,
@@ -81,7 +81,7 @@
       "output": {
         ".html": {
           "relative_path": "api/Microsoft.Azure.WebJobs.DurableOrchestrationStatus.html",
-          "hash": "qcO/PA8PKECofJ1vBtIZzw=="
+          "hash": "z/K7VRoM0v73EzwP8tgFsw=="
         }
       },
       "is_incremental": false,
@@ -93,7 +93,7 @@
       "output": {
         ".html": {
           "relative_path": "api/Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.html",
-          "hash": "rAe94/V/EGtU6XMwMKSGpA=="
+          "hash": "05oWlie9jUkh6lh/YgkZYA=="
         }
       },
       "is_incremental": false,
@@ -105,7 +105,19 @@
       "output": {
         ".html": {
           "relative_path": "api/Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskJobHostConfigurationExtensions.html",
-          "hash": "SuhxZozhvxNFb5U1fPac/g=="
+          "hash": "REPFELirPyoyyAagNreEDw=="
+        }
+      },
+      "is_incremental": false,
+      "version": ""
+    },
+    {
+      "type": "ManagedReference",
+      "source_relative_path": "api/Microsoft.Azure.WebJobs.Extensions.DurableTask.HttpManagementPayload.yml",
+      "output": {
+        ".html": {
+          "relative_path": "api/Microsoft.Azure.WebJobs.Extensions.DurableTask.HttpManagementPayload.html",
+          "hash": "iWm9+Ue+liShMdpQIUEc+g=="
         }
       },
       "is_incremental": false,
@@ -117,7 +129,7 @@
       "output": {
         ".html": {
           "relative_path": "api/Microsoft.Azure.WebJobs.Extensions.DurableTask.html",
-          "hash": "tot8tznjE73KX4ZPoJgQ1A=="
+          "hash": "exgA7Ch/W7JLmolZrghMKg=="
         }
       },
       "is_incremental": false,
@@ -129,7 +141,7 @@
       "output": {
         ".html": {
           "relative_path": "api/Microsoft.Azure.WebJobs.FunctionFailedException.html",
-          "hash": "GqOriEm+R3rijurGqnKxJA=="
+          "hash": "oYFdGOV5DHlWMElbsUdBXw=="
         }
       },
       "is_incremental": false,
@@ -141,7 +153,7 @@
       "output": {
         ".html": {
           "relative_path": "api/Microsoft.Azure.WebJobs.OrchestrationClientAttribute.html",
-          "hash": "whcif+ORldhUHmronvkVBQ=="
+          "hash": "yIrcvGn25CWzguCGCujpnQ=="
         }
       },
       "is_incremental": false,
@@ -153,7 +165,7 @@
       "output": {
         ".html": {
           "relative_path": "api/Microsoft.Azure.WebJobs.OrchestrationRuntimeStatus.html",
-          "hash": "bayqt72IwmGHZSbPb7OAPw=="
+          "hash": "f6g4OnCZBmah0IW/wgr0rg=="
         }
       },
       "is_incremental": false,
@@ -165,7 +177,7 @@
       "output": {
         ".html": {
           "relative_path": "api/Microsoft.Azure.WebJobs.OrchestrationTriggerAttribute.html",
-          "hash": "AZ53sHOEUmniIxYc/CgKAw=="
+          "hash": "0c2ZE4UattbRucxPOq1acA=="
         }
       },
       "is_incremental": false,
@@ -177,7 +189,7 @@
       "output": {
         ".html": {
           "relative_path": "api/Microsoft.Azure.WebJobs.RetryOptions.html",
-          "hash": "ZwKNpZu8OlKDC5BRdliThA=="
+          "hash": "DN81GcQevJ2lUcfo650vnQ=="
         }
       },
       "is_incremental": false,
@@ -189,7 +201,7 @@
       "output": {
         ".html": {
           "relative_path": "api/Microsoft.Azure.WebJobs.StartOrchestrationArgs.html",
-          "hash": "jHIzGyM0G7dfCx45N5BDyg=="
+          "hash": "hUNKLQ9/5LVEkhIlGWFpQg=="
         }
       },
       "is_incremental": false,
@@ -201,7 +213,7 @@
       "output": {
         ".html": {
           "relative_path": "api/Microsoft.Azure.WebJobs.html",
-          "hash": "kTwYpEFrKZdwiUPtSe542A=="
+          "hash": "fcSHm8cgm+tFIM0zWLmFJA=="
         }
       },
       "is_incremental": false,
@@ -213,7 +225,7 @@
       "output": {
         ".html": {
           "relative_path": "api/toc.html",
-          "hash": "/Hf3J6t4nBYFnHqdE+urFQ=="
+          "hash": "D0cNbpVr6OUZUD604DTA4w=="
         }
       },
       "is_incremental": false,
@@ -225,10 +237,10 @@
       "output": {
         ".html": {
           "relative_path": "index.html",
-          "hash": "OuR8pgeB0bXC0QN+tdZTvg=="
+          "hash": "xXhNO3Pl+j8VOBnTmnls+g=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -237,7 +249,7 @@
       "output": {
         ".html": {
           "relative_path": "toc.html",
-          "hash": "PWAZ4CfRQkEcWKDeWYQvIw=="
+          "hash": "2SBX6A661gqiyyIhsAL19Q=="
         }
       },
       "is_incremental": false,
@@ -247,30 +259,29 @@
   "incremental_info": [
     {
       "status": {
-        "can_incremental": false,
-        "details": "Disable incremental build by force rebuild option.",
+        "can_incremental": true,
         "incrementalPhase": "build"
       },
       "processors": {
         "TocDocumentProcessor": {
           "can_incremental": false,
-          "details": "Processor TocDocumentProcessor cannot suppport incremental build because the processor doesn't implement ISupportIncrementalDocumentProcessor interface.",
+          "details": "Processor TocDocumentProcessor cannot support incremental build because the processor doesn't implement ISupportIncrementalDocumentProcessor interface.",
           "incrementalPhase": "build"
         },
         "ManagedReferenceDocumentProcessor": {
-          "can_incremental": false,
+          "can_incremental": true,
           "incrementalPhase": "build"
         },
         "ConceptualDocumentProcessor": {
-          "can_incremental": false,
+          "can_incremental": true,
           "incrementalPhase": "build"
         }
       }
     },
     {
       "status": {
-        "can_incremental": false,
-        "details": "Cannot support incremental post processing, the reason is: it's disabled.",
+        "can_incremental": true,
+        "details": "Can support incremental post processing.",
         "incrementalPhase": "postProcessing"
       },
       "processors": {}

--- a/docs/toc.html
+++ b/docs/toc.html
@@ -10,7 +10,7 @@
     <meta name="robots" content="none">
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Table of Content ">
-    <meta name="generator" content="docfx 2.35.4.0">
+    <meta name="generator" content="docfx 2.36.2.0">
     
     <link rel="shortcut icon" href="favicon.ico">
     <link rel="stylesheet" href="styles/docfx.vendor.css">

--- a/docs/xrefmap.yml
+++ b/docs/xrefmap.yml
@@ -80,12 +80,31 @@ references:
   isSpec: "True"
   fullName: Microsoft.Azure.WebJobs.DurableOrchestrationClient.CreateCheckStatusResponse
   nameWithType: DurableOrchestrationClient.CreateCheckStatusResponse
+- uid: Microsoft.Azure.WebJobs.DurableOrchestrationClient.CreateHttpManagementPayload(System.String)
+  name: CreateHttpManagementPayload(String)
+  href: api/Microsoft.Azure.WebJobs.DurableOrchestrationClient.html#Microsoft_Azure_WebJobs_DurableOrchestrationClient_CreateHttpManagementPayload_System_String_
+  commentId: M:Microsoft.Azure.WebJobs.DurableOrchestrationClient.CreateHttpManagementPayload(System.String)
+  fullName: Microsoft.Azure.WebJobs.DurableOrchestrationClient.CreateHttpManagementPayload(System.String)
+  nameWithType: DurableOrchestrationClient.CreateHttpManagementPayload(String)
+- uid: Microsoft.Azure.WebJobs.DurableOrchestrationClient.CreateHttpManagementPayload*
+  name: CreateHttpManagementPayload
+  href: api/Microsoft.Azure.WebJobs.DurableOrchestrationClient.html#Microsoft_Azure_WebJobs_DurableOrchestrationClient_CreateHttpManagementPayload_
+  commentId: Overload:Microsoft.Azure.WebJobs.DurableOrchestrationClient.CreateHttpManagementPayload
+  isSpec: "True"
+  fullName: Microsoft.Azure.WebJobs.DurableOrchestrationClient.CreateHttpManagementPayload
+  nameWithType: DurableOrchestrationClient.CreateHttpManagementPayload
 - uid: Microsoft.Azure.WebJobs.DurableOrchestrationClient.GetStatusAsync(System.String,System.Boolean,System.Boolean)
   name: GetStatusAsync(String, Boolean, Boolean)
   href: api/Microsoft.Azure.WebJobs.DurableOrchestrationClient.html#Microsoft_Azure_WebJobs_DurableOrchestrationClient_GetStatusAsync_System_String_System_Boolean_System_Boolean_
   commentId: M:Microsoft.Azure.WebJobs.DurableOrchestrationClient.GetStatusAsync(System.String,System.Boolean,System.Boolean)
   fullName: Microsoft.Azure.WebJobs.DurableOrchestrationClient.GetStatusAsync(System.String, System.Boolean, System.Boolean)
   nameWithType: DurableOrchestrationClient.GetStatusAsync(String, Boolean, Boolean)
+- uid: Microsoft.Azure.WebJobs.DurableOrchestrationClient.GetStatusAsync(System.Threading.CancellationToken)
+  name: GetStatusAsync(CancellationToken)
+  href: api/Microsoft.Azure.WebJobs.DurableOrchestrationClient.html#Microsoft_Azure_WebJobs_DurableOrchestrationClient_GetStatusAsync_System_Threading_CancellationToken_
+  commentId: M:Microsoft.Azure.WebJobs.DurableOrchestrationClient.GetStatusAsync(System.Threading.CancellationToken)
+  fullName: Microsoft.Azure.WebJobs.DurableOrchestrationClient.GetStatusAsync(System.Threading.CancellationToken)
+  nameWithType: DurableOrchestrationClient.GetStatusAsync(CancellationToken)
 - uid: Microsoft.Azure.WebJobs.DurableOrchestrationClient.GetStatusAsync*
   name: GetStatusAsync
   href: api/Microsoft.Azure.WebJobs.DurableOrchestrationClient.html#Microsoft_Azure_WebJobs_DurableOrchestrationClient_GetStatusAsync_
@@ -177,6 +196,19 @@ references:
   isSpec: "True"
   fullName: Microsoft.Azure.WebJobs.DurableOrchestrationClientBase.CreateCheckStatusResponse
   nameWithType: DurableOrchestrationClientBase.CreateCheckStatusResponse
+- uid: Microsoft.Azure.WebJobs.DurableOrchestrationClientBase.CreateHttpManagementPayload(System.String)
+  name: CreateHttpManagementPayload(String)
+  href: api/Microsoft.Azure.WebJobs.DurableOrchestrationClientBase.html#Microsoft_Azure_WebJobs_DurableOrchestrationClientBase_CreateHttpManagementPayload_System_String_
+  commentId: M:Microsoft.Azure.WebJobs.DurableOrchestrationClientBase.CreateHttpManagementPayload(System.String)
+  fullName: Microsoft.Azure.WebJobs.DurableOrchestrationClientBase.CreateHttpManagementPayload(System.String)
+  nameWithType: DurableOrchestrationClientBase.CreateHttpManagementPayload(String)
+- uid: Microsoft.Azure.WebJobs.DurableOrchestrationClientBase.CreateHttpManagementPayload*
+  name: CreateHttpManagementPayload
+  href: api/Microsoft.Azure.WebJobs.DurableOrchestrationClientBase.html#Microsoft_Azure_WebJobs_DurableOrchestrationClientBase_CreateHttpManagementPayload_
+  commentId: Overload:Microsoft.Azure.WebJobs.DurableOrchestrationClientBase.CreateHttpManagementPayload
+  isSpec: "True"
+  fullName: Microsoft.Azure.WebJobs.DurableOrchestrationClientBase.CreateHttpManagementPayload
+  nameWithType: DurableOrchestrationClientBase.CreateHttpManagementPayload
 - uid: Microsoft.Azure.WebJobs.DurableOrchestrationClientBase.GetStatusAsync(System.String)
   name: GetStatusAsync(String)
   href: api/Microsoft.Azure.WebJobs.DurableOrchestrationClientBase.html#Microsoft_Azure_WebJobs_DurableOrchestrationClientBase_GetStatusAsync_System_String_
@@ -195,6 +227,12 @@ references:
   commentId: M:Microsoft.Azure.WebJobs.DurableOrchestrationClientBase.GetStatusAsync(System.String,System.Boolean,System.Boolean)
   fullName: Microsoft.Azure.WebJobs.DurableOrchestrationClientBase.GetStatusAsync(System.String, System.Boolean, System.Boolean)
   nameWithType: DurableOrchestrationClientBase.GetStatusAsync(String, Boolean, Boolean)
+- uid: Microsoft.Azure.WebJobs.DurableOrchestrationClientBase.GetStatusAsync(System.Threading.CancellationToken)
+  name: GetStatusAsync(CancellationToken)
+  href: api/Microsoft.Azure.WebJobs.DurableOrchestrationClientBase.html#Microsoft_Azure_WebJobs_DurableOrchestrationClientBase_GetStatusAsync_System_Threading_CancellationToken_
+  commentId: M:Microsoft.Azure.WebJobs.DurableOrchestrationClientBase.GetStatusAsync(System.Threading.CancellationToken)
+  fullName: Microsoft.Azure.WebJobs.DurableOrchestrationClientBase.GetStatusAsync(System.Threading.CancellationToken)
+  nameWithType: DurableOrchestrationClientBase.GetStatusAsync(CancellationToken)
 - uid: Microsoft.Azure.WebJobs.DurableOrchestrationClientBase.GetStatusAsync*
   name: GetStatusAsync
   href: api/Microsoft.Azure.WebJobs.DurableOrchestrationClientBase.html#Microsoft_Azure_WebJobs_DurableOrchestrationClientBase_GetStatusAsync_
@@ -994,6 +1032,45 @@ references:
   isSpec: "True"
   fullName: Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.EventGridKeySettingName
   nameWithType: DurableTaskExtension.EventGridKeySettingName
+- uid: Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.EventGridPublishRetryCount
+  name: EventGridPublishRetryCount
+  href: api/Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.html#Microsoft_Azure_WebJobs_Extensions_DurableTask_DurableTaskExtension_EventGridPublishRetryCount
+  commentId: P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.EventGridPublishRetryCount
+  fullName: Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.EventGridPublishRetryCount
+  nameWithType: DurableTaskExtension.EventGridPublishRetryCount
+- uid: Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.EventGridPublishRetryCount*
+  name: EventGridPublishRetryCount
+  href: api/Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.html#Microsoft_Azure_WebJobs_Extensions_DurableTask_DurableTaskExtension_EventGridPublishRetryCount_
+  commentId: Overload:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.EventGridPublishRetryCount
+  isSpec: "True"
+  fullName: Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.EventGridPublishRetryCount
+  nameWithType: DurableTaskExtension.EventGridPublishRetryCount
+- uid: Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.EventGridPublishRetryHttpStatus
+  name: EventGridPublishRetryHttpStatus
+  href: api/Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.html#Microsoft_Azure_WebJobs_Extensions_DurableTask_DurableTaskExtension_EventGridPublishRetryHttpStatus
+  commentId: P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.EventGridPublishRetryHttpStatus
+  fullName: Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.EventGridPublishRetryHttpStatus
+  nameWithType: DurableTaskExtension.EventGridPublishRetryHttpStatus
+- uid: Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.EventGridPublishRetryHttpStatus*
+  name: EventGridPublishRetryHttpStatus
+  href: api/Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.html#Microsoft_Azure_WebJobs_Extensions_DurableTask_DurableTaskExtension_EventGridPublishRetryHttpStatus_
+  commentId: Overload:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.EventGridPublishRetryHttpStatus
+  isSpec: "True"
+  fullName: Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.EventGridPublishRetryHttpStatus
+  nameWithType: DurableTaskExtension.EventGridPublishRetryHttpStatus
+- uid: Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.EventGridPublishRetryInterval
+  name: EventGridPublishRetryInterval
+  href: api/Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.html#Microsoft_Azure_WebJobs_Extensions_DurableTask_DurableTaskExtension_EventGridPublishRetryInterval
+  commentId: P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.EventGridPublishRetryInterval
+  fullName: Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.EventGridPublishRetryInterval
+  nameWithType: DurableTaskExtension.EventGridPublishRetryInterval
+- uid: Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.EventGridPublishRetryInterval*
+  name: EventGridPublishRetryInterval
+  href: api/Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.html#Microsoft_Azure_WebJobs_Extensions_DurableTask_DurableTaskExtension_EventGridPublishRetryInterval_
+  commentId: Overload:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.EventGridPublishRetryInterval
+  isSpec: "True"
+  fullName: Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.EventGridPublishRetryInterval
+  nameWithType: DurableTaskExtension.EventGridPublishRetryInterval
 - uid: Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.EventGridTopicEndpoint
   name: EventGridTopicEndpoint
   href: api/Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.html#Microsoft_Azure_WebJobs_Extensions_DurableTask_DurableTaskExtension_EventGridTopicEndpoint
@@ -1059,6 +1136,19 @@ references:
   isSpec: "True"
   fullName: Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.HubName
   nameWithType: DurableTaskExtension.HubName
+- uid: Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.LogReplayEvents
+  name: LogReplayEvents
+  href: api/Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.html#Microsoft_Azure_WebJobs_Extensions_DurableTask_DurableTaskExtension_LogReplayEvents
+  commentId: P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.LogReplayEvents
+  fullName: Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.LogReplayEvents
+  nameWithType: DurableTaskExtension.LogReplayEvents
+- uid: Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.LogReplayEvents*
+  name: LogReplayEvents
+  href: api/Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.html#Microsoft_Azure_WebJobs_Extensions_DurableTask_DurableTaskExtension_LogReplayEvents_
+  commentId: Overload:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.LogReplayEvents
+  isSpec: "True"
+  fullName: Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.LogReplayEvents
+  nameWithType: DurableTaskExtension.LogReplayEvents
 - uid: Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.MaxConcurrentActivityFunctions
   name: MaxConcurrentActivityFunctions
   href: api/Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.html#Microsoft_Azure_WebJobs_Extensions_DurableTask_DurableTaskExtension_MaxConcurrentActivityFunctions
@@ -1192,6 +1282,64 @@ references:
   isSpec: "True"
   fullName: Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskJobHostConfigurationExtensions.UseDurableTask
   nameWithType: DurableTaskJobHostConfigurationExtensions.UseDurableTask
+- uid: Microsoft.Azure.WebJobs.Extensions.DurableTask.HttpManagementPayload
+  name: HttpManagementPayload
+  href: api/Microsoft.Azure.WebJobs.Extensions.DurableTask.HttpManagementPayload.html
+  commentId: T:Microsoft.Azure.WebJobs.Extensions.DurableTask.HttpManagementPayload
+  fullName: Microsoft.Azure.WebJobs.Extensions.DurableTask.HttpManagementPayload
+  nameWithType: HttpManagementPayload
+- uid: Microsoft.Azure.WebJobs.Extensions.DurableTask.HttpManagementPayload.Id
+  name: Id
+  href: api/Microsoft.Azure.WebJobs.Extensions.DurableTask.HttpManagementPayload.html#Microsoft_Azure_WebJobs_Extensions_DurableTask_HttpManagementPayload_Id
+  commentId: P:Microsoft.Azure.WebJobs.Extensions.DurableTask.HttpManagementPayload.Id
+  fullName: Microsoft.Azure.WebJobs.Extensions.DurableTask.HttpManagementPayload.Id
+  nameWithType: HttpManagementPayload.Id
+- uid: Microsoft.Azure.WebJobs.Extensions.DurableTask.HttpManagementPayload.Id*
+  name: Id
+  href: api/Microsoft.Azure.WebJobs.Extensions.DurableTask.HttpManagementPayload.html#Microsoft_Azure_WebJobs_Extensions_DurableTask_HttpManagementPayload_Id_
+  commentId: Overload:Microsoft.Azure.WebJobs.Extensions.DurableTask.HttpManagementPayload.Id
+  isSpec: "True"
+  fullName: Microsoft.Azure.WebJobs.Extensions.DurableTask.HttpManagementPayload.Id
+  nameWithType: HttpManagementPayload.Id
+- uid: Microsoft.Azure.WebJobs.Extensions.DurableTask.HttpManagementPayload.SendEventPostUri
+  name: SendEventPostUri
+  href: api/Microsoft.Azure.WebJobs.Extensions.DurableTask.HttpManagementPayload.html#Microsoft_Azure_WebJobs_Extensions_DurableTask_HttpManagementPayload_SendEventPostUri
+  commentId: P:Microsoft.Azure.WebJobs.Extensions.DurableTask.HttpManagementPayload.SendEventPostUri
+  fullName: Microsoft.Azure.WebJobs.Extensions.DurableTask.HttpManagementPayload.SendEventPostUri
+  nameWithType: HttpManagementPayload.SendEventPostUri
+- uid: Microsoft.Azure.WebJobs.Extensions.DurableTask.HttpManagementPayload.SendEventPostUri*
+  name: SendEventPostUri
+  href: api/Microsoft.Azure.WebJobs.Extensions.DurableTask.HttpManagementPayload.html#Microsoft_Azure_WebJobs_Extensions_DurableTask_HttpManagementPayload_SendEventPostUri_
+  commentId: Overload:Microsoft.Azure.WebJobs.Extensions.DurableTask.HttpManagementPayload.SendEventPostUri
+  isSpec: "True"
+  fullName: Microsoft.Azure.WebJobs.Extensions.DurableTask.HttpManagementPayload.SendEventPostUri
+  nameWithType: HttpManagementPayload.SendEventPostUri
+- uid: Microsoft.Azure.WebJobs.Extensions.DurableTask.HttpManagementPayload.StatusQueryGetUri
+  name: StatusQueryGetUri
+  href: api/Microsoft.Azure.WebJobs.Extensions.DurableTask.HttpManagementPayload.html#Microsoft_Azure_WebJobs_Extensions_DurableTask_HttpManagementPayload_StatusQueryGetUri
+  commentId: P:Microsoft.Azure.WebJobs.Extensions.DurableTask.HttpManagementPayload.StatusQueryGetUri
+  fullName: Microsoft.Azure.WebJobs.Extensions.DurableTask.HttpManagementPayload.StatusQueryGetUri
+  nameWithType: HttpManagementPayload.StatusQueryGetUri
+- uid: Microsoft.Azure.WebJobs.Extensions.DurableTask.HttpManagementPayload.StatusQueryGetUri*
+  name: StatusQueryGetUri
+  href: api/Microsoft.Azure.WebJobs.Extensions.DurableTask.HttpManagementPayload.html#Microsoft_Azure_WebJobs_Extensions_DurableTask_HttpManagementPayload_StatusQueryGetUri_
+  commentId: Overload:Microsoft.Azure.WebJobs.Extensions.DurableTask.HttpManagementPayload.StatusQueryGetUri
+  isSpec: "True"
+  fullName: Microsoft.Azure.WebJobs.Extensions.DurableTask.HttpManagementPayload.StatusQueryGetUri
+  nameWithType: HttpManagementPayload.StatusQueryGetUri
+- uid: Microsoft.Azure.WebJobs.Extensions.DurableTask.HttpManagementPayload.TerminatePostUri
+  name: TerminatePostUri
+  href: api/Microsoft.Azure.WebJobs.Extensions.DurableTask.HttpManagementPayload.html#Microsoft_Azure_WebJobs_Extensions_DurableTask_HttpManagementPayload_TerminatePostUri
+  commentId: P:Microsoft.Azure.WebJobs.Extensions.DurableTask.HttpManagementPayload.TerminatePostUri
+  fullName: Microsoft.Azure.WebJobs.Extensions.DurableTask.HttpManagementPayload.TerminatePostUri
+  nameWithType: HttpManagementPayload.TerminatePostUri
+- uid: Microsoft.Azure.WebJobs.Extensions.DurableTask.HttpManagementPayload.TerminatePostUri*
+  name: TerminatePostUri
+  href: api/Microsoft.Azure.WebJobs.Extensions.DurableTask.HttpManagementPayload.html#Microsoft_Azure_WebJobs_Extensions_DurableTask_HttpManagementPayload_TerminatePostUri_
+  commentId: Overload:Microsoft.Azure.WebJobs.Extensions.DurableTask.HttpManagementPayload.TerminatePostUri
+  isSpec: "True"
+  fullName: Microsoft.Azure.WebJobs.Extensions.DurableTask.HttpManagementPayload.TerminatePostUri
+  nameWithType: HttpManagementPayload.TerminatePostUri
 - uid: Microsoft.Azure.WebJobs.FunctionFailedException
   name: FunctionFailedException
   href: api/Microsoft.Azure.WebJobs.FunctionFailedException.html

--- a/samples/VSSample.Tests/VSSample.Tests.csproj
+++ b/samples/VSSample.Tests/VSSample.Tests.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="1.4.0" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="1.5.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="Moq" Version="4.8.1" />
     <PackageReference Include="xunit" Version="2.3.1" />

--- a/samples/fsharp/DurableFSharp.fsproj
+++ b/samples/fsharp/DurableFSharp.fsproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="TaskBuilder.fs" Version="1.0.0" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="1.4.0" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="1.5.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Twilio" Version="3.0.0-beta5" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.13" />
   </ItemGroup>

--- a/samples/precompiled/VSSample.csproj
+++ b/samples/precompiled/VSSample.csproj
@@ -6,7 +6,7 @@
 
   <!-- Common packages for all targets -->
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="1.4.0" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="1.5.0" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.13" />
   </ItemGroup>
 

--- a/samples/webjobssdk/chaining/DFWebJobsSample.csproj
+++ b/samples/webjobssdk/chaining/DFWebJobsSample.csproj
@@ -56,7 +56,7 @@
       <Version>2.2.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask">
-      <Version>1.4.0</Version>
+      <Version>1.5.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights">
       <Version>2.2.0</Version>

--- a/src/WebJobs.Extensions.DurableTask/HttpManagementPayload.cs
+++ b/src/WebJobs.Extensions.DurableTask/HttpManagementPayload.cs
@@ -13,24 +13,36 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// <summary>
         /// Gets the ID of the orchestration instance.
         /// </summary>
+        /// <value>
+        /// The ID of the orchestration instance.
+        /// </value>
         [JsonProperty("id")]
         public string Id { get; internal set; }
 
         /// <summary>
         /// Gets the HTTP GET status query endpoint URL.
         /// </summary>
+        /// <value>
+        /// The HTTP URL for fetching the instance status.
+        /// </value>
         [JsonProperty("statusQueryGetUri")]
         public string StatusQueryGetUri { get; internal set; }
 
         /// <summary>
         /// Gets the HTTP POST external event sending endpoint URL.
         /// </summary>
+        /// <value>
+        /// The HTTP URL for posting external event notifications.
+        /// </value>
         [JsonProperty("sendEventPostUri")]
         public string SendEventPostUri { get; internal set; }
 
         /// <summary>
         /// Gets the HTTP POST instance termination endpoint.
         /// </summary>
+        /// <value>
+        /// The HTTP URL for posting instance termination commands.
+        /// </value>
         [JsonProperty("terminatePostUri")]
         public string TerminatePostUri { get; internal set; }
     }

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
@@ -498,9 +498,9 @@
             or contains the payload containing the output of the completed orchestration.
             </summary>
             <remarks>
-            If the orchestration instance completes within the specified timeout, then the HTTP response payload will
+            If the orchestration instance completes within the default 10 second timeout, then the HTTP response payload will
             contain the output of the orchestration instance formatted as JSON. However, if the orchestration does not
-            complete within the specified timeout, then the HTTP response will be identical to that of the
+            complete within this timeout, then the HTTP response will be identical to that of the
             <see cref="M:Microsoft.Azure.WebJobs.DurableOrchestrationClientBase.CreateCheckStatusResponse(System.Net.Http.HttpRequestMessage,System.String)"/> API.
             </remarks>
             <param name="request">The HTTP request that triggered the current function.</param>

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
@@ -294,21 +294,33 @@
             <summary>
             Gets the ID of the orchestration instance.
             </summary>
+            <value>
+            The ID of the orchestration instance.
+            </value>
         </member>
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.HttpManagementPayload.StatusQueryGetUri">
             <summary>
             Gets the HTTP GET status query endpoint URL.
             </summary>
+            <value>
+            The HTTP URL for fetching the instance status.
+            </value>
         </member>
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.HttpManagementPayload.SendEventPostUri">
             <summary>
             Gets the HTTP POST external event sending endpoint URL.
             </summary>
+            <value>
+            The HTTP URL for posting external event notifications.
+            </value>
         </member>
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.HttpManagementPayload.TerminatePostUri">
             <summary>
             Gets the HTTP POST instance termination endpoint.
             </summary>
+            <value>
+            The HTTP URL for posting instance termination commands.
+            </value>
         </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.TaskActivityShim">
             <summary>

--- a/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
+++ b/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
@@ -29,7 +29,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="DurableTask.AzureStorage" Version="1.2.3" />
+    <PackageReference Include="DurableTask.AzureStorage.Private" Version="1.2.4" />
   </ItemGroup>
 
   <!-- NuGet Publishing Metadata -->


### PR DESCRIPTION
Updating code comments, auto-generated API docs, and sample projects.

There is also a correction in WebJobs.Extensions.DurableTask.csproj to point to the newer DurableTask.AzureStorage.Private instead of DurableTask.AzureStorage.