### PR TITLE
Adding query feature for the conditional query

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableOrchestrationClient.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableOrchestrationClient.cs
@@ -324,7 +324,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// <inheritdoc />
         async Task<OrchestrationStatusQueryResult> IDurableOrchestrationClient.GetStatusAsync(
             OrchestrationStatusQueryCondition condition,
-            string continuationToken,
             CancellationToken cancellationToken)
         {
             // TODO this cast is to avoid to adding methods to the core IOrchestrationService/Client interface in DurableTask.Core. Eventually we will need
@@ -335,7 +334,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 throw new NotSupportedException("Only the Azure Storage state provider is currently supported for the paginated orchestration status query.");
             }
 
-            var statusContext = await serviceClient.GetOrchestrationStateAsync(condition.Parse(), condition.PageSize, continuationToken, cancellationToken);
+            var statusContext = await serviceClient.GetOrchestrationStateAsync(condition.Parse(), condition.PageSize, condition.ContinuationToken, cancellationToken);
 
             return this.ConvertFrom(statusContext);
         }

--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableOrchestrationClient.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableOrchestrationClient.cs
@@ -301,28 +301,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
         /// <inheritdoc />
         async Task<OrchestrationStatusQueryResult> IDurableOrchestrationClient.GetStatusAsync(
-            DateTime createdTimeFrom,
-            DateTime? createdTimeTo,
-            IEnumerable<OrchestrationRuntimeStatus> runtimeStatus,
-            int pageSize,
-            string continuationToken,
-            CancellationToken cancellationToken)
-        {
-            // TODO this cast is to avoid to adding methods to the core IOrchestrationService/Client interface in DurableTask.Core. Eventually we will need
-            // a better way of handling this
-            var serviceClient = this.client.ServiceClient as AzureStorageOrchestrationService;
-            if (serviceClient == null)
-            {
-                throw new NotSupportedException("Only the Azure Storage state provider is currently supported for the paginated orchestration status query.");
-            }
-
-            var statusContext = await serviceClient.GetOrchestrationStateAsync(createdTimeFrom, createdTimeTo, runtimeStatus.Select(x => (OrchestrationStatus)x), pageSize, continuationToken, cancellationToken);
-
-            return this.ConvertFrom(statusContext);
-        }
-
-        /// <inheritdoc />
-        async Task<OrchestrationStatusQueryResult> IDurableOrchestrationClient.GetStatusAsync(
             OrchestrationStatusQueryCondition condition,
             CancellationToken cancellationToken)
         {

--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableOrchestrationClient.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableOrchestrationClient.cs
@@ -324,7 +324,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// <inheritdoc />
         async Task<OrchestrationStatusQueryResult> IDurableOrchestrationClient.GetStatusAsync(
             OrchestrationStatusQueryCondition condition,
-            int pageSize,
             string continuationToken,
             CancellationToken cancellationToken)
         {
@@ -336,7 +335,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 throw new NotSupportedException("Only the Azure Storage state provider is currently supported for the paginated orchestration status query.");
             }
 
-            var statusContext = await serviceClient.GetOrchestrationStateAsync(condition.Parse(), pageSize, continuationToken, cancellationToken);
+            var statusContext = await serviceClient.GetOrchestrationStateAsync(condition.Parse(), condition.PageSize, continuationToken, cancellationToken);
 
             return this.ConvertFrom(statusContext);
         }

--- a/src/WebJobs.Extensions.DurableTask/ContextInterfaces/IDurableOrchestrationClient.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextInterfaces/IDurableOrchestrationClient.cs
@@ -202,5 +202,15 @@ namespace Microsoft.Azure.WebJobs
         /// <param name="cancellationToken">Cancellation token that can be used to cancel the status query operation.</param>
         /// <returns>Returns each page of orchestration status for all instances and continuation token of next page.</returns>
         Task<OrchestrationStatusQueryResult> GetStatusAsync(DateTime createdTimeFrom, DateTime? createdTimeTo, IEnumerable<OrchestrationRuntimeStatus> runtimeStatus, int pageSize, string continuationToken, CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
+        /// Gets the status of all orchestration instances with paging that match the specified conditions.
+        /// </summary>
+        /// <param name="condition">Return orchestration instances that match the specified conditions.</param>
+        /// <param name="pageSize">Number of records per one request.</param>
+        /// <param name="continuationToken">ContinuationToken of the pager.</param>
+        /// <param name="cancellationToken">Cancellation token that can be used to cancel the status query operation.</param>
+        /// <returns>Returns each page of orchestration status for all instances and continuation token of next page.</returns>
+        Task<OrchestrationStatusQueryResult> GetStatusAsync(OrchestrationStatusQueryCondition condition, int pageSize, string continuationToken, CancellationToken cancellationToken);
     }
 }

