### PR TITLE
Mark Serializable to FunctionFailedException

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/FunctionFailedException.cs
+++ b/src/WebJobs.Extensions.DurableTask/FunctionFailedException.cs
@@ -14,6 +14,7 @@ namespace Microsoft.Azure.WebJobs
     /// The `InnerException` property of this instance will contain additional information
     /// about the failed sub-orchestrator or activity function.
     /// </remarks>
+    [Serializable]
     public class FunctionFailedException : Exception
     {
         internal FunctionFailedException()


### PR DESCRIPTION
`SerializableAttribute` is required when serialize using Json.NET.

Therefore, `InnerException` is empty in the case of serializing `FunctionFailedException` (mainly using sub orchestrator).

#### Impact

Already serialized exceptions can not deserialize correctly before adding [Serializable].