### PR TITLE
Add DTFx ETW traces to test output

### DIFF
--- a/test/Common/DurableTaskEndToEndTests.cs
+++ b/test/Common/DurableTaskEndToEndTests.cs
@@ -60,7 +60,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             };
 
             this.eventSourceListener.OnTraceLog += this.OnEventSourceListenerTraceLog;
-            this.eventSourceListener.CaptureLogs(traceConfig, filteredEvents);
+
+            string sessionName = "DTFxTrace" + Guid.NewGuid().ToString("N");
+            this.eventSourceListener.CaptureLogs(sessionName, traceConfig, filteredEvents);
         }
 
         private void OnEventSourceListenerTraceLog(object sender, LogEventTraceListener.TraceLogEventArgs e)

--- a/test/Common/DurableTaskEndToEndTests.cs
+++ b/test/Common/DurableTaskEndToEndTests.cs
@@ -11,6 +11,7 @@ using System.Threading.Tasks;
 using DurableTask.Core;
 using Microsoft.Azure.WebJobs.Host;
 using Microsoft.Azure.WebJobs.Host.TestCommon;
+using Microsoft.Diagnostics.Tracing;
 using Microsoft.WindowsAzure.Storage;
 using Microsoft.WindowsAzure.Storage.Blob;
 using Newtonsoft.Json;
