### PR TITLE
Refactored test timeout settings to improve consistency

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
@@ -199,7 +199,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             this.HttpApiHandler = new HttpApiHandler(this, logger);
             this.connectionStringResolver = new WebJobsConnectionStringProvider();
             this.nameResolver = context.Config.NameResolver;
-            this.LifeCycleNotificationHelper = this.CreateLifeCycleNotificationHelper();            
+            this.LifeCycleNotificationHelper = this.CreateLifeCycleNotificationHelper();
 #endif
         }
 

--- a/test/Common/BindingTests.cs
+++ b/test/Common/BindingTests.cs
@@ -39,9 +39,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 startArgs.FunctionName = nameof(TestActivities.BindToJObject);
                 startArgs.Input = new { Foo = "Bar" };
 
-                var timeout = Debugger.IsAttached ? TimeSpan.FromMinutes(5) : TimeSpan.FromSeconds(30);
                 var client = await host.StartOrchestratorAsync(nameof(TestOrchestrations.CallActivity), startArgs, this.output);
-                var status = await client.WaitForCompletionAsync(timeout, this.output);
+                var status = await client.WaitForCompletionAsync(this.output);
 
                 // The function checks to see if there is a property called "Foo" which is set to a value
                 // called "Bar" and returns true if this is the case. Otherwise returns false.
@@ -67,9 +66,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 var input = new { Foo = "Bar" };
                 startArgs.Input = input;
 
-                var timeout = Debugger.IsAttached ? TimeSpan.FromMinutes(5) : TimeSpan.FromSeconds(30);
                 var client = await host.StartOrchestratorAsync(nameof(TestOrchestrations.CallActivity), startArgs, this.output);
-                var status = await client.WaitForCompletionAsync(timeout, this.output);
+                var status = await client.WaitForCompletionAsync(this.output);
 
                 // The function echos back the 'Foo' input property value
                 Assert.Equal(OrchestrationRuntimeStatus.Completed, status?.RuntimeStatus);
@@ -92,9 +90,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 startArgs.FunctionName = nameof(TestActivities.BindToDouble);
                 startArgs.Input = 3.14;
 
-                var timeout = Debugger.IsAttached ? TimeSpan.FromMinutes(5) : TimeSpan.FromSeconds(30);
                 var client = await host.StartOrchestratorAsync(nameof(TestOrchestrations.CallActivity), startArgs, this.output);
-                var status = await client.WaitForCompletionAsync(timeout, this.output);
+                var status = await client.WaitForCompletionAsync(this.output);
 
                 // The function echos back the input value
                 Assert.Equal(OrchestrationRuntimeStatus.Completed, status?.RuntimeStatus);
@@ -139,9 +136,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 startArgs.FunctionName = nameof(TestActivities.BindToBlobViaParameterName);
                 startArgs.Input = OriginalBlobName;
 
-                var timeout = Debugger.IsAttached ? TimeSpan.FromMinutes(5) : TimeSpan.FromSeconds(30);
                 var client = await host.StartOrchestratorAsync(nameof(TestOrchestrations.CallActivity), startArgs, this.output);
-                var status = await client.WaitForCompletionAsync(timeout, this.output);
+                var status = await client.WaitForCompletionAsync(this.output);
 
                 Assert.Equal(OrchestrationRuntimeStatus.Completed, status?.RuntimeStatus);
 
@@ -198,9 +194,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 startArgs.FunctionName = nameof(TestActivities.BindToBlobViaJsonPayload);
                 startArgs.Input = data;
 
-                var timeout = Debugger.IsAttached ? TimeSpan.FromMinutes(5) : TimeSpan.FromSeconds(30);
                 var client = await host.StartOrchestratorAsync(nameof(TestOrchestrations.CallActivity), startArgs, this.output);
-                var status = await client.WaitForCompletionAsync(timeout, this.output);
+                var status = await client.WaitForCompletionAsync(this.output);
 
                 Assert.Equal(OrchestrationRuntimeStatus.Completed, status?.RuntimeStatus);
 

--- a/test/Common/DurableTaskEndToEndTests.cs
+++ b/test/Common/DurableTaskEndToEndTests.cs
@@ -86,7 +86,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 await host.StartAsync();
 
                 var client = await host.StartOrchestratorAsync(orchestratorFunctionNames[0], "World", this.output);
-                var status = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(30), this.output);
+                var status = await client.WaitForCompletionAsync(this.output);
 
                 Assert.Equal(OrchestrationRuntimeStatus.Completed, status?.RuntimeStatus);
                 Assert.Equal("World", status?.Input);
@@ -143,7 +143,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                     "World",
                     this.output,
                     useTaskHubFromAppSettings: false);
-                var status = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(30), this.output);
+                var status = await client.WaitForCompletionAsync(this.output);
 
                 Assert.Equal(OrchestrationRuntimeStatus.Completed, status?.RuntimeStatus);
                 Assert.Equal("World", status?.Input);
@@ -155,7 +155,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                     "World",
                     this.output,
                     useTaskHubFromAppSettings: true);
-                status = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(30), this.output);
+                status = await client.WaitForCompletionAsync(this.output);
 
                 Assert.Equal(OrchestrationRuntimeStatus.Completed, status?.RuntimeStatus);
                 Assert.Equal("World", status?.Input);
@@ -188,7 +188,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 await host.StartAsync();
 
                 var client = await host.StartOrchestratorAsync(orchestratorFunctionNames[0], null, this.output);
