### PR TITLE
Remove validation for deregistered functions

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/Bindings/OrchestrationTriggerAttributeBindingProvider.cs
+++ b/src/WebJobs.Extensions.DurableTask/Bindings/OrchestrationTriggerAttributeBindingProvider.cs
@@ -141,7 +141,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 // We may need to revisit this assumption when Functions v2 adds support
                 // for "out-of-proc" .NET.
                 var isOutOfProc = !typeof(DurableOrchestrationContextBase).IsAssignableFrom(this.parameterInfo.ParameterType);
-                this.config.RegisterOrchestrator(this.orchestratorName, new OrchestratorInfo(context.Executor, isOutOfProc));
+                this.config.RegisterOrchestrator(this.orchestratorName, new RegisteredFunctionInfo(context.Executor, isOutOfProc));
 
                 var listener = new DurableTaskListener(
                     this.config,

--- a/src/WebJobs.Extensions.DurableTask/Bindings/RegisteredFunctionInfo.cs
+++ b/src/WebJobs.Extensions.DurableTask/Bindings/RegisteredFunctionInfo.cs
@@ -5,15 +5,18 @@ using Microsoft.Azure.WebJobs.Host.Executors;
 
 namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 {
-    internal class OrchestratorInfo
+    internal class RegisteredFunctionInfo
     {
-        internal OrchestratorInfo(ITriggeredFunctionExecutor executor, bool isOutOfProc)
+        internal RegisteredFunctionInfo(ITriggeredFunctionExecutor executor, bool isOutOfProc)
         {
             this.Executor = executor;
             this.IsOutOfProc = isOutOfProc;
         }
 
-        internal ITriggeredFunctionExecutor Executor { get; }
+        internal ITriggeredFunctionExecutor Executor { get; set; }
+
+        // This flag is set when a function is disabled or the host is shutting down.
+        internal bool IsDeregistered { get; set; }
 
         internal bool IsOutOfProc { get; }
     }

--- a/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
@@ -467,6 +467,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
         internal void RegisterOrchestrator(FunctionName orchestratorFunction, RegisteredFunctionInfo orchestratorInfo)
         {
+            orchestratorInfo.IsDeregistered = false;
+
             if (this.knownOrchestrators.TryAdd(orchestratorFunction, orchestratorInfo))
             {
                 this.TraceHelper.ExtensionInformationalEvent(
@@ -485,7 +487,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         internal void DeregisterOrchestrator(FunctionName orchestratorFunction)
         {
             RegisteredFunctionInfo existing;
-            if (this.knownOrchestrators.TryGetValue(orchestratorFunction, out existing))
+            if (this.knownOrchestrators.TryGetValue(orchestratorFunction, out existing) && !existing.IsDeregistered)
             {
                 existing.IsDeregistered = true;
 
@@ -529,7 +531,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         internal void DeregisterActivity(FunctionName activityFunction)
         {
             RegisteredFunctionInfo info;
-            if (this.knownActivities.TryGetValue(activityFunction, out info))
+            if (this.knownActivities.TryGetValue(activityFunction, out info) && !info.IsDeregistered)
             {
                 info.IsDeregistered = true;
 

--- a/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
@@ -467,7 +467,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
         internal void RegisterOrchestrator(FunctionName orchestratorFunction, RegisteredFunctionInfo orchestratorInfo)
         {
-            orchestratorInfo.IsDeregistered = false;
+            if (orchestratorInfo != null)
+            {
+                orchestratorInfo.IsDeregistered = false;
+            }
 
             if (this.knownOrchestrators.TryAdd(orchestratorFunction, orchestratorInfo))
             {

--- a/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Concurrent;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Reflection;
@@ -43,11 +44,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         private readonly ConcurrentDictionary<OrchestrationClientAttribute, DurableOrchestrationClient> cachedClients =
             new ConcurrentDictionary<OrchestrationClientAttribute, DurableOrchestrationClient>();
 
-        private readonly ConcurrentDictionary<FunctionName, OrchestratorInfo> registeredOrchestrators =
-            new ConcurrentDictionary<FunctionName, OrchestratorInfo>();
+        private readonly ConcurrentDictionary<FunctionName, RegisteredFunctionInfo> knownOrchestrators =
+            new ConcurrentDictionary<FunctionName, RegisteredFunctionInfo>();
 
-        private readonly ConcurrentDictionary<FunctionName, ITriggeredFunctionExecutor> registeredActivities =
-            new ConcurrentDictionary<FunctionName, ITriggeredFunctionExecutor>();
+        private readonly ConcurrentDictionary<FunctionName, RegisteredFunctionInfo> knownActivities =
+            new ConcurrentDictionary<FunctionName, RegisteredFunctionInfo>();
 
         private readonly AsyncLock taskHubLock = new AsyncLock();
 
@@ -283,8 +284,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         {
             FunctionName activityFunction = new FunctionName(name);
 
-            ITriggeredFunctionExecutor executor;
-            if (!this.registeredActivities.TryGetValue(activityFunction, out executor))
+            RegisteredFunctionInfo info;
+            if (!this.knownActivities.TryGetValue(activityFunction, out info))
             {
                 string message = $"Activity function '{activityFunction}' does not exist.";
                 this.TraceHelper.ExtensionWarningEvent(
@@ -295,7 +296,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 throw new InvalidOperationException(message);
             }
 
-            return new TaskActivityShim(this, executor, name);
+            return new TaskActivityShim(this, info.Executor, name);
         }
 
         private async Task OrchestrationMiddleware(DispatchMiddlewareContext dispatchContext, Func<Task> next)
@@ -317,8 +318,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
             FunctionName orchestratorFunction = new FunctionName(context.Name);
 
-            OrchestratorInfo info;
-            if (!this.registeredOrchestrators.TryGetValue(orchestratorFunction, out info))
+            RegisteredFunctionInfo info;
+            if (!this.knownOrchestrators.TryGetValue(orchestratorFunction, out info))
             {
                 string message = this.GetInvalidOrchestratorFunctionMessage(orchestratorFunction.Name);
                 this.TraceHelper.ExtensionWarningEvent(
@@ -464,85 +465,92 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             };
         }
 
-        internal void RegisterOrchestrator(FunctionName orchestratorFunction, OrchestratorInfo orchestratorInfo)
+        internal void RegisterOrchestrator(FunctionName orchestratorFunction, RegisteredFunctionInfo orchestratorInfo)
         {
-            if (!this.registeredOrchestrators.TryUpdate(orchestratorFunction, orchestratorInfo, null))
+            if (this.knownOrchestrators.TryAdd(orchestratorFunction, orchestratorInfo))
             {
                 this.TraceHelper.ExtensionInformationalEvent(
                     this.Options.HubName,
                     instanceId: string.Empty,
                     functionName: orchestratorFunction.Name,
-                    message: $"Registering orchestrator function named {orchestratorFunction}.",
+                    message: $"Registered orchestrator function named {orchestratorFunction}.",
                     writeToUserLogs: false);
-
-                if (!this.registeredOrchestrators.TryAdd(orchestratorFunction, orchestratorInfo))
-                {
-                    throw new ArgumentException(
-                        $"The orchestrator function named '{orchestratorFunction}' is already registered.");
-                }
+            }
+            else
+            {
+                this.knownOrchestrators[orchestratorFunction] = orchestratorInfo;
             }
         }
 
         internal void DeregisterOrchestrator(FunctionName orchestratorFunction)
         {
-            this.TraceHelper.ExtensionInformationalEvent(
-                this.Options.HubName,
-                instanceId: string.Empty,
-                functionName: orchestratorFunction.Name,
-                message: $"Deregistering orchestrator function named {orchestratorFunction}.",
-                writeToUserLogs: false);
+            RegisteredFunctionInfo existing;
+            if (this.knownOrchestrators.TryGetValue(orchestratorFunction, out existing))
+            {
+                existing.IsDeregistered = true;
 
-            this.registeredOrchestrators.TryRemove(orchestratorFunction, out _);
+                this.TraceHelper.ExtensionInformationalEvent(
+                    this.Options.HubName,
+                    instanceId: string.Empty,
+                    functionName: orchestratorFunction.Name,
+                    message: $"Deregistered orchestrator function named {orchestratorFunction}.",
+                    writeToUserLogs: false);
+            }
         }
 
-        internal OrchestratorInfo GetOrchestratorInfo(FunctionName orchestratorFunction)
+        internal RegisteredFunctionInfo GetOrchestratorInfo(FunctionName orchestratorFunction)
         {
-            OrchestratorInfo info;
-            this.registeredOrchestrators.TryGetValue(orchestratorFunction, out info);
+            RegisteredFunctionInfo info;
+            this.knownOrchestrators.TryGetValue(orchestratorFunction, out info);
 
             return info;
         }
 
         internal void RegisterActivity(FunctionName activityFunction, ITriggeredFunctionExecutor executor)
         {
-            // Allow adding with a null key and subsequently updating with a non-null key.
-            if (!this.registeredActivities.TryUpdate(activityFunction, executor, null))
+            if (this.knownActivities.TryGetValue(activityFunction, out RegisteredFunctionInfo existing))
+            {
+                existing.Executor = executor;
+            }
+            else
             {
                 this.TraceHelper.ExtensionInformationalEvent(
                     this.Options.HubName,
                     instanceId: string.Empty,
                     functionName: activityFunction.Name,
-                    message: $"Registering orchestrator function named {activityFunction}.",
+                    message: $"Registering activity function named {activityFunction}.",
                     writeToUserLogs: false);
 
-                if (!this.registeredActivities.TryAdd(activityFunction, executor))
-                {
-                    throw new ArgumentException($"The activity function named '{activityFunction}' is already registered.");
-                }
+                var info = new RegisteredFunctionInfo(executor, isOutOfProc: false);
+                this.knownActivities[activityFunction] = info;
             }
         }
 
         internal void DeregisterActivity(FunctionName activityFunction)
         {
-            this.TraceHelper.ExtensionInformationalEvent(
-                this.Options.HubName,
-                instanceId: string.Empty,
-                functionName: activityFunction.Name,
-                message: $"Deregistering orchestrator function named {activityFunction}.",
-                writeToUserLogs: false);
+            RegisteredFunctionInfo info;
+            if (this.knownActivities.TryGetValue(activityFunction, out info))
+            {
+                info.IsDeregistered = true;
 
-            this.registeredActivities.TryRemove(activityFunction, out _);
+                this.TraceHelper.ExtensionInformationalEvent(
+                    this.Options.HubName,
+                    instanceId: string.Empty,
+                    functionName: activityFunction.Name,
+                    message: $"Deregistered activity function named {activityFunction}.",
+                    writeToUserLogs: false);
+            }
         }
 
         internal void ThrowIfFunctionDoesNotExist(string name, FunctionType functionType)
         {
             var functionName = new FunctionName(name);
 
-            if (functionType == FunctionType.Activity && !this.registeredActivities.ContainsKey(functionName))
+            if (functionType == FunctionType.Activity && !this.knownActivities.ContainsKey(functionName))
             {
                 throw new ArgumentException(this.GetInvalidActivityFunctionMessage(name));
             }
-            else if (functionType == FunctionType.Orchestrator && !this.registeredOrchestrators.ContainsKey(functionName))
+            else if (functionType == FunctionType.Orchestrator && !this.knownOrchestrators.ContainsKey(functionName))
             {
                 throw new ArgumentException(this.GetInvalidOrchestratorFunctionMessage(name));
             }
@@ -551,9 +559,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         internal string GetInvalidActivityFunctionMessage(string name)
         {
             string message = $"The function '{name}' doesn't exist, is disabled, or is not an activity function. Additional info: ";
-            if (this.registeredActivities.Keys.Count > 0)
+            if (this.knownActivities.Keys.Count > 0)
             {
-                message += $"The following are the active activity functions: '{string.Join("', '", this.registeredActivities.Keys)}'.";
+                message += $"The following are the known activity functions: '{string.Join("', '", this.knownActivities.Keys)}'.";
             }
             else
             {
@@ -566,9 +574,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         internal string GetInvalidOrchestratorFunctionMessage(string name)
         {
             string message = $"The function '{name}' doesn't exist, is disabled, or is not an orchestrator function. Additional info: ";
-            if (this.registeredOrchestrators.Keys.Count > 0)
+            if (this.knownOrchestrators.Keys.Count > 0)
             {
-                message += $"The following are the active orchestrator functions: '{string.Join("', '", this.registeredOrchestrators.Keys)}'.";
+                message += $"The following are the known orchestrator functions: '{string.Join("', '", this.knownOrchestrators.Keys)}'.";
             }
             else
             {
@@ -614,8 +622,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             using (await this.taskHubLock.AcquireAsync())
             {
                 if (this.isTaskHubWorkerStarted &&
-                    this.registeredOrchestrators.Count == 0 &&
-                    this.registeredActivities.Count == 0)
+                    this.knownOrchestrators.Values.Count(info => !info.IsDeregistered) == 0 &&
+                    this.knownActivities.Values.Count(info => !info.IsDeregistered) == 0)
                 {
                     this.TraceHelper.ExtensionInformationalEvent(
                         this.Options.HubName,


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-functions-durable-extension/issues/577

This PR addresses a race condition that happens during Functions host shutdown. Instead of removing deregistered functions from internal dictionary, we keep them in that dictionary and just set a `IsDeregistered` bit to `true`. This avoids the exception which can happen if an orchestrator function tries to schedule an activity function at the same time as a host shutdown.