### PR TITLE
Adding TypeNameHandling to Exception serializer settings

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/MessagePayloadDataConverter.cs
+++ b/src/WebJobs.Extensions.DurableTask/MessagePayloadDataConverter.cs
@@ -24,6 +24,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         private static readonly JsonSerializerSettings ErrorSettings = new JsonSerializerSettings
         {
             ContractResolver = new ExceptionResolver(),
+            TypeNameHandling = TypeNameHandling.Objects,
         };
 
         // Default singleton instances

--- a/test/Common/DurableTaskEndToEndTests.cs
+++ b/test/Common/DurableTaskEndToEndTests.cs
@@ -1375,7 +1375,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
                 string output = status.Output.ToString();
                 this.output.WriteLine($"Orchestration output string: {output}");
-                Assert.StartsWith($"Orchestrator function '{orchestratorFunctionNames[0]}' failed: The orchestrator function 'ThrowOrchestrator' failed: \"Value cannot be null.\"", output);
+                Assert.StartsWith($"Orchestrator function '{orchestratorFunctionNames[0]}' failed: The orchestrator function 'ThrowOrchestrator' failed: \"Value cannot be null.\r\nParameter name: message\"", output);
 
                 string subOrchestrationInstanceId = (string)status.CustomStatus;
                 Assert.NotNull(subOrchestrationInstanceId);


### PR DESCRIPTION
Keep actual `Exception` type in serialization. #361

#### Discussion needed

- Check if the exception was defined in C# script
  - Use type namespace (ex. `Submission#0.TestException`) or assembly location (`Assembly.Location` is empty from C# script)
  - Switch `TypeNameHandling.None` for exceptions defined in C# script