-                var status = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(30), this.output);
+                var status = await client.WaitForCompletionAsync(this.output);
 
                 Assert.Equal(OrchestrationRuntimeStatus.Completed, status?.RuntimeStatus);
                 Assert.Equal("", status.Output.ToString());
@@ -268,7 +268,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
                 var client = await host.StartOrchestratorAsync(orchestratorFunctionNames[0], "World", this.output);
                 DurableOrchestrationStatus status =
-                    await client.WaitForCompletionAsync(TimeSpan.FromSeconds(30), this.output);
+                    await client.WaitForCompletionAsync(this.output);
 
                 Assert.NotNull(status);
                 Assert.Equal(OrchestrationRuntimeStatus.Completed, status.RuntimeStatus);
@@ -301,7 +301,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
                 var client = await host.StartOrchestratorAsync(orchestratorFunctionNames[0], null, this.output);
                 DurableOrchestrationStatus status =
-                    await client.WaitForCompletionAsync(TimeSpan.FromSeconds(30), this.output);
+                    await client.WaitForCompletionAsync(this.output);
 
                 Assert.NotNull(status);
                 Assert.Equal(OrchestrationRuntimeStatus.Completed, status.RuntimeStatus);
@@ -333,7 +333,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
                 var client = await host.StartOrchestratorAsync(orchestratorFunctionNames[0], null, this.output);
                 DurableOrchestrationStatus status =
-                    await client.WaitForCompletionAsync(TimeSpan.FromSeconds(30), this.output);
+                    await client.WaitForCompletionAsync(this.output);
 
                 Assert.NotNull(status);
                 Assert.Equal(OrchestrationRuntimeStatus.Completed, status.RuntimeStatus);
@@ -360,7 +360,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 await host.StartAsync();
 
                 var client = await host.StartOrchestratorAsync(orchestratorFunctionNames[0], "World", this.output);
-                DurableOrchestrationStatus status = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(30), this.output, showHistory, showHistoryOutput);
+                DurableOrchestrationStatus status = await client.WaitForCompletionAsync(this.output, showHistory, showHistoryOutput);
 
                 Assert.NotNull(status);
                 Assert.Equal(OrchestrationRuntimeStatus.Completed, status.RuntimeStatus);
@@ -441,7 +441,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 await host.StartAsync();
 
                 var client = await host.StartOrchestratorAsync(orchestratorFunctionNames[0], "World", this.output);
-                DurableOrchestrationStatus status = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(30), this.output);
+                DurableOrchestrationStatus status = await client.WaitForCompletionAsync(this.output);
 
                 Assert.NotNull(status);
                 Assert.Equal(OrchestrationRuntimeStatus.Completed, status.RuntimeStatus);
@@ -491,7 +491,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 var client = await host.StartOrchestratorAsync(nameof(TestOrchestrations.Factorial), 10, this.output);
                 instanceId = client.InstanceId;
 
-                var status = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(30), this.output);
+                var status = await client.WaitForCompletionAsync(this.output);
 
                 Assert.Equal(OrchestrationRuntimeStatus.Completed, status?.RuntimeStatus);
                 Assert.Equal(10, status?.Input);
@@ -531,7 +531,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 await host.StartAsync();
 
                 var client = await host.StartOrchestratorAsync(nameof(TestOrchestrations.DiskUsage), Environment.CurrentDirectory, this.output);
-                var status = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(90), this.output);
+                var status = await client.WaitForCompletionAsync(this.output, timeout: TimeSpan.FromSeconds(90));
 
                 Assert.Equal(OrchestrationRuntimeStatus.Completed, status?.RuntimeStatus);
                 Assert.Equal(Environment.CurrentDirectory, status?.Input);
@@ -563,8 +563,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 instanceId = client.InstanceId;
 
                 // Wait for the instance to go into the Running state. This is necessary to ensure log validation consistency.
+                await client.WaitForStartupAsync(this.output);
+
                 TimeSpan waitTimeout = TimeSpan.FromSeconds(Debugger.IsAttached ? 300 : 10);
-                await client.WaitForStartupAsync(waitTimeout, this.output);
 
                 // Perform some operations
                 await client.RaiseEventAsync("operation", "incr", this.output);
@@ -587,7 +588,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 // The end message will cause the actor to complete itself.
                 await client.RaiseEventAsync("operation", "end", this.output);
 
-                status = await client.WaitForCompletionAsync(waitTimeout, this.output);
+                status = await client.WaitForCompletionAsync(this.output, timeout: waitTimeout);
 
                 Assert.Equal(OrchestrationRuntimeStatus.Completed, status?.RuntimeStatus);
                 Assert.Equal(3, (int?)status?.Output);
@@ -636,7 +637,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 await client.RaiseEventAsync("operation", "incr", this.output);
                 await client.RaiseEventAsync("operation", "end", this.output);
 
-                var status = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(10), this.output);
+                var status = await client.WaitForCompletionAsync(this.output);
 
                 Assert.Equal(OrchestrationRuntimeStatus.Completed, status?.RuntimeStatus);
                 Assert.Equal(3, (int?)status?.Output);
@@ -673,13 +674,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 await client.RaiseEventAsync("newItem", "item4", this.output);
 
                 // Make sure it's still running and didn't complete early (or fail).
-                var status = await client.WaitForStartupAsync(TimeSpan.FromSeconds(10), this.output);
+                var status = await client.WaitForStartupAsync(this.output);
                 Assert.Equal(OrchestrationRuntimeStatus.Running, status?.RuntimeStatus);
 
                 // Sending this last item will cause the actor to complete itself.
                 await client.RaiseEventAsync("newItem", "item5", this.output);
 
