### PR TITLE
Adding support for configuring Task Hub Name via OrchestrationClientAttribute

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/DurableOrchestrationClient.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableOrchestrationClient.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Azure.WebJobs
 
             this.client = new TaskHubClient(serviceClient);
             this.traceHelper = config.TraceHelper;
-            this.hubName = config.Options.HubName;
+            this.hubName = attribute.TaskHub ?? config.Options.HubName;
             this.attribute = attribute;
         }
 

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
@@ -22,6 +22,11 @@
             Configuration for the Durable Functions extension.
             </summary>
         </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.#ctor">
+            <summary>
+            Obsolete. Please use an alternate constructor overload.
+            </summary>
+        </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.#ctor(Microsoft.Extensions.Options.IOptions{Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskOptions},Microsoft.Extensions.Logging.ILoggerFactory,Microsoft.Azure.WebJobs.INameResolver,Microsoft.Azure.WebJobs.Extensions.DurableTask.IConnectionStringResolver)">
             <summary>
             Initializes a new instance of the <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension"/>.
@@ -30,6 +35,17 @@
             <param name="loggerFactory">The logger factory used for extension-specific logging and orchestration tracking.</param>
             <param name="nameResolver">The name resolver to use for looking up application settings.</param>
             <param name="connectionStringResolver">The resolver to use for looking up connection strings.</param>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.HubName">
+            <summary>
+            Gets or sets default task hub name to be used by all <see cref="T:Microsoft.Azure.WebJobs.DurableOrchestrationClient"/>,
+            <see cref="T:Microsoft.Azure.WebJobs.DurableOrchestrationContext"/>, and <see cref="T:Microsoft.Azure.WebJobs.DurableActivityContext"/> instances.
+            </summary>
+            <remarks>
+            A task hub is a logical grouping of storage resources. Alternate task hub names can be used to isolate
+            multiple Durable Functions applications from each other, even if they are using the same storage backend.
+            </remarks>
+            <value>The name of the default task hub.</value>
         </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.Microsoft#Azure#WebJobs#Host#Config#IExtensionConfigProvider#Initialize(Microsoft.Azure.WebJobs.Host.Config.ExtensionConfigContext)">
             <summary>
@@ -86,28 +102,12 @@
             Extension for registering a Durable Functions configuration with <c>JobHostConfiguration</c>.
             </summary>
         </member>
-        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskJobHostConfigurationExtensions.AddDurableTask(Microsoft.Azure.WebJobs.IWebJobsBuilder)">
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskJobHostConfigurationExtensions.UseDurableTask(Microsoft.Azure.WebJobs.JobHostConfiguration,Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension)">
             <summary>
-            Adds the Durable Task extension to the provided <see cref="T:Microsoft.Azure.WebJobs.IWebJobsBuilder"/>.
+            Enable running durable orchestrations implemented as functions.
             </summary>
-            <param name="builder">The <see cref="T:Microsoft.Azure.WebJobs.IWebJobsBuilder"/> to configure.</param>
-            <returns>Returns the provided <see cref="T:Microsoft.Azure.WebJobs.IWebJobsBuilder"/>.</returns>
-        </member>
-        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskJobHostConfigurationExtensions.AddDurableTask(Microsoft.Azure.WebJobs.IWebJobsBuilder,Microsoft.Extensions.Options.IOptions{Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskOptions})">
-            <summary>
-            Adds the Durable Task extension to the provided <see cref="T:Microsoft.Azure.WebJobs.IWebJobsBuilder"/>.
-            </summary>
-            <param name="builder">The <see cref="T:Microsoft.Azure.WebJobs.IWebJobsBuilder"/> to configure.</param>
-            <param name="options">The configuration options for this extension.</param>
-            <returns>Returns the provided <see cref="T:Microsoft.Azure.WebJobs.IWebJobsBuilder"/>.</returns>
-        </member>
-        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskJobHostConfigurationExtensions.AddDurableTask(Microsoft.Azure.WebJobs.IWebJobsBuilder,System.Action{Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskOptions})">
-            <summary>
-            Adds the Durable Task extension to the provided <see cref="T:Microsoft.Azure.WebJobs.IWebJobsBuilder"/>.
-            </summary>
-            <param name="builder">The <see cref="T:Microsoft.Azure.WebJobs.IWebJobsBuilder"/> to configure.</param>
-            <param name="configure">An <see cref="T:System.Action`1"/> to configure the provided <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskOptions"/>.</param>
-            <returns>Returns the modified <paramref name="builder"/> object.</returns>
+            <param name="hostConfig">Configuration settings of the current <c>JobHost</c> instance.</param>
+            <param name="listenerConfig">Durable Functions configuration.</param>
         </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskOptions">
             <summary>
@@ -463,12 +463,6 @@
             <summary>
             Connection string provider which resolves connection strings from the WebJobs context.
             </summary>
