### PR TITLE
Modified out-of-proc OrchestrationClient binding data.

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/Bindings/BindingHelper.cs
+++ b/src/WebJobs.Extensions.DurableTask/Bindings/BindingHelper.cs
@@ -29,7 +29,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
         public string DurableOrchestrationClientToString(DurableOrchestrationClient client, OrchestrationClientAttribute attr)
         {
-            var payload = this.config.HttpApiHandler.CreateHttpManagementPayload(InstanceIdPlaceholder, attr?.TaskHub, attr?.ConnectionName);
+            var payload = new OrchestrationClientInputData
+            {
+                TaskHubName = client.TaskHubName,
+                CreationUrls = this.config.HttpApiHandler.GetInstanceCreationLinks(),
+                ManagementUrls = this.config.HttpApiHandler.CreateHttpManagementPayload(InstanceIdPlaceholder, attr?.TaskHub, attr?.ConnectionName),
+            };
             return JsonConvert.SerializeObject(payload);
         }
 
@@ -69,6 +74,18 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             {
                 return Task.CompletedTask;
             }
+        }
+
+        private class OrchestrationClientInputData
+        {
+            [JsonProperty("taskHubName")]
+            public string TaskHubName { get; set; }
+
+            [JsonProperty("creationUrls")]
+            public HttpCreationPayload CreationUrls { get; set; }
+
+            [JsonProperty("managementUrls")]
+            public HttpManagementPayload ManagementUrls { get; set; }
         }
     }
 }

--- a/src/WebJobs.Extensions.DurableTask/HttpCreationPayload.cs
+++ b/src/WebJobs.Extensions.DurableTask/HttpCreationPayload.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license info
+
+using Newtonsoft.Json;
+
+namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
+{
+    /// <summary>
+    /// Data structure containing orchestration instance creation HTTP endpoints.
+    /// </summary>
+    internal class HttpCreationPayload
+    {
+        /// <summary>
+        /// Gets the HTTP POST orchestration instance creation endpoint URL.
+        /// </summary>
+        /// <value>
+        /// The HTTP URL for creating a new orchestration instance.
+        /// </value>
+        [JsonProperty("createNewInstancePostUri")]
+        internal string CreateNewInstancePostUri { get; set; }
+
+        /// <summary>
+        /// Gets the HTTP POST orchestration instance create-and-wait endpoint URL.
+        /// </summary>
+        /// <value>
+        /// The HTTP URL for creating a new orchestration instance and waiting on its completion.
+        /// </value>
+        [JsonProperty("createAndWaitOnNewInstancePostUri")]
+        internal string CreateAndWaitOnNewInstancePostUri { get; set; }
+    }
+}

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
@@ -22,6 +22,11 @@
             Configuration for the Durable Functions extension.
             </summary>
         </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.#ctor">
+            <summary>
+            Obsolete. Please use an alternate constructor overload.
+            </summary>
+        </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.#ctor(Microsoft.Extensions.Options.IOptions{Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskOptions},Microsoft.Extensions.Logging.ILoggerFactory,Microsoft.Azure.WebJobs.INameResolver,Microsoft.Azure.WebJobs.Extensions.DurableTask.IConnectionStringResolver)">
             <summary>
             Initializes a new instance of the <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension"/>.
@@ -30,6 +35,17 @@
             <param name="loggerFactory">The logger factory used for extension-specific logging and orchestration tracking.</param>
             <param name="nameResolver">The name resolver to use for looking up application settings.</param>
             <param name="connectionStringResolver">The resolver to use for looking up connection strings.</param>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.HubName">
+            <summary>
+            Gets or sets default task hub name to be used by all <see cref="T:Microsoft.Azure.WebJobs.DurableOrchestrationClient"/>,
+            <see cref="T:Microsoft.Azure.WebJobs.DurableOrchestrationContext"/>, and <see cref="T:Microsoft.Azure.WebJobs.DurableActivityContext"/> instances.
+            </summary>
+            <remarks>
+            A task hub is a logical grouping of storage resources. Alternate task hub names can be used to isolate
+            multiple Durable Functions applications from each other, even if they are using the same storage backend.
+            </remarks>
+            <value>The name of the default task hub.</value>
         </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.Microsoft#Azure#WebJobs#Host#Config#IExtensionConfigProvider#Initialize(Microsoft.Azure.WebJobs.Host.Config.ExtensionConfigContext)">
             <summary>
