### PR TITLE
Added name property to HTTP API instance queries.

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
+++ b/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
@@ -397,6 +397,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         {
             return new StatusResponsePayload
             {
+                Name = status.Name,
                 InstanceId = status.InstanceId,
                 RuntimeStatus = status.RuntimeStatus.ToString(),
                 Input = status.Input,

--- a/src/WebJobs.Extensions.DurableTask/StatusResponsePayload.cs
+++ b/src/WebJobs.Extensions.DurableTask/StatusResponsePayload.cs
@@ -13,6 +13,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
     internal class StatusResponsePayload
     {
         /// <summary>
+        /// Name.
+        /// </summary>
+        [DataMember(Name = "name")]
+        public string Name { get; set; }
+
+        /// <summary>
         /// InstanceId.
         /// </summary>
         [DataMember(Name = "instanceId")]

--- a/test/Common/HttpApiHandlerTests.cs
+++ b/test/Common/HttpApiHandlerTests.cs
@@ -319,11 +319,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             {
                 new DurableOrchestrationStatus
                 {
+                    Name = "DoThis",
                     InstanceId = "01",
                     RuntimeStatus = OrchestrationRuntimeStatus.Running,
                 },
                 new DurableOrchestrationStatus
                 {
+                    Name = "DoThat",
                     InstanceId = "02",
                     RuntimeStatus = OrchestrationRuntimeStatus.Completed,
                 },
@@ -348,8 +350,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             Assert.Equal(string.Empty, responseMessage.Headers.GetValues("x-ms-continuation-token").FirstOrDefault());
             var actual = JsonConvert.DeserializeObject<IList<StatusResponsePayload>>(await responseMessage.Content.ReadAsStringAsync());
 
+            Assert.Equal("DoThis", actual[0].Name);
             Assert.Equal("01", actual[0].InstanceId);
             Assert.Equal("Running", actual[0].RuntimeStatus);
+            Assert.Equal("DoThat", actual[1].Name);
             Assert.Equal("02", actual[1].InstanceId);
             Assert.Equal("Completed", actual[1].RuntimeStatus);
         }
@@ -362,12 +366,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             {
                 new DurableOrchestrationStatus
                 {
+                    Name = "DoThis",
                     InstanceId = "01",
                     CreatedTime = new DateTime(2018, 3, 10, 10, 10, 10),
                     RuntimeStatus = OrchestrationRuntimeStatus.Running,
                 },
                 new DurableOrchestrationStatus
                 {
+                    Name = "DoThat",
                     InstanceId = "02",
                     CreatedTime = new DateTime(2018, 3, 10, 10, 6, 10),
                     RuntimeStatus = OrchestrationRuntimeStatus.Running,
@@ -399,8 +405,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             Assert.Equal(HttpStatusCode.OK, responseMessage.StatusCode);
             var actual = JsonConvert.DeserializeObject<IList<StatusResponsePayload>>(await responseMessage.Content.ReadAsStringAsync());
             clientMock.Verify(x => x.GetStatusAsync(createdTimeFrom, createdTimeTo, runtimeStatus, It.IsAny<CancellationToken>()));
+            Assert.Equal("DoThis", actual[0].Name);
             Assert.Equal("01", actual[0].InstanceId);
             Assert.Equal("Running", actual[0].RuntimeStatus);
+            Assert.Equal("DoThat", actual[1].Name);
             Assert.Equal("02", actual[1].InstanceId);
             Assert.Equal("Running", actual[1].RuntimeStatus);
         }
@@ -413,12 +421,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             {
                 new DurableOrchestrationStatus
                 {
+                    Name = "DoThis",
                     InstanceId = "01",
                     CreatedTime = new DateTime(2018, 3, 10, 10, 10, 10, DateTimeKind.Utc),
                     RuntimeStatus = OrchestrationRuntimeStatus.Running,
                 },
                 new DurableOrchestrationStatus
                 {
+                    Name = "DoThat",
                     InstanceId = "02",
                     CreatedTime = new DateTime(2018, 3, 10, 10, 6, 10, DateTimeKind.Utc),
                     RuntimeStatus = OrchestrationRuntimeStatus.Running,
@@ -461,8 +471,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             Assert.Equal("YYYY-YYYYYYYY-YYYYYYYYYYYY", responseMessage.Headers.GetValues("x-ms-continuation-token").FirstOrDefault());
             var actual = JsonConvert.DeserializeObject<IList<StatusResponsePayload>>(await responseMessage.Content.ReadAsStringAsync());
             clientMock.Verify(x => x.GetStatusAsync(createdTimeFrom, createdTimeTo, runtimeStatus, pageSize, continuationToken, It.IsAny<CancellationToken>()));
+            Assert.Equal("DoThis", actual[0].Name);
             Assert.Equal("01", actual[0].InstanceId);
             Assert.Equal("Running", actual[0].RuntimeStatus);
+            Assert.Equal("DoThat", actual[1].Name);
             Assert.Equal("02", actual[1].InstanceId);
             Assert.Equal("Running", actual[1].RuntimeStatus);
         }
@@ -475,12 +487,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             {
                 new DurableOrchestrationStatus
                 {
+                    Name = "DoThis",
                     InstanceId = "01",
                     CreatedTime = new DateTime(2018, 3, 10, 10, 10, 10),
                     RuntimeStatus = OrchestrationRuntimeStatus.Running,
                 },
                 new DurableOrchestrationStatus
                 {
+                    Name = "DoThat",
                     InstanceId = "02",
                     CreatedTime = new DateTime(2018, 3, 10, 10, 6, 10),
                     RuntimeStatus = OrchestrationRuntimeStatus.Completed,
@@ -515,8 +529,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             Assert.Equal(HttpStatusCode.OK, responseMessage.StatusCode);
             var actual = JsonConvert.DeserializeObject<IList<StatusResponsePayload>>(await responseMessage.Content.ReadAsStringAsync());
             clientMock.Verify(x => x.GetStatusAsync(createdTimeFrom, createdTimeTo, runtimeStatus, It.IsAny<CancellationToken>()));
+            Assert.Equal("DoThis", actual[0].Name);
             Assert.Equal("01", actual[0].InstanceId);
             Assert.Equal("Running", actual[0].RuntimeStatus);
+            Assert.Equal("DoThat", actual[1].Name);
             Assert.Equal("02", actual[1].InstanceId);
             Assert.Equal("Completed", actual[1].RuntimeStatus);
         }
@@ -529,12 +545,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             {
                 new DurableOrchestrationStatus
                 {
+                    Name = "DoThis",
                     InstanceId = "01",
                     CreatedTime = new DateTime(2018, 3, 10, 10, 10, 10),
                     RuntimeStatus = OrchestrationRuntimeStatus.Running,
                 },
                 new DurableOrchestrationStatus
                 {
+                    Name = "DoThat",
                     InstanceId = "02",
                     CreatedTime = new DateTime(2018, 3, 10, 10, 6, 10),
                     RuntimeStatus = OrchestrationRuntimeStatus.Completed,
@@ -562,8 +580,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             Assert.Equal(HttpStatusCode.OK, responseMessage.StatusCode);
             var actual = JsonConvert.DeserializeObject<IList<StatusResponsePayload>>(await responseMessage.Content.ReadAsStringAsync());
             clientMock.Verify(x => x.GetStatusAsync(createdTimeFrom, default(DateTime), new List<OrchestrationRuntimeStatus>(), It.IsAny<CancellationToken>()));
+            Assert.Equal("DoThis", actual[0].Name);
             Assert.Equal("01", actual[0].InstanceId);
             Assert.Equal("Running", actual[0].RuntimeStatus);
+            Assert.Equal("DoThat", actual[1].Name);
             Assert.Equal("02", actual[1].InstanceId);
             Assert.Equal("Completed", actual[1].RuntimeStatus);
         }


### PR DESCRIPTION
Simple modification to add the `name` property to the payload returned by the HTTP API's instance queries. Addresses the initial concern of #567 and aligns the behavior of the JavaScript OrchestrationClient.getStatus methods in line with that of their C# counterparts.