-        </member>
-        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.WebJobsConnectionStringProvider.#ctor(Microsoft.Extensions.Configuration.IConfiguration)">
-            <summary>
-            Initializes a new instance of the <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.WebJobsConnectionStringProvider"/> class.
-            </summary>
-            <param name="hostConfiguration">A <see cref="T:Microsoft.Extensions.Configuration.IConfiguration"/> object provided by the WebJobs host.</param>
         </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.WebJobsConnectionStringProvider.Resolve(System.String)">
             <inheritdoc />
@@ -1654,6 +1648,29 @@
             </summary>
         </member>
         <member name="P:Microsoft.Azure.WebJobs.StartOrchestrationArgs.FunctionName">
+            <summary>
+            Gets or sets the name of the orchestrator function to start.
+            </summary>
+            <value>The name of the orchestrator function to start.</value>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.StartOrchestrationArgs.InstanceId">
+            <summary>
+            Gets or sets the instance ID to assign to the started orchestration.
+            </summary>
+            <remarks>
+            If this property value is null (the default), then a randomly generated instance ID will be assigned automatically.
+            </remarks>
+            <value>The instance ID to assign.</value>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.StartOrchestrationArgs.Input">
+            <summary>
+            Gets or sets the JSON-serializeable input data for the orchestrator function.
+            </summary>
+            <value>JSON-serializeable input value for the orchestrator function.</value>
+        </member>
+    </members>
+</doc>
+r name="P:Microsoft.Azure.WebJobs.StartOrchestrationArgs.FunctionName">
             <summary>
             Gets or sets the name of the orchestrator function to start.
             </summary>

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
@@ -22,11 +22,6 @@
             Configuration for the Durable Functions extension.
             </summary>
         </member>
-        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.#ctor">
-            <summary>
-            Obsolete. Please use an alternate constructor overload.
-            </summary>
-        </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.#ctor(Microsoft.Extensions.Options.IOptions{Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskOptions},Microsoft.Extensions.Logging.ILoggerFactory,Microsoft.Azure.WebJobs.INameResolver,Microsoft.Azure.WebJobs.Extensions.DurableTask.IConnectionStringResolver)">
             <summary>
             Initializes a new instance of the <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension"/>.
@@ -35,17 +30,6 @@
             <param name="loggerFactory">The logger factory used for extension-specific logging and orchestration tracking.</param>
             <param name="nameResolver">The name resolver to use for looking up application settings.</param>
             <param name="connectionStringResolver">The resolver to use for looking up connection strings.</param>
-        </member>
-        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.HubName">
-            <summary>
-            Gets or sets default task hub name to be used by all <see cref="T:Microsoft.Azure.WebJobs.DurableOrchestrationClient"/>,
-            <see cref="T:Microsoft.Azure.WebJobs.DurableOrchestrationContext"/>, and <see cref="T:Microsoft.Azure.WebJobs.DurableActivityContext"/> instances.
-            </summary>
-            <remarks>
-            A task hub is a logical grouping of storage resources. Alternate task hub names can be used to isolate
-            multiple Durable Functions applications from each other, even if they are using the same storage backend.
-            </remarks>
-            <value>The name of the default task hub.</value>
         </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.Microsoft#Azure#WebJobs#Host#Config#IExtensionConfigProvider#Initialize(Microsoft.Azure.WebJobs.Host.Config.ExtensionConfigContext)">
             <summary>
@@ -102,12 +86,28 @@
             Extension for registering a Durable Functions configuration with <c>JobHostConfiguration</c>.
             </summary>
         </member>
-        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskJobHostConfigurationExtensions.UseDurableTask(Microsoft.Azure.WebJobs.JobHostConfiguration,Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension)">
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskJobHostConfigurationExtensions.AddDurableTask(Microsoft.Azure.WebJobs.IWebJobsBuilder)">
             <summary>
-            Enable running durable orchestrations implemented as functions.
+            Adds the Durable Task extension to the provided <see cref="T:Microsoft.Azure.WebJobs.IWebJobsBuilder"/>.
             </summary>
-            <param name="hostConfig">Configuration settings of the current <c>JobHost</c> instance.</param>
-            <param name="listenerConfig">Durable Functions configuration.</param>
+            <param name="builder">The <see cref="T:Microsoft.Azure.WebJobs.IWebJobsBuilder"/> to configure.</param>
+            <returns>Returns the provided <see cref="T:Microsoft.Azure.WebJobs.IWebJobsBuilder"/>.</returns>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskJobHostConfigurationExtensions.AddDurableTask(Microsoft.Azure.WebJobs.IWebJobsBuilder,Microsoft.Extensions.Options.IOptions{Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskOptions})">
+            <summary>
+            Adds the Durable Task extension to the provided <see cref="T:Microsoft.Azure.WebJobs.IWebJobsBuilder"/>.
+            </summary>
+            <param name="builder">The <see cref="T:Microsoft.Azure.WebJobs.IWebJobsBuilder"/> to configure.</param>
+            <param name="options">The configuration options for this extension.</param>
+            <returns>Returns the provided <see cref="T:Microsoft.Azure.WebJobs.IWebJobsBuilder"/>.</returns>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskJobHostConfigurationExtensions.AddDurableTask(Microsoft.Azure.WebJobs.IWebJobsBuilder,System.Action{Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskOptions})">
+            <summary>
+            Adds the Durable Task extension to the provided <see cref="T:Microsoft.Azure.WebJobs.IWebJobsBuilder"/>.
+            </summary>
+            <param name="builder">The <see cref="T:Microsoft.Azure.WebJobs.IWebJobsBuilder"/> to configure.</param>
+            <param name="configure">An <see cref="T:System.Action`1"/> to configure the provided <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskOptions"/>.</param>
+            <returns>Returns the modified <paramref name="builder"/> object.</returns>
         </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskOptions">
             <summary>