@@ -86,28 +102,12 @@
             Extension for registering a Durable Functions configuration with <c>JobHostConfiguration</c>.
             </summary>
         </member>
-        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskJobHostConfigurationExtensions.AddDurableTask(Microsoft.Azure.WebJobs.IWebJobsBuilder)">
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskJobHostConfigurationExtensions.UseDurableTask(Microsoft.Azure.WebJobs.JobHostConfiguration,Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension)">
             <summary>
-            Adds the Durable Task extension to the provided <see cref="T:Microsoft.Azure.WebJobs.IWebJobsBuilder"/>.
+            Enable running durable orchestrations implemented as functions.
             </summary>
-            <param name="builder">The <see cref="T:Microsoft.Azure.WebJobs.IWebJobsBuilder"/> to configure.</param>
-            <returns>Returns the provided <see cref="T:Microsoft.Azure.WebJobs.IWebJobsBuilder"/>.</returns>
-        </member>
-        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskJobHostConfigurationExtensions.AddDurableTask(Microsoft.Azure.WebJobs.IWebJobsBuilder,Microsoft.Extensions.Options.IOptions{Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskOptions})">
-            <summary>
-            Adds the Durable Task extension to the provided <see cref="T:Microsoft.Azure.WebJobs.IWebJobsBuilder"/>.
-            </summary>
-            <param name="builder">The <see cref="T:Microsoft.Azure.WebJobs.IWebJobsBuilder"/> to configure.</param>
-            <param name="options">The configuration options for this extension.</param>
-            <returns>Returns the provided <see cref="T:Microsoft.Azure.WebJobs.IWebJobsBuilder"/>.</returns>
-        </member>
-        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskJobHostConfigurationExtensions.AddDurableTask(Microsoft.Azure.WebJobs.IWebJobsBuilder,System.Action{Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskOptions})">
-            <summary>
-            Adds the Durable Task extension to the provided <see cref="T:Microsoft.Azure.WebJobs.IWebJobsBuilder"/>.
-            </summary>
-            <param name="builder">The <see cref="T:Microsoft.Azure.WebJobs.IWebJobsBuilder"/> to configure.</param>
-            <param name="configure">An <see cref="T:System.Action`1"/> to configure the provided <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskOptions"/>.</param>
-            <returns>Returns the modified <paramref name="builder"/> object.</returns>
+            <param name="hostConfig">Configuration settings of the current <c>JobHost</c> instance.</param>
+            <param name="listenerConfig">Durable Functions configuration.</param>
         </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskOptions">
             <summary>
@@ -315,6 +315,27 @@
             The type of a function.
             </summary>
         </member>
+        <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.HttpCreationPayload">
+            <summary>
+            Data structure containing orchestration instance creation HTTP endpoints.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.HttpCreationPayload.CreateNewInstancePostUri">
+            <summary>
+            Gets the HTTP POST orchestration instance creation endpoint URL.
+            </summary>
+            <value>
+            The HTTP URL for creating a new orchestration instance.
+            </value>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.HttpCreationPayload.WaitOnNewInstancePostUri">
+            <summary>
+            Gets the HTTP POST orchestration instance create-and-wait endpoint URL.
+            </summary>
+            <value>
+            The HTTP URL for creating a new orchestration instance and waiting on its completion.
+            </value>
+        </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.HttpManagementPayload">
             <summary>
             Data structure containing status, terminate and send external event HTTP endpoints.
@@ -442,12 +463,6 @@
             <summary>
             Connection string provider which resolves connection strings from the WebJobs context.
             </summary>
-        </member>
-        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.WebJobsConnectionStringProvider.#ctor(Microsoft.Extensions.Configuration.IConfiguration)">
-            <summary>
-            Initializes a new instance of the <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.WebJobsConnectionStringProvider"/> class.
-            </summary>
-            <param name="hostConfiguration">A <see cref="T:Microsoft.Extensions.Configuration.IConfiguration"/> object provided by the WebJobs host.</param>
         </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.WebJobsConnectionStringProvider.Resolve(System.String)">
             <inheritdoc />
@@ -1329,7 +1344,30 @@
         </member>
         <member name="P:Microsoft.Azure.WebJobs.DurableOrchestrationStatus.History">
             <summary>
