### PR TITLE
Added TrackingStoreConnectionStringName and TrackingStoreNamePrefix settings

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
@@ -462,6 +462,28 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 ExtendedSessionsEnabled = this.Options.ExtendedSessionsEnabled,
                 ExtendedSessionIdleTimeout = extendedSessionTimeout,
                 MaxQueuePollingInterval = this.Options.MaxQueuePollingInterval,
+                TrackingStoreStorageAccountDetails = this.GetStorageAccountDetailsOrNull(
+                    this.Options.TrackingStoreConnectionStringName),
+                TrackingStoreNamePrefix = this.Options.TrackingStoreNamePrefix,
+            };
+        }
+
+        private StorageAccountDetails GetStorageAccountDetailsOrNull(string connectionName)
+        {
+            if (string.IsNullOrEmpty(connectionName))
+            {
+                return null;
+            }
+
+            string resolvedStorageConnectionString = this.connectionStringResolver.Resolve(connectionName);
+            if (string.IsNullOrEmpty(resolvedStorageConnectionString))
+            {
+                throw new InvalidOperationException($"Unable to resolve the Azure Storage connection named '{connectionName}'.");
+            }
+
+            return new StorageAccountDetails
+            {
+                ConnectionString = resolvedStorageConnectionString,
             };
         }
 

--- a/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
@@ -449,7 +449,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             TimeSpan extendedSessionTimeout = TimeSpan.FromSeconds(
                 Math.Max(this.Options.ExtendedSessionIdleTimeoutInSeconds, 0));
 
-            return new AzureStorageOrchestrationServiceSettings
+            var settings = new AzureStorageOrchestrationServiceSettings
             {
                 StorageConnectionString = resolvedStorageConnectionString,
                 TaskHubName = taskHubNameOverride ?? this.Options.HubName,
@@ -464,8 +464,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 MaxQueuePollingInterval = this.Options.MaxQueuePollingInterval,
                 TrackingStoreStorageAccountDetails = this.GetStorageAccountDetailsOrNull(
                     this.Options.TrackingStoreConnectionStringName),
-                TrackingStoreNamePrefix = this.Options.TrackingStoreNamePrefix,
             };
+
+            if (!string.IsNullOrEmpty(this.Options.TrackingStoreNamePrefix))
+            {
+                settings.TrackingStoreNamePrefix = this.Options.TrackingStoreNamePrefix;
+            }
+
+            return settings;
         }
 
         private StorageAccountDetails GetStorageAccountDetailsOrNull(string connectionName)

--- a/src/WebJobs.Extensions.DurableTask/DurableTaskOptions.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskOptions.cs
@@ -98,6 +98,32 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         public string AzureStorageConnectionStringName { get; set; }
 
         /// <summary>
+        /// Gets or sets the name of the Azure Storage connection string to use for the 
+        /// durable tracking store (History and Instances tables).
+        /// </summary>
+        /// <remarks><para>
+        /// If not specified, the <see cref="AzureStorageConnectionStringName"/> connection string is used
+        /// for the durable tracking store.
+        /// </para><para>
+        /// This property is primarily useful when deploying multiple apps that need to share the same
+        /// tracking infrastructure. For example, when deploying two versions of an app side by side, using
+        /// the same tracking store allows both versions to save history into the same table, which allows
+        /// clients to query for instance status across all versions.
+        /// </para></remarks>
+        /// <value>The name of a connection string that exists in the app's application settings.</value>
+        public string TrackingStoreConnectionStringName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the name prefix to use for history and instance tables in Azure Storage.
+        /// </summary>
+        /// <remarks>
+        /// This property is only used when <see cref="TrackingStoreConnectionStringName"/> is specified.
+        /// If no prefix is specified, the default prefix value is "DurableTask".
+        /// </remarks>
+        /// <value>The prefix to use when naming the generated Azure tables.</value>
+        public string TrackingStoreNamePrefix { get; set; }
+
+        /// <summary>
         /// Gets or sets the base URL for the HTTP APIs managed by this extension.
         /// </summary>
         /// <remarks>
@@ -253,9 +279,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 sb.Append(nameof(this.NotificationUrl)).Append(": ").Append(url).Append(", ");
             }
 
-            sb.Append(nameof(this.LogReplayEvents)).Append(": ").Append(this.LogReplayEvents);
-            sb.Append(nameof(this.MaxQueuePollingInterval)).Append(": ").Append(this.MaxQueuePollingInterval).Append(", ");
+            sb.Append(nameof(this.TrackingStoreConnectionStringName)).Append(": ").Append(this.TrackingStoreConnectionStringName).Append(", ");
+            if (!string.IsNullOrEmpty(this.TrackingStoreConnectionStringName))
+            {
+                sb.Append(nameof(this.TrackingStoreNamePrefix)).Append(": ").Append(this.TrackingStoreNamePrefix).Append(", ");
+            }
 
+            sb.Append(nameof(this.MaxQueuePollingInterval)).Append(": ").Append(this.MaxQueuePollingInterval).Append(", ");
+            sb.Append(nameof(this.LogReplayEvents)).Append(": ").Append(this.LogReplayEvents);
             return sb.ToString();
         }
 


### PR DESCRIPTION
This PR adds two new properties to the `DurableTaskOptions` class. It allows multiple function apps to share a common History and Instances table, while having separate queues for polling.

The two main scenarios for this PR are:

* Zero downtime deployments (side-by-side versioning)
* Improved scalability - multiple function apps can all use separate storage accounts for queues and a common storage account for tables.

It is the followup change to https://github.com/Azure/durabletask/pull/252