-                status = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(10), this.output);
+                status = await client.WaitForCompletionAsync(this.output);
 
                 Assert.Equal(OrchestrationRuntimeStatus.Completed, status?.RuntimeStatus);
 
@@ -712,13 +713,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 await client.RaiseEventAsync("deleteItem", this.output); // deletes last item in the list: item2
 
                 // Make sure it's still running and didn't complete early (or fail).
-                var status = await client.WaitForStartupAsync(TimeSpan.FromSeconds(10), this.output);
+                var status = await client.WaitForStartupAsync(this.output);
                 Assert.Equal(OrchestrationRuntimeStatus.Running, status?.RuntimeStatus);
 
                 // Sending this last event will cause the actor to complete itself.
                 await client.RaiseEventAsync("deleteItem", this.output); // deletes last item in the list: item1
 
-                status = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(10), this.output);
+                status = await client.WaitForCompletionAsync(this.output);
 
                 Assert.Equal(OrchestrationRuntimeStatus.Completed, status?.RuntimeStatus);
 
@@ -749,14 +750,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 await client.RaiseEventAsync("newItem", "item3", this.output);
 
                 // Make sure it's still running and didn't complete early (or fail).
-                await client.WaitForStartupAsync(TimeSpan.FromSeconds(30), this.output);
+                await client.WaitForStartupAsync(this.output);
                 await Task.Delay(TimeSpan.FromSeconds(5));
                 var status = await client.GetStatusAsync();
                 Assert.Equal(OrchestrationRuntimeStatus.Running, status?.RuntimeStatus);
 
                 // Sending this last item will cause the actor to complete itself.
                 await client.RaiseEventAsync("newItem", "item4", this.output);
-                status = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(10), this.output);
+                status = await client.WaitForCompletionAsync(this.output);
                 Assert.Equal(OrchestrationRuntimeStatus.Completed, status?.RuntimeStatus);
                 await host.StopAsync();
             }
@@ -783,9 +784,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 await client.RaiseEventAsync("done", null, this.output);
 
                 // Make sure it actually completed
-                var status = await client.WaitForCompletionAsync(
-                    TimeSpan.FromSeconds(1000),
-                    this.output);
+                var status = await client.WaitForCompletionAsync(this.output);
                 Assert.Equal(OrchestrationRuntimeStatus.Completed, status?.RuntimeStatus);
                 Assert.Equal(2, status.Output);
 
@@ -820,11 +819,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 // Need to wait for the instance to start before we can terminate it.
                 // TODO: This requirement may not be ideal and should be revisited.
                 // BUG: https://github.com/Azure/azure-functions-durable-extension/issues/101
-                await client.WaitForStartupAsync(TimeSpan.FromSeconds(10), this.output);
+                await client.WaitForStartupAsync(this.output);
 
                 await client.TerminateAsync("sayōnara");
 
-                var status = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(10), this.output);
+                var status = await client.WaitForCompletionAsync(this.output);
 
                 Assert.Equal(OrchestrationRuntimeStatus.Terminated, status?.RuntimeStatus);
                 Assert.Equal("sayōnara", status?.Output);
@@ -868,9 +867,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
                 var client = await host.StartOrchestratorAsync(orchestratorFunctionNames[0], "Catherine", this.output);
 
-                await client.WaitForStartupAsync(TimeSpan.FromSeconds(10), this.output);
+                await client.WaitForStartupAsync(this.output);
 
-                var statusFail = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(30), this.output);
+                var statusFail = await client.WaitForCompletionAsync(this.output);
 
                 Assert.Equal(OrchestrationRuntimeStatus.Failed, statusFail?.RuntimeStatus);
 
@@ -878,7 +877,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
                 await client.RewindAsync("rewind!");
 
-                var status = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(10), this.output);
+                var status = await client.WaitForCompletionAsync(this.output);
 
                 Assert.Equal(OrchestrationRuntimeStatus.Completed, status?.RuntimeStatus);
                 Assert.Equal("Hello, Catherine!", status?.Output);
@@ -922,14 +921,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
                 var timeout = TimeSpan.FromSeconds(10);
                 var client = await host.StartOrchestratorAsync(orchestratorFunctionNames[0], timeout, this.output);
-
-                // Need to wait for the instance to start before sending events to it.
-                // TODO: This requirement may not be ideal and should be revisited.
-                // BUG: https://github.com/Azure/azure-functions-durable-extension/issues/101
-                await client.WaitForStartupAsync(TimeSpan.FromSeconds(10), this.output);
+                await client.WaitForStartupAsync(this.output);
                 await client.RaiseEventAsync("approval", eventData: true, output: this.output);
 
-                var status = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(10), this.output);
+                var status = await client.WaitForCompletionAsync(this.output);
                 Assert.Equal(OrchestrationRuntimeStatus.Completed, status?.RuntimeStatus);
                 Assert.Equal("Approved", status?.Output);
 
@@ -971,15 +966,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
                 var timeout = TimeSpan.FromSeconds(10);
                 var client = await host.StartOrchestratorAsync(orchestratorFunctionNames[0], timeout, this.output);
-
-                // Need to wait for the instance to start before sending events to it.
-                // TODO: This requirement may not be ideal and should be revisited.
-                // BUG: https://github.com/Azure/azure-functions-durable-extension/issues/101
-                await client.WaitForStartupAsync(TimeSpan.FromSeconds(10), this.output);
+                await client.WaitForStartupAsync(this.output);
 
                 // Don't send any notification - let the internal timeout expire
 