@@ -463,6 +463,12 @@
             <summary>
             Connection string provider which resolves connection strings from the WebJobs context.
             </summary>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.WebJobsConnectionStringProvider.#ctor(Microsoft.Extensions.Configuration.IConfiguration)">
+            <summary>
+            Initializes a new instance of the <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.WebJobsConnectionStringProvider"/> class.
+            </summary>
+            <param name="hostConfiguration">A <see cref="T:Microsoft.Extensions.Configuration.IConfiguration"/> object provided by the WebJobs host.</param>
         </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.WebJobsConnectionStringProvider.Resolve(System.String)">
             <inheritdoc />

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
@@ -63,7 +63,19 @@
             <summary>
             Called by the Durable Task Framework: Not used.
             </summary>
-      used.
+            <param name="creator">This parameter is not used.</param>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.DurableTask#Core#INameVersionObjectManager{DurableTask#Core#TaskOrchestration}#GetObject(System.String,System.String)">
+            <summary>
+            Called by the Durable Task Framework: Returns the specified <see cref="T:DurableTask.Core.TaskOrchestration"/>.
+            </summary>
+            <param name="name">The name of the orchestration to return.</param>
+            <param name="version">Not used.</param>
+            <returns>An orchestration shim that delegates execution to an orchestrator function.</returns>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.DurableTask#Core#INameVersionObjectManager{DurableTask#Core#TaskActivity}#Add(DurableTask.Core.ObjectCreator{DurableTask.Core.TaskActivity})">
+            <summary>
+            Called by the durable task framework: Not used.
             </summary>
             <param name="creator">This parameter is not used.</param>
         </member>
@@ -90,28 +102,12 @@
             Extension for registering a Durable Functions configuration with <c>JobHostConfiguration</c>.
             </summary>
         </member>
-        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskJobHostConfigurationExtensions.AddDurableTask(Microsoft.Azure.WebJobs.IWebJobsBuilder)">
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskJobHostConfigurationExtensions.UseDurableTask(Microsoft.Azure.WebJobs.JobHostConfiguration,Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension)">
             <summary>
-            Adds the Durable Task extension to the provided <see cref="T:Microsoft.Azure.WebJobs.IWebJobsBuilder"/>.
+            Enable running durable orchestrations implemented as functions.
             </summary>
-            <param name="builder">The <see cref="T:Microsoft.Azure.WebJobs.IWebJobsBuilder"/> to configure.</param>
-            <returns>Returns the provided <see cref="T:Microsoft.Azure.WebJobs.IWebJobsBuilder"/>.</returns>
-        </member>
-        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskJobHostConfigurationExtensions.AddDurableTask(Microsoft.Azure.WebJobs.IWebJobsBuilder,Microsoft.Extensions.Options.IOptions{Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskOptions})">
-            <summary>
-            Adds the Durable Task extension to the provided <see cref="T:Microsoft.Azure.WebJobs.IWebJobsBuilder"/>.
-            </summary>
-            <param name="builder">The <see cref="T:Microsoft.Azure.WebJobs.IWebJobsBuilder"/> to configure.</param>
-            <param name="options">The configuration options for this extension.</param>
-            <returns>Returns the provided <see cref="T:Microsoft.Azure.WebJobs.IWebJobsBuilder"/>.</returns>
-        </member>
-        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskJobHostConfigurationExtensions.AddDurableTask(Microsoft.Azure.WebJobs.IWebJobsBuilder,System.Action{Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskOptions})">
-            <summary>
-            Adds the Durable Task extension to the provided <see cref="T:Microsoft.Azure.WebJobs.IWebJobsBuilder"/>.
-            </summary>
-            <param name="builder">The <see cref="T:Microsoft.Azure.WebJobs.IWebJobsBuilder"/> to configure.</param>
-            <param name="configure">An <see cref="T:System.Action`1"/> to configure the provided <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskOptions"/>.</param>
-            <returns>Returns the modified <paramref name="builder"/> object.</returns>
+            <param name="hostConfig">Configuration settings of the current <c>JobHost</c> instance.</param>
+            <param name="listenerConfig">Durable Functions configuration.</param>
         </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskOptions">
             <summary>
