### PR TITLE
Opt-out of specific lifecycle events that are published to Event Grid

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/DurableTaskOptions.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskOptions.cs
@@ -163,6 +163,28 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// <value>A list of HTTP status codes, e.g. 400, 403.</value>
         public int[] EventGridPublishRetryHttpStatus { get; set; }
 
+
+        /// <summary>
+        /// Gets or sets if the 'Running' Event should be published to Event Grid.
+        /// </summary>
+        public bool EventGridPublishRunningEvent { get; set; } = true;
+
+        /// <summary>
+        /// Gets or sets if the 'Completed' Event should be published to Event Grid.
+        /// </summary>
+        public bool EventGridPublishCompletedEvent { get; set; } = true;
+
+
+        /// <summary>
+        /// Gets or sets if the 'Failed' Event should be published to Event Grid.
+        /// </summary>
+        public bool EventGridPublishFailedEvent { get; set; } = true;
+
+        /// <summary>
+        /// Gets or sets if the 'Terminated' Event should be published to Event Grid.
+        /// </summary>
+        public bool EventGridPublishTerminatedEvent { get; set; } = true;
+
         /// <summary>
         /// Gets or sets a flag indicating whether to enable extended sessions.
         /// </summary>

--- a/src/WebJobs.Extensions.DurableTask/DurableTaskOptions.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskOptions.cs
@@ -163,27 +163,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// <value>A list of HTTP status codes, e.g. 400, 403.</value>
         public int[] EventGridPublishRetryHttpStatus { get; set; }
 
-
         /// <summary>
-        /// Gets or sets if the 'Running' Event should be published to Event Grid.
+        /// gets or sets the event types that will be published to Event Grid. 
         /// </summary>
-        public bool EventGridPublishRunningEvent { get; set; } = true;
-
-        /// <summary>
-        /// Gets or sets if the 'Completed' Event should be published to Event Grid.
-        /// </summary>
-        public bool EventGridPublishCompletedEvent { get; set; } = true;
-
-
-        /// <summary>
-        /// Gets or sets if the 'Failed' Event should be published to Event Grid.
-        /// </summary>
-        public bool EventGridPublishFailedEvent { get; set; } = true;
-
-        /// <summary>
-        /// Gets or sets if the 'Terminated' Event should be published to Event Grid.
-        /// </summary>
-        public bool EventGridPublishTerminatedEvent { get; set; } = true;
+        /// <value>
+        /// An array of strings. Possible values 'Started', 'Completed', 'Failed', 'Terminated'.
+        /// </value>
+        public string[] EventGridPublishEventTypes { get; set; }
 
         /// <summary>
         /// Gets or sets a flag indicating whether to enable extended sessions.

--- a/src/WebJobs.Extensions.DurableTask/EventGridLifeCycleNotificationHelper.cs
+++ b/src/WebJobs.Extensions.DurableTask/EventGridLifeCycleNotificationHelper.cs
@@ -22,6 +22,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         private readonly bool useTrace;
         private readonly string eventGridKeyValue;
         private readonly string eventGridTopicEndpoint;
+        private readonly bool eventGridPublishRunningEvent;
+        private readonly bool eventGridPublishCompletedEvent;
+        private readonly bool eventGridPublishFailedEvent;
+        private readonly bool eventGridPublishTerminatedEvent;
         private static HttpClient httpClient = null;
         private static HttpMessageHandler httpMessageHandler = null;
 
@@ -40,6 +44,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
             this.eventGridKeyValue = nameResolver.Resolve(config.EventGridKeySettingName);
             this.eventGridTopicEndpoint = config.EventGridTopicEndpoint;
+            this.eventGridPublishRunningEvent = config.EventGridPublishRunningEvent;
+            this.eventGridPublishCompletedEvent = config.EventGridPublishCompletedEvent;
+            this.eventGridPublishFailedEvent = config.EventGridPublishFailedEvent;
+            this.eventGridPublishTerminatedEvent = config.EventGridPublishTerminatedEvent;
+
             if (nameResolver.TryResolveWholeString(config.EventGridTopicEndpoint, out var endpoint))
             {
                 this.eventGridTopicEndpoint = endpoint;
@@ -169,6 +178,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 return;
             }
 
+            if (!this.eventGridPublishRunningEvent)
+            {
+                return;
+            }
+
             EventGridEvent[] sendObject = this.CreateEventGridEvent(
                 hubName,
                 functionName,
@@ -186,6 +200,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             bool isReplay)
         {
             if (!this.useTrace)
+            {
+                return;
+            }
+
+            if (!this.eventGridPublishCompletedEvent)
             {
                 return;
             }
@@ -211,6 +230,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 return;
             }
 
