### PR TITLE
Allow to configure max polling interval via host.json

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
@@ -460,6 +460,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 MaxConcurrentTaskActivityWorkItems = this.Options.MaxConcurrentActivityFunctions,
                 ExtendedSessionsEnabled = this.Options.ExtendedSessionsEnabled,
                 ExtendedSessionIdleTimeout = extendedSessionTimeout,
+                MaxQueuePollingInterval = this.Options.MaxQueuePollingInterval,
             };
         }
 

--- a/src/WebJobs.Extensions.DurableTask/DurableTaskOptions.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskOptions.cs
@@ -210,6 +210,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// <value>Assembly qualified class name that implements <see cref="ILifeCycleNotificationHelper">ILifeCycleNotificationHelper</see>.</value>
         public string CustomLifeCycleNotificationHelperType { get; set; }
 
+        /// <summary>
+        /// Gets or sets the maximum queue polling interval.
+        /// </summary>
+        /// <value>Maximum interval for polling control and work-item queues.</value>
+        public TimeSpan MaxQueuePollingInterval { get; set; } = TimeSpan.FromSeconds(30);
+
         // Used for mocking the lifecycle notification helper.
         internal HttpMessageHandler NotificationHandler { get; set; }
 
@@ -248,6 +254,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             }
 
             sb.Append(nameof(this.LogReplayEvents)).Append(": ").Append(this.LogReplayEvents);
+            sb.Append(nameof(this.MaxQueuePollingInterval)).Append(": ").Append(this.MaxQueuePollingInterval).Append(", ");
 
             return sb.ToString();
         }
@@ -302,6 +309,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 this.EventGridPublishRetryInterval > TimeSpan.FromMinutes(60))
             {
                 throw new InvalidOperationException($"{nameof(this.EventGridPublishRetryInterval)} must be non-negative and no more than 60 minutes.");
+            }
+
+            if (this.MaxQueuePollingInterval <= TimeSpan.Zero)
+            {
+                throw new InvalidOperationException($"{nameof(this.MaxQueuePollingInterval)} must be non-negative.");
             }
         }
     }

--- a/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
+++ b/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
@@ -47,7 +47,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage" Version="1.4.2" />
+    <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage" Version="1.5.0" />
   </ItemGroup>
 
   <!-- NuGet Publishing Metadata -->

--- a/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
+++ b/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
@@ -6,8 +6,8 @@
     <RootNamespace>Microsoft.Azure.WebJobs.Extensions.DurableTask</RootNamespace>
     <DocumentationFile>Microsoft.Azure.WebJobs.Extensions.DurableTask.xml</DocumentationFile>
     <MajorVersion>1</MajorVersion>
-    <MinorVersion>7</MinorVersion>
-    <PatchVersion>1</PatchVersion>
+    <MinorVersion>8</MinorVersion>
+    <PatchVersion>0</PatchVersion>
     <Version>$(MajorVersion).$(MinorVersion).$(PatchVersion)</Version>
     <FileVersion>$(MajorVersion).$(MinorVersion).$(PatchVersion)</FileVersion>
     <AssemblyVersion>$(MajorVersion).0.0.0</AssemblyVersion>

--- a/test/Common/TestHelpers.cs
+++ b/test/Common/TestHelpers.cs
@@ -31,7 +31,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             int[] eventGridRetryHttpStatus = null,
             bool logReplayEvents = true,
             Uri notificationUrl = null,
-            HttpMessageHandler eventGridNotificationHandler = null)
+            HttpMessageHandler eventGridNotificationHandler = null,
+            TimeSpan? maxQueuePollingInterval = null)
         {
             var durableTaskOptions = new DurableTaskOptions
             {
@@ -60,6 +61,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             if (eventGridRetryHttpStatus != null)
             {
                 durableTaskOptions.EventGridPublishRetryHttpStatus = eventGridRetryHttpStatus;
+            }
+
+            if (maxQueuePollingInterval != null)
+            {
+                durableTaskOptions.MaxQueuePollingInterval = maxQueuePollingInterval.Value;
             }
 
             var optionsWrapper = new OptionsWrapper<DurableTaskOptions>(durableTaskOptions);

--- a/test/FunctionsV1/WebJobs.Extensions.DurableTask.Tests.V1.csproj
+++ b/test/FunctionsV1/WebJobs.Extensions.DurableTask.Tests.V1.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="4.19.4" />
-    <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage" Version="1.4.2" />
+    <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage" Version="1.5.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="2.2.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" Version="2.2.0" />
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.33" />

--- a/test/FunctionsV2/WebJobs.Extensions.DurableTask.Tests.V2.csproj
+++ b/test/FunctionsV2/WebJobs.Extensions.DurableTask.Tests.V2.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="4.19.4" />
-    <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage" Version="1.4.2" />
+    <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage" Version="1.5.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="3.0.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" Version="3.0.0" />


### PR DESCRIPTION
Makes the maximum queue polling interval configurable via host.json.

Second step to resolving [Azure/azure-functions-durable-extension#618](https://github.com/Azure/azure-functions-durable-extension/issues/618).