@@ -467,12 +463,6 @@
             <summary>
             Connection string provider which resolves connection strings from the WebJobs context.
             </summary>
-        </member>
-        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.WebJobsConnectionStringProvider.#ctor(Microsoft.Extensions.Configuration.IConfiguration)">
-            <summary>
-            Initializes a new instance of the <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.WebJobsConnectionStringProvider"/> class.
-            </summary>
-            <param name="hostConfiguration">A <see cref="T:Microsoft.Extensions.Configuration.IConfiguration"/> object provided by the WebJobs host.</param>
         </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.WebJobsConnectionStringProvider.Resolve(System.String)">
             <inheritdoc />

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
@@ -63,19 +63,7 @@
             <summary>
             Called by the Durable Task Framework: Not used.
             </summary>
-            <param name="creator">This parameter is not used.</param>
-        </member>
-        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.DurableTask#Core#INameVersionObjectManager{DurableTask#Core#TaskOrchestration}#GetObject(System.String,System.String)">
-            <summary>
-            Called by the Durable Task Framework: Returns the specified <see cref="T:DurableTask.Core.TaskOrchestration"/>.
-            </summary>
-            <param name="name">The name of the orchestration to return.</param>
-            <param name="version">Not used.</param>
-            <returns>An orchestration shim that delegates execution to an orchestrator function.</returns>
-        </member>
-        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.DurableTask#Core#INameVersionObjectManager{DurableTask#Core#TaskActivity}#Add(DurableTask.Core.ObjectCreator{DurableTask.Core.TaskActivity})">
-            <summary>
-            Called by the durable task framework: Not used.
+      used.
             </summary>
             <param name="creator">This parameter is not used.</param>
         </member>
@@ -102,12 +90,28 @@
             Extension for registering a Durable Functions configuration with <c>JobHostConfiguration</c>.
             </summary>
         </member>
-        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskJobHostConfigurationExtensions.UseDurableTask(Microsoft.Azure.WebJobs.JobHostConfiguration,Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension)">
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskJobHostConfigurationExtensions.AddDurableTask(Microsoft.Azure.WebJobs.IWebJobsBuilder)">
             <summary>
-            Enable running durable orchestrations implemented as functions.
+            Adds the Durable Task extension to the provided <see cref="T:Microsoft.Azure.WebJobs.IWebJobsBuilder"/>.
             </summary>
-            <param name="hostConfig">Configuration settings of the current <c>JobHost</c> instance.</param>
-            <param name="listenerConfig">Durable Functions configuration.</param>
+            <param name="builder">The <see cref="T:Microsoft.Azure.WebJobs.IWebJobsBuilder"/> to configure.</param>
+            <returns>Returns the provided <see cref="T:Microsoft.Azure.WebJobs.IWebJobsBuilder"/>.</returns>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskJobHostConfigurationExtensions.AddDurableTask(Microsoft.Azure.WebJobs.IWebJobsBuilder,Microsoft.Extensions.Options.IOptions{Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskOptions})">
+            <summary>
+            Adds the Durable Task extension to the provided <see cref="T:Microsoft.Azure.WebJobs.IWebJobsBuilder"/>.
+            </summary>
+            <param name="builder">The <see cref="T:Microsoft.Azure.WebJobs.IWebJobsBuilder"/> to configure.</param>
+            <param name="options">The configuration options for this extension.</param>
+            <returns>Returns the provided <see cref="T:Microsoft.Azure.WebJobs.IWebJobsBuilder"/>.</returns>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskJobHostConfigurationExtensions.AddDurableTask(Microsoft.Azure.WebJobs.IWebJobsBuilder,System.Action{Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskOptions})">
+            <summary>
+            Adds the Durable Task extension to the provided <see cref="T:Microsoft.Azure.WebJobs.IWebJobsBuilder"/>.
+            </summary>
+            <param name="builder">The <see cref="T:Microsoft.Azure.WebJobs.IWebJobsBuilder"/> to configure.</param>
+            <param name="configure">An <see cref="T:System.Action`1"/> to configure the provided <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskOptions"/>.</param>
+            <returns>Returns the modified <paramref name="builder"/> object.</returns>
         </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskOptions">
             <summary>
@@ -463,6 +467,12 @@
             <summary>
             Connection string provider which resolves connection strings from the WebJobs context.
             </summary>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.WebJobsConnectionStringProvider.#ctor(Microsoft.Extensions.Configuration.IConfiguration)">
+            <summary>
+            Initializes a new instance of the <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.WebJobsConnectionStringProvider"/> class.
+            </summary>
+            <param name="hostConfiguration">A <see cref="T:Microsoft.Extensions.Configuration.IConfiguration"/> object provided by the WebJobs host.</param>
         </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.WebJobsConnectionStringProvider.Resolve(System.String)">
             <inheritdoc />

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
@@ -22,6 +22,11 @@
             Configuration for the Durable Functions extension.
             </summary>
         </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.#ctor">
