### PR TITLE
Adding custom LifeCycle notification helper

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
@@ -214,7 +214,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         private ILifeCycleNotificationHelper CreateLifeCycleNotificationHelper()
         {
             // First: EventGrid
-            if (!string.IsNullOrEmpty(this.Options.EventGridTopicEndpoint) && !string.IsNullOrEmpty(this.Options.EventGridKeySettingName))
+            if (!string.IsNullOrEmpty(this.Options.EventGridTopicEndpoint) || !string.IsNullOrEmpty(this.Options.EventGridKeySettingName))
             {
                 return new EventGridLifeCycleNotificationHelper(this.Options, this.nameResolver, this.TraceHelper);
             }

--- a/src/WebJobs.Extensions.DurableTask/DurableTaskOptions.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskOptions.cs
@@ -204,6 +204,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// </value>
         public bool LogReplayEvents { get; set; }
 
+        public string CustomLifeCycleNotificationHelperType { get; set; }
+
         // Used for mocking the lifecycle notification helper.
         internal HttpMessageHandler NotificationHandler { get; set; }
 

--- a/src/WebJobs.Extensions.DurableTask/DurableTaskOptions.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskOptions.cs
@@ -204,6 +204,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// </value>
         public bool LogReplayEvents { get; set; }
 
+        /// <summary>
+        /// Gets or sets the type name of a custom to use for handling lifecycle notification events.
+        /// </summary>
+        /// <value>Assembly qualified class name that implements <see cref="ILifeCycleNotificationHelper">ILifeCycleNotificationHelper</see>.</value>
         public string CustomLifeCycleNotificationHelperType { get; set; }
 
         // Used for mocking the lifecycle notification helper.

--- a/src/WebJobs.Extensions.DurableTask/EventGridLifeCycleNotificationHelper.cs
+++ b/src/WebJobs.Extensions.DurableTask/EventGridLifeCycleNotificationHelper.cs
@@ -162,7 +162,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             string hubName,
             string functionName,
             string instanceId,
-            FunctionType functionType,
             bool isReplay)
         {
             if (!this.useTrace)
@@ -184,7 +183,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             string functionName,
             string instanceId,
             bool continuedAsNew,
-            FunctionType functionType,
             bool isReplay)
         {
             if (!this.useTrace)
@@ -206,7 +204,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             string functionName,
             string instanceId,
             string reason,
-            FunctionType functionType,
             bool isReplay)
         {
             if (!this.useTrace)

--- a/src/WebJobs.Extensions.DurableTask/EventGridLifeCycleNotificationHelper.cs
+++ b/src/WebJobs.Extensions.DurableTask/EventGridLifeCycleNotificationHelper.cs
@@ -15,7 +15,7 @@ using Newtonsoft.Json;
 
 namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 {
-    internal class LifeCycleNotificationHelper
+    internal class EventGridLifeCycleNotificationHelper : ILifeCycleNotificationHelper
     {
         private readonly DurableTaskOptions config;
         private readonly EndToEndTraceHelper traceHelper;
@@ -25,7 +25,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         private static HttpClient httpClient = null;
         private static HttpMessageHandler httpMessageHandler = null;
 
-        public LifeCycleNotificationHelper(
+        public EventGridLifeCycleNotificationHelper(
             DurableTaskOptions config,
             INameResolver nameResolver,
             EndToEndTraceHelper traceHelper)

--- a/src/WebJobs.Extensions.DurableTask/FunctionType.cs
+++ b/src/WebJobs.Extensions.DurableTask/FunctionType.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
     /// <summary>
     /// The type of a function.
     /// </summary>
-    public enum FunctionType
+    internal enum FunctionType
     {
         Activity,
         Orchestrator,

--- a/src/WebJobs.Extensions.DurableTask/FunctionType.cs
+++ b/src/WebJobs.Extensions.DurableTask/FunctionType.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
     /// <summary>
     /// The type of a function.
     /// </summary>
-    internal enum FunctionType
+    public enum FunctionType
     {
         Activity,
         Orchestrator,

--- a/src/WebJobs.Extensions.DurableTask/ILifeCycleNotificationHelper.cs
+++ b/src/WebJobs.Extensions.DurableTask/ILifeCycleNotificationHelper.cs
@@ -10,12 +10,46 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
     /// </summary>
     public interface ILifeCycleNotificationHelper
     {
-        Task OrchestratorStartingAsync(string hubName, string functionName, string instanceId, FunctionType functionType, bool isReplay);
+        /// <summary>
+        /// The orchestrator was starting.
+        /// </summary>
+        /// <param name="hubName">The name of the task hub.</param>
+        /// <param name="functionName">The name of the orchestrator function to call.</param>
+        /// <param name="instanceId">The ID to use for the orchestration instance.</param>
+        /// <param name="isReplay">The orchestrator function is currently replaying itself.</param>
+        /// <returns>A task that completes when the lifecycle notification message has been sent.</returns>
+        Task OrchestratorStartingAsync(string hubName, string functionName, string instanceId, bool isReplay);
 
-        Task OrchestratorCompletedAsync(string hubName, string functionName, string instanceId, bool continuedAsNew, FunctionType functionType, bool isReplay);
+        /// <summary>
+        /// The orchestrator was completed.
+        /// </summary>
+        /// <param name="hubName">The name of the task hub.</param>
+        /// <param name="functionName">The name of the orchestrator function to call.</param>
+        /// <param name="instanceId">The ID to use for the orchestration instance.</param>
+        /// <param name="continuedAsNew">The orchestration completed with ContinueAsNew as is in the process of restarting.</param>
+        /// <param name="isReplay">The orchestrator function is currently replaying itself.</param>
+        /// <returns>A task that completes when the lifecycle notification message has been sent.</returns>
+        Task OrchestratorCompletedAsync(string hubName, string functionName, string instanceId, bool continuedAsNew, bool isReplay);
 
-        Task OrchestratorFailedAsync(string hubName, string functionName, string instanceId, string reason, FunctionType functionType, bool isReplay);
+        /// <summary>
+        /// The orchestrator was failed.
+        /// </summary>
+        /// <param name="hubName">The name of the task hub.</param>
+        /// <param name="functionName">The name of the orchestrator function to call.</param>
+        /// <param name="instanceId">The ID to use for the orchestration instance.</param>
+        /// <param name="reason">Additional data associated with the tracking event.</param>
+        /// <param name="isReplay">The orchestrator function is currently replaying itself.</param>
+        /// <returns>A task that completes when the lifecycle notification message has been sent.</returns>
+        Task OrchestratorFailedAsync(string hubName, string functionName, string instanceId, string reason, bool isReplay);
 
+        /// <summary>
+        /// The orchestrator was terminated.
+        /// </summary>
+        /// <param name="hubName">The name of the task hub.</param>
+        /// <param name="functionName">The name of the orchestrator function to call.</param>
+        /// <param name="instanceId">The ID to use for the orchestration instance.</param>
+        /// <param name="reason">Additional data associated with the tracking event.</param>
+        /// <returns>A task that completes when the lifecycle notification message has been sent.</returns>
         Task OrchestratorTerminatedAsync(string hubName, string functionName, string instanceId, string reason);
     }
 }

--- a/src/WebJobs.Extensions.DurableTask/ILifeCycleNotificationHelper.cs
+++ b/src/WebJobs.Extensions.DurableTask/ILifeCycleNotificationHelper.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Threading.Tasks;
+
+namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
+{
+    /// <summary>
+    /// Interface defining methods to life cycle notifications.
+    /// </summary>
+    public interface ILifeCycleNotificationHelper
+    {
+        Task OrchestratorStartingAsync(string hubName, string functionName, string instanceId, FunctionType functionType, bool isReplay);
+
+        Task OrchestratorCompletedAsync(string hubName, string functionName, string instanceId, bool continuedAsNew, FunctionType functionType, bool isReplay);
+
+        Task OrchestratorFailedAsync(string hubName, string functionName, string instanceId, string reason, FunctionType functionType, bool isReplay);
+
+        Task OrchestratorTerminatedAsync(string hubName, string functionName, string instanceId, string reason);
+    }
+}

--- a/src/WebJobs.Extensions.DurableTask/Listener/TaskOrchestrationShim.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/TaskOrchestrationShim.cs
@@ -77,7 +77,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     this.context.HubName,
                     this.context.Name,
                     this.context.InstanceId,
-                    FunctionType.Orchestrator,
                     this.context.IsReplaying));
             }
 
@@ -114,7 +113,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                         this.context.Name,
                         this.context.InstanceId,
                         exceptionDetails,
-                        FunctionType.Orchestrator,
                         this.context.IsReplaying));
                 }
 
