### PR TITLE
Save dropped events

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/DurableOrchestrationContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableOrchestrationContext.cs
@@ -317,11 +317,11 @@ namespace Microsoft.Azure.WebJobs
                 else
                 {
                     this.config.TraceHelper.FunctionListening(
-                    this.config.Options.HubName,
-                    this.orchestrationName,
-                    this.InstanceId,
-                    reason: $"WaitForExternalEvent:{name}",
-                    isReplay: this.innerContext.IsReplaying);
+                        this.config.Options.HubName,
+                        this.orchestrationName,
+                        this.InstanceId,
+                        reason: $"WaitForExternalEvent:{name}",
+                        isReplay: this.innerContext.IsReplaying);
                 }
 
                 return tcs.Task;

--- a/src/WebJobs.Extensions.DurableTask/EndToEndTraceHelper.cs
+++ b/src/WebJobs.Extensions.DurableTask/EndToEndTraceHelper.cs
@@ -342,7 +342,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             }
         }
 
-        public void ExternalEventDropped(
+        public void ExternalEventSaved(
             string hubName,
             string functionName,
             string instanceId,
@@ -351,7 +351,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         {
             FunctionType functionType = FunctionType.Orchestrator;
 
-            EtwEventSource.Instance.ExternalEventDropped(
+            EtwEventSource.Instance.ExternalEventSaved(
                 hubName,
                 LocalAppName,
                 LocalSlotName,
@@ -365,7 +365,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             if (this.ShouldLogEvent(isReplay: false))
             {
                 this.logger.LogInformation(
-                    "{instanceId}: Function '{functionName} ({functionType})' dropped a '{eventName}' event. State: {state}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}. SequenceNumber: {sequenceNumber}.",
+                    "{instanceId}: Function '{functionName} ({functionType})' saved a '{eventName}' event to an in-memory queue. State: {state}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}. SequenceNumber: {sequenceNumber}.",
                     instanceId, functionName, functionType, eventName, FunctionState.ExternalEventDropped, hubName,
                     LocalAppName, LocalSlotName, ExtensionVersion, this.sequenceNumber++);
             }

--- a/src/WebJobs.Extensions.DurableTask/EtwEventSource.cs
+++ b/src/WebJobs.Extensions.DurableTask/EtwEventSource.cs
@@ -240,7 +240,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         }
 
         [Event(215, Level = EventLevel.Warning)]
-        public void ExternalEventDropped(
+        public void ExternalEventSaved(
             string TaskHub,
             string AppName,
             string SlotName,

--- a/src/WebJobs.Extensions.DurableTask/EtwEventSource.cs
+++ b/src/WebJobs.Extensions.DurableTask/EtwEventSource.cs
@@ -239,7 +239,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             this.WriteEvent(214, TaskHub, AppName, SlotName, FunctionName ?? string.Empty, InstanceId ?? string.Empty, Details, ExtensionVersion);
         }
 
-        [Event(215, Level = EventLevel.Warning)]
+        [Event(215, Level = EventLevel.Informational, Version = 2)]
         public void ExternalEventSaved(
             string TaskHub,
             string AppName,

--- a/test/Common/TestActivities.cs
+++ b/test/Common/TestActivities.cs
@@ -30,6 +30,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             return a * b;
         }
 
+        public static long Add([ActivityTrigger] DurableActivityContext ctx)
+        {
+            (long a, long b) = ctx.GetInput<(long, long)>();
+            return a + b;
+        }
+
         public static string[] GetFileList([ActivityTrigger] DurableActivityContext ctx)
         {
             string directory = ctx.GetInput<string>();

--- a/test/Common/TestOrchestrations.cs
+++ b/test/Common/TestOrchestrations.cs
@@ -473,5 +473,26 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
             return "Done";
         }
+
+        public static async Task<int> WaitForEventAndCallActivity(
+            [OrchestrationTrigger] DurableOrchestrationContext context)
+        {
+            int sum = 0;
+
+            // Sums all of the inputs and intermediate sums
+            // If the 4 inputs are 0-4, then the calls are as following:
+            // 0 + (0 + 0) = 0
+            // 0 + (0 + 1) = 1
+            // 1 + (1 + 2) = 4
+            // 4 + (4 + 3) = 11
+            // 11 + (11 + 4) = 26
+            for (int i = 0; i < 5; i++)
+            {
+                int number = await context.WaitForExternalEvent<int>("add");
+                sum += await context.CallActivityAsync<int>("Add", (sum, number));
+            }
+
+            return sum;
+        }
     }
 }


### PR DESCRIPTION
**Problem:** If no orchestrator is listening for a specific event at a given time, then that event will be discarded. This causes dropped messages, even when there is an orchestrator listening for that event at around the same time (due to the race conditions seen in #573). This PR should address the main issue brought up in #378.

**Solution:** Messages that would have been dropped before are now added to an (in-memory) queue. When `WaitForExternalEvent(name)` is called, it checks its queues for an event associated with `name.` If found, `RaiseEvent` is called on it immediately.

**Notes**: This is my first stab at solving this problem - I'm not sure if it fully solves issue 573, but it does make the 10 activities/events execute in the proper order in 378. 

I also need to think about how to cleanup the queue. If someone calls `RaiseEvent` with an event name that an orchestrator will never listen for, all of those messages may stick around forever in the `DurableOrchestrationContext`'s `bufferedExternalEvents` object. Presumably, we do want to drop some messages (given that we had logic in place to do so), so discerning between messages we will eventually want and messages we will never want is something I should think about.