@@ -21,12 +22,13 @@ using Xunit.Sdk;
 
 namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 {
-    public class DurableTaskEndToEndTests
+    public class DurableTaskEndToEndTests : IDisposable
     {
         private readonly ITestOutputHelper output;
 
         private readonly TestLoggerProvider loggerProvider;
         private readonly bool useTestLogger = true;
+        private readonly LogEventTraceListener eventSourceListener;
 
         private static readonly string InstrumentationKey = Environment.GetEnvironmentVariable("APPINSIGHTS_INSTRUMENTATIONKEY");
 
@@ -34,6 +36,36 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         {
             this.output = output;
             this.loggerProvider = new TestLoggerProvider(output);
+            this.eventSourceListener = new LogEventTraceListener();
+            this.StartLogCapture();
+        }
+
+        public void Dispose()
+        {
+            this.eventSourceListener.Dispose();
+        }
+
+        private void StartLogCapture()
+        {
+            var traceConfig = new Dictionary<string, TraceEventLevel>
+            {
+                { "DurableTask-AzureStorage", TraceEventLevel.Informational },
+                { "7DA4779A-152E-44A2-A6F2-F80D991A5BEE", TraceEventLevel.Warning }, // DurableTask.Core
+            };
+
+            // Filter out some of the partition management informational events
+            var filteredEvents = new Dictionary<string, IEnumerable<int>>
+            {
+                { "DurableTask-AzureStorage", new int[] { 120, 126, 127 } },
+            };
+
+            this.eventSourceListener.OnTraceLog += this.OnEventSourceListenerTraceLog;
+            this.eventSourceListener.CaptureLogs(traceConfig, filteredEvents);
+        }
+
+        private void OnEventSourceListenerTraceLog(object sender, LogEventTraceListener.TraceLogEventArgs e)
+        {
+            this.output.WriteLine($"      ETW: {e.ProviderName} [{e.Level}] : {e.Message}");
         }
 
         /// <summary>

--- a/test/Common/LogEventTraceListener.cs
+++ b/test/Common/LogEventTraceListener.cs
@@ -1,0 +1,142 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using Microsoft.Diagnostics.Tracing;
+using Microsoft.Diagnostics.Tracing.Session;
+
+namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
+{
+    public sealed class LogEventTraceListener : IDisposable
+    {
+        private readonly bool preferFormattedMessages;
+        private TraceEventSession currentSession;
+
+        public LogEventTraceListener()
+            : this(preferFormattedMessages: false)
+        {
+        }
+
+        public LogEventTraceListener(bool preferFormattedMessages)
+        {
+            this.preferFormattedMessages = preferFormattedMessages;
+        }
+
+        public event EventHandler<TraceLogEventArgs> OnTraceLog;
+
+        public void CaptureLogs(
+            IDictionary<string, TraceEventLevel> providers,
+            IDictionary<string, IEnumerable<int>> eventIdFilters = null)
+        {
+            if (this.currentSession != null)
+            {
+                throw new InvalidOperationException("A trace session is already running.");
+            }
+
+            ThreadPool.QueueUserWorkItem(_ =>
+            {
+                Thread.CurrentThread.Name = "ListenForEventTraceLogs";
+
+                this.currentSession = new TraceEventSession("EtwListenerLogSession");
+                this.currentSession.Source.Dynamic.All += data =>
+                {
+                    EventHandler<TraceLogEventArgs> handler = this.OnTraceLog;
+                    if (handler == null)
+                    {
+                        return;
+                    }
+
+                    // Ignore events that seem to come from MDS infrastructure.
+                    if (ShouldExcludeEvent(data, eventIdFilters))
+                    {
+                        return;
+                    }
+
+                    var builder = new StringBuilder(1024);
+                    builder.Append(data.TimeStamp.ToString("yyyy-MM-ddTHH:mm:ss.fffZ")).Append(':');
+                    builder.Append(" [").Append(data.ActivityID.ToString("N").Substring(0, 4));
+                    builder.Append(", ").Append(data.RelatedActivityID.ToString("N").Substring(0, 4)).Append("] ");
+                    builder.Append(data.EventName).Append(": ");
+
+                    if (this.preferFormattedMessages && !string.IsNullOrEmpty(data.FormattedMessage))
+                    {
+                        builder.Append(data.FormattedMessage);
+                    }
+                    else
+                    {
+                        for (int i = 0; i < data.PayloadNames.Length; i++)
+                        {
+                            builder.Append(data.PayloadNames[i]).Append('=').Append(data.PayloadValue(i));
+                            builder.Append(", ");
+                        }
+
+                        // remove trailing ", "
+                        builder.Remove(builder.Length - 2, 2);
+                    }
+
+                    string message = builder.ToString();
+                    var eventArgs = new TraceLogEventArgs(data.ProviderName, data.Level, message);
+                    handler(this, eventArgs);
+                };
+
+                foreach (KeyValuePair<string, TraceEventLevel> provider in providers)
+                {
+                    this.currentSession.EnableProvider(provider.Key, provider.Value);
+                }
+
+                // This is a blocking call.
+                this.currentSession.Source.Process();
+            });
+        }
+
+        private static bool ShouldExcludeEvent(TraceEvent traceEvent, IDictionary<string, IEnumerable<int>> eventIdFilters)
+        {
+            // infrastructure events
+            if (traceEvent.EventName == "EventSourceMessage" || traceEvent.EventName == "ManifestData")
+            {
+                return true;
+            }
+
+            // explicitly filtered events
+            if (eventIdFilters != null &&
+                eventIdFilters.TryGetValue(traceEvent.ProviderName, out IEnumerable<int> filteredEvents))
+            {
+                return filteredEvents.Contains((int)traceEvent.ID);
+            }
+
+            return false;
+        }
+
+        public void Stop()
+        {
+            this.currentSession?.Source.StopProcessing();
+            this.currentSession?.Dispose();
+            this.currentSession = null;
+        }
+
+        public void Dispose()
+        {
+            this.Stop();
+        }
+
+        public class TraceLogEventArgs : EventArgs
+        {
+            public TraceLogEventArgs(string providerName, TraceEventLevel level, string message)
+            {
+                this.ProviderName = providerName ?? throw new ArgumentNullException(nameof(providerName));
+                this.Level = level;
+                this.Message = message ?? throw new ArgumentNullException(nameof(message));
+            }
+
+            public string ProviderName { get; }
+
+            public TraceEventLevel Level { get; }
+
+            public string Message { get; }
+        }
+    }
+}

--- a/test/FunctionsV1/WebJobs.Extensions.DurableTask.Tests.V1.csproj
+++ b/test/FunctionsV1/WebJobs.Extensions.DurableTask.Tests.V1.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage" Version="1.4.1" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="2.2.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.33" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
     <PackageReference Include="Moq" Version="4.7.145" />
     <PackageReference Include="xunit" Version="2.3.1" />

--- a/test/FunctionsV2/WebJobs.Extensions.DurableTask.Tests.V2.csproj
+++ b/test/FunctionsV2/WebJobs.Extensions.DurableTask.Tests.V2.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="3.0.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.33" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
     <PackageReference Include="Moq" Version="4.7.145" />
     <PackageReference Include="xunit" Version="2.3.1" />


### PR DESCRIPTION
It's currently very difficult to debug test failures due to underlying DTFx issues. This PR updates the end-to-end tests to capture the DTFx ETW events and include them in the test output.