--- a/src/WebJobs.Extensions.DurableTask/ContextInterfaces/IDurableOrchestrationClient.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextInterfaces/IDurableOrchestrationClient.cs
@@ -194,18 +194,6 @@ namespace Microsoft.Azure.WebJobs
         /// <summary>
         /// Gets the status of all orchestration instances with paging that match the specified conditions.
         /// </summary>
-        /// <param name="createdTimeFrom">Return orchestration instances which were created after this DateTime.</param>
-        /// <param name="createdTimeTo">Return orchestration instances which were created before this DateTime.</param>
-        /// <param name="runtimeStatus">Return orchestration instances which matches the runtimeStatus.</param>
-        /// <param name="pageSize">Number of records per one request.</param>
-        /// <param name="continuationToken">ContinuationToken of the pager.</param>
-        /// <param name="cancellationToken">Cancellation token that can be used to cancel the status query operation.</param>
-        /// <returns>Returns each page of orchestration status for all instances and continuation token of next page.</returns>
-        Task<OrchestrationStatusQueryResult> GetStatusAsync(DateTime createdTimeFrom, DateTime? createdTimeTo, IEnumerable<OrchestrationRuntimeStatus> runtimeStatus, int pageSize, string continuationToken, CancellationToken cancellationToken = default(CancellationToken));
-
-        /// <summary>
-        /// Gets the status of all orchestration instances with paging that match the specified conditions.
-        /// </summary>
         /// <param name="condition">Return orchestration instances that match the specified conditions.</param>
         /// <param name="cancellationToken">Cancellation token that can be used to cancel the status query operation.</param>
         /// <returns>Returns each page of orchestration status for all instances and continuation token of next page.</returns>

--- a/src/WebJobs.Extensions.DurableTask/ContextInterfaces/IDurableOrchestrationClient.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextInterfaces/IDurableOrchestrationClient.cs
@@ -207,9 +207,8 @@ namespace Microsoft.Azure.WebJobs
         /// Gets the status of all orchestration instances with paging that match the specified conditions.
         /// </summary>
         /// <param name="condition">Return orchestration instances that match the specified conditions.</param>
-        /// <param name="continuationToken">ContinuationToken of the pager.</param>
         /// <param name="cancellationToken">Cancellation token that can be used to cancel the status query operation.</param>
         /// <returns>Returns each page of orchestration status for all instances and continuation token of next page.</returns>
-        Task<OrchestrationStatusQueryResult> GetStatusAsync(OrchestrationStatusQueryCondition condition, string continuationToken, CancellationToken cancellationToken);
+        Task<OrchestrationStatusQueryResult> GetStatusAsync(OrchestrationStatusQueryCondition condition, CancellationToken cancellationToken);
     }
 }

--- a/src/WebJobs.Extensions.DurableTask/ContextInterfaces/IDurableOrchestrationClient.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextInterfaces/IDurableOrchestrationClient.cs
@@ -207,10 +207,9 @@ namespace Microsoft.Azure.WebJobs
         /// Gets the status of all orchestration instances with paging that match the specified conditions.
         /// </summary>
         /// <param name="condition">Return orchestration instances that match the specified conditions.</param>
-        /// <param name="pageSize">Number of records per one request.</param>
         /// <param name="continuationToken">ContinuationToken of the pager.</param>
         /// <param name="cancellationToken">Cancellation token that can be used to cancel the status query operation.</param>
         /// <returns>Returns each page of orchestration status for all instances and continuation token of next page.</returns>
-        Task<OrchestrationStatusQueryResult> GetStatusAsync(OrchestrationStatusQueryCondition condition, int pageSize, string continuationToken, CancellationToken cancellationToken);
+        Task<OrchestrationStatusQueryResult> GetStatusAsync(OrchestrationStatusQueryCondition condition, string continuationToken, CancellationToken cancellationToken);
     }
 }

--- a/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
+++ b/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
+using System.Threading;
 using System.Threading.Tasks;
 using DurableTask.Core;
 using Microsoft.Extensions.Logging;
@@ -258,7 +259,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
             if (pageSize > 0)
             {
-                var context = await client.GetStatusAsync(createdTimeFrom, createdTimeTo, runtimeStatus, pageSize, continuationToken);
+                var condition = new OrchestrationStatusQueryCondition()
+                {
+                    CreatedTimeFrom = createdTimeFrom,
+                    CreatedTimeTo = createdTimeTo,
+                    RuntimeStatus = runtimeStatus,
+                    PageSize = pageSize,
+                    ContinuationToken = continuationToken,
+                };
+                var context = await client.GetStatusAsync(condition, CancellationToken.None);
                 statusForAllInstances = context.DurableOrchestrationState.ToList();
                 nextContinuationToken = context.ContinuationToken;
             }

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
@@ -195,7 +195,7 @@
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableOrchestrationClient.Microsoft#Azure#WebJobs#IDurableOrchestrationClient#GetStatusAsync(System.DateTime,System.Nullable{System.DateTime},System.Collections.Generic.IEnumerable{Microsoft.Azure.WebJobs.OrchestrationRuntimeStatus},System.Int32,System.String,System.Threading.CancellationToken)">
             <inheritdoc />
         </member>