@@ -168,7 +166,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     this.context.Name,
                     this.context.InstanceId,
                     this.context.ContinuedAsNew,
-                    FunctionType.Orchestrator,
                     this.context.IsReplaying));
             }
 

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
@@ -305,6 +305,12 @@
             Boolean value specifying if the replay events should be logged.
             </value>
         </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskOptions.CustomLifeCycleNotificationHelperType">
+            <summary>
+            Gets or sets the type name of a custom to use for handling lifecycle notification events.
+            </summary>
+            <value>Assembly qualified class name that implements <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.ILifeCycleNotificationHelper">ILifeCycleNotificationHelper</see>.</value>
+        </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.EtwEventSource">
             <summary>
             ETW Event Provider for the WebJobs.Extensions.DurableTask extension.
@@ -405,6 +411,53 @@
             </summary>
             <param name="connectionStringName">The name of the connection string.</param>
             <returns>Returns the resolved connection string value.</returns>
+        </member>
+        <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.ILifeCycleNotificationHelper">
+            <summary>
+            Interface defining methods to life cycle notifications.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.ILifeCycleNotificationHelper.OrchestratorStartingAsync(System.String,System.String,System.String,System.Boolean)">
+            <summary>
+            The orchestrator was starting.
+            </summary>
+            <param name="hubName">The name of the task hub.</param>
+            <param name="functionName">The name of the orchestrator function to call.</param>
+            <param name="instanceId">The ID to use for the orchestration instance.</param>
+            <param name="isReplay">The orchestrator function is currently replaying itself.</param>
+            <returns>A task that completes when the lifecycle notification message has been sent.</returns>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.ILifeCycleNotificationHelper.OrchestratorCompletedAsync(System.String,System.String,System.String,System.Boolean,System.Boolean)">
+            <summary>
+            The orchestrator was completed.
+            </summary>
+            <param name="hubName">The name of the task hub.</param>
+            <param name="functionName">The name of the orchestrator function to call.</param>
+            <param name="instanceId">The ID to use for the orchestration instance.</param>
+            <param name="continuedAsNew">The orchestration completed with ContinueAsNew as is in the process of restarting.</param>
+            <param name="isReplay">The orchestrator function is currently replaying itself.</param>
+            <returns>A task that completes when the lifecycle notification message has been sent.</returns>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.ILifeCycleNotificationHelper.OrchestratorFailedAsync(System.String,System.String,System.String,System.String,System.Boolean)">
+            <summary>
+            The orchestrator was failed.
+            </summary>
+            <param name="hubName">The name of the task hub.</param>
+            <param name="functionName">The name of the orchestrator function to call.</param>
+            <param name="instanceId">The ID to use for the orchestration instance.</param>
+            <param name="reason">Additional data associated with the tracking event.</param>
+            <param name="isReplay">The orchestrator function is currently replaying itself.</param>
+            <returns>A task that completes when the lifecycle notification message has been sent.</returns>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.ILifeCycleNotificationHelper.OrchestratorTerminatedAsync(System.String,System.String,System.String,System.String)">
+            <summary>
+            The orchestrator was terminated.
+            </summary>
+            <param name="hubName">The name of the task hub.</param>
+            <param name="functionName">The name of the orchestrator function to call.</param>
+            <param name="instanceId">The ID to use for the orchestration instance.</param>
+            <param name="reason">Additional data associated with the tracking event.</param>
+            <returns>A task that completes when the lifecycle notification message has been sent.</returns>
         </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.TaskActivityShim">
             <summary>
