### PR TITLE
Fix race condition with RaiseEventAsync and ContinueAsNew

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/DurableOrchestrationClient.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableOrchestrationClient.cs
@@ -155,6 +155,10 @@ namespace Microsoft.Azure.WebJobs
                 state.OrchestrationStatus == OrchestrationStatus.Pending ||
                 state.OrchestrationStatus == OrchestrationStatus.ContinuedAsNew)
             {
+                // Terminate events are not supposed to target any particular execution ID.
+                // We need to clear it to avoid sending messages to an expired ContinueAsNew instance.
+                state.OrchestrationInstance.ExecutionId = null;
+
                 await this.client.TerminateInstanceAsync(state.OrchestrationInstance, reason);
 
                 this.traceHelper.FunctionTerminated(this.hubName, state.Name, instanceId, reason);
@@ -434,6 +438,10 @@ namespace Microsoft.Azure.WebJobs
                 status.OrchestrationStatus == OrchestrationStatus.Pending ||
                 status.OrchestrationStatus == OrchestrationStatus.ContinuedAsNew)
             {
+                // External events are not supposed to target any particular execution ID.
+                // We need to clear it to avoid sending messages to an expired ContinueAsNew instance.
+                status.OrchestrationInstance.ExecutionId = null;
+
                 await taskHubClient.RaiseEventAsync(status.OrchestrationInstance, eventName, eventData);
 
                 this.traceHelper.FunctionScheduled(

--- a/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
+++ b/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
@@ -47,7 +47,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage" Version="1.4.1" />
+    <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage" Version="1.4.2" />
   </ItemGroup>
 
   <!-- NuGet Publishing Metadata -->

--- a/test/Common/DurableTaskEndToEndTests.cs
+++ b/test/Common/DurableTaskEndToEndTests.cs
@@ -620,9 +620,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                         new[] { nameof(TestOrchestrations.Counter) });
                 }
             }
-
-            // Delete task hub resources only if tests succeed
-            await TestHelpers.DeleteTaskHubResources(testName, extendedSessions);
         }
 
         /// <summary>
@@ -767,9 +764,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
                 await host.StopAsync();
             }
-
-            // Delete task hub resources only if tests succeed
-            await TestHelpers.DeleteTaskHubResources(testName, extendedSessions);
         }
 
         /// <summary>
@@ -1932,9 +1926,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
                 await host.StopAsync();
             }
-
-            // Delete task hub resources only if tests succeed
-            await TestHelpers.DeleteTaskHubResources(testName, extendedSessions);
         }
 
         [Fact]
@@ -1970,9 +1961,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 DurableOrchestrationStatus status = await client.GetStatusAsync(showHistory: false, showHistoryOutput: false, showInput: false);
                 Assert.True(string.IsNullOrEmpty(status.Input.ToString()));
             }
-
-            // Delete task hub resources only if tests succeed
-            await TestHelpers.DeleteTaskHubResources(testName, false);
         }
 
         [Fact]
@@ -1989,9 +1977,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 DurableOrchestrationStatus status = await client.GetStatusAsync(showHistory: false, showHistoryOutput: false);
                 Assert.Equal("1", status.Input.ToString());
             }
-
-            // Delete task hub resources only if tests succeed
-            await TestHelpers.DeleteTaskHubResources(testName, false);
         }
 
         [Fact]
@@ -2154,10 +2139,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 await host1.StopAsync();
                 await host2.StopAsync();
             }
-
-            // Delete task hub resources only if tests succeed
-            await TestHelpers.DeleteTaskHubResources("ActorOrchestration1", extendedSessions);
-            await TestHelpers.DeleteTaskHubResources("ActorOrchestration2", extendedSessions);
         }
 
         [Theory]

--- a/test/Common/DurableTaskEndToEndTests.cs
+++ b/test/Common/DurableTaskEndToEndTests.cs
@@ -602,7 +602,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 status = await client.WaitForCompletionAsync(waitTimeout, this.output);
 
                 Assert.Equal(OrchestrationRuntimeStatus.Completed, status?.RuntimeStatus);
-                Assert.Equal(3, (int)status?.Output);
+                Assert.Equal(3, (int?)status?.Output);
 
                 // When using ContinueAsNew, the original input is discarded and replaced with the most recent state.
                 Assert.NotEqual(initialValue, status?.Input);
@@ -2185,19 +2185,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 await client2.RaiseEventAsync(taskHubName1, instanceId, "done", null, this.output);
 
                 // Make sure it actually completed
-                var status = await client1.WaitForCompletionAsync(
-                    TimeSpan.FromSeconds(1000),
-                    this.output);
+                var status = await client1.WaitForCompletionAsync(TimeSpan.FromSeconds(10), this.output);
                 Assert.Equal(OrchestrationRuntimeStatus.Completed, status?.RuntimeStatus);
-                Assert.Equal(2, status.Output);
+                Assert.Equal(2, (int)status.Output);
 
                 await host1.StopAsync();
                 await host2.StopAsync();
             }
-
-            // Delete task hub resources only if tests succeed
-            await TestHelpers.DeleteTaskHubResources("MultipleNamesLooping1", extendedSessions);
-            await TestHelpers.DeleteTaskHubResources("MultipleNamesLooping2", extendedSessions);
         }
 
         [Theory]

