### PR TITLE
Http Method Fix

### DIFF
--- a/samples/javascript/HttpStart/function.json
+++ b/samples/javascript/HttpStart/function.json
@@ -6,7 +6,7 @@
       "type": "httpTrigger",
       "direction": "in",
       "route": "orchestrators/{functionName}",
-      "methods": ["post"]
+      "methods": ["get"]
     },
     {
       "name": "$return",


### PR DESCRIPTION
The article here suggests copy-pasting the URL into a browser. To make that work the method allowed needs to be a GET instead of a POST. https://docs.microsoft.com/en-us/azure/azure-functions/durable/quickstart-js-vscode