@@ -1154,20 +1207,6 @@
             </exception>
         </member>
         <member name="M:Microsoft.Azure.WebJobs.DurableOrchestrationContextBase.CallSubOrchestratorWithRetryAsync(System.String,Microsoft.Azure.WebJobs.RetryOptions,System.Object)">
-            <summ       <param name="instanceId">A unique ID to use for the sub-orchestration instance.</param>
-            <param name="input">The JSON-serializeable input to pass to the orchestrator function.</param>
-            <returns>A durable task that completes when the called orchestrator function completes or fails.</returns>
-            <exception cref="T:System.ArgumentException">
-            The specified function does not exist, is disabled, or is not an orchestrator function.
-            </exception>
-            <exception cref="T:System.InvalidOperationException">
-            The current thread is different than the thread which started the orchestrator execution.
-            </exception>
-            <exception cref="T:Microsoft.Azure.WebJobs.FunctionFailedException">
-            The activity function failed with an unhandled exception.
-            </exception>
-        </member>
-        <member name="M:Microsoft.Azure.WebJobs.DurableOrchestrationContextBase.CallSubOrchestratorWithRetryAsync(System.String,Microsoft.Azure.WebJobs.RetryOptions,System.Object)">
             <summary>
             Schedules an orchestrator function named <paramref name="functionName"/> for execution with retry options.
             </summary>
