### PR TITLE
Orchestrator should throw exception when activity fails

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/DurableOrchestrationContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableOrchestrationContext.cs
@@ -56,6 +56,8 @@ namespace Microsoft.Azure.WebJobs
 
         internal bool IsCompleted { get; set; }
 
+        internal OrchestrationFailureException OrchestrationException { get; set; }
+
         internal string HubName => this.config.Options.HubName;
 
         internal string Name => this.orchestrationName;

--- a/src/WebJobs.Extensions.DurableTask/Listener/TaskOrchestrationShim.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/TaskOrchestrationShim.cs
@@ -117,9 +117,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                         this.context.IsReplaying));
                 }
 
-                throw new OrchestrationFailureException(
+                var orchestrationException = new OrchestrationFailureException(
                     $"Orchestrator function '{this.context.Name}' failed: {e.Message}",
                     Utils.SerializeCause(e, MessagePayloadDataConverter.ErrorConverter));
+
+                this.context.OrchestrationException = orchestrationException;
+
+                throw orchestrationException;
             }
             finally
             {


### PR DESCRIPTION
Fixes #411 

In the case where an activity function fails, that execution of the orchestrator function should also fail. The Functions host determines an execution's success/failure from the presence of an exception. The orchestration function now throws an `OrchestrationFailureException` that the host can pick up. 

For each activity function, the orchestrator logs have two entries: one for the scheduling of the activity, and one for the execution. Only the log representing the execution of the activity will show a failure.
![image](https://user-images.githubusercontent.com/10789958/50715146-b0ab4600-1030-11e9-8d6f-191bc22c3a3b.png)