-                var status = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(20), this.output);
+                var status = await client.WaitForCompletionAsync(this.output);
                 Assert.Equal(OrchestrationRuntimeStatus.Completed, status?.RuntimeStatus);
                 Assert.Equal("Expired", status?.Output);
 
@@ -1020,11 +1011,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
                 var timeout = TimeSpan.FromSeconds(10);
                 var client = await host.StartOrchestratorAsync(orchestratorFunctionNames[0], (timeout, defaultValue), this.output);
-
-                // Need to wait for the instance to start before sending events to it.
-                // TODO: This requirement may not be ideal and should be revisited.
-                // BUG: https://github.com/Azure/azure-functions-durable-extension/issues/101
-                await client.WaitForStartupAsync(TimeSpan.FromSeconds(10), this.output);
+                await client.WaitForStartupAsync(this.output);
 
                 // Don't send any notification - let the internal timeout expire
                 if (sendEvent)
@@ -1032,7 +1019,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                     await client.RaiseEventAsync("Approval", "ApprovalValue", this.output);
                 }
 
-                var status = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(20), this.output);
+                var status = await client.WaitForCompletionAsync(this.output);
                 Assert.Equal(OrchestrationRuntimeStatus.Completed, status?.RuntimeStatus);
                 Assert.Equal(expectedResponse, status?.Output);
 
@@ -1060,7 +1047,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 {
                     var timeout = TimeSpan.FromSeconds(10);
                     var client = await host.StartOrchestratorAsync(nameof(TestOrchestrations.Approval), timeout, this.output);
-                    await client.WaitForCompletionAsync(TimeSpan.FromSeconds(60), this.output);
+                    await client.WaitForCompletionAsync(this.output, timeout: TimeSpan.FromSeconds(60));
 
                     // Don't send any notification - let the internal timeout expire
                 };
@@ -1101,7 +1088,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
                 // Empty string input should result in ArgumentNullException in the orchestration code.
                 var client = await host.StartOrchestratorAsync(nameof(TestOrchestrations.TryCatchLoop), 5, this.output);
-                var status = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(30), this.output);
+                var status = await client.WaitForCompletionAsync(this.output);
 
                 Assert.Equal(OrchestrationRuntimeStatus.Completed, status?.RuntimeStatus);
                 Assert.Equal(5, status?.Output);
@@ -1130,7 +1117,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                     nameof(TestOrchestrations.SubOrchestrationThrow),
                     message,
                     this.output);
-                var status = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(30), this.output);
+                var status = await client.WaitForCompletionAsync(this.output);
 
                 Assert.Equal(OrchestrationRuntimeStatus.Failed, status?.RuntimeStatus);
                 Assert.Contains(message, (string)status.Output);
@@ -1162,7 +1149,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
                 // Null input should result in ArgumentNullException in the orchestration code.
                 var client = await host.StartOrchestratorAsync(orchestratorFunctionNames[0], null, this.output);
-                var status = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(10), this.output);
+                var status = await client.WaitForCompletionAsync(this.output);
 
                 Assert.Equal(OrchestrationRuntimeStatus.Failed, status?.RuntimeStatus);
 
@@ -1210,7 +1197,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 await host.StartAsync();
 
                 var client = await host.StartOrchestratorAsync(orchestratorFunctionNames[0], null, this.output);
-                var status = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(20), this.output);
+                var status = await client.WaitForCompletionAsync(this.output);
 
                 Assert.NotNull(status);
                 Assert.Equal(OrchestrationRuntimeStatus.Completed, status.RuntimeStatus);
@@ -1285,9 +1272,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 };
 
                 var client = await host.StartOrchestratorAsync(parentOrchestrator, input, this.output);
-                var status = await client.WaitForCompletionAsync(
-                    Debugger.IsAttached ? TimeSpan.FromMinutes(5) : TimeSpan.FromSeconds(20),
-                    this.output);
+                var status = await client.WaitForCompletionAsync(this.output);
 
                 Assert.NotNull(status);
                 Assert.Equal(OrchestrationRuntimeStatus.Completed, status.RuntimeStatus);
@@ -1333,7 +1318,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
                 var client = await host.StartOrchestratorAsync(parentOrchestrator, input, this.output);
                 var status = await client.WaitForCompletionAsync(
-                    Debugger.IsAttached ? TimeSpan.FromMinutes(5) : TimeSpan.FromSeconds(20),
                     this.output,
                     showHistory,
                     showHistoryOutput);
@@ -1425,7 +1409,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
                 // Null input should result in ArgumentNullException in the orchestration code.
                 var client = await host.StartOrchestratorAsync(orchestratorFunctionNames[0], null, this.output);
-                var status = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(50), this.output);
+                var status = await client.WaitForCompletionAsync(this.output, timeout: TimeSpan.FromSeconds(50));
 
                 Assert.Equal(OrchestrationRuntimeStatus.Failed, status?.RuntimeStatus);
 
@@ -1471,7 +1455,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
                 // Null input should result in ArgumentNullException in the orchestration code.
                 var client = await host.StartOrchestratorAsync(orchestratorFunctionNames[0], null, this.output);
-                var status = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(50), this.output);
+                var status = await client.WaitForCompletionAsync(this.output, timeout: TimeSpan.FromSeconds(50));
 
                 Assert.Equal(OrchestrationRuntimeStatus.Failed, status?.RuntimeStatus);
 
@@ -1510,10 +1494,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 await host.StartAsync();
 
                 string message = "Kah-BOOOOM!!!";