@@ -1210,7 +1249,22 @@
             The activity function failed with an unhandled exception.
             </exception>
         </member>
-        <member name="M:Microsoft.Azure.WebJobs.DurableOrchestrationContextBase.CallSubOrchestratorWithRetryAexception cref="T:System.InvalidOperationException">
+        <member name="M:Microsoft.Azure.WebJobs.DurableOrchestrationContextBase.CallSubOrchestratorWithRetryAsync``1(System.String,Microsoft.Azure.WebJobs.RetryOptions,System.Object)">
+            <summary>
+            Schedules an orchestrator function named <paramref name="functionName"/> for execution with retry options.
+            </summary>
+            <typeparam name="TResult">The return type of the scheduled orchestrator function.</typeparam>
+            <param name="functionName">The name of the orchestrator function to call.</param>
+            <param name="retryOptions">The retry option for the orchestrator function.</param>
+            <param name="input">The JSON-serializeable input to pass to the orchestrator function.</param>
+            <returns>A durable task that completes when the called orchestrator function completes or fails.</returns>
+            <exception cref="T:System.ArgumentNullException">
+            The retry option object is null.
+            </exception>
+            <exception cref="T:System.ArgumentException">
+            The specified function does not exist, is disabled, or is not an orchestrator function.
+            </exception>
+            <exception cref="T:System.InvalidOperationException">
             The current thread is different than the thread which started the orchestrator execution.
             </exception>
             <exception cref="T:Microsoft.Azure.WebJobs.FunctionFailedException">
@@ -1678,33 +1732,6 @@
             </summary>
             <value>
             The TimeSpan of the max retry interval, defaults to <see cref="F:System.TimeSpan.MaxValue"/>.
-            </value>
-        </member>
-        <member name="P:Microsoft.Azure.WebJobs.RetryOptions.BackoffCoefficient">
-            <summary>
-            Gets or sets the backoff coefficient.
-            </summary>
-            <value>
-            The backoff coefficient used to determine rate of increase of backoff. Defaults to 1.
-            </value>
-        </member>
-        <member name="P:Microsoft.Azure.WebJobs.RetryOptions.RetryTimeout">
-            <summary>
-            Gets or sets the timeout for retries.
-            </summary>
-            <value>
-            The TimeSpan timeout for retries, defaults to <see cref="F:System.TimeSpan.MaxValue"/>.
-            </value>
-        </member>
-        <member name="P:Microsoft.Azure.WebJobs.RetryOptions.MaxNumberOfAttempts">
-            <summary>
-            Gets or sets the max number of attempts.
-            </summary>
-            <value>
-            The maximum number of retry attempts.
-            </value>
-        </member>
-        <memb retry interval, defaults to <see cref="F:System.TimeSpan.MaxValue"/>.
             </value>
         </member>
         <member name="P:Microsoft.Azure.WebJobs.RetryOptions.BackoffCoefficient">

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
@@ -1154,6 +1154,20 @@
             </exception>
         </member>
         <member name="M:Microsoft.Azure.WebJobs.DurableOrchestrationContextBase.CallSubOrchestratorWithRetryAsync(System.String,Microsoft.Azure.WebJobs.RetryOptions,System.Object)">
