### PR TITLE
Reuse AzureStorageOrchestrationService instances across client and host

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
@@ -54,6 +54,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         private readonly bool isOptionsConfigured;
 
         private AzureStorageOrchestrationService orchestrationService;
+        private AzureStorageOrchestrationServiceSettings orchestrationServiceSettings;
         private TaskHubWorker taskHubWorker;
         private IConnectionStringResolver connectionStringResolver;
         private bool isTaskHubWorkerStarted;
@@ -172,8 +173,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             context.AddBindingRule<ActivityTriggerAttribute>()
                 .BindToTrigger(new ActivityTriggerAttributeBindingProvider(this, context, this.TraceHelper));
 
-            AzureStorageOrchestrationServiceSettings settings = this.GetOrchestrationServiceSettings();
-            this.orchestrationService = new AzureStorageOrchestrationService(settings);
+            this.orchestrationServiceSettings = this.GetOrchestrationServiceSettings();
+            this.orchestrationService = new AzureStorageOrchestrationService(this.orchestrationServiceSettings);
             this.taskHubWorker = new TaskHubWorker(this.orchestrationService, this, this);
             this.taskHubWorker.AddOrchestrationDispatcherMiddleware(this.OrchestrationMiddleware);
         }
@@ -367,7 +368,23 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 attr =>
                 {
                     AzureStorageOrchestrationServiceSettings settings = this.GetOrchestrationServiceSettings(attr);
-                    var innerClient = new AzureStorageOrchestrationService(settings);
+
+                    AzureStorageOrchestrationService innerClient;
+                    if (this.orchestrationServiceSettings != null &&
+                        this.orchestrationService != null &&
+                        string.Equals(this.orchestrationServiceSettings.TaskHubName, settings.TaskHubName, StringComparison.OrdinalIgnoreCase) &&
+                        string.Equals(this.orchestrationServiceSettings.StorageConnectionString, settings.StorageConnectionString, StringComparison.OrdinalIgnoreCase))
+                    {
+                        // It's important that clients use the same AzureStorageOrchestrationService instance
+                        // as the host when possible to ensure we any send operations can be picked up
+                        // immediately instead of waiting for the next queue polling interval.
+                        innerClient = this.orchestrationService;
+                    }
+                    else
+                    {
+                        innerClient = new AzureStorageOrchestrationService(settings);
+                    }
+
                     return new DurableOrchestrationClient(innerClient, this, attr);
                 });
 

--- a/test/FunctionsV1/WebJobs.Extensions.DurableTask.Tests.V1.csproj
+++ b/test/FunctionsV1/WebJobs.Extensions.DurableTask.Tests.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net47</TargetFramework>
+    <TargetFramework>net461</TargetFramework>
     <Company>Microsoft Corporation</Company>
     <NoWarn>SA0001;SA1600;SA1615</NoWarn>
     <SignAssembly>true</SignAssembly>


### PR DESCRIPTION
Resolves https://github.com/Azure/azure-functions-durable-extension/issues/449.

**DurableTask.AzureStorage** has a queue polling optimization where if a client sends a message to a queue, then the polling loop will pick it up immediately instead of waiting for the next polling interval. This optimization only works if both the client and host are using the same `AzureStorageOrchestrationService` instance in memory. This was not the case previously, defeating the purpose of this optimization.

This PR also includes a change to target our full framework tests to **.NET Framework 4.6.1** instead of 4.7. This is to make it easier for developers to run these tests (.NET 4.6.1 is installed by default by Visual Studio 2017, but .NET 4.7 is not).