### PR TITLE
removing redundant setting

### DIFF
--- a/samples/javascript/local.settings.json
+++ b/samples/javascript/local.settings.json
@@ -3,7 +3,6 @@
   "Values": {
     "FUNCTIONS_WORKER_RUNTIME": "node",
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
-    "AZURE_STORAGE_CONNECTION_STRING": "UseDevelopmentStorage=true",
     "TwilioAccountSid": "<Put your Twilio Account SID here>",
     "TwilioAuthToken": "<Put your Twilio Auth Token here>",
     "TwilioPhoneNumber": "<Put your Twilio Phone Number here>",


### PR DESCRIPTION
@kashimiz I don't think we need this value? I don't see it being accessed from any samples and adds some confusion especially when running without storage emulator

per feedback from @sdras  