+            <summ       <param name="instanceId">A unique ID to use for the sub-orchestration instance.</param>
+            <param name="input">The JSON-serializeable input to pass to the orchestrator function.</param>
+            <returns>A durable task that completes when the called orchestrator function completes or fails.</returns>
+            <exception cref="T:System.ArgumentException">
+            The specified function does not exist, is disabled, or is not an orchestrator function.
+            </exception>
+            <exception cref="T:System.InvalidOperationException">
+            The current thread is different than the thread which started the orchestrator execution.
+            </exception>
+            <exception cref="T:Microsoft.Azure.WebJobs.FunctionFailedException">
+            The activity function failed with an unhandled exception.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.DurableOrchestrationContextBase.CallSubOrchestratorWithRetryAsync(System.String,Microsoft.Azure.WebJobs.RetryOptions,System.Object)">
             <summary>
             Schedules an orchestrator function named <paramref name="functionName"/> for execution with retry options.
             </summary>
@@ -1196,22 +1210,7 @@
             The activity function failed with an unhandled exception.
             </exception>
         </member>
-        <member name="M:Microsoft.Azure.WebJobs.DurableOrchestrationContextBase.CallSubOrchestratorWithRetryAsync``1(System.String,Microsoft.Azure.WebJobs.RetryOptions,System.Object)">
-            <summary>
-            Schedules an orchestrator function named <paramref name="functionName"/> for execution with retry options.
-            </summary>
-            <typeparam name="TResult">The return type of the scheduled orchestrator function.</typeparam>
-            <param name="functionName">The name of the orchestrator function to call.</param>
-            <param name="retryOptions">The retry option for the orchestrator function.</param>
-            <param name="input">The JSON-serializeable input to pass to the orchestrator function.</param>
-            <returns>A durable task that completes when the called orchestrator function completes or fails.</returns>
-            <exception cref="T:System.ArgumentNullException">
-            The retry option object is null.
-            </exception>
-            <exception cref="T:System.ArgumentException">
-            The specified function does not exist, is disabled, or is not an orchestrator function.
-            </exception>
-            <exception cref="T:System.InvalidOperationException">
+        <member name="M:Microsoft.Azure.WebJobs.DurableOrchestrationContextBase.CallSubOrchestratorWithRetryAexception cref="T:System.InvalidOperationException">
             The current thread is different than the thread which started the orchestrator execution.
             </exception>
             <exception cref="T:Microsoft.Azure.WebJobs.FunctionFailedException">
@@ -1679,6 +1678,33 @@
             </summary>
             <value>
             The TimeSpan of the max retry interval, defaults to <see cref="F:System.TimeSpan.MaxValue"/>.
+            </value>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.RetryOptions.BackoffCoefficient">
+            <summary>
+            Gets or sets the backoff coefficient.
+            </summary>
+            <value>
+            The backoff coefficient used to determine rate of increase of backoff. Defaults to 1.
+            </value>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.RetryOptions.RetryTimeout">
+            <summary>
+            Gets or sets the timeout for retries.
+            </summary>
+            <value>
+            The TimeSpan timeout for retries, defaults to <see cref="F:System.TimeSpan.MaxValue"/>.
+            </value>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.RetryOptions.MaxNumberOfAttempts">
+            <summary>
+            Gets or sets the max number of attempts.
+            </summary>
+            <value>
+            The maximum number of retry attempts.
+            </value>
+        </member>
+        <memb retry interval, defaults to <see cref="F:System.TimeSpan.MaxValue"/>.
             </value>
         </member>
         <member name="P:Microsoft.Azure.WebJobs.RetryOptions.BackoffCoefficient">

