### PR TITLE
Changed SayHello sample to look more chained

### DIFF
--- a/samples/VSSample.Tests/HelloSequenceActivityTests.cs
+++ b/samples/VSSample.Tests/HelloSequenceActivityTests.cs
@@ -10,8 +10,22 @@ namespace VSSample.Tests
         [Fact]
         public void SayHello_returns_greeting()
         {
-            var result = HelloSequence.SayHello("John");
-            Assert.Equal("Hello John!", result);
+            var result = HelloSequence.SayHello("there!");
+            Assert.Equal("Hello there!", result);
+        }
+
+        [Fact]
+        public void SayHelloPlusSeattle_returns_Seattle_attatched()
+        {
+            var result = HelloSequence.SayHelloPlusSeattle("Added:");
+            Assert.Equal("Added: and Seattle", result);
+        }
+
+        [Fact]
+        public void SayHelloPlusLondon_returns_London_attatched()
+        {
+            var result = HelloSequence.SayHelloPlusLondon("Added:");
+            Assert.Equal("Added: and London!", result);
         }
     }
 }

--- a/samples/VSSample.Tests/HelloSequenceOrchestratorTests.cs
+++ b/samples/VSSample.Tests/HelloSequenceOrchestratorTests.cs
@@ -14,16 +14,13 @@ namespace VSSample.Tests
         public async Task Run_returns_multiple_greetings()
         {
             var durableOrchestrationContextMock = new Mock<DurableOrchestrationContextBase>();
-            durableOrchestrationContextMock.Setup(x => x.CallActivityAsync<string>("E1_SayHello", "Tokyo")).ReturnsAsync("Hello Tokyo!");
-            durableOrchestrationContextMock.Setup(x => x.CallActivityAsync<string>("E1_SayHello", "Seattle")).ReturnsAsync("Hello Seattle!");
-            durableOrchestrationContextMock.Setup(x => x.CallActivityAsync<string>("E1_SayHello", "London")).ReturnsAsync("Hello London!");
+            durableOrchestrationContextMock.Setup(x => x.CallActivityAsync<string>("E1_SayHello", "Tokyo")).ReturnsAsync("Hello Tokyo");
+            durableOrchestrationContextMock.Setup(x => x.CallActivityAsync<string>("E1_SayHelloPlusSeattle", "Hello Tokyo")).ReturnsAsync("Hello Tokyo and Seattle");
+            durableOrchestrationContextMock.Setup(x => x.CallActivityAsync<string>("E1_SayHelloPlusLondon", "Hello Tokyo and Seattle")).ReturnsAsync("Hello Tokyo and Seattle and London!");
 
             var result = await HelloSequence.Run(durableOrchestrationContextMock.Object);
 
-            Assert.Equal(3, result.Count);
-            Assert.Equal("Hello Tokyo!", result[0]);
-            Assert.Equal("Hello Seattle!", result[1]);
-            Assert.Equal("Hello London!", result[2]);
+            Assert.Equal("Hello Tokyo and Seattle and London!", result);
         }
     }
 }

--- a/samples/precompiled/HelloSequence.cs
+++ b/samples/precompiled/HelloSequence.cs
@@ -10,23 +10,34 @@ namespace VSSample
     public static class HelloSequence
     {
         [FunctionName("E1_HelloSequence")]
-        public static async Task<List<string>> Run(
+        public static async Task<string> Run(
             [OrchestrationTrigger] DurableOrchestrationContextBase context)
         {
-            var outputs = new List<string>();
 
-            outputs.Add(await context.CallActivityAsync<string>("E1_SayHello", "Tokyo"));
-            outputs.Add(await context.CallActivityAsync<string>("E1_SayHello", "Seattle"));
-            outputs.Add(await context.CallActivityAsync<string>("E1_SayHello", "London"));
+            var output1 = await context.CallActivityAsync<string>("E1_SayHello", "Tokyo");
+            var output2 = await context.CallActivityAsync<string>("E1_SayHelloPlusSeattle", output1);
+            var output3 = await context.CallActivityAsync<string>("E1_SayHelloPlusLondon", output2);
 
-            // returns ["Hello Tokyo!", "Hello Seattle!", "Hello London!"]
-            return outputs;
+            // returns "Hello Tokyo and Seattle and London!"
+            return output3;
         }
 
         [FunctionName("E1_SayHello")]
-        public static string SayHello([ActivityTrigger] string name)
+        public static string SayHello([ActivityTrigger] string input)
         {
-            return $"Hello {name}!";
+            return $"Hello {input}";
+        }
+
+        [FunctionName("E1_SayHelloPlusSeattle")]
+        public static string SayHelloPlusSeattle([ActivityTrigger] string input)
+        {
+            return $"{input} and Seattle";
+        }
+
+        [FunctionName("E1_SayHelloPlusLondon")]
+        public static string SayHelloPlusLondon([ActivityTrigger] string input)
+        {
+            return $"{input} and London!";
         }
     }
  }


### PR DESCRIPTION
**Reason for PR**
According to the Chaining-Sample in MS docs (https://docs.microsoft.com/en-gb/azure/azure-functions/durable-functions-sequence), this modified sample code supports better understanding of what chaining is. It means output of one function is input for another function.

**What's changed**
- VSSample > HelloSequence
  instead calling one function after another with independent out- and input, there are different functions, using the output of it's predecessor.
- it will sequence the create "Hello Tokyo and Seattle and London!".   Start -> Func1("Tokyo") >> "Hello Tokyo" -> Func2(..) >> "Hello Tokyo and Seattle" -> Func3(..) >> "Hello Tokyo and Seattle and London!" -> End

It would be nice, if you could take such an example, instead of the current one.