+            <summary>
+            Obsolete. Please use an alternate constructor overload.
+            </summary>
+        </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.#ctor(Microsoft.Extensions.Options.IOptions{Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskOptions},Microsoft.Extensions.Logging.ILoggerFactory,Microsoft.Azure.WebJobs.INameResolver,Microsoft.Azure.WebJobs.Extensions.DurableTask.IConnectionStringResolver)">
             <summary>
             Initializes a new instance of the <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension"/>.
@@ -30,6 +35,17 @@
             <param name="loggerFactory">The logger factory used for extension-specific logging and orchestration tracking.</param>
             <param name="nameResolver">The name resolver to use for looking up application settings.</param>
             <param name="connectionStringResolver">The resolver to use for looking up connection strings.</param>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.HubName">
+            <summary>
+            Gets or sets default task hub name to be used by all <see cref="T:Microsoft.Azure.WebJobs.DurableOrchestrationClient"/>,
+            <see cref="T:Microsoft.Azure.WebJobs.DurableOrchestrationContext"/>, and <see cref="T:Microsoft.Azure.WebJobs.DurableActivityContext"/> instances.
+            </summary>
+            <remarks>
+            A task hub is a logical grouping of storage resources. Alternate task hub names can be used to isolate
+            multiple Durable Functions applications from each other, even if they are using the same storage backend.
+            </remarks>
+            <value>The name of the default task hub.</value>
         </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.Microsoft#Azure#WebJobs#Host#Config#IExtensionConfigProvider#Initialize(Microsoft.Azure.WebJobs.Host.Config.ExtensionConfigContext)">
             <summary>
@@ -86,28 +102,12 @@
             Extension for registering a Durable Functions configuration with <c>JobHostConfiguration</c>.
             </summary>
         </member>
-        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskJobHostConfigurationExtensions.AddDurableTask(Microsoft.Azure.WebJobs.IWebJobsBuilder)">
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskJobHostConfigurationExtensions.UseDurableTask(Microsoft.Azure.WebJobs.JobHostConfiguration,Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension)">
             <summary>
-            Adds the Durable Task extension to the provided <see cref="T:Microsoft.Azure.WebJobs.IWebJobsBuilder"/>.
+            Enable running durable orchestrations implemented as functions.
             </summary>
-            <param name="builder">The <see cref="T:Microsoft.Azure.WebJobs.IWebJobsBuilder"/> to configure.</param>
-            <returns>Returns the provided <see cref="T:Microsoft.Azure.WebJobs.IWebJobsBuilder"/>.</returns>
-        </member>
-        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskJobHostConfigurationExtensions.AddDurableTask(Microsoft.Azure.WebJobs.IWebJobsBuilder,Microsoft.Extensions.Options.IOptions{Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskOptions})">
-            <summary>
-            Adds the Durable Task extension to the provided <see cref="T:Microsoft.Azure.WebJobs.IWebJobsBuilder"/>.
-            </summary>
-            <param name="builder">The <see cref="T:Microsoft.Azure.WebJobs.IWebJobsBuilder"/> to configure.</param>
-            <param name="options">The configuration options for this extension.</param>
-            <returns>Returns the provided <see cref="T:Microsoft.Azure.WebJobs.IWebJobsBuilder"/>.</returns>
-        </member>
-        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskJobHostConfigurationExtensions.AddDurableTask(Microsoft.Azure.WebJobs.IWebJobsBuilder,System.Action{Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskOptions})">
-            <summary>
-            Adds the Durable Task extension to the provided <see cref="T:Microsoft.Azure.WebJobs.IWebJobsBuilder"/>.
-            </summary>
-            <param name="builder">The <see cref="T:Microsoft.Azure.WebJobs.IWebJobsBuilder"/> to configure.</param>
-            <param name="configure">An <see cref="T:System.Action`1"/> to configure the provided <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskOptions"/>.</param>
-            <returns>Returns the modified <paramref name="builder"/> object.</returns>
+            <param name="hostConfig">Configuration settings of the current <c>JobHost</c> instance.</param>
+            <param name="listenerConfig">Durable Functions configuration.</param>
         </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskOptions">
             <summary>
@@ -463,12 +463,6 @@
             <summary>
             Connection string provider which resolves connection strings from the WebJobs context.
             </summary>
-        </member>
-        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.WebJobsConnectionStringProvider.#ctor(Microsoft.Extensions.Configuration.IConfiguration)">
-            <summary>
-            Initializes a new instance of the <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.WebJobsConnectionStringProvider"/> class.
-            </summary>
-            <param name="hostConfiguration">A <see cref="T:Microsoft.Extensions.Configuration.IConfiguration"/> object provided by the WebJobs host.</param>
         </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.WebJobsConnectionStringProvider.Resolve(System.String)">
             <inheritdoc />

--- a/src/WebJobs.Extensions.DurableTask/OrchestrationClientAttribute.cs
+++ b/src/WebJobs.Extensions.DurableTask/OrchestrationClientAttribute.cs
@@ -24,6 +24,7 @@ namespace Microsoft.Azure.WebJobs
         /// The default behavior is to use the task hub name specified in <see cref="DurableTaskOptions.HubName"/>.
         /// If no value exists there, then a default value will be used.
         /// </remarks>