--- a/test/Common/TestHelpers.cs
+++ b/test/Common/TestHelpers.cs
@@ -5,6 +5,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
+using System.Threading.Tasks;
+using DurableTask.AzureStorage;
 using Microsoft.Azure.WebJobs.Host.TestCommon;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -86,6 +88,19 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         public static string GetStorageConnectionString()
         {
             return Environment.GetEnvironmentVariable("AzureWebJobsStorage");
+        }
+
+        public static Task DeleteTaskHubResources(string testName, bool enableExtendedSessions)
+        {
+            string hubName = GetTaskHubNameFromTestName(testName, enableExtendedSessions);
+            var settings = new AzureStorageOrchestrationServiceSettings
+            {
+                TaskHubName = hubName,
+                StorageConnectionString = GetStorageConnectionString(),
+            };
+
+            var service = new AzureStorageOrchestrationService(settings);
+            return service.DeleteAsync();
         }
 
         public static void AssertLogMessageSequence(

--- a/test/Common/TestOrchestratorClient.cs
+++ b/test/Common/TestOrchestratorClient.cs
@@ -55,13 +55,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             return status;
         }
 
-        public async Task RaiseEventAsync(string eventName)
+        public async Task RaiseEventAsync(string eventName, ITestOutputHelper output)
         {
+            output?.WriteLine($"Raising event {eventName} to {this.instanceId}.");
             await this.innerClient.RaiseEventAsync(this.instanceId, eventName);
         }
 
-        public async Task RaiseEventAsync(string eventName, object eventData)
+        public async Task RaiseEventAsync(string eventName, object eventData, ITestOutputHelper output)
         {
+            output?.WriteLine($"Raising event {eventName} to {this.instanceId}. Payload: {eventData}");
             await this.innerClient.RaiseEventAsync(this.instanceId, eventName, eventData);
         }
 
@@ -85,6 +87,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             Stopwatch sw = Stopwatch.StartNew();
             do
             {
+                output.WriteLine($"Waiting for instance {this.instanceId} to start.");
+
                 DurableOrchestrationStatus status = await this.GetStatusAsync();
                 if (status != null && status.RuntimeStatus != OrchestrationRuntimeStatus.Pending)
                 {
@@ -104,6 +108,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             Stopwatch sw = Stopwatch.StartNew();
             do
             {
+                output.WriteLine($"Waiting for instance {this.instanceId} to complete.");
+
                 DurableOrchestrationStatus status = await this.GetStatusAsync(showHistory, showHistoryOutput);
                 if (status?.RuntimeStatus == OrchestrationRuntimeStatus.Completed ||
                     status?.RuntimeStatus == OrchestrationRuntimeStatus.Failed ||

--- a/test/Common/TestOrchestratorClient.cs
+++ b/test/Common/TestOrchestratorClient.cs
@@ -67,8 +67,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             await this.innerClient.RaiseEventAsync(this.instanceId, eventName, eventData);
         }
 
-        public async Task RaiseEventAsync(string taskHubName, string instanceid, string eventName, object eventData, string connectionName = null)
+        public async Task RaiseEventAsync(string taskHubName, string instanceid, string eventName, object eventData, ITestOutputHelper output, string connectionName = null)
         {
+            output?.WriteLine($"Raising event {eventName} to {this.instanceId} in task hub {taskHubName}. Payload: {eventData}");
             await this.innerClient.RaiseEventAsync(taskHubName, instanceid, eventName, eventData);
         }
 

--- a/test/FunctionsV1/PlatformSpecificHelpers.FunctionsV1.cs
+++ b/test/FunctionsV1/PlatformSpecificHelpers.FunctionsV1.cs
@@ -14,6 +14,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
     {
         public const string VersionSuffix = "V1";
         public const string TestCategory = "Functions" + VersionSuffix;
+        public const string FlakeyTestCategory = TestCategory + "_Flakey";
 
         public static JobHost CreateJobHost(
             IOptions<DurableTaskOptions> options,

--- a/test/FunctionsV1/WebJobs.Extensions.DurableTask.Tests.V1.csproj
+++ b/test/FunctionsV1/WebJobs.Extensions.DurableTask.Tests.V1.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="4.19.4" />
-    <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage" Version="1.4.1" />
+    <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage" Version="1.4.2" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="2.2.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" Version="2.2.0" />
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.33" />

--- a/test/FunctionsV2/PlatformSpecificHelpers.FunctionsV2.cs
+++ b/test/FunctionsV2/PlatformSpecificHelpers.FunctionsV2.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
     {
         public const string VersionSuffix = "V2";
         public const string TestCategory = "Functions" + VersionSuffix;
+        public const string FlakeyTestCategory = TestCategory + "_Flakey";
 
         public static JobHost CreateJobHost(
             IOptions<DurableTaskOptions> options,

--- a/test/FunctionsV2/WebJobs.Extensions.DurableTask.Tests.V2.csproj
+++ b/test/FunctionsV2/WebJobs.Extensions.DurableTask.Tests.V2.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="4.19.4" />
-    <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage" Version="1.4.1" />
+    <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage" Version="1.4.2" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="3.0.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" Version="3.0.0" />


### PR DESCRIPTION
* Updated to DurableTask.AzureStorage v1.4.2 which has a fix for the abandon scenario
* Added flakey test category
* Added improved test tracing
* Fixed race condition w/RaiseEventAsync + ContinueAsNew which was causing several tests to be flakey.