### PR TITLE
Fixed issue where function failures were always being logged on replays

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/EndToEndTraceHelper.cs
+++ b/src/WebJobs.Extensions.DurableTask/EndToEndTraceHelper.cs
@@ -302,7 +302,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         {
             EtwEventSource.Instance.FunctionFailed(hubName, LocalAppName, LocalSlotName, functionName,
                 instanceId, reason, functionType.ToString(), ExtensionVersion, isReplay);
-            if (this.ShouldLogEvent(isReplay: false))
+            if (this.ShouldLogEvent(isReplay))
             {
                 this.logger.LogError(
                     "{instanceId}: Function '{functionName} ({functionType})' failed with an error. Reason: {reason}. IsReplay: {isReplay}. State: {state}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}. SequenceNumber: {sequenceNumber}.",


### PR DESCRIPTION
@glennamanns noticed an issue in [my previous PR](https://github.com/Azure/azure-functions-durable-extension/pull/585) where it turns out we are also spamming Application Insights (and probably the console in the case of local development) with replayed exception messages. This PR addresses that issue, so that by default we only log function exceptions when they actually happen, and not during replay.

Possibly related issue: https://github.com/Azure/azure-functions-durable-extension/issues/586