### PR TITLE
Ability to carry over buffered external events on ContinueAsNew

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/DurableOrchestrationContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableOrchestrationContext.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Azure.WebJobs
 
         internal bool ContinuedAsNew { get; private set; }
 
-        internal bool PreserveUnprocessEvents { get; private set; }
+        internal bool PreserveUnprocessedEvents { get; private set; }
 
         internal bool IsOutputSet => this.serializedOutput != null;
 
@@ -387,13 +387,13 @@ namespace Microsoft.Azure.WebJobs
         public override void ContinueAsNew(object input) => this.ContinueAsNew(input, false);
 
         /// <inheritdoc />
-        public override void ContinueAsNew(object input, bool preserveUnprocessEvents)
+        public override void ContinueAsNew(object input, bool preserveUnprocessedEvents)
         {
             this.ThrowIfInvalidAccess();
 
             this.innerContext.ContinueAsNew(input);
             this.ContinuedAsNew = true;
-            this.PreserveUnprocessEvents = preserveUnprocessEvents;
+            this.PreserveUnprocessedEvents = preserveUnprocessedEvents;
         }
 
         private async Task<TResult> CallDurableTaskFunctionAsync<TResult>(

--- a/src/WebJobs.Extensions.DurableTask/DurableOrchestrationContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableOrchestrationContext.cs
@@ -29,8 +29,8 @@ namespace Microsoft.Azure.WebJobs
         private readonly Dictionary<string, Stack> pendingExternalEvents =
             new Dictionary<string, Stack>(StringComparer.OrdinalIgnoreCase);
 
-        private readonly Dictionary<string, Queue> bufferedExternalEvents =
-            new Dictionary<string, Queue>(StringComparer.OrdinalIgnoreCase);
+        private readonly Dictionary<string, Queue<string>> bufferedExternalEvents =
+            new Dictionary<string, Queue<string>>(StringComparer.OrdinalIgnoreCase);
 
         private readonly DurableTaskExtension config;
         private readonly string orchestrationName;
@@ -56,6 +56,8 @@ namespace Microsoft.Azure.WebJobs
         public override bool IsReplaying => this.innerContext?.IsReplaying ?? base.IsReplaying;
 
         internal bool ContinuedAsNew { get; private set; }
+
+        internal bool PreserveUnprocessEvents { get; private set; }
 
         internal bool IsOutputSet => this.serializedOutput != null;
 
@@ -301,9 +303,9 @@ namespace Microsoft.Azure.WebJobs
                 }
 
                 // Check the queue to see if any events came in before the orchestrator was listening
-                if (this.bufferedExternalEvents.TryGetValue(name, out Queue queue))
+                if (this.bufferedExternalEvents.TryGetValue(name, out Queue<string> queue))
                 {
-                    object input = queue.Dequeue();
+                    string rawInput = queue.Dequeue();
 
                     if (queue.Count == 0)
                     {
@@ -311,7 +313,7 @@ namespace Microsoft.Azure.WebJobs
                     }
 
                     // We can call raise event right away, since we already have an event's input
-                    this.RaiseEvent(name, input.ToString());
+                    this.RaiseEvent(name, rawInput);
                 }
                 else
                 {
@@ -382,12 +384,16 @@ namespace Microsoft.Azure.WebJobs
         }
 
         /// <inheritdoc />