--- a/src/WebJobs.Extensions.DurableTask/NullLifeCycleNotificationHelper.cs
+++ b/src/WebJobs.Extensions.DurableTask/NullLifeCycleNotificationHelper.cs
@@ -7,17 +7,17 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 {
     internal class NullLifeCycleNotificationHelper : ILifeCycleNotificationHelper
     {
-        public Task OrchestratorStartingAsync(string hubName, string functionName, string instanceId, FunctionType functionType, bool isReplay)
+        public Task OrchestratorStartingAsync(string hubName, string functionName, string instanceId, bool isReplay)
         {
             return Task.CompletedTask;
         }
 
-        public Task OrchestratorCompletedAsync(string hubName, string functionName, string instanceId, bool continuedAsNew, FunctionType functionType, bool isReplay)
+        public Task OrchestratorCompletedAsync(string hubName, string functionName, string instanceId, bool continuedAsNew, bool isReplay)
         {
             return Task.CompletedTask;
         }
 
-        public Task OrchestratorFailedAsync(string hubName, string functionName, string instanceId, string reason, FunctionType functionType, bool isReplay)
+        public Task OrchestratorFailedAsync(string hubName, string functionName, string instanceId, string reason, bool isReplay)
         {
             return Task.CompletedTask;
         }

--- a/src/WebJobs.Extensions.DurableTask/NullLifeCycleNotificationHelper.cs
+++ b/src/WebJobs.Extensions.DurableTask/NullLifeCycleNotificationHelper.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Threading.Tasks;
+
+namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
+{
+    internal class NullLifeCycleNotificationHelper : ILifeCycleNotificationHelper
+    {
+        public Task OrchestratorStartingAsync(string hubName, string functionName, string instanceId, FunctionType functionType, bool isReplay)
+        {
+            return Task.CompletedTask;
+        }
+
+        public Task OrchestratorCompletedAsync(string hubName, string functionName, string instanceId, bool continuedAsNew, FunctionType functionType, bool isReplay)
+        {
+            return Task.CompletedTask;
+        }
+
+        public Task OrchestratorFailedAsync(string hubName, string functionName, string instanceId, string reason, FunctionType functionType, bool isReplay)
+        {
+            return Task.CompletedTask;
+        }
+
+        public Task OrchestratorTerminatedAsync(string hubName, string functionName, string instanceId, string reason)
+        {
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/test/Common/DurableTaskLifeCycleNotificationTest.cs
+++ b/test/Common/DurableTaskLifeCycleNotificationTest.cs
@@ -1010,17 +1010,17 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
         public class TestLifeCycleNotificationHelper : ILifeCycleNotificationHelper
         {
-            public Task OrchestratorStartingAsync(string hubName, string functionName, string instanceId, FunctionType functionType, bool isReplay)
+            public Task OrchestratorStartingAsync(string hubName, string functionName, string instanceId, bool isReplay)
             {
                 return Task.CompletedTask;
             }
 
-            public Task OrchestratorCompletedAsync(string hubName, string functionName, string instanceId, bool continuedAsNew, FunctionType functionType, bool isReplay)
+            public Task OrchestratorCompletedAsync(string hubName, string functionName, string instanceId, bool continuedAsNew, bool isReplay)
             {
                 return Task.CompletedTask;
             }
 
-            public Task OrchestratorFailedAsync(string hubName, string functionName, string instanceId, string reason, FunctionType functionType, bool isReplay)
+            public Task OrchestratorFailedAsync(string hubName, string functionName, string instanceId, string reason, bool isReplay)
             {
                 return Task.CompletedTask;
             }


### PR DESCRIPTION
Change LifeCycle notification helper to extensible. #602 

- Introduced `ILifeCycleNotificationHelper` and `NullLifeCycleNotificationHelper`
- Renamed `LifeCycleNotificationHelper` to `EventGridLifeCycleNotificationHelper`
- Added `CustomLifeCycleNotificationHelperType` option
- Added test cases