+            if (!this.eventGridPublishFailedEvent)
+            {
+                return;
+            }
+
             EventGridEvent[] sendObject = this.CreateEventGridEvent(
                 hubName,
                 functionName,
@@ -227,6 +251,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             string reason)
         {
             if (!this.useTrace)
+            {
+                return;
+            }
+
+            if (!this.eventGridPublishTerminatedEvent)
             {
                 return;
             }

--- a/src/WebJobs.Extensions.DurableTask/EventGridLifeCycleNotificationHelper.cs
+++ b/src/WebJobs.Extensions.DurableTask/EventGridLifeCycleNotificationHelper.cs
@@ -23,10 +23,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         private readonly string eventGridKeyValue;
         private readonly string eventGridTopicEndpoint;
         private readonly OrchestrationRuntimeStatus[] eventGridPublishEventTypes;
-        private readonly bool eventGridPublishRunningEvent;
-        private readonly bool eventGridPublishCompletedEvent;
-        private readonly bool eventGridPublishFailedEvent;
-        private readonly bool eventGridPublishTerminatedEvent;
         private static HttpClient httpClient = null;
         private static HttpMessageHandler httpMessageHandler = null;
 
@@ -56,7 +52,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 if (!string.IsNullOrEmpty(config.EventGridKeySettingName))
                 {
                     this.useTrace = true;
-
 
                     var retryStatusCode = config.EventGridPublishRetryHttpStatus?
                                               .Where(x => Enum.IsDefined(typeof(HttpStatusCode), x))

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
@@ -22,6 +22,11 @@
             Configuration for the Durable Functions extension.
             </summary>
         </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.#ctor">
+            <summary>
+            Obsolete. Please use an alternate constructor overload.
+            </summary>
+        </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.#ctor(Microsoft.Extensions.Options.IOptions{Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskOptions},Microsoft.Extensions.Logging.ILoggerFactory,Microsoft.Azure.WebJobs.INameResolver,Microsoft.Azure.WebJobs.Extensions.DurableTask.IConnectionStringResolver)">
             <summary>
             Initializes a new instance of the <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension"/>.
@@ -30,6 +35,17 @@
             <param name="loggerFactory">The logger factory used for extension-specific logging and orchestration tracking.</param>
             <param name="nameResolver">The name resolver to use for looking up application settings.</param>
             <param name="connectionStringResolver">The resolver to use for looking up connection strings.</param>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.HubName">
+            <summary>
+            Gets or sets default task hub name to be used by all <see cref="T:Microsoft.Azure.WebJobs.DurableOrchestrationClient"/>,
+            <see cref="T:Microsoft.Azure.WebJobs.DurableOrchestrationContext"/>, and <see cref="T:Microsoft.Azure.WebJobs.DurableActivityContext"/> instances.
+            </summary>
+            <remarks>
+            A task hub is a logical grouping of storage resources. Alternate task hub names can be used to isolate
+            multiple Durable Functions applications from each other, even if they are using the same storage backend.
+            </remarks>
+            <value>The name of the default task hub.</value>
         </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.Microsoft#Azure#WebJobs#Host#Config#IExtensionConfigProvider#Initialize(Microsoft.Azure.WebJobs.Host.Config.ExtensionConfigContext)">
             <summary>
@@ -48,18 +64,6 @@
             Called by the Durable Task Framework: Not used.
             </summary>
             <param name="creator">This parameter is not used.</param>
-        </member>
-        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.DurableTask#Core#INameVersionObjectManager{DurableTask#Core#TaskOrchestration}#GetObject(System.String,System.String)">
-            <summary>
-            Called by the Durable Task Framework: Returns the specified <see cref="T:DurableTask.Core.TaskOrchestration"/>.
-            </summary>
-            <param name="name">The name of the orchestration to return.</param>
-            <param name="version">Not used.</param>
-            <returns>An orchestration shim that delegates execution to an orchestrator function.</returns>
-        </member>
-        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.DurableTask#Core#INameVersionObjectManager{DurableTask#Core#TaskActivity}#Add(DurableTask.Core.ObjectCreator{DurableTask.Core.TaskActivity})">
-            <summary>
-            Called by the durable task framework: Not       <param name="creator">This parameter is not used.</param>
         </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.DurableTask#Core#INameVersionObjectManager{DurableTask#Core#TaskOrchestration}#GetObject(System.String,System.String)">
             <summary>
@@ -260,25 +264,13 @@
             </summary>
             <value>A list of HTTP status codes, e.g. 400, 403.</value>
         </member>
-        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskOptions.EventGridPublishRunningEvent">
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskOptions.EventGridPublishEventTypes">
             <summary>
-            Gets or sets if the 'Running' Event should be published to Event Grid.
+            gets or sets the event types that will be published to Event Grid. 
             </summary>
-        </member>
-        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskOptions.EventGridPublishCompletedEvent">
-            <summary>
-            Gets or sets if the 'Completed' Event should be published to Event Grid.
-            </summary>
-        </member>
-        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskOptions.EventGridPublishFailedEvent">
-            <summary>
-            Gets or sets if the 'Failed' Event should be published to Event Grid.
-            </summary>
-        </member>
-        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskOptions.EventGridPublishTerminatedEvent">
-            <summary>
-            Gets or sets if the 'Terminated' Event should be published to Event Grid.
-            </summary>
+            <value>
+            An array of strings. Possible values 'Started', 'Completed', 'Failed', 'Terminated'.
+            </value>
         </member>
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskOptions.ExtendedSessionsEnabled">
             <summary>
@@ -1031,26 +1023,6 @@
             <remarks>
             The instance ID is generated and fixed when the orchestrator function is scheduled. It can be either
             auto-generated, in which case it is formatted as a GUID, or it can be user-specified with any format.
-            </rdoc/>
-        </member>
-        <member name="M:Microsoft.Azure.WebJobs.DurableOrchestrationContext.WaitForExternalEvent``1(System.String,System.TimeSpan,``0)">
-            <inheritdoc/>
-        </member>
-        <member name="M:Microsoft.Azure.WebJobs.DurableOrchestrationContext.ContinueAsNew(System.Object)">
-            <inheritdoc />
-        </member>
-        <member name="T:Microsoft.Azure.WebJobs.DurableOrchestrationContextBase">
-            <summary>
-            Abstract base class for <see cref="T:Microsoft.Azure.WebJobs.DurableOrchestrationContext"/>.
-            </summary>
-        </member>
-        <member name="P:Microsoft.Azure.WebJobs.DurableOrchestrationContextBase.InstanceId">
-            <summary>
-            Gets the instance ID of the currently executing orchestration.
-            </summary>
-            <remarks>
-            The instance ID is generated and fixed when the orchestrator function is scheduled. It can be either
-            auto-generated, in which case it is formatted as a GUID, or it can be user-specified with any format.
             </remarks>
             <value>
             The ID of the current orchestration instance.
@@ -1102,7 +1074,23 @@
         <member name="M:Microsoft.Azure.WebJobs.DurableOrchestrationContextBase.NewGuid">
             <summary>
             Creates a new GUID that is safe for replay within an orchestrator function.
-   ed function does not exist, is disabled, or is not an orchestrator function.
+            </summary>
+            <remarks>
+            The default implementation of this method creates a name-based UUID using the algorithm from
+            RFC 4122 §4.3. The name input used to generate this value is a combination of the orchestration
+            instance ID and an internally managed sequence number.
+            </remarks>
+            <returns>The new <see cref="T:System.Guid"/> value.</returns>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.DurableOrchestrationContextBase.CallActivityAsync(System.String,System.Object)">
+            <summary>
+            Schedules an activity function named <paramref name="functionName"/> for execution.
+            </summary>
+            <param name="functionName">The name of the activity function to call.</param>
+            <param name="input">The JSON-serializeable input to pass to the activity function.</param>
+            <returns>A durable task that completes when the called function completes or fails.</returns>
+            <exception cref="T:System.ArgumentException">
+            The specified function does not exist, is disabled, or is not an orchestrator function.
             </exception>
             <exception cref="T:System.InvalidOperationException">
             The current thread is different than the thread which started the orchestrator execution.
@@ -1145,21 +1133,6 @@
             </exception>
             <exception cref="T:System.InvalidOperationException">
             The current thread is different than the thread which started the orchestrator execution.
-            </exception>
-            <exception cref="T:Microsoft.Azure.WebJobs.FunctionFailedException">
-            The activity function failed with an unhandled exception.
-            </exception>
-        </member>
-        <member name="M:Microsoft.Azure.WebJobs.DurableOrchestrationContextBase.CallActivityWithRetryAsync``1(System.String,Microsoft.Azure.WebJobs.RetryOptions,System.Object)">
-            <summary>
-            Schedules an activity function named <paramref name="functionName"/> for execution with retry options.
-            </summary>
-            <typeparam name="TResult">The return type of the scheduled activity function.</typeparam>
-            <param name="functionName">The name of the activity function to call.</param>
-            <param name="retryOptions">The retry option for the activity function.</param>
-            <param name="input">The JSON-serializeable input to pass to the activity function.</param>
-            <returns>A durable task that completes when the called activity function completes or fails.</returns>
-            <exceptionecution.
             </exception>
             <exception cref="T:Microsoft.Azure.WebJobs.FunctionFailedException">
             The activity function failed with an unhandled exception.
@@ -1217,6 +1190,21 @@
             </exception>
             <exception cref="T:System.InvalidOperationException">
             The current thread is different than the thread which started the orchestrator execution.
+            </exception>
+            <exception cref="T:Microsoft.Azure.WebJobs.FunctionFailedException">
+            The activity function failed with an unhandled exception.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.DurableOrchestrationContextBase.CallSubOrchestratorAsync``1(System.String,System.Object)">
+            <summary>
+            Schedules an orchestration function named <paramref name="functionName"/> for execution.
+            </summary>
+            <typeparam name="TResult">The return type of the scheduled orchestrator function.</typeparam>
+            <param name="functionName">The name of the orchestrator function to call.</param>
+            <param name="input">The JSON-serializeable input to pass to the orchestrator function.</param>
+            <returns>A durable task that completes when the called orchestrator function completes or fails.</returns>
+            <exception cref="T:System.ArgumentException">
+            The specified function does not exist, is disabled, or is not an orchestrator function.
             </exception>
             <exception cref="T:System.InvalidOperationException">
             The current thread is different than the thread which started the orchestrator execution.
@@ -1316,22 +1304,6 @@
             <typeparam name="TResult">The return type of the scheduled orchestrator function.</typeparam>
             <param name="functionName">The name of the orchestrator function to call.</param>
             <param name="retryOptions">The retry option for the orchestrator function.</param>
-            <param name="instanceId">A unique ID to use for the sub-orchestration instance.</param>
-            <param name="input">The JSON-serializeable input to pass to the orchestrator function.</param>
-            <returns>A durable task that completes when the called orchestrator function completes or fails.</returns>
-            <exception cref="T:System.ArgumentNullException">
-            The retry option object is null.
-            </exception>
-            <exception cref="T:System.ArgumentException">
-            The specified function does not exist, is disabled, or is not an orchestrator function.
-            </exception>
-            <exception cref="T:System.InvalidOperationException">
-            The current thread is different than the thread which started the orchestrator execution.
-            </exception>
-            <exception cref="T:Microsoft.Azure.WebJobs.FunctionFailedException">
-            The activity function failed with an unhandled exception.
-            </exception>
-        </memberions">The retry option for the orchestrator function.</param>
             <param name="instanceId">A unique ID to use for the sub-orchestration instance.</param>
             <param name="input">The JSON-serializeable input to pass to the orchestrator function.</param>
             <returns>A durable task that completes when the called orchestrator function completes or fails.</returns>

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
@@ -22,11 +22,6 @@
             Configuration for the Durable Functions extension.
             </summary>
         </member>
-        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.#ctor">
-            <summary>
-            Obsolete. Please use an alternate constructor overload.
-            </summary>
-        </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.#ctor(Microsoft.Extensions.Options.IOptions{Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskOptions},Microsoft.Extensions.Logging.ILoggerFactory,Microsoft.Azure.WebJobs.INameResolver,Microsoft.Azure.WebJobs.Extensions.DurableTask.IConnectionStringResolver)">
             <summary>
             Initializes a new instance of the <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension"/>.
@@ -35,17 +30,6 @@
             <param name="loggerFactory">The logger factory used for extension-specific logging and orchestration tracking.</param>
             <param name="nameResolver">The name resolver to use for looking up application settings.</param>
             <param name="connectionStringResolver">The resolver to use for looking up connection strings.</param>
-        </member>
-        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.HubName">
-            <summary>
-            Gets or sets default task hub name to be used by all <see cref="T:Microsoft.Azure.WebJobs.DurableOrchestrationClient"/>,
-            <see cref="T:Microsoft.Azure.WebJobs.DurableOrchestrationContext"/>, and <see cref="T:Microsoft.Azure.WebJobs.DurableActivityContext"/> instances.
-            </summary>
-            <remarks>
-            A task hub is a logical grouping of storage resources. Alternate task hub names can be used to isolate
-            multiple Durable Functions applications from each other, even if they are using the same storage backend.
-            </remarks>
-            <value>The name of the default task hub.</value>
         </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.Microsoft#Azure#WebJobs#Host#Config#IExtensionConfigProvider#Initialize(Microsoft.Azure.WebJobs.Host.Config.ExtensionConfigContext)">
             <summary>
@@ -64,6 +48,18 @@
             Called by the Durable Task Framework: Not used.
             </summary>
             <param name="creator">This parameter is not used.</param>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.DurableTask#Core#INameVersionObjectManager{DurableTask#Core#TaskOrchestration}#GetObject(System.String,System.String)">
+            <summary>
+            Called by the Durable Task Framework: Returns the specified <see cref="T:DurableTask.Core.TaskOrchestration"/>.
+            </summary>
+            <param name="name">The name of the orchestration to return.</param>
+            <param name="version">Not used.</param>
+            <returns>An orchestration shim that delegates execution to an orchestrator function.</returns>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.DurableTask#Core#INameVersionObjectManager{DurableTask#Core#TaskActivity}#Add(DurableTask.Core.ObjectCreator{DurableTask.Core.TaskActivity})">
+            <summary>
+            Called by the durable task framework: Not       <param name="creator">This parameter is not used.</param>
         </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.DurableTask#Core#INameVersionObjectManager{DurableTask#Core#TaskOrchestration}#GetObject(System.String,System.String)">
             <summary>
@@ -263,6 +259,26 @@
             Gets or sets the Event Grid publish request http status.
             </summary>
             <value>A list of HTTP status codes, e.g. 400, 403.</value>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskOptions.EventGridPublishRunningEvent">
+            <summary>
+            Gets or sets if the 'Running' Event should be published to Event Grid.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskOptions.EventGridPublishCompletedEvent">
+            <summary>
+            Gets or sets if the 'Completed' Event should be published to Event Grid.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskOptions.EventGridPublishFailedEvent">
+            <summary>
+            Gets or sets if the 'Failed' Event should be published to Event Grid.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskOptions.EventGridPublishTerminatedEvent">
+            <summary>
+            Gets or sets if the 'Terminated' Event should be published to Event Grid.
+            </summary>
         </member>
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskOptions.ExtendedSessionsEnabled">
             <summary>
@@ -1015,6 +1031,26 @@
             <remarks>
             The instance ID is generated and fixed when the orchestrator function is scheduled. It can be either
             auto-generated, in which case it is formatted as a GUID, or it can be user-specified with any format.
+            </rdoc/>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.DurableOrchestrationContext.WaitForExternalEvent``1(System.String,System.TimeSpan,``0)">
+            <inheritdoc/>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.DurableOrchestrationContext.ContinueAsNew(System.Object)">
+            <inheritdoc />
+        </member>
+        <member name="T:Microsoft.Azure.WebJobs.DurableOrchestrationContextBase">
+            <summary>
+            Abstract base class for <see cref="T:Microsoft.Azure.WebJobs.DurableOrchestrationContext"/>.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.DurableOrchestrationContextBase.InstanceId">
+            <summary>
+            Gets the instance ID of the currently executing orchestration.
+            </summary>
+            <remarks>
+            The instance ID is generated and fixed when the orchestrator function is scheduled. It can be either
+            auto-generated, in which case it is formatted as a GUID, or it can be user-specified with any format.
             </remarks>
             <value>
             The ID of the current orchestration instance.
@@ -1066,23 +1102,7 @@
         <member name="M:Microsoft.Azure.WebJobs.DurableOrchestrationContextBase.NewGuid">
             <summary>
             Creates a new GUID that is safe for replay within an orchestrator function.
-            </summary>
-            <remarks>
-            The default implementation of this method creates a name-based UUID using the algorithm from
-            RFC 4122 §4.3. The name input used to generate this value is a combination of the orchestration
-            instance ID and an internally managed sequence number.
-            </remarks>
-            <returns>The new <see cref="T:System.Guid"/> value.</returns>
-        </member>
-        <member name="M:Microsoft.Azure.WebJobs.DurableOrchestrationContextBase.CallActivityAsync(System.String,System.Object)">
-            <summary>
-            Schedules an activity function named <paramref name="functionName"/> for execution.
-            </summary>
-            <param name="functionName">The name of the activity function to call.</param>
-            <param name="input">The JSON-serializeable input to pass to the activity function.</param>
-            <returns>A durable task that completes when the called function completes or fails.</returns>
-            <exception cref="T:System.ArgumentException">
-            The specified function does not exist, is disabled, or is not an orchestrator function.
+   ed function does not exist, is disabled, or is not an orchestrator function.
             </exception>
             <exception cref="T:System.InvalidOperationException">
             The current thread is different than the thread which started the orchestrator execution.
@@ -1125,6 +1145,21 @@
             </exception>
             <exception cref="T:System.InvalidOperationException">
             The current thread is different than the thread which started the orchestrator execution.
+            </exception>
+            <exception cref="T:Microsoft.Azure.WebJobs.FunctionFailedException">
+            The activity function failed with an unhandled exception.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.DurableOrchestrationContextBase.CallActivityWithRetryAsync``1(System.String,Microsoft.Azure.WebJobs.RetryOptions,System.Object)">
+            <summary>
+            Schedules an activity function named <paramref name="functionName"/> for execution with retry options.
+            </summary>
+            <typeparam name="TResult">The return type of the scheduled activity function.</typeparam>
+            <param name="functionName">The name of the activity function to call.</param>
+            <param name="retryOptions">The retry option for the activity function.</param>
+            <param name="input">The JSON-serializeable input to pass to the activity function.</param>
+            <returns>A durable task that completes when the called activity function completes or fails.</returns>
+            <exceptionecution.
             </exception>
             <exception cref="T:Microsoft.Azure.WebJobs.FunctionFailedException">
             The activity function failed with an unhandled exception.
@@ -1182,21 +1217,6 @@
             </exception>
             <exception cref="T:System.InvalidOperationException">
             The current thread is different than the thread which started the orchestrator execution.
-            </exception>
-            <exception cref="T:Microsoft.Azure.WebJobs.FunctionFailedException">
-            The activity function failed with an unhandled exception.
-            </exception>
-        </member>
-        <member name="M:Microsoft.Azure.WebJobs.DurableOrchestrationContextBase.CallSubOrchestratorAsync``1(System.String,System.Object)">
-            <summary>
-            Schedules an orchestration function named <paramref name="functionName"/> for execution.
-            </summary>
-            <typeparam name="TResult">The return type of the scheduled orchestrator function.</typeparam>
-            <param name="functionName">The name of the orchestrator function to call.</param>
-            <param name="input">The JSON-serializeable input to pass to the orchestrator function.</param>
-            <returns>A durable task that completes when the called orchestrator function completes or fails.</returns>
-            <exception cref="T:System.ArgumentException">
-            The specified function does not exist, is disabled, or is not an orchestrator function.
             </exception>
             <exception cref="T:System.InvalidOperationException">
             The current thread is different than the thread which started the orchestrator execution.
@@ -1296,6 +1316,22 @@
             <typeparam name="TResult">The return type of the scheduled orchestrator function.</typeparam>
             <param name="functionName">The name of the orchestrator function to call.</param>
             <param name="retryOptions">The retry option for the orchestrator function.</param>
+            <param name="instanceId">A unique ID to use for the sub-orchestration instance.</param>
+            <param name="input">The JSON-serializeable input to pass to the orchestrator function.</param>
+            <returns>A durable task that completes when the called orchestrator function completes or fails.</returns>
+            <exception cref="T:System.ArgumentNullException">
+            The retry option object is null.
+            </exception>
+            <exception cref="T:System.ArgumentException">
+            The specified function does not exist, is disabled, or is not an orchestrator function.
+            </exception>
+            <exception cref="T:System.InvalidOperationException">
+            The current thread is different than the thread which started the orchestrator execution.
+            </exception>
+            <exception cref="T:Microsoft.Azure.WebJobs.FunctionFailedException">
+            The activity function failed with an unhandled exception.
+            </exception>
+        </memberions">The retry option for the orchestrator function.</param>
             <param name="instanceId">A unique ID to use for the sub-orchestration instance.</param>
             <param name="input">The JSON-serializeable input to pass to the orchestrator function.</param>
             <returns>A durable task that completes when the called orchestrator function completes or fails.</returns>

--- a/test/Common/DurableTaskLifeCycleNotificationTest.cs
+++ b/test/Common/DurableTaskLifeCycleNotificationTest.cs
@@ -116,6 +116,244 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             }
         }
 