-        public override void ContinueAsNew(object input)
+        public override void ContinueAsNew(object input) => this.ContinueAsNew(input, false);
+
+        /// <inheritdoc />
+        public override void ContinueAsNew(object input, bool preserveUnprocessEvents)
         {
             this.ThrowIfInvalidAccess();
 
             this.innerContext.ContinueAsNew(input);
             this.ContinuedAsNew = true;
+            this.PreserveUnprocessEvents = preserveUnprocessEvents;
         }
 
         private async Task<TResult> CallDurableTaskFunctionAsync<TResult>(
@@ -547,9 +553,9 @@ namespace Microsoft.Azure.WebJobs
                 else
                 {
                     // Add the event to an (in-memory) queue, so we don't drop or lose it
-                    if (!this.bufferedExternalEvents.TryGetValue(name, out Queue bufferedEvents))
+                    if (!this.bufferedExternalEvents.TryGetValue(name, out Queue<string> bufferedEvents))
                     {
-                        bufferedEvents = new Queue();
+                        bufferedEvents = new Queue<string>();
                         this.bufferedExternalEvents[name] = bufferedEvents;
                     }
 
@@ -561,6 +567,25 @@ namespace Microsoft.Azure.WebJobs
                         this.InstanceId,
                         name,
                         this.IsReplaying);
+                }
+            }
+        }
+
+        internal void RescheduleBufferedExternalEvents()
+        {
+            var instance = new OrchestrationInstance { InstanceId = this.InstanceId };
+
+            foreach (var pair in this.bufferedExternalEvents)
+            {
+                string eventName = pair.Key;
+                Queue<string> events = pair.Value;
+
+                while (events.Count > 0)
+                {
+                    // Need to round-trip serialization since SendEvent always tries to serialize.
+                    string rawInput = events.Dequeue();
+                    JToken jsonData = JToken.Parse(rawInput);
+                    this.innerContext.SendEvent(instance, eventName, jsonData);
                 }
             }
         }

--- a/src/WebJobs.Extensions.DurableTask/DurableOrchestrationContextBase.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableOrchestrationContextBase.cs
@@ -455,6 +455,22 @@ namespace Microsoft.Azure.WebJobs
         public abstract void ContinueAsNew(object input);
 
         /// <summary>
+        /// Restarts the orchestration by clearing its history.
+        /// </summary>
+        /// <remarks>
+        /// <para>Large orchestration histories can consume a lot of memory and cause delays in
+        /// instance load times. This method can be used to periodically truncate the stored
+        /// history of an orchestration instance.</para>
+        /// </remarks>
+        /// <param name="input">The JSON-serializeable data to re-initialize the instance with.</param>
+        /// <param name="preserveUnprocessEvents">
+        /// If set to <c>true</c>, re-adds any unprocessed external events into the new execution
+        /// history when the orchestration instance restarts. If <c>false</c>, any unprocessed
+        /// external events will be discarded when the orchestration instance restarts.
+        /// </param>
+        public virtual void ContinueAsNew(object input, bool preserveUnprocessEvents) => throw new NotImplementedException();
+
+        /// <summary>
         /// Sets the JSON-serializeable status of the current orchestrator function.
         /// </summary>
         /// <remarks>

--- a/src/WebJobs.Extensions.DurableTask/DurableOrchestrationContextBase.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableOrchestrationContextBase.cs
@@ -463,12 +463,12 @@ namespace Microsoft.Azure.WebJobs
         /// history of an orchestration instance.</para>
         /// </remarks>
         /// <param name="input">The JSON-serializeable data to re-initialize the instance with.</param>
-        /// <param name="preserveUnprocessEvents">
+        /// <param name="preserveUnprocessedEvents">
         /// If set to <c>true</c>, re-adds any unprocessed external events into the new execution
         /// history when the orchestration instance restarts. If <c>false</c>, any unprocessed
         /// external events will be discarded when the orchestration instance restarts.
         /// </param>
-        public virtual void ContinueAsNew(object input, bool preserveUnprocessEvents) => throw new NotImplementedException();
+        public virtual void ContinueAsNew(object input, bool preserveUnprocessedEvents) => throw new NotImplementedException();
 
         /// <summary>
         /// Sets the JSON-serializeable status of the current orchestrator function.

--- a/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
@@ -51,9 +51,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         private readonly ConcurrentDictionary<FunctionName, RegisteredFunctionInfo> knownActivities =
             new ConcurrentDictionary<FunctionName, RegisteredFunctionInfo>();
 
-        private readonly ConcurrentDictionary<string, DurableOrchestrationContext> continueAsNewContexts =
-            new ConcurrentDictionary<string, DurableOrchestrationContext>(StringComparer.OrdinalIgnoreCase);
-
         private readonly AsyncLock taskHubLock = new AsyncLock();
 
         private readonly bool isOptionsConfigured;