+        [AutoResolve]
         public string TaskHub { get; set; }
 
         /// <summary>

--- a/test/Common/ClientFunctions.cs
+++ b/test/Common/ClientFunctions.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Threading.Tasks;
-using DurableTask.Core;
 
 namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 {

--- a/test/Common/ClientFunctions.cs
+++ b/test/Common/ClientFunctions.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Threading.Tasks;
+using DurableTask.Core;
 
 namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 {
@@ -11,6 +12,24 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         [NoAutomaticTrigger]
         public static async Task StartFunction(
             [OrchestrationClient] DurableOrchestrationClient client,
+            string functionName,
+            string instanceId,
+            object input,
+            TestOrchestratorClient[] clientRef)
+        {
+            DateTime instanceCreationTime = DateTime.UtcNow;
+
+            instanceId = await client.StartNewAsync(functionName, instanceId, input);
+            clientRef[0] = new TestOrchestratorClient(
+                client,
+                functionName,
+                instanceId,
+                instanceCreationTime);
+        }
+
+        [NoAutomaticTrigger]
+        public static async Task StartFunctionWithTaskHub(
+            [OrchestrationClient(TaskHub = "testtaskhub")] DurableOrchestrationClient client,
             string functionName,
             string instanceId,
             object input,

--- a/test/Common/ClientFunctions.cs
+++ b/test/Common/ClientFunctions.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
         [NoAutomaticTrigger]
         public static async Task StartFunctionWithTaskHub(
-            [OrchestrationClient(TaskHub = "testtaskhubV2")] DurableOrchestrationClient client,
+            [OrchestrationClient(TaskHub = "%TaskHubName%")] DurableOrchestrationClient client,
             string functionName,
             string instanceId,
             object input,

--- a/test/Common/ClientFunctions.cs
+++ b/test/Common/ClientFunctions.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
         [NoAutomaticTrigger]
         public static async Task StartFunctionWithTaskHub(
-            [OrchestrationClient(TaskHub = "%TaskHubName%")] DurableOrchestrationClient client,
+            [OrchestrationClient(TaskHub = "%TestTaskHub%")] DurableOrchestrationClient client,
             string functionName,
             string instanceId,
             object input,

--- a/test/Common/ClientFunctions.cs
+++ b/test/Common/ClientFunctions.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
         [NoAutomaticTrigger]
         public static async Task StartFunctionWithTaskHub(
-            [OrchestrationClient(TaskHub = "testtaskhub")] DurableOrchestrationClient client,
+            [OrchestrationClient(TaskHub = "testtaskhubV2")] DurableOrchestrationClient client,
             string functionName,
             string instanceId,
             object input,

--- a/test/Common/DurableTaskEndToEndTests.cs
+++ b/test/Common/DurableTaskEndToEndTests.cs
@@ -96,7 +96,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             string taskHubName = "testtaskhub";
             Dictionary<string, string> values = new Dictionary<string, string>
             {
-                { "TaskHubName", $"{taskHubName}{PlatformSpecificHelpers.VersionSuffix}" },
+                { "TestTaskHub", $"{taskHubName}{PlatformSpecificHelpers.VersionSuffix}" },
             };
 
             using (var defaultHost = TestHelpers.GetJobHost(
@@ -107,7 +107,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 this.loggerProvider,
                 taskHubName,
                 false,
-                nameResolver: new TestNameResolver(values)))
+                nameResolver: new SimpleNameResolver(values)))
             {
                 await defaultHost.StartAsync();
                 await customHost.StartAsync();
@@ -2297,23 +2297,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
                 [DataMember]
                 public TimeSpan F { get; set; }
-            }
-        }
-
-        public class TestNameResolver : INameResolver
-        {
-            private readonly Dictionary<string, string> values;
-
-            public TestNameResolver(Dictionary<string, string> values)
-            {
-                this.values = values;
-            }
-
-            public string Resolve(string name)
-            {
-                string result;
-                this.values.TryGetValue(name, out result);
-                return result;
             }
         }
     }

--- a/test/Common/DurableTaskEndToEndTests.cs
+++ b/test/Common/DurableTaskEndToEndTests.cs
@@ -93,14 +93,21 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 nameof(TestOrchestrations.SayHelloInline),
             };
 
+            string taskHubName = "testtaskhub";
+            Dictionary<string, string> values = new Dictionary<string, string>
+            {
+                { "TaskHubName", $"{taskHubName}{PlatformSpecificHelpers.VersionSuffix}" },
+            };
+
             using (var defaultHost = TestHelpers.GetJobHost(
                 this.loggerProvider,
                 nameof(this.HelloWorld_OrchestrationClientTaskHub),
                 false))
             using (var customHost = TestHelpers.GetJobHost(
                 this.loggerProvider,
-                "testtaskhub",
-                false))
+                taskHubName,
+                false,
+                nameResolver: new TestNameResolver(values)))
             {
                 await defaultHost.StartAsync();
                 await customHost.StartAsync();
@@ -2290,6 +2297,23 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
                 [DataMember]
                 public TimeSpan F { get; set; }
+            }
+        }
+
+        public class TestNameResolver : INameResolver
+        {
+            private readonly Dictionary<string, string> values;
+
+            public TestNameResolver(Dictionary<string, string> values)
+            {
+                this.values = values;
+            }
+
+            public string Resolve(string name)
+            {
+                string result;
+                this.values.TryGetValue(name, out result);
+                return result;
             }
         }
     }