+        #region optouts
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task OrchestrationStartOptOutOfEvent(bool extendedSessionsEnabled)
+        {
+            var testName = nameof(this.OrchestrationStartAndCompleted);
+            var functionName = nameof(TestOrchestrations.SayHelloInline);
+            var eventGridKeyValue = "testEventGridKey";
+            var eventGridKeySettingName = "eventGridKeySettingName";
+           
+            var eventGridEndpoint = "http://dymmy.com/";
+            var mockNameResolver = GetNameResolverMock(new[] { (eventGridKeySettingName, eventGridKeyValue) });
+
+            string createdInstanceId = Guid.NewGuid().ToString("N");
+
+            Func<HttpRequestMessage, HttpResponseMessage> responseGenerator =
+                (HttpRequestMessage req) => req.CreateResponse(HttpStatusCode.OK, "{\"message\":\"OK!\"}");
+
+            HttpMessageHandler httpMessageHandler = this.ConfigureEventGridMockHandler(
+                TestHelpers.GetTaskHubNameFromTestName(testName, extendedSessionsEnabled),
+                functionName,
+                createdInstanceId,
+                eventGridKeyValue,
+                eventGridEndpoint,
+                responseGenerator,
+                handler: (JObject eventPayload) =>
+                {
+                    dynamic o = eventPayload;
+                    Assert.NotEqual("durable/orchestrator/Running", (string)o.subject);
+                    Assert.NotEqual("Running", (string)o.data.runtimeStatus);
+                },
+                asserts: out List<Action> eventGridRequestValidators);
+
+            using (JobHost host = TestHelpers.GetJobHost(
+                this.loggerProvider,
+                testName,
+                extendedSessionsEnabled,
+                eventGridKeySettingName,
+                mockNameResolver.Object,
+                eventGridEndpoint,
+                eventGridNotificationHandler: httpMessageHandler,
+                eventGridPublishRunningEvent: false))
+            {
+                await host.StartAsync();
+
+                var client = await host.StartOrchestratorAsync(
+                    functionName,
+                    "World",
+                    this.output,
+                    createdInstanceId);
+                var status = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(30), this.output);
+
+                eventGridRequestValidators.ForEach(v => v.Invoke());
+
+                await host.StopAsync();
+            }
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task OrchestrationCompleteOptOutOfEvent(bool extendedSessionsEnabled)
+        {
+            var testName = nameof(this.OrchestrationStartAndCompleted);
+            var functionName = nameof(TestOrchestrations.SayHelloInline);
+            var eventGridKeyValue = "testEventGridKey";
+            var eventGridKeySettingName = "eventGridKeySettingName";
+            var eventGridEndpoint = "http://dymmy.com/";
+            var mockNameResolver = GetNameResolverMock(new[] { (eventGridKeySettingName, eventGridKeyValue) });
+
+            string createdInstanceId = Guid.NewGuid().ToString("N");
+
+            Func<HttpRequestMessage, HttpResponseMessage> responseGenerator =
+                (HttpRequestMessage req) => req.CreateResponse(HttpStatusCode.OK, "{\"message\":\"OK!\"}");
+
+            HttpMessageHandler httpMessageHandler = this.ConfigureEventGridMockHandler(
+                TestHelpers.GetTaskHubNameFromTestName(testName, extendedSessionsEnabled),
+                functionName,
+                createdInstanceId,
+                eventGridKeyValue,
+                eventGridEndpoint,
+                responseGenerator,
+                handler: (JObject eventPayload) =>
+                {
+                    dynamic o = eventPayload;
+                    Assert.NotEqual("durable/orchestrator/Completed", (string)o.subject);
+                    Assert.NotEqual("Completed", (string)o.data.runtimeStatus);
+                },
+                asserts: out List<Action> eventGridRequestValidators);
+
+            using (JobHost host = TestHelpers.GetJobHost(
+                this.loggerProvider,
+                testName,
+                extendedSessionsEnabled,
+                eventGridKeySettingName,
+                mockNameResolver.Object,
+                eventGridEndpoint,
+                eventGridNotificationHandler: httpMessageHandler,
+                eventGridPublishCompletedEvent: false))
+            {
+                await host.StartAsync();
+
+                var client = await host.StartOrchestratorAsync(
+                    functionName,
+                    "World",
+                    this.output,
+                    createdInstanceId);
+                var status = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(30), this.output);
+
+                eventGridRequestValidators.ForEach(v => v.Invoke());
+
+                await host.StopAsync();
+            }
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task OrchestrationFailedOptOutOfEvent(bool extendedSessionsEnabled)
+        {
+            var testName = nameof(this.OrchestrationFailed);
+            var functionName = nameof(TestOrchestrations.ThrowOrchestrator);
+            var eventGridKeyValue = "testEventGridKey";
+            var eventGridKeySettingName = "eventGridKeySettingName";
+            var eventGridEndpoint = "http://dymmy.com/";
+            var mockNameResolver = GetNameResolverMock(new[] { (eventGridKeySettingName, eventGridKeyValue) });
+
+            string createdInstanceId = Guid.NewGuid().ToString("N");
+
+            Func<HttpRequestMessage, HttpResponseMessage> responseGenerator =
+                (HttpRequestMessage req) => req.CreateResponse(HttpStatusCode.OK, "{\"message\":\"OK!\"}");
+
+            HttpMessageHandler httpMessageHandler = this.ConfigureEventGridMockHandler(
+                TestHelpers.GetTaskHubNameFromTestName(testName, extendedSessionsEnabled),
+                functionName,
+                createdInstanceId,
+                eventGridKeyValue,
+                eventGridEndpoint,
+                responseGenerator,
+                handler: (JObject eventPayload) =>
+                {
+                    dynamic o = eventPayload;
+                    Assert.NotEqual("durable/orchestrator/Failed", (string)o.subject);
+                    Assert.NotEqual("Failed", (string)o.data.runtimeStatus);
+                },
+                asserts: out List<Action> eventGridRequestValidators);
+
+            using (JobHost host = TestHelpers.GetJobHost(
+                this.loggerProvider,
+                testName,
+                extendedSessionsEnabled,
+                eventGridKeySettingName,
+                mockNameResolver.Object,
+                eventGridEndpoint,
+                eventGridNotificationHandler: httpMessageHandler,
+                eventgridPublishFailedEvent: false))
+            {
+                await host.StartAsync();
+
+                // Null input should result in ArgumentNullException in the orchestration code.
+                var client = await host.StartOrchestratorAsync(
+                    functionName,
+                    null,
+                    this.output,
+                    createdInstanceId);
+                var status = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(30), this.output);
+
+                eventGridRequestValidators.ForEach(v => v.Invoke());
+
+                await host.StopAsync();
+            }
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task OrchestrationTerminateOptOutOfEvent(bool extendedSessionsEnabled)
+        {
+            var testName = nameof(this.OrchestrationTerminate);
+
+            // Using the counter orchestration because it will wait indefinitely for input.
+            var functionName = nameof(TestOrchestrations.Counter);
+            var eventGridKeyValue = "testEventGridKey";
+            var eventGridKeySettingName = "eventGridKeySettingName";
+            var eventGridEndpoint = "http://dymmy.com/";
+            var mockNameResolver = GetNameResolverMock(new[] { (eventGridKeySettingName, eventGridKeyValue) });
+
+            string createdInstanceId = Guid.NewGuid().ToString("N");
+
+            Func<HttpRequestMessage, HttpResponseMessage> responseGenerator =
+                (HttpRequestMessage req) => req.CreateResponse(HttpStatusCode.OK, "{\"message\":\"OK!\"}");
+
+            HttpMessageHandler httpMessageHandler = this.ConfigureEventGridMockHandler(
+                TestHelpers.GetTaskHubNameFromTestName(testName, extendedSessionsEnabled),
+                functionName,
+                createdInstanceId,
+                eventGridKeyValue,
+                eventGridEndpoint,
+                responseGenerator,
+                handler: (JObject eventPayload) =>
+                {
+                    dynamic o = eventPayload;
+                    Assert.NotEqual("durable/orchestrator/Terminated", (string)o.subject);
+                    Assert.NotEqual("Terminated", (string)o.data.runtimeStatus);
+                },
+                asserts: out List<Action> eventGridRequestValidators);
+
+            using (JobHost host = TestHelpers.GetJobHost(
+                this.loggerProvider,
+                testName,
+                extendedSessionsEnabled,
+                eventGridKeySettingName,
+                mockNameResolver.Object,
+                eventGridEndpoint,
+                eventGridNotificationHandler: httpMessageHandler,
+                eventgridPublishTerminatedEvent: false))
+            {
+                await host.StartAsync();
+
+                var client = await host.StartOrchestratorAsync(
+                    functionName,
+                    0,
+                    this.output,
+                    createdInstanceId);
+
+                await client.WaitForStartupAsync(TimeSpan.FromSeconds(30), this.output);
+                await client.TerminateAsync("sayōnara");
+
+                var status = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(30), this.output);
+
+                eventGridRequestValidators.ForEach(v => v.Invoke());
+
+                await host.StopAsync();
+            }
+        }
+        #endregion
+
         [Theory]
         [InlineData(true)]
         [InlineData(false)]