@@ -370,7 +367,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
             if (context.IsCompleted &&
                 context.ContinuedAsNew &&
-                context.PreserveUnprocessEvents)
+                context.PreserveUnprocessedEvents)
             {
                 // Reschedule any unprocessed external events so that they can be picked up
                 // in the next iteration.

--- a/src/WebJobs.Extensions.DurableTask/OrchestrationRuntimeStatus.cs
+++ b/src/WebJobs.Extensions.DurableTask/OrchestrationRuntimeStatus.cs
@@ -12,6 +12,11 @@ namespace Microsoft.Azure.WebJobs
     public enum OrchestrationRuntimeStatus
     {
         /// <summary>
+        /// The status of the orchestration could not be determined.
+        /// </summary>
+        Unknown = -1,
+
+        /// <summary>
         /// The orchestration is running (it may be actively running or waiting for input).
         /// </summary>
         Running = 0,

--- a/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
+++ b/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
@@ -26,9 +26,7 @@
   </ItemGroup>
   
   <ItemGroup Condition="'$(Configuration)' == 'Debug'">
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta009">
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.1-*" PrivateAssets="All"/>
   </ItemGroup>
   
   <ItemGroup Condition="'$(TargetFramework)' == 'net461'">

--- a/test/Common/DurableTaskEndToEndTests.cs
+++ b/test/Common/DurableTaskEndToEndTests.cs
@@ -628,7 +628,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         {
             using (JobHost host = TestHelpers.GetJobHost(
                 this.loggerProvider,
-                nameof(this.ActorOrchestration),
+                nameof(this.ActorOrchestration_NoWaiting),
                 extendedSessions))
             {
                 await host.StartAsync();
@@ -1018,7 +1018,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             var extendedSessions = false;
             using (JobHost host = TestHelpers.GetJobHost(
                 this.loggerProvider,
-                nameof(this.TimerExpiration),
+                nameof(this.WaitForExternalEventWithTimeout),
                 extendedSessions))
             {
                 await host.StartAsync();

--- a/test/Common/LogEventTraceListener.cs
+++ b/test/Common/LogEventTraceListener.cs
@@ -129,7 +129,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         public void Stop()
         {
             this.currentSession?.Source.StopProcessing();
-            this.backgroundTraceThread.Join(TimeSpan.FromSeconds(10));
+            this.backgroundTraceThread?.Join(TimeSpan.FromSeconds(10));
             this.currentSession?.Dispose();
             this.currentSession = null;
         }

--- a/test/Common/TestActivities.cs
+++ b/test/Common/TestActivities.cs
@@ -100,6 +100,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             return httpManagementPayload;
         }
 
+        public static Task Delay([ActivityTrigger] TimeSpan duration)
+        {
+            return Task.Delay(duration);
+        }
+
         public static DurableOrchestrationStatus UpdateDurableOrchestrationStatus([ActivityTrigger] DurableActivityContext ctx)
         {
             DurableOrchestrationStatus durableOrchestrationStatus = ctx.GetInput<DurableOrchestrationStatus>();

--- a/test/Common/TestActivities.cs
+++ b/test/Common/TestActivities.cs
@@ -100,11 +100,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             return httpManagementPayload;
         }
 
-        public static Task Delay([ActivityTrigger] TimeSpan duration)
-        {
-            return Task.Delay(duration);
-        }
-
         public static DurableOrchestrationStatus UpdateDurableOrchestrationStatus([ActivityTrigger] DurableActivityContext ctx)
         {
             DurableOrchestrationStatus durableOrchestrationStatus = ctx.GetInput<DurableOrchestrationStatus>();

--- a/test/Common/TestOrchestrations.cs
+++ b/test/Common/TestOrchestrations.cs
@@ -159,7 +159,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
             if (!done)
             {
-                ctx.ContinueAsNew(currentValue);
+                ctx.ContinueAsNew(currentValue, preserveUnprocessedEvents: true);
             }
 
             return currentValue;


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-functions-durable-extension/issues/676 (Events added to in-memory queue are not being raised after ContinueAsNew called)

Included in this PR are also some test fixes which may help resolve https://github.com/Azure/azure-functions-durable-extension/issues/646 (integration test flakiness)