--- a/test/Common/DurableTaskEndToEndTests.cs
+++ b/test/Common/DurableTaskEndToEndTests.cs
@@ -80,6 +80,39 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             }
         }
 
+        // <summary>
+        /// End-to-end test which validates task hub name configured via the <see cref="OrchestrationClientAttribute"/> when 
+        /// simple orchestrator function which that doesn't call any activity functions is executed.
+        /// </summary>
+        [Theory]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task HelloWorld_OrchestrationClientTaskHub(bool extendedSessions)
+        {
+            string[] orchestratorFunctionNames =
+            {
+                nameof(TestOrchestrations.SayHelloInline),
+            };
+
+            using (var host = TestHelpers.GetJobHost(
+                this.loggerProvider,
+                nameof(this.HelloWorld_OrchestrationClientTaskHub),
+                extendedSessions))
+            {
+                await host.StartAsync();
+
+                var client = await host.StartOrchestratorAsync(orchestratorFunctionNames[0], "World", this.output, null, true);
+                var status = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(30), this.output);
+
+                Assert.Equal(OrchestrationRuntimeStatus.Completed, status?.RuntimeStatus);
+                Assert.Equal("World", status?.Input);
+                Assert.Equal("Hello, World!", status?.Output);
+
+                await host.StopAsync();
+            }
+        }
+
         /// <summary>
         /// End-to-end test which validates a simple orchestrator function does not have assigned value for <see cref="DurableOrchestrationContext.ParentInstanceId"/>.
         /// </summary>

--- a/test/Common/DurableTaskHostExtensions.cs
+++ b/test/Common/DurableTaskHostExtensions.cs
@@ -14,9 +14,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             string functionName,
             object input,
             ITestOutputHelper output,
-            string instanceId = null)
+            string instanceId = null,
+            bool isTaskHubConfiguredViaOrchestrationClient = false)
         {
-            var startFunction = typeof(ClientFunctions).GetMethod(nameof(ClientFunctions.StartFunction));
+            var startFunction = isTaskHubConfiguredViaOrchestrationClient ?
+                typeof(ClientFunctions).GetMethod(nameof(ClientFunctions.StartFunctionWithTaskHub)) :
+                typeof(ClientFunctions).GetMethod(nameof(ClientFunctions.StartFunction));
             var clientRef = new TestOrchestratorClient[1];
             var args = new Dictionary<string, object>
             {

--- a/test/Common/DurableTaskLifeCycleNotificationTest.cs
+++ b/test/Common/DurableTaskLifeCycleNotificationTest.cs
@@ -933,7 +933,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         private static Mock<INameResolver> GetNameResolverMock((string Key, string Value)[] settings)
         {
             var mock = new Mock<INameResolver>();
-            foreach (var setting in settings)
+            var settingList = settings.ToList();
+            settingList.Add(("TestTaskHub", string.Empty));
+            foreach (var setting in settingList)
             {
                 mock.Setup(x => x.Resolve(setting.Key)).Returns(setting.Value);
             }

--- a/test/Common/HttpApiHandlerTests.cs
+++ b/test/Common/HttpApiHandlerTests.cs
@@ -827,7 +827,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             protected internal override DurableOrchestrationClient GetClient(OrchestrationClientAttribute attribute)
             {
                 var orchestrationServiceClientMock = new Mock<IOrchestrationServiceClient>();
-                return new DurableOrchestrationClientMock(orchestrationServiceClientMock.Object, this, null);
+                return new DurableOrchestrationClientMock(orchestrationServiceClientMock.Object, this, attribute);
             }
         }
     }

--- a/test/Common/TestHelpers.cs
+++ b/test/Common/TestHelpers.cs
@@ -643,7 +643,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
     }
 
     /// <summary>
-    /// Helper name resolver class. 
+    /// Test implementation of INameResolver interface.
     /// </summary>
     public class SimpleNameResolver : INameResolver
     {

--- a/test/Common/TestHelpers.cs
+++ b/test/Common/TestHelpers.cs
@@ -642,6 +642,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         }
     }
 
+    /// <summary>
+    /// Helper name resolver class. 
+    /// </summary>
     public class SimpleNameResolver : INameResolver
     {
         private readonly Dictionary<string, string> values = null;

--- a/test/Common/TestHelpers.cs
+++ b/test/Common/TestHelpers.cs
@@ -643,7 +643,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
     }
 
     /// <summary>