--- a/test/Common/TestHelpers.cs
+++ b/test/Common/TestHelpers.cs
@@ -32,7 +32,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             bool logReplayEvents = true,
             Uri notificationUrl = null,
             HttpMessageHandler eventGridNotificationHandler = null,
-            TimeSpan? maxQueuePollingInterval = null)
+            TimeSpan? maxQueuePollingInterval = null,
+            bool eventGridPublishRunningEvent = true,
+            bool eventGridPublishCompletedEvent = true,
+            bool eventgridPublishFailedEvent = true,
+            bool eventgridPublishTerminatedEvent = true)
         {
             var durableTaskOptions = new DurableTaskOptions
             {
@@ -46,6 +50,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 LogReplayEvents = logReplayEvents,
                 NotificationUrl = notificationUrl,
                 NotificationHandler = eventGridNotificationHandler,
+                EventGridPublishRunningEvent = eventGridPublishRunningEvent,
+                EventGridPublishCompletedEvent = eventGridPublishCompletedEvent,
+                EventGridPublishFailedEvent = eventgridPublishFailedEvent,
+                EventGridPublishTerminatedEvent = eventgridPublishTerminatedEvent
             };
 
             if (eventGridRetryCount.HasValue)

--- a/test/Common/TestHelpers.cs
+++ b/test/Common/TestHelpers.cs
@@ -33,10 +33,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             Uri notificationUrl = null,
             HttpMessageHandler eventGridNotificationHandler = null,
             TimeSpan? maxQueuePollingInterval = null,
-            bool eventGridPublishRunningEvent = true,
-            bool eventGridPublishCompletedEvent = true,
-            bool eventgridPublishFailedEvent = true,
-            bool eventgridPublishTerminatedEvent = true)
+            string[] eventGridPublishEventTypes = null)
         {
             var durableTaskOptions = new DurableTaskOptions
             {
@@ -50,10 +47,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 LogReplayEvents = logReplayEvents,
                 NotificationUrl = notificationUrl,
                 NotificationHandler = eventGridNotificationHandler,
-                EventGridPublishRunningEvent = eventGridPublishRunningEvent,
-                EventGridPublishCompletedEvent = eventGridPublishCompletedEvent,
-                EventGridPublishFailedEvent = eventgridPublishFailedEvent,
-                EventGridPublishTerminatedEvent = eventgridPublishTerminatedEvent
+                EventGridPublishEventTypes = eventGridPublishEventTypes,
             };
 
             if (eventGridRetryCount.HasValue)


### PR DESCRIPTION
I care about 'Failed' life cycle events in order to generate operational alerts in my system. I don't need to receive events for other the other life cycle events.

Yes, using Event Grid I can subscribe to only the 'Failed' events, but I am still charged to publish all the events to the Topic.

This isn't a problem when the volume of Orchestration instances is low, but in a high volume scenario (millions of new instances starting and completing every day) this can be a source of considerable, and unnecessary financial cost, not to mention the overhead of unnecessary HTTP traffic.

This pull request gives the integrator the power to decide what, if any, events should be published at source.

This change has been implemented in an 'opt-out' manner so that existing integrations will continue work as-is without introducing a breaking change into the host.json configuration.

In this example, ```Running``` ,```Completed``` and ```Terminated``` events are **not** published, leaving just ```Failed``` to be publish to Event Grid.

```
{
  "version": "2.0",
  "durableTask": {
    "EventGridTopicEndpoint": "%EgTopic%",
    "EventGridKeySettingName": "EgKey",
    "EventGridPublishRunningEvent": "false",
    "EventGridPublishCompletedEvent": "false",
    "EventGridPublishTerminatedEvent": "false"
  }
}
```