-        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableOrchestrationClient.Microsoft#Azure#WebJobs#IDurableOrchestrationClient#GetStatusAsync(Microsoft.Azure.WebJobs.Extensions.DurableTask.OrchestrationStatusQueryCondition,System.String,System.Threading.CancellationToken)">
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableOrchestrationClient.Microsoft#Azure#WebJobs#IDurableOrchestrationClient#GetStatusAsync(Microsoft.Azure.WebJobs.Extensions.DurableTask.OrchestrationStatusQueryCondition,System.Threading.CancellationToken)">
             <inheritdoc />
         </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableOrchestrationContext">
@@ -883,6 +883,11 @@
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.OrchestrationStatusQueryCondition.PageSize">
             <summary>
             Number of records per one request. The default value is 100.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.OrchestrationStatusQueryCondition.ContinuationToken">
+            <summary>
+            ContinuationToken of the pager.
             </summary>
         </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.OrchestrationStatusQueryResult">
@@ -1668,12 +1673,11 @@
             <param name="cancellationToken">Cancellation token that can be used to cancel the status query operation.</param>
             <returns>Returns each page of orchestration status for all instances and continuation token of next page.</returns>
         </member>
-        <member name="M:Microsoft.Azure.WebJobs.IDurableOrchestrationClient.GetStatusAsync(Microsoft.Azure.WebJobs.Extensions.DurableTask.OrchestrationStatusQueryCondition,System.String,System.Threading.CancellationToken)">
+        <member name="M:Microsoft.Azure.WebJobs.IDurableOrchestrationClient.GetStatusAsync(Microsoft.Azure.WebJobs.Extensions.DurableTask.OrchestrationStatusQueryCondition,System.Threading.CancellationToken)">
             <summary>
             Gets the status of all orchestration instances with paging that match the specified conditions.
             </summary>
             <param name="condition">Return orchestration instances that match the specified conditions.</param>
-            <param name="continuationToken">ContinuationToken of the pager.</param>
             <param name="cancellationToken">Cancellation token that can be used to cancel the status query operation.</param>
             <returns>Returns each page of orchestration status for all instances and continuation token of next page.</returns>
         </member>

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
@@ -195,7 +195,7 @@
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableOrchestrationClient.Microsoft#Azure#WebJobs#IDurableOrchestrationClient#GetStatusAsync(System.DateTime,System.Nullable{System.DateTime},System.Collections.Generic.IEnumerable{Microsoft.Azure.WebJobs.OrchestrationRuntimeStatus},System.Int32,System.String,System.Threading.CancellationToken)">
             <inheritdoc />
         </member>
-        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableOrchestrationClient.Microsoft#Azure#WebJobs#IDurableOrchestrationClient#GetStatusAsync(Microsoft.Azure.WebJobs.Extensions.DurableTask.OrchestrationStatusQueryCondition,System.Int32,System.String,System.Threading.CancellationToken)">
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableOrchestrationClient.Microsoft#Azure#WebJobs#IDurableOrchestrationClient#GetStatusAsync(Microsoft.Azure.WebJobs.Extensions.DurableTask.OrchestrationStatusQueryCondition,System.String,System.Threading.CancellationToken)">
             <inheritdoc />
         </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableOrchestrationContext">
@@ -867,13 +867,22 @@
         </member>
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.OrchestrationStatusQueryCondition.CreatedTimeFrom">
             <summary>
-            Return orchestration instances which were created after this DateTime. 
+            Return orchestration instances which were created after this DateTime.
             </summary>
         </member>
-        <!-- Badly formed XML comment ignored for member "P:Microsoft.Azure.WebJobs.Extensions.DurableTask.OrchestrationStatusQueryCondition.CreatedTimeTo" -->
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.OrchestrationStatusQueryCondition.CreatedTimeTo">
+            <summary>
+            Return orchestration instances which were created before this DateTime.
+            </summary>
+        </member>
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.OrchestrationStatusQueryCondition.TaskHubNames">
             <summary>
             Return orchestration instances which matches the TaskHubNames.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.OrchestrationStatusQueryCondition.PageSize">
+            <summary>
+            Number of records per one request. The default value is 100.
             </summary>
         </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.OrchestrationStatusQueryResult">
@@ -1659,12 +1668,11 @@
             <param name="cancellationToken">Cancellation token that can be used to cancel the status query operation.</param>
             <returns>Returns each page of orchestration status for all instances and continuation token of next page.</returns>
         </member>
