### PR TITLE
Add TaskHubName parameter to RaiseEventAsync method

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/DurableOrchestrationClientBase.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableOrchestrationClientBase.cs
@@ -163,6 +163,26 @@ namespace Microsoft.Azure.WebJobs
         public abstract Task RaiseEventAsync(string instanceId, string eventName, object eventData);
 
         /// <summary>
+        /// Sends an event notification message to a waiting orchestration instance.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// In order to handle the event, the target orchestration instance must be waiting for an
+        /// event named <paramref name="eventName"/> using the
+        /// <see cref="DurableOrchestrationContext.WaitForExternalEvent{T}"/> API.
+        /// </para><para>
+        /// If the specified instance is not found or not running, this operation will have no effect.
+        /// </para>
+        /// </remarks>
+        /// <param name="taskHubName">The TaskHubName of the orchestration that will handle the event.</param>
+        /// <param name="instanceId">The ID of the orchestration instance that will handle the event.</param>
+        /// <param name="eventName">The name of the event.</param>
+        /// <param name="eventData">The JSON-serializeable data associated with the event.</param>
+        /// <returns>A task that completes when the event notification message has been enqueued.</returns>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1030:UseEventsWhereAppropriate", Justification = "This method does not work with the .NET Framework event model.")]
+        public abstract Task RaiseEventAsync(string taskHubName, string instanceId, string eventName, object eventData, string connectionName = null);
+
+        /// <summary>
         /// Terminates a running orchestration instance.
         /// </summary>
         /// <remarks>

--- a/test/DurableTaskEndToEndTests.cs
+++ b/test/DurableTaskEndToEndTests.cs
@@ -1774,7 +1774,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
-        public async Task ExternalEvents_WithTaskHubNam_MultipleNamesLooping(bool extendedSessions)
+        public async Task ExternalEvents_WithTaskHubName_MultipleNamesLooping(bool extendedSessions)
         {
             var taskHubName1 = "MultipleNamesLooping1";
             var taskHubName2 = "MultipleNamesLooping2";

--- a/test/TestOrchestratorClient.cs
+++ b/test/TestOrchestratorClient.cs
@@ -28,6 +28,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             this.instanceCreationTime = instanceCreationTime;
         }
 
+        public string TaskHubName => this.innerClient.TaskHubName;
+
         public string FunctionName => this.functionName;
 
         public string InstanceId => this.instanceId;
@@ -55,6 +57,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         public async Task RaiseEventAsync(string eventName, object eventData)
         {
             await this.innerClient.RaiseEventAsync(this.instanceId, eventName, eventData);
+        }
+
+        public async Task RaiseEventAsync(string taskHubName, string instanceid, string eventName, object eventData, string connectionName = null)
+        {
+            await this.innerClient.RaiseEventAsync(taskHubName, instanceid, eventName, eventData);
         }
 
         public async Task TerminateAsync(string reason)


### PR DESCRIPTION
Hi.
I created this PullRequest because I wanted to specify TaskHubName as a parameter of RiaseEventAsync function of DurableTaskClient.

There are two kinds of means to activate Orchestrator waiting in WaitForExternal: a method of making a Post request to Api and a method of using DurableOrchestrationClient.RaiseEventAsync function.

The way to make a Post request to Api is to specify InstanceId, event name and TaskHubName, but with the method using DurableOrchestrationClient.RaiseEventAsync function you can only specify event name and InstanceId.