-                var timeout = Debugger.IsAttached ? TimeSpan.FromMinutes(5) : TimeSpan.FromSeconds(60);
 
                 var client = await host.StartOrchestratorAsync(orchestratorFunctionNames[0], message, this.output);
-                var status = await client.WaitForCompletionAsync(timeout, this.output);
+                var status = await client.WaitForCompletionAsync(this.output);
 
                 Assert.Equal(OrchestrationRuntimeStatus.Failed, status?.RuntimeStatus);
 
@@ -1563,12 +1546,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                     Input = exceptionMessage,
                 };
 
-                var timeout = Debugger.IsAttached ? TimeSpan.FromMinutes(5) : TimeSpan.FromSeconds(60);
                 var client = await host.StartOrchestratorAsync(
                     nameof(TestOrchestrations.CallOrchestrator),
                     args,
                     this.output);
-                var status = await client.WaitForCompletionAsync(timeout, this.output);
+                var status = await client.WaitForCompletionAsync(this.output);
 
                 Assert.Equal(OrchestrationRuntimeStatus.Failed, status?.RuntimeStatus);
 
@@ -1612,7 +1594,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
                 string message = "Kah-BOOOOM!!!";
                 var client = await host.StartOrchestratorAsync(orchestratorFunctionNames[0], message, this.output);
-                var status = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(40), this.output);
+                var status = await client.WaitForCompletionAsync(this.output, timeout: TimeSpan.FromSeconds(40));
 
                 Assert.Equal(OrchestrationRuntimeStatus.Failed, status?.RuntimeStatus);
 
@@ -1655,7 +1637,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 string message = "Kah-BOOOOM!!!";
                 string orchestratorFunctionName = nameof(TestOrchestrations.ActivityWithRetry_NullRetryOptions);
                 var client = await host.StartOrchestratorAsync(orchestratorFunctionName, message, this.output);
-                var status = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(40), this.output);
+                var status = await client.WaitForCompletionAsync(this.output, timeout: TimeSpan.FromSeconds(40));
 
                 Assert.Equal(OrchestrationRuntimeStatus.Failed, status?.RuntimeStatus);
 
@@ -1692,7 +1674,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                     await client.RaiseEventAsync("add", i, this.output);
                 }
 
-                var status = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(60), this.output);
+                var status = await client.WaitForCompletionAsync(this.output, timeout: TimeSpan.FromSeconds(60));
 
                 Assert.Equal(OrchestrationRuntimeStatus.Completed, status?.RuntimeStatus);
 
@@ -1763,7 +1745,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 };
 
                 var client = await host.StartOrchestratorAsync(orchestratorFunctionNames[0], startArgs, this.output);
-                var status = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(30), this.output);
+                var status = await client.WaitForCompletionAsync(this.output);
 
                 Assert.Equal(OrchestrationRuntimeStatus.Failed, status?.RuntimeStatus);
                 Assert.StartsWith(errorMessage, (string)status?.Output);
@@ -1821,7 +1803,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
                 // Function type call chain: 'CallActivity' (orchestrator) -> 'SayHelloWithActivity' (orchestrator) -> 'Hello' (activity)
                 var client = await host.StartOrchestratorAsync(orchestratorFunctionNames[0], startArgs, this.output, parentInstanceId);
-                var status = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(30), this.output);
+                var status = await client.WaitForCompletionAsync(this.output);
                 var statusInput = JsonConvert.DeserializeObject<Dictionary<string, object>>(status?.Input.ToString());
 
                 Assert.NotNull(status);
@@ -1864,7 +1846,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 // https://github.com/Azure/azure-functions-durable-extension/issues/14
                 DateTime fireAt = DateTime.UtcNow.AddDays(7);
                 var client = await host.StartOrchestratorAsync(nameof(TestOrchestrations.Timer), fireAt, this.output);
-                var status = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(30), this.output);
+                var status = await client.WaitForCompletionAsync(this.output);
 
                 Assert.NotNull(status);
                 Assert.Equal(OrchestrationRuntimeStatus.Failed, status.RuntimeStatus);
@@ -1906,7 +1888,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 };
 
                 var client = await host.StartOrchestratorAsync(orchestratorFunctionNames[0], startArgs, this.output);
-                var status = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(30), this.output);
+                var status = await client.WaitForCompletionAsync(this.output);
 
                 Assert.Equal(OrchestrationRuntimeStatus.Failed, status?.RuntimeStatus);
                 Assert.True(status?.Output.ToString().Contains(errorMessage));
@@ -1938,14 +1920,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 await host.StartAsync();
 
                 var orchestrator = nameof(TestOrchestrations.BigReturnValue);
-                var timeout = Debugger.IsAttached ? TimeSpan.FromMinutes(5) : TimeSpan.FromSeconds(30);
 
                 // The expected maximum payload size is 60 KB.
                 // Strings in Azure Storage are encoded in UTF-16, which is 2 bytes per character.
                 int stringLength = (61 * 1024) / 2;
 
                 var client = await host.StartOrchestratorAsync(orchestrator, stringLength, this.output);
-                var status = await client.WaitForCompletionAsync(timeout, this.output);
+                var status = await client.WaitForCompletionAsync(this.output);
 
                 Assert.Equal(OrchestrationRuntimeStatus.Completed, status?.RuntimeStatus);
                 await ValidateBlobUrlAsync(client.TaskHubName, client.InstanceId, (string)status.Output);
@@ -1967,7 +1948,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 await host.StartAsync();
 
                 var orchestrator = nameof(TestOrchestrations.CallActivity);