-        <member name="M:Microsoft.Azure.WebJobs.IDurableOrchestrationClient.GetStatusAsync(Microsoft.Azure.WebJobs.Extensions.DurableTask.OrchestrationStatusQueryCondition,System.Int32,System.String,System.Threading.CancellationToken)">
+        <member name="M:Microsoft.Azure.WebJobs.IDurableOrchestrationClient.GetStatusAsync(Microsoft.Azure.WebJobs.Extensions.DurableTask.OrchestrationStatusQueryCondition,System.String,System.Threading.CancellationToken)">
             <summary>
             Gets the status of all orchestration instances with paging that match the specified conditions.
             </summary>
             <param name="condition">Return orchestration instances that match the specified conditions.</param>
-            <param name="pageSize">Number of records per one request.</param>
             <param name="continuationToken">ContinuationToken of the pager.</param>
             <param name="cancellationToken">Cancellation token that can be used to cancel the status query operation.</param>
             <returns>Returns each page of orchestration status for all instances and continuation token of next page.</returns>

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
@@ -192,9 +192,6 @@
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableOrchestrationClient.Microsoft#Azure#WebJobs#IDurableOrchestrationClient#PurgeInstanceHistoryAsync(System.DateTime,System.Nullable{System.DateTime},System.Collections.Generic.IEnumerable{DurableTask.Core.OrchestrationStatus})">
             <inheritdoc />
         </member>
-        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableOrchestrationClient.Microsoft#Azure#WebJobs#IDurableOrchestrationClient#GetStatusAsync(System.DateTime,System.Nullable{System.DateTime},System.Collections.Generic.IEnumerable{Microsoft.Azure.WebJobs.OrchestrationRuntimeStatus},System.Int32,System.String,System.Threading.CancellationToken)">
-            <inheritdoc />
-        </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableOrchestrationClient.Microsoft#Azure#WebJobs#IDurableOrchestrationClient#GetStatusAsync(Microsoft.Azure.WebJobs.Extensions.DurableTask.OrchestrationStatusQueryCondition,System.Threading.CancellationToken)">
             <inheritdoc />
         </member>
@@ -1660,18 +1657,6 @@
             <param name="createdTimeTo">End creation time for querying instances for purging.</param>
             <param name="runtimeStatus">List of runtime status for querying instances for purging. Only Completed, Terminated, or Failed will be processed.</param>
             <returns>Returns an instance of <see cref="T:Microsoft.Azure.WebJobs.PurgeHistoryResult"/>.</returns>
-        </member>
-        <member name="M:Microsoft.Azure.WebJobs.IDurableOrchestrationClient.GetStatusAsync(System.DateTime,System.Nullable{System.DateTime},System.Collections.Generic.IEnumerable{Microsoft.Azure.WebJobs.OrchestrationRuntimeStatus},System.Int32,System.String,System.Threading.CancellationToken)">
-            <summary>
-            Gets the status of all orchestration instances with paging that match the specified conditions.
-            </summary>
-            <param name="createdTimeFrom">Return orchestration instances which were created after this DateTime.</param>
-            <param name="createdTimeTo">Return orchestration instances which were created before this DateTime.</param>
-            <param name="runtimeStatus">Return orchestration instances which matches the runtimeStatus.</param>
-            <param name="pageSize">Number of records per one request.</param>
-            <param name="continuationToken">ContinuationToken of the pager.</param>
-            <param name="cancellationToken">Cancellation token that can be used to cancel the status query operation.</param>
-            <returns>Returns each page of orchestration status for all instances and continuation token of next page.</returns>
         </member>
         <member name="M:Microsoft.Azure.WebJobs.IDurableOrchestrationClient.GetStatusAsync(Microsoft.Azure.WebJobs.Extensions.DurableTask.OrchestrationStatusQueryCondition,System.Threading.CancellationToken)">
             <summary>

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
@@ -195,6 +195,9 @@
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableOrchestrationClient.Microsoft#Azure#WebJobs#IDurableOrchestrationClient#GetStatusAsync(System.DateTime,System.Nullable{System.DateTime},System.Collections.Generic.IEnumerable{Microsoft.Azure.WebJobs.OrchestrationRuntimeStatus},System.Int32,System.String,System.Threading.CancellationToken)">
             <inheritdoc />
         </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableOrchestrationClient.Microsoft#Azure#WebJobs#IDurableOrchestrationClient#GetStatusAsync(Microsoft.Azure.WebJobs.Extensions.DurableTask.OrchestrationStatusQueryCondition,System.Int32,System.String,System.Threading.CancellationToken)">
+            <inheritdoc />
+        </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableOrchestrationContext">
             <summary>
             Parameter data for orchestration bindings that can be used to schedule function-based activities.
@@ -851,6 +854,27 @@
             A helper method to help retrieve the connection string name for the configured storage provider.
             </summary>
             <returns>The connection string name for the configured storage provider.</returns>