-            Gets the execution histor The name of a durable function.
+            Gets the execution history of the orchestration instance.
+            </summary>
+            <remarks>
+            The history log can be large and is therefore <c>null</c> by default.
+            It is populated only when explicitly requested in the call to
+            <see cref="M:Microsoft.Azure.WebJobs.DurableOrchestrationClient.GetStatusAsync(System.String,System.Boolean,System.Boolean)"/>.
+            </remarks>
+            <value>
+            The output as a <c>JArray</c> object or <c>null</c>.
+            </value>
+        </member>
+        <member name="T:Microsoft.Azure.WebJobs.FunctionFailedException">
+            <summary>
+            The exception that is thrown when a sub-orchestrator or activity function fails
+            with an error.
+            </summary>
+            <remarks>
+            The `InnerException` property of this instance will contain additional information
+            about the failed sub-orchestrator or activity function.
+            </remarks>
+        </member>
+        <member name="T:Microsoft.Azure.WebJobs.FunctionName">
+            <summary>
+            The name of a durable function.
             </summary>
         </member>
         <member name="M:Microsoft.Azure.WebJobs.FunctionName.#ctor(System.String)">
@@ -1377,23 +1415,6 @@
             </summary>
             <param name="other">The other object to compare to.</param>
             <returns><c>true</c> if the two objects are equal using value semantics; otherwise <c>false</c>.</returns>
-        </member>
-        <member name="M:Microsoft.Azure.WebJobs.FunctionName.GetHashCode">
-            <summary>
-            Calculates a hash code value for the current <see cref="T:Microsoft.Azure.WebJobs.FunctionName"/> instance.
-            </summary>
-            <returns>A 32-bit hash code value.</returns>
-        </member>
-        <member name="M:Microsoft.Azure.WebJobs.FunctionName.ToString">
-            <summary>
-            Gets the string value of the current <see cref="T:Microsoft.Azure.WebJobs.FunctionName"/> instance.
-            </summary>
-            <returns>The name and optional version of the current <see cref="T:Microsoft.Azure.WebJobs.FunctionName"/> instance.</returns>
-        </member>
-        <member name="T:Microsoft.Azure.WebJobs.OrchestrationClientAttribute">
-            <summary>
-            Attribute used to bind a function parameter to a <see cref="T:Microsoft.Azure.WebJobs.DurableOrchestrationClient"/> instance.
-                      <returns><c>true</c> if the two objects are equal using value semantics; otherwise <c>false</c>.</returns>
         </member>
         <member name="M:Microsoft.Azure.WebJobs.FunctionName.GetHashCode">
             <summary>


### PR DESCRIPTION
Added orchestration start webhook templates to out-of-proc OrchestrationClient binding data, modified said data structure to resemble the following:

```json
{
  "taskHubName": "SampleHubJS",
  "creationPayload": {
    "createNewInstancePostUri": "http://localhost:7071/runtime/webhooks/durabletask/orchestrators/{functionName}[/{instanceId}]?code=code",
    "waitOnNewInstancePostUri": "http://localhost:7071/runtime/webhooks/durabletask/orchestrators/{functionName}[/{instanceId}]?timeoutInterval={timeoutInSeconds}&pollingInterval={intervalInSeconds}&code=code"
  },
  "managementPayload": {
    "id": "some-guid",
    "statusQueryGetUri": "http://localhost:7071/runtime/webhooks/durabletask/instances/some-guid?taskHub=SampleHubJS&connection=Storage&code=code",
    "sendEventPostUri": "http://localhost:7071/runtime/webhooks/durabletask/instances/some-guid/raiseEvent/{eventName}?taskHub=SampleHubJS&connection=Storage&code=code",
    "terminatePostUri": "http://localhost:7071/runtime/webhooks/durabletask/instances/some-guid/terminate?reason={text}&taskHub=SampleHubJS&connection=Storage&code=code",
    "rewindPostUri": "http://localhost:7071/runtime/webhooks/durabletask/instances/some-guid/rewind?reason={text}&taskHub=SampleHubJS&connection=Storage&code=code"
  }
}
```

Centralizing the definition of the webhook templates relieves consuming clients, such as [azure-functions-durable-js](https://github.com/Azure/azure-functions-durable-js), of monitoring for changes to our webhook syntax.