-                var timeout = Debugger.IsAttached ? TimeSpan.FromMinutes(5) : TimeSpan.FromSeconds(30);
 
                 // The expected maximum payload size is 60 KB.
                 // Strings in Azure Storage are encoded in UTF-16, which is 2 bytes per character.
@@ -1979,7 +1959,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 };
 
                 var client = await host.StartOrchestratorAsync(orchestrator, input, this.output);
-                var status = await client.WaitForCompletionAsync(timeout, this.output);
+                var status = await client.WaitForCompletionAsync(this.output);
 
                 Assert.Equal(OrchestrationRuntimeStatus.Completed, status?.RuntimeStatus);
                 await ValidateBlobUrlAsync(client.TaskHubName, client.InstanceId, (string)status.Output);
@@ -2000,7 +1980,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 await host.StartAsync();
 
                 var orchestrator = nameof(TestOrchestrations.CallOrchestrator);
-                var timeout = Debugger.IsAttached ? TimeSpan.FromMinutes(5) : TimeSpan.FromSeconds(30);
 
                 var input = new StartOrchestrationArgs
                 {
@@ -2010,7 +1989,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 };
 
                 var client = await host.StartOrchestratorAsync(orchestrator, input, this.output);
-                var status = await client.WaitForStartupAsync(timeout, this.output);
+                var status = await client.WaitForStartupAsync(this.output);
 
                 Assert.Equal(OrchestrationRuntimeStatus.Running, status?.RuntimeStatus);
 
@@ -2018,7 +1997,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 await Task.Delay(TimeSpan.FromSeconds(5));
                 await client.InnerClient.RaiseEventAsync(input.InstanceId, "approval", true);
 
-                status = await client.WaitForCompletionAsync(timeout, this.output);
+                status = await client.WaitForCompletionAsync(this.output);
                 Assert.Equal("Approved", status?.Output);
 
                 await host.StopAsync();
@@ -2041,7 +2020,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 await host.StartAsync();
 
                 var client = await host.StartOrchestratorAsync(nameof(TestOrchestrations.SetStatus), null, this.output);
-                await client.WaitForStartupAsync(TimeSpan.FromSeconds(10), this.output);
+                await client.WaitForStartupAsync(this.output);
 
                 DurableOrchestrationStatus orchestrationStatus = await client.GetStatusAsync();
                 Assert.Equal(JTokenType.Null, orchestrationStatus.CustomStatus?.Type);
@@ -2058,7 +2037,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 // Test setting the custom status to a complex object.
                 var newCustomStatus = new { Foo = "Bar", Count = 2, };
                 await client.RaiseEventAsync("UpdateStatus", newCustomStatus, this.output);
-                orchestrationStatus = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(10), this.output);
+                orchestrationStatus = await client.WaitForCompletionAsync(this.output);
                 Assert.Equal(newCustomStatus.Foo, (string)orchestrationStatus.CustomStatus["Foo"]);
                 Assert.Equal(newCustomStatus.Count, (int)orchestrationStatus.CustomStatus["Count"]);
                 Assert.Equal(OrchestrationRuntimeStatus.Completed, orchestrationStatus?.RuntimeStatus);
@@ -2077,7 +2056,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
                 // Start a dummy orchestration just to help us get a client object
                 var client = await host.StartOrchestratorAsync(nameof(TestOrchestrations.SayHelloInline), null, this.output);
-                await client.WaitForCompletionAsync(TimeSpan.FromSeconds(30), this.output);
+                await client.WaitForCompletionAsync(this.output);
 
                 string bogusInstanceId = "BOGUS_" + Guid.NewGuid().ToString("N");
                 this.output.WriteLine($"Fetching status for fake instance: {bogusInstanceId}");
@@ -2132,7 +2111,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                     nameof(TestOrchestrations.GetDurableOrchestrationStatus),
                     input,
                     this.output);
-                DurableOrchestrationStatus desereliazedStatus = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(30), this.output);
+                DurableOrchestrationStatus desereliazedStatus = await client.WaitForCompletionAsync(this.output);
 
                 Assert.NotNull(desereliazedStatus);
                 Assert.Equal(OrchestrationRuntimeStatus.Completed, desereliazedStatus.RuntimeStatus);
@@ -2166,7 +2145,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 await host.StartAsync();
 
                 var client = await host.StartOrchestratorAsync(orchestratorFunctionNames[0], null, this.output);
-                var status = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(30), this.output);
+                var status = await client.WaitForCompletionAsync(this.output);
 
                 Assert.Equal(OrchestrationRuntimeStatus.Completed, status?.RuntimeStatus);
                 HttpManagementPayload httpManagementPayload = status.Output.ToObject<HttpManagementPayload>();
@@ -2198,7 +2177,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 await host.StartAsync();
 
                 var client = await host.StartOrchestratorAsync(orchestratorFunctionNames[0], "World", this.output);
-                var status = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(30), this.output);
+                var status = await client.WaitForCompletionAsync(this.output);
 
                 HttpManagementPayload httpManagementPayload = client.InnerClient.CreateHttpManagementPayload(status.InstanceId);
                 ValidateHttpManagementPayload(httpManagementPayload, extendedSessions, "OrchestrationClientGetsHttpManagementPayload");
@@ -2265,7 +2244,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 // The end message will cause the actor to complete itself.
                 await client2.RaiseEventAsync(taskHubName1, instanceId, "operation", "end", this.output);
 
