### PR TITLE
Added OrchestrationClient binding output converter.

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/Bindings/BindingHelper.cs
+++ b/src/WebJobs.Extensions.DurableTask/Bindings/BindingHelper.cs
@@ -10,6 +10,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 {
     internal class BindingHelper
     {
+        private const string InstanceIdPlaceholder = "INSTANCEID";
+
         private readonly DurableTaskExtension config;
         private readonly EndToEndTraceHelper traceHelper;
 
@@ -23,6 +25,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         {
             DurableOrchestrationClientBase client = this.config.GetClient(clientAttribute);
             return new OrchestrationClientAsyncCollector(client);
+        }
+
+        public string DurableOrchestrationClientToString(DurableOrchestrationClient client, OrchestrationClientAttribute attr)
+        {
+            var payload = this.config.HttpApiHandler.CreateHttpManagementPayload(InstanceIdPlaceholder, attr?.TaskHub, attr?.ConnectionName);
+            return JsonConvert.SerializeObject(payload);
         }
 
         public StartOrchestrationArgs JObjectToStartOrchestrationArgs(JObject input, OrchestrationClientAttribute attr)

--- a/src/WebJobs.Extensions.DurableTask/Listener/TaskOrchestrationShim.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/TaskOrchestrationShim.cs
@@ -191,6 +191,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         private async Task HandleOutOfProcExecution(JObject executionResult)
         {
             var execution = JsonConvert.DeserializeObject<OutOfProcOrchestratorState>(executionResult.ToString());
+            if (execution.CustomStatus != null)
+            {
+                this.context.SetCustomStatus(execution.CustomStatus);
+            }
+
             await this.ProcessAsyncActions(execution.Actions);
 
             if (execution.IsDone)
@@ -267,6 +272,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
             [JsonProperty("output")]
             internal object Output { get; set; }
+
+            [JsonProperty("customStatus")]
+            internal object CustomStatus { get; set; }
         }
 
         private class AsyncAction


### PR DESCRIPTION
This commit adds a converter for OrchestrationClient when used as output. This is necessary to enable an [improved orchestration client experience](https://github.com/Azure/azure-functions-durable-js/issues/12) in Durable JS and other (upcoming) out-of-proc languages, given current limitations on out-of-proc bindings in Azure Functions.

Partially enables #296.