### PR TITLE
ETW spam: FunctionFailed ETW events hardcode IsReplay to false

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/EndToEndTraceHelper.cs
+++ b/src/WebJobs.Extensions.DurableTask/EndToEndTraceHelper.cs
@@ -301,7 +301,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             bool isReplay)
         {
             EtwEventSource.Instance.FunctionFailed(hubName, LocalAppName, LocalSlotName, functionName,
-                instanceId, reason, functionType.ToString(), ExtensionVersion, IsReplay: false);
+                instanceId, reason, functionType.ToString(), ExtensionVersion, isReplay);
             if (this.ShouldLogEvent(isReplay: false))
             {
                 this.logger.LogError(


### PR DESCRIPTION
Fix issue where FunctionFailed ETW events have the incorrect value for the IsReplay column.

The app insights logging does the right thing, it's just the ETW logs (used internally by Microsoft) which are incorrect.