-                status = await client1.WaitForCompletionAsync(TimeSpan.FromSeconds(10), this.output);
+                status = await client1.WaitForCompletionAsync(this.output);
 
                 Assert.Equal(OrchestrationRuntimeStatus.Completed, status?.RuntimeStatus);
                 Assert.Equal(3, (int)status?.Output);
@@ -2303,7 +2282,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 await client2.RaiseEventAsync(taskHubName1, instanceId, "done", null, this.output);
 
                 // Make sure it actually completed
-                var status = await client1.WaitForCompletionAsync(TimeSpan.FromSeconds(10), this.output);
+                var status = await client1.WaitForCompletionAsync(this.output);
                 Assert.Equal(OrchestrationRuntimeStatus.Completed, status?.RuntimeStatus);
                 Assert.Equal(2, (int)status.Output);
 
@@ -2328,7 +2307,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 string instanceId = Guid.NewGuid().ToString();
                 string message = GenerateMediumRandomStringPayload().ToString();
                 TestOrchestratorClient client = await host.StartOrchestratorAsync(nameof(TestOrchestrations.EchoWithActivity), message, this.output, instanceId);
-                var status = await client.WaitForCompletionAsync(TimeSpan.FromMinutes(2), this.output);
+                var status = await client.WaitForCompletionAsync(this.output, timeout: TimeSpan.FromMinutes(2));
                 Assert.Equal(OrchestrationRuntimeStatus.Completed, status?.RuntimeStatus);
 
                 DurableOrchestrationStatus orchestrationStatus = await client.GetStatusAsync(true);
@@ -2369,7 +2348,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
                 string firstInstanceId = Guid.NewGuid().ToString();
                 var client = await host.StartOrchestratorAsync(nameof(TestOrchestrations.FanOutFanIn), 50, this.output, firstInstanceId);
-                await client.WaitForCompletionAsync(TimeSpan.FromSeconds(30), this.output);
+                await client.WaitForCompletionAsync(this.output);
 
                 var status = await client.InnerClient.GetStatusAsync(firstInstanceId, true);
                 Assert.Equal(OrchestrationRuntimeStatus.Completed, status?.RuntimeStatus);
@@ -2378,7 +2357,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
                 string secondInstanceId = Guid.NewGuid().ToString();
                 client = await host.StartOrchestratorAsync(nameof(TestOrchestrations.FanOutFanIn), 50, this.output, secondInstanceId);
-                await client.WaitForCompletionAsync(TimeSpan.FromSeconds(30), this.output);
+                await client.WaitForCompletionAsync(this.output);
 
                 status = await client.InnerClient.GetStatusAsync(secondInstanceId, true);
                 Assert.Equal(OrchestrationRuntimeStatus.Completed, status?.RuntimeStatus);
@@ -2387,7 +2366,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
                 string thirdInstanceId = Guid.NewGuid().ToString();
                 client = await host.StartOrchestratorAsync(nameof(TestOrchestrations.FanOutFanIn), 50, this.output, thirdInstanceId);
-                await client.WaitForCompletionAsync(TimeSpan.FromSeconds(30), this.output);
+                await client.WaitForCompletionAsync(this.output);
 
                 status = await client.InnerClient.GetStatusAsync(thirdInstanceId, true);
                 Assert.Equal(OrchestrationRuntimeStatus.Completed, status?.RuntimeStatus);
@@ -2397,7 +2376,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 string fourthInstanceId = Guid.NewGuid().ToString();
                 string message = GenerateMediumRandomStringPayload().ToString();
                 client = await host.StartOrchestratorAsync(nameof(TestOrchestrations.EchoWithActivity), message, this.output, fourthInstanceId);
-                await client.WaitForCompletionAsync(TimeSpan.FromMinutes(2), this.output);
+                await client.WaitForCompletionAsync(this.output, timeout: TimeSpan.FromMinutes(2));
 
                 status = await client.InnerClient.GetStatusAsync(fourthInstanceId, true);
                 Assert.Equal(OrchestrationRuntimeStatus.Completed, status?.RuntimeStatus);
@@ -2453,7 +2432,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
                 string firstInstanceId = Guid.NewGuid().ToString();
                 var client = await host.StartOrchestratorAsync(nameof(TestOrchestrations.FanOutFanIn), 50, this.output, firstInstanceId);
-                await client.WaitForCompletionAsync(TimeSpan.FromSeconds(30), this.output);
+                await client.WaitForCompletionAsync(this.output);
 
                 var status = await client.InnerClient.GetStatusAsync(firstInstanceId, true);
                 Assert.Equal(OrchestrationRuntimeStatus.Completed, status?.RuntimeStatus);
@@ -2465,7 +2444,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
                 string secondInstanceId = Guid.NewGuid().ToString();
                 client = await host.StartOrchestratorAsync(nameof(TestOrchestrations.FanOutFanIn), 50, this.output, secondInstanceId);
-                await client.WaitForCompletionAsync(TimeSpan.FromSeconds(30), this.output);
+                await client.WaitForCompletionAsync(this.output);
 
                 status = await client.InnerClient.GetStatusAsync(secondInstanceId, true);
                 Assert.Equal(OrchestrationRuntimeStatus.Completed, status?.RuntimeStatus);
@@ -2474,7 +2453,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
                 string thirdInstanceId = Guid.NewGuid().ToString();
                 client = await host.StartOrchestratorAsync(nameof(TestOrchestrations.FanOutFanIn), 50, this.output, thirdInstanceId);
-                await client.WaitForCompletionAsync(TimeSpan.FromSeconds(30), this.output);
+                await client.WaitForCompletionAsync(this.output);
 
                 status = await client.InnerClient.GetStatusAsync(thirdInstanceId, true);
                 Assert.Equal(OrchestrationRuntimeStatus.Completed, status?.RuntimeStatus);