+        </member>
+        <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.OrchestrationStatusQueryCondition">
+            <summary>
+            Query condition for searching the status of orchestration instances.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.OrchestrationStatusQueryCondition.RuntimeStatus">
+            <summary>
+            Return orchestration instances which matches the runtimeStatus.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.OrchestrationStatusQueryCondition.CreatedTimeFrom">
+            <summary>
+            Return orchestration instances which were created after this DateTime. 
+            </summary>
+        </member>
+        <!-- Badly formed XML comment ignored for member "P:Microsoft.Azure.WebJobs.Extensions.DurableTask.OrchestrationStatusQueryCondition.CreatedTimeTo" -->
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.OrchestrationStatusQueryCondition.TaskHubNames">
+            <summary>
+            Return orchestration instances which matches the TaskHubNames.
+            </summary>
         </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.OrchestrationStatusQueryResult">
             <summary>
@@ -1630,6 +1654,16 @@
             <param name="createdTimeFrom">Return orchestration instances which were created after this DateTime.</param>
             <param name="createdTimeTo">Return orchestration instances which were created before this DateTime.</param>
             <param name="runtimeStatus">Return orchestration instances which matches the runtimeStatus.</param>
+            <param name="pageSize">Number of records per one request.</param>
+            <param name="continuationToken">ContinuationToken of the pager.</param>
+            <param name="cancellationToken">Cancellation token that can be used to cancel the status query operation.</param>
+            <returns>Returns each page of orchestration status for all instances and continuation token of next page.</returns>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.IDurableOrchestrationClient.GetStatusAsync(Microsoft.Azure.WebJobs.Extensions.DurableTask.OrchestrationStatusQueryCondition,System.Int32,System.String,System.Threading.CancellationToken)">
+            <summary>
+            Gets the status of all orchestration instances with paging that match the specified conditions.
+            </summary>
+            <param name="condition">Return orchestration instances that match the specified conditions.</param>
             <param name="pageSize">Number of records per one request.</param>
             <param name="continuationToken">ContinuationToken of the pager.</param>
             <param name="cancellationToken">Cancellation token that can be used to cancel the status query operation.</param>

--- a/src/WebJobs.Extensions.DurableTask/OrchestrationStatusQueryCondition.cs
+++ b/src/WebJobs.Extensions.DurableTask/OrchestrationStatusQueryCondition.cs
@@ -1,0 +1,49 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using DurableTask.AzureStorage.Tracking;
+using DurableTask.Core;
+
+namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
+{
+    /// <summary>
+    /// Query condition for searching the status of orchestration instances.
+    /// </summary>
+    public class OrchestrationStatusQueryCondition
+    {
+        /// <summary>
+        /// Return orchestration instances which matches the runtimeStatus.
+        /// </summary>
+        public IEnumerable<OrchestrationRuntimeStatus> RuntimeStatus { get; set; }
+
+        /// <summary>
+        /// Return orchestration instances which were created after this DateTime. 
+        /// </summary>
+        public DateTime CreatedTimeFrom { get; set; }
+
+        /// <summary>
+        /// Return orchestration instances which were created before this DateTime.</param>
+        /// </summary>
+        public DateTime CreatedTimeTo { get; set; }
+
+        /// <summary>
+        /// Return orchestration instances which matches the TaskHubNames.
+        /// </summary>
+        public IEnumerable<string> TaskHubNames { get; set; }
+
+        internal OrchestrationInstanceStatusQueryCondition Parse()
+        {
+            return new OrchestrationInstanceStatusQueryCondition
+            {
+               RuntimeStatus = this.RuntimeStatus.Select(
+                    p => (OrchestrationStatus)Enum.Parse(typeof(OrchestrationStatus), p.ToString())),
+               CreatedTimeFrom = this.CreatedTimeFrom,
+               CreatedTimeTo = this.CreatedTimeTo,
+               TaskHubNames = this.TaskHubNames,
+            };
+        }
+    }
+}

--- a/src/WebJobs.Extensions.DurableTask/OrchestrationStatusQueryCondition.cs
+++ b/src/WebJobs.Extensions.DurableTask/OrchestrationStatusQueryCondition.cs
@@ -20,12 +20,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         public IEnumerable<OrchestrationRuntimeStatus> RuntimeStatus { get; set; }
 
         /// <summary>
-        /// Return orchestration instances which were created after this DateTime. 
+        /// Return orchestration instances which were created after this DateTime.
         /// </summary>
         public DateTime CreatedTimeFrom { get; set; }
 
         /// <summary>
-        /// Return orchestration instances which were created before this DateTime.</param>
+        /// Return orchestration instances which were created before this DateTime.
         /// </summary>
         public DateTime CreatedTimeTo { get; set; }
 
