### PR TITLE
Eliminate usage of $(SolutionDir) in test .csproj file

### DIFF
--- a/test/FunctionsV2/WebJobs.Extensions.DurableTask.Tests.V2.csproj
+++ b/test/FunctionsV2/WebJobs.Extensions.DurableTask.Tests.V2.csproj
@@ -27,7 +27,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <ProjectReference Include="$(SolutionDir)\src\WebJobs.Extensions.DurableTask\WebJobs.Extensions.DurableTask.csproj" />
+    <ProjectReference Include="..\..\src\WebJobs.Extensions.DurableTask\WebJobs.Extensions.DurableTask.csproj" />
   </ItemGroup>
 
   <ItemGroup>
@@ -37,8 +37,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <AdditionalFiles Include="$(SolutionDir)\.stylecop\stylecop.json" Link="stylecop.json" />
-    <Compile Include="$(SolutionDir)\.stylecop\GlobalSuppressions.cs" Link="GlobalSuppressions.cs" />
+    <AdditionalFiles Include="..\..\.stylecop\stylecop.json" Link="stylecop.json" />
+    <Compile Include="..\..\.stylecop\GlobalSuppressions.cs" Link="GlobalSuppressions.cs" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This fixes a few things:

1. We can now run `dotnet build` and `dotnet test` in `test/FunctionsV2` directory and directly against `test/FunctionsV2/WebJobs.Extensions.DurableTask.Tests.V2.csproj` without errors.
2. Enables running and debugging tests via [OmniSharp for VS Code](https://github.com/OmniSharp/omnisharp-vscode/wiki/How-to-run-and-debug-unit-tests).
3. Enables [.NET test explorer in VS Code](https://marketplace.visualstudio.com/items?itemName=formulahendry.dotnet-test-explorer). This likely is just a side affect of fixing Omnisharp, but it seems to be a popular tool for .NET develoment with VS Code.