-    /// Helper implementation of INameResolver interface.
+    /// Test helper implementation of INameResolver interface.
     /// </summary>
     public class SimpleNameResolver : INameResolver
     {

--- a/test/Common/TestHelpers.cs
+++ b/test/Common/TestHelpers.cs
@@ -650,7 +650,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         {
             this.values = new Dictionary<string, string>
             {
-                { "TestTaskHub", "" },
+                { "TestTaskHub", string.Empty },
             };
         }
 

--- a/test/Common/TestHelpers.cs
+++ b/test/Common/TestHelpers.cs
@@ -31,6 +31,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             Uri notificationUrl = null,
             HttpMessageHandler eventGridNotificationHandler = null)
         {
+            if (nameResolver == null) { nameResolver = new SimpleNameResolver(); }
             var durableTaskOptions = new DurableTaskOptions
             {
                 HubName = GetTaskHubNameFromTestName(testName, enableExtendedSessions),
@@ -638,6 +639,34 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
                 return value;
             }
+        }
+    }
+
+    public class SimpleNameResolver : INameResolver
+    {
+        private readonly Dictionary<string, string> values = null;
+
+        public SimpleNameResolver()
+        {
+            this.values = new Dictionary<string, string>
+            {
+                { "TestTaskHub", "" },
+            };
+        }
+
+        public SimpleNameResolver(Dictionary<string, string> values)
+        {
+            this.values = values;
+        }
+
+        public string Resolve(string name)
+        {
+            if (this.values == null)
+            {
+                return null;
+            }
+
+            return !this.values.TryGetValue(name, out string result) ? null : result;
         }
     }
 }

--- a/test/Common/TestHelpers.cs
+++ b/test/Common/TestHelpers.cs
@@ -643,7 +643,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
     }
 
     /// <summary>
-    /// Test implementation of INameResolver interface.
+    /// Test helper implementation of INameResolver interface.
     /// </summary>
     public class SimpleNameResolver : INameResolver
     {

--- a/test/Common/TestHelpers.cs
+++ b/test/Common/TestHelpers.cs
@@ -643,7 +643,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
     }
 
     /// <summary>
-    /// Test helper implementation of INameResolver interface.
+    /// Helper implementation of INameResolver interface.
     /// </summary>
     public class SimpleNameResolver : INameResolver
     {


### PR DESCRIPTION
Hello @cgillum,

I wanted to open this PR and start the discussion for resolving https://github.com/Azure/azure-functions-durable-extension/issues/499.


Thank you for the guidance for the `AutoResolve` attribute. It works as expected and it is able to resolve the value of the app setting variable. However, when using it the orchestration gets stacked in the pending state. We don't get any entries to the History table and the initial control queue message stays unprocessed. I think the runtime for some reason is trying to pull from the original task hub (configured in `host.json`) control queues. My guess is it is because the `TaskHubWorker` is initialized with the original `TaskHubName` set in `host.json` in `DurableTaskExtension.Initialize` :


```csharp
this.orchestrationServiceSettings = this.GetOrchestrationServiceSettings();
            this.orchestrationService = new AzureStorageOrchestrationService(this.orchestrationServiceSettings);
            this.taskHubWorker = new TaskHubWorker(this.orchestrationService, this, this);
            this.taskHubWorker.AddOrchestrationDispatcherMiddleware(this.OrchestrationMiddleware);
```

And when we use the new `TaskHubName` coming from the attribute we only execute the following code in `DurableTaskExtension`:

```csharp
protected internal virtual DurableOrchestrationClient GetClient(OrchestrationClientAttribute attribute)
        {
            DurableOrchestrationClient client = this.cachedClients.GetOrAdd(
                attribute,
                attr =>
                {
                    AzureStorageOrchestrationServiceSettings settings = this.GetOrchestrationServiceSettings(attr);
                    AzureStorageOrchestrationService innerClient;
                    if (this.orchestrationServiceSettings != null &&
                        this.orchestrationService != null &&
                        string.Equals(this.orchestrationServiceSettings.TaskHubName, settings.TaskHubName, StringComparison.OrdinalIgnoreCase) &&
                        string.Equals(this.orchestrationServiceSettings.StorageConnectionString, settings.StorageConnectionString, StringComparison.OrdinalIgnoreCase))
                    {
                        // It's important that clients use the same AzureStorageOrchestrationService instance
                        // as the host when possible to ensure we any send operations can be picked up
                        // immediately instead of waiting for the next queue polling interval.
                        innerClient = this.orchestrationService;
                    }
                    else
                    {
                        innerClient = new AzureStorageOrchestrationService(settings);
                    }
                    return new DurableOrchestrationClient(innerClient, this, attr);
                });
            return client;
        }

```
But we continue to use the previous instances of the `TaskHubWorker`.

I tried re-initializing the `TaskHubWorker` in the `GetClient` method but it did not help.

May I ask you to confirm my current understanding?

Thank you!