@@ -33,6 +33,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// Return orchestration instances which matches the TaskHubNames.
         /// </summary>
         public IEnumerable<string> TaskHubNames { get; set; }
+
+        /// <summary>
+        /// Number of records per one request. The default value is 100.
+        /// </summary>
+        public int PageSize { get; set; } = 100;
 
         internal OrchestrationInstanceStatusQueryCondition Parse()
         {

--- a/src/WebJobs.Extensions.DurableTask/OrchestrationStatusQueryCondition.cs
+++ b/src/WebJobs.Extensions.DurableTask/OrchestrationStatusQueryCondition.cs
@@ -39,6 +39,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// </summary>
         public int PageSize { get; set; } = 100;
 
+        /// <summary>
+        /// ContinuationToken of the pager.
+        /// </summary>
+        public string ContinuationToken { get; set; }
+
         internal OrchestrationInstanceStatusQueryCondition Parse()
         {
             return new OrchestrationInstanceStatusQueryCondition

--- a/test/Common/DurableTaskEndToEndTests.cs
+++ b/test/Common/DurableTaskEndToEndTests.cs
@@ -2604,7 +2604,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 var condition1 = new OrchestrationStatusQueryCondition
                 {
                     RuntimeStatus = new List<OrchestrationRuntimeStatus>()
-                        {OrchestrationRuntimeStatus.Running, OrchestrationRuntimeStatus.Completed},
+                        { OrchestrationRuntimeStatus.Running, OrchestrationRuntimeStatus.Completed },
                     CreatedTimeFrom = yesterday,
                     CreatedTimeTo = tomorrow,
                     TaskHubNames = new List<string>() { taskHubName1 },
@@ -2612,7 +2612,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 var condition2 = new OrchestrationStatusQueryCondition
                 {
                     RuntimeStatus = new List<OrchestrationRuntimeStatus>()
-                        {OrchestrationRuntimeStatus.Running, OrchestrationRuntimeStatus.Completed},
+                        { OrchestrationRuntimeStatus.Running, OrchestrationRuntimeStatus.Completed },
                     CreatedTimeFrom = yesterday,
                     CreatedTimeTo = tomorrow,
                     TaskHubNames = new List<string>() { taskHubName2 },
@@ -2622,11 +2622,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 await client1.WaitForCompletionAsync(TimeSpan.FromSeconds(10), this.output);
                 await client2.WaitForCompletionAsync(TimeSpan.FromSeconds(10), this.output);
                 await client3.WaitForCompletionAsync(TimeSpan.FromSeconds(10), this.output);
+
                 // Perform some operations
                 var result1 = await client1.GetStatusAsync(condition1, CancellationToken.None);
                 var result2 = await client2.GetStatusAsync(condition2, CancellationToken.None);
 
-                Assert.Equal(1, result1.DurableOrchestrationState.Count());
+                Assert.Single(result1.DurableOrchestrationState);
                 Assert.Equal(2, result2.DurableOrchestrationState.Count());
 
                 await host1.StopAsync();

--- a/test/Common/DurableTaskEndToEndTests.cs
+++ b/test/Common/DurableTaskEndToEndTests.cs
@@ -2623,8 +2623,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 await client2.WaitForCompletionAsync(TimeSpan.FromSeconds(10), this.output);
                 await client3.WaitForCompletionAsync(TimeSpan.FromSeconds(10), this.output);
                 // Perform some operations
-                var result1 = await client1.GetStatusAsync(condition1, null, CancellationToken.None);
-                var result2 = await client2.GetStatusAsync(condition2, null, CancellationToken.None);
+                var result1 = await client1.GetStatusAsync(condition1, CancellationToken.None);
+                var result2 = await client2.GetStatusAsync(condition2, CancellationToken.None);
 
                 Assert.Equal(1, result1.DurableOrchestrationState.Count());
                 Assert.Equal(2, result2.DurableOrchestrationState.Count());

--- a/test/Common/DurableTaskEndToEndTests.cs
+++ b/test/Common/DurableTaskEndToEndTests.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using System.Runtime.Serialization;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using DurableTask.Core;
 using Microsoft.Azure.WebJobs.Host;
@@ -2119,6 +2120,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             }
         }
 
+
+
         [Theory]
         [Trait("Category", PlatformSpecificHelpers.TestCategory)]
         [MemberData(nameof(TestDataGenerator.GetStorageProviderOptions), MemberType = typeof(TestDataGenerator))]
@@ -2570,6 +2573,64 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 Assert.True(status.History.Count > 0);
 
                 await host.StopAsync();
+            }
+        }
+
+        [Theory]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        [MemberData(nameof(TestDataGenerator.GetExtendedSessionAndStorageProviderOptions), MemberType = typeof(TestDataGenerator))]
+        public async Task GetStatus_WithCondition(bool extendedSessions, string storageProvider)
+        {
+            var taskHubName1 = "GetStatus1";
+            var taskHubName2 = "GetStatus2";
+            await TestHelpers.DeleteTaskHubResources(taskHubName1, extendedSessions);
+            await TestHelpers.DeleteTaskHubResources(taskHubName2, extendedSessions);
+            using (JobHost host1 = TestHelpers.GetJobHost(this.loggerProvider, taskHubName1, extendedSessions, storageProviderType: storageProvider))
+            using (JobHost host2 = TestHelpers.GetJobHost(this.loggerProvider, taskHubName2, extendedSessions, storageProviderType: storageProvider))
+            {
+                await host1.StartAsync();
+                await host2.StartAsync();
+                var client1 = await host1.StartOrchestratorAsync(nameof(TestOrchestrations.SayHelloWithActivity), "foo", this.output);
+                var client2 = await host2.StartOrchestratorAsync(nameof(TestOrchestrations.SayHelloWithActivity), "bar", this.output);
+                var client3 = await host2.StartOrchestratorAsync(nameof(TestOrchestrations.SayHelloWithActivity), "baz", this.output);
+
+                taskHubName1 = client1.TaskHubName;
+                taskHubName2 = client2.TaskHubName;
+                var instanceId = client1.InstanceId;
+
+                var yesterday = DateTime.UtcNow.Subtract(TimeSpan.FromDays(1));
+                var tomorrow = DateTime.UtcNow.Add(TimeSpan.FromDays(1));
+
+                var condition1 = new OrchestrationStatusQueryCondition
+                {
+                    RuntimeStatus = new List<OrchestrationRuntimeStatus>()
+                        {OrchestrationRuntimeStatus.Running, OrchestrationRuntimeStatus.Completed},
+                    CreatedTimeFrom = yesterday,
+                    CreatedTimeTo = tomorrow,
+                    TaskHubNames = new List<string>() { taskHubName1 },
+                };
+                var condition2 = new OrchestrationStatusQueryCondition
+                {
+                    RuntimeStatus = new List<OrchestrationRuntimeStatus>()
+                        {OrchestrationRuntimeStatus.Running, OrchestrationRuntimeStatus.Completed},
+                    CreatedTimeFrom = yesterday,
+                    CreatedTimeTo = tomorrow,
+                    TaskHubNames = new List<string>() { taskHubName2 },
+                };
+
+                // Make sure it actually completed
+                await client1.WaitForCompletionAsync(TimeSpan.FromSeconds(10), this.output);
+                await client2.WaitForCompletionAsync(TimeSpan.FromSeconds(10), this.output);
+                await client3.WaitForCompletionAsync(TimeSpan.FromSeconds(10), this.output);
+                // Perform some operations
+                var result1 = await client1.GetStatusAsync(condition1, 10, null, CancellationToken.None);
+                var result2 = await client2.GetStatusAsync(condition2, 10, null, CancellationToken.None);
+
+                Assert.Equal(1, result1.DurableOrchestrationState.Count());
+                Assert.Equal(2, result2.DurableOrchestrationState.Count());
+
+                await host1.StopAsync();
+                await host2.StopAsync();
             }
         }
 

--- a/test/Common/DurableTaskEndToEndTests.cs
+++ b/test/Common/DurableTaskEndToEndTests.cs
@@ -2623,8 +2623,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 await client2.WaitForCompletionAsync(TimeSpan.FromSeconds(10), this.output);
                 await client3.WaitForCompletionAsync(TimeSpan.FromSeconds(10), this.output);
                 // Perform some operations
-                var result1 = await client1.GetStatusAsync(condition1, 10, null, CancellationToken.None);
-                var result2 = await client2.GetStatusAsync(condition2, 10, null, CancellationToken.None);
+                var result1 = await client1.GetStatusAsync(condition1, null, CancellationToken.None);
+                var result2 = await client2.GetStatusAsync(condition2, null, CancellationToken.None);
 
                 Assert.Equal(1, result1.DurableOrchestrationState.Count());
                 Assert.Equal(2, result2.DurableOrchestrationState.Count());

--- a/test/Common/TestOrchestratorClient.cs
+++ b/test/Common/TestOrchestratorClient.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
 using Xunit;
@@ -56,6 +57,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             }
 
             return status;
+        }
+
+        public Task<OrchestrationStatusQueryResult> GetStatusAsync(OrchestrationStatusQueryCondition condition, int pageSize, string continuationToken, CancellationToken cancellationToken)
+        {
+            return this.innerClient.GetStatusAsync(condition, pageSize, continuationToken, cancellationToken);
         }
 
         public async Task RaiseEventAsync(string eventName, ITestOutputHelper output)

--- a/test/Common/TestOrchestratorClient.cs
+++ b/test/Common/TestOrchestratorClient.cs
@@ -59,9 +59,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             return status;
         }
 
-        public Task<OrchestrationStatusQueryResult> GetStatusAsync(OrchestrationStatusQueryCondition condition, int pageSize, string continuationToken, CancellationToken cancellationToken)
+        public Task<OrchestrationStatusQueryResult> GetStatusAsync(OrchestrationStatusQueryCondition condition, string continuationToken, CancellationToken cancellationToken)
         {
-            return this.innerClient.GetStatusAsync(condition, pageSize, continuationToken, cancellationToken);
+            return this.innerClient.GetStatusAsync(condition, continuationToken, cancellationToken);
         }
 
         public async Task RaiseEventAsync(string eventName, ITestOutputHelper output)

--- a/test/Common/TestOrchestratorClient.cs
+++ b/test/Common/TestOrchestratorClient.cs
@@ -59,9 +59,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             return status;
         }
 
-        public Task<OrchestrationStatusQueryResult> GetStatusAsync(OrchestrationStatusQueryCondition condition, string continuationToken, CancellationToken cancellationToken)
+        public Task<OrchestrationStatusQueryResult> GetStatusAsync(OrchestrationStatusQueryCondition condition, CancellationToken cancellationToken)
         {
-            return this.innerClient.GetStatusAsync(condition, continuationToken, cancellationToken);
+            return this.innerClient.GetStatusAsync(condition, cancellationToken);
         }
 
         public async Task RaiseEventAsync(string eventName, ITestOutputHelper output)

--- a/test/FunctionsV2/OrchestrationStatusQueryConditionTest.cs
+++ b/test/FunctionsV2/OrchestrationStatusQueryConditionTest.cs
@@ -1,0 +1,54 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using DurableTask.Core;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Extensions.DurableTask;
+using Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests;
+using Xunit;
+
+namespace WebJobs.Extensions.DurableTask.Tests.V2
+{
+    public class OrchestrationStatusQueryConditionTest
+    {
+
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public void Parse_OrchestrationStatusQueryCondition()
+        {
+            var runtimeStatus = new List<OrchestrationRuntimeStatus>()
+            {
+                OrchestrationRuntimeStatus.Failed,
+                OrchestrationRuntimeStatus.Terminated,
+            };
+            var createdTimeFrom = new DateTime(2019, 1, 3);
+            var createdTimeTo = new DateTime(2019, 1, 4);
+            var taskHubNames = new List<string>()
+            {
+                "baz",
+                "qux",
+            };
+
+            var condition = new OrchestrationStatusQueryCondition
+            {
+                RuntimeStatus = runtimeStatus,
+                CreatedTimeFrom = createdTimeFrom,
+                CreatedTimeTo = createdTimeTo,
+                TaskHubNames = taskHubNames,
+            };
+
+            var result = condition.Parse();
+
+            Assert.Equal(OrchestrationStatus.Failed, result.RuntimeStatus.First());
+            Assert.Equal(OrchestrationStatus.Terminated, result.RuntimeStatus.Last());
+            Assert.Equal(createdTimeFrom, result.CreatedTimeFrom);
+            Assert.Equal(createdTimeTo, result.CreatedTimeTo);
+            Assert.Equal(taskHubNames, result.TaskHubNames);
+        }
+
+    }
+}

--- a/test/FunctionsV2/OrchestrationStatusQueryConditionTest.cs
+++ b/test/FunctionsV2/OrchestrationStatusQueryConditionTest.cs
@@ -15,7 +15,6 @@ namespace WebJobs.Extensions.DurableTask.Tests.V2
 {
     public class OrchestrationStatusQueryConditionTest
     {
-
         [Fact]
         [Trait("Category", PlatformSpecificHelpers.TestCategory)]
         public void Parse_OrchestrationStatusQueryCondition()
@@ -49,6 +48,5 @@ namespace WebJobs.Extensions.DurableTask.Tests.V2
             Assert.Equal(createdTimeTo, result.CreatedTimeTo);
             Assert.Equal(taskHubNames, result.TaskHubNames);
         }
-
     }
 }


### PR DESCRIPTION
Hi @cgillum ,

I enable the GetStatus query with condition object. This PR is created toward V2 implementation.  I see the V2 introduce the structure change. So I thought that it might be better to contribute towards V2 branch. 

This is related issue.
https://github.com/Azure/azure-functions-durable-extension/issues/668

# What I did

* Adding GetStatus with Condition query
* Refactor the duplication between GetStatus methods
* Introduce OrchestrationStatusQueryCondition which is the durable extension representation of the OrchestrationInstanceStatusQueryCondition that is DurableTask object. 
* Create Unit Test for the QueryCondition 
* Create E2E Test for testing GetStatus

# Todo 

* Add TaskHubNames Query for HttpApi side

# Review Points 

Currently, E2E test takes two minutes. If you have a suggestion to shorten the E2E test execution time, please let me know. 