--- a/test/Common/DurableTaskLifeCycleNotificationTest.cs
+++ b/test/Common/DurableTaskLifeCycleNotificationTest.cs
@@ -97,7 +97,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                     "World",
                     this.output,
                     createdInstanceId);
-                var status = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(30), this.output);
+                var status = await client.WaitForCompletionAsync(this.output);
 
                 Assert.Equal(OrchestrationRuntimeStatus.Completed, status?.RuntimeStatus);
                 Assert.Equal("World", status?.Input);
@@ -184,7 +184,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                     null,
                     this.output,
                     createdInstanceId);
-                var status = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(30), this.output);
+                var status = await client.WaitForCompletionAsync(this.output);
 
                 Assert.Equal(OrchestrationRuntimeStatus.Failed, status?.RuntimeStatus);
                 Assert.True(status?.Output.ToString().Contains("Value cannot be null"));
@@ -271,10 +271,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                     this.output,
                     createdInstanceId);
 
-                await client.WaitForStartupAsync(TimeSpan.FromSeconds(30), this.output);
+                await client.WaitForStartupAsync(this.output);
                 await client.TerminateAsync("sayōnara");
 
-                var status = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(30), this.output);
+                var status = await client.WaitForCompletionAsync(this.output);
 
                 Assert.Equal(OrchestrationRuntimeStatus.Terminated, status?.RuntimeStatus);
                 Assert.Equal("sayōnara", status?.Output);
@@ -344,7 +344,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                     "World",
                     this.output,
                     createdInstanceId);
-                var status = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(30), this.output);
+                var status = await client.WaitForCompletionAsync(this.output);
 
                 eventGridRequestValidators.ForEach(v => v.Invoke());
 
@@ -402,7 +402,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                     "World",
                     this.output,
                     createdInstanceId);
-                var status = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(30), this.output);
+                var status = await client.WaitForCompletionAsync(this.output);
 
                 eventGridRequestValidators.ForEach(v => v.Invoke());
 
@@ -461,7 +461,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                     null,
                     this.output,
                     createdInstanceId);
-                var status = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(30), this.output);
+                var status = await client.WaitForCompletionAsync(this.output);
 
                 eventGridRequestValidators.ForEach(v => v.Invoke());
 
@@ -522,10 +522,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                     this.output,
                     createdInstanceId);
 
-                await client.WaitForStartupAsync(TimeSpan.FromSeconds(30), this.output);
+                await client.WaitForStartupAsync(this.output);
                 await client.TerminateAsync("sayōnara");
 
-                var status = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(30), this.output);
+                var status = await client.WaitForCompletionAsync(this.output);
 
                 eventGridRequestValidators.ForEach(v => v.Invoke());
 
@@ -600,7 +600,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                     "World",
                     this.output,
                     createdInstanceId);
-                var status = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(30), this.output);
+                var status = await client.WaitForCompletionAsync(this.output);
 
                 Assert.Equal(OrchestrationRuntimeStatus.Completed, status?.RuntimeStatus);
                 Assert.Equal("World", status?.Input);
@@ -869,7 +869,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 await host.StartAsync();
 
                 var client = await host.StartOrchestratorAsync(orchestratorFunctionNames[0], "World", this.output);
-                var status = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(30), this.output);
+                var status = await client.WaitForCompletionAsync(this.output);
 
                 Assert.Equal(OrchestrationRuntimeStatus.Completed, status?.RuntimeStatus);
                 Assert.Equal("World", status?.Input);
@@ -948,7 +948,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 await host.StartAsync();
 
                 var client = await host.StartOrchestratorAsync(orchestratorFunctionNames[0], "World", this.output);
-                var status = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(30), this.output);
+                var status = await client.WaitForCompletionAsync(this.output);
 
                 Assert.Equal(OrchestrationRuntimeStatus.Completed, status?.RuntimeStatus);
                 Assert.Equal("World", status?.Input);
@@ -1018,7 +1018,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 await host.StartAsync();
 
                 var client = await host.StartOrchestratorAsync(orchestratorFunctionNames[0], "World", this.output);
-                var status = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(300), this.output);
+                var status = await client.WaitForCompletionAsync(this.output);
 
                 Assert.Equal(OrchestrationRuntimeStatus.Completed, status?.RuntimeStatus);
                 Assert.Equal("World", status?.Input);
@@ -1088,7 +1088,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 await host.StartAsync();
 
                 var client = await host.StartOrchestratorAsync(orchestratorFunctionNames[0], "World", this.output);
-                var status = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(300), this.output);
+                var status = await client.WaitForCompletionAsync(this.output);
 
                 Assert.Equal(OrchestrationRuntimeStatus.Completed, status?.RuntimeStatus);
                 Assert.Equal("World", status?.Input);
@@ -1182,7 +1182,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 await host.StartAsync();
 
                 var client = await host.StartOrchestratorAsync(orchestratorFunctionNames[0], "World", this.output);
-                var status = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(30), this.output);
+                var status = await client.WaitForCompletionAsync(this.output);
 
                 Assert.Equal(OrchestrationRuntimeStatus.Completed, status?.RuntimeStatus);
                 Assert.Equal("World", status?.Input);


### PR DESCRIPTION
This is expected to help with https://github.com/Azure/azure-functions-durable-extension/issues/646 because many failed tests seem to just need more time. The reason they need more time is not always understood but a lot of it seems to do with partition management operations.