### PR TITLE
Signal or call actors using interfaces and reflection (step 1)

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/EntityScheduler/Entity.cs
+++ b/src/WebJobs.Extensions.DurableTask/EntityScheduler/Entity.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using Microsoft.Azure.WebJobs.Extensions.DurableTask;
+
+namespace Microsoft.Azure.WebJobs
+{
+    /// <summary>
+    /// Statically accessible context for entity operations.
+    /// </summary>
+    public static class Entity
+    {
+        private static readonly AsyncLocal<IDurableEntityContext> EntityContext
+            = new AsyncLocal<IDurableEntityContext>();
+
+        /// <summary>
+        /// The context of the currently executing entity.
+        /// </summary>
+        public static IDurableEntityContext Context => EntityContext.Value;
+
+        /// <summary>
+        /// The key of the currently executing entity.
+        /// </summary>
+        public static string Key => EntityContext.Value.Key;
+
+        /// <summary>
+        /// The entity reference for the currently executing entity.
+        /// </summary>
+        public static EntityId Self => EntityContext.Value.Self;
+
+        internal static void SetContext(IDurableEntityContext context)
+        {
+            EntityContext.Value = context;
+        }
+    }
+}

--- a/src/WebJobs.Extensions.DurableTask/EntityScheduler/Entity.cs
+++ b/src/WebJobs.Extensions.DurableTask/EntityScheduler/Entity.cs
@@ -20,21 +20,25 @@ namespace Microsoft.Azure.WebJobs
         /// <summary>
         /// The context of the currently executing entity.
         /// </summary>
-        public static IDurableEntityContext Context => EntityContext.Value;
-
-        /// <summary>
-        /// The key of the currently executing entity.
-        /// </summary>
-        public static string Key => EntityContext.Value.Key;
-
-        /// <summary>
-        /// The entity reference for the currently executing entity.
-        /// </summary>
-        public static EntityId Self => EntityContext.Value.Self;
+        public static IDurableEntityContext Current => EntityContext.Value;
 
         internal static void SetContext(IDurableEntityContext context)
         {
             EntityContext.Value = context;
+        }
+
+        /// <summary>
+        /// Sets the current context to a mocked context for unit testing.
+        /// </summary>
+        /// <param name="mockContext">The mocked context.</param>
+        public static void SetMockContext(IDurableEntityContext mockContext)
+        {
+            if (mockContext is DurableEntityContext)
+            {
+                throw new InvalidOperationException("Only mocked entity contexts are supported, not real ones.");
+            }
+
+            EntityContext.Value = mockContext;
         }
     }
 }

--- a/src/WebJobs.Extensions.DurableTask/EntityScheduler/TypedInvocationExtensions.cs
+++ b/src/WebJobs.Extensions.DurableTask/EntityScheduler/TypedInvocationExtensions.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Azure.WebJobs
         /// <returns>A task that completes when the dispatched operation has finished.</returns>
         /// <exception cref="AmbiguousMatchException">If there is more than one method with the given operation name.</exception>
         /// <exception cref="MissingMethodException">If there is no method with the given operation name.</exception>
-        /// <exception cref="InvalidCastException">If the method has more than one argument.</exception>
+        /// <exception cref="InvalidOperationException">If the method has more than one argument.</exception>
         /// <remarks>
         /// If the entity's state is null, an object of type <typeparamref name="T"/> is created first. Then, reflection
         /// is used to try to find a matching method. This match is based on the method name
@@ -46,7 +46,7 @@ namespace Microsoft.Azure.WebJobs
             var parameters = method.GetParameters();
             if (parameters.Length > 1)
             {
-                throw new InvalidCastException("only a single argument can be used for operation input");
+                throw new InvalidOperationException("Only a single argument can be used for operation input.");
             }
 
             object[] args;

--- a/src/WebJobs.Extensions.DurableTask/EntityScheduler/TypedInvocationExtensions.cs
+++ b/src/WebJobs.Extensions.DurableTask/EntityScheduler/TypedInvocationExtensions.cs
@@ -1,0 +1,87 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Runtime.Serialization.Formatters.Binary;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Extensions.DurableTask;
+
+namespace Microsoft.Azure.WebJobs
+{
+    /// <summary>
+    /// Extends the durable entity context to support reflection-based invocation of entity operations.
+    /// </summary>
+    public static class TypedInvocationExtensions
+    {
+        /// <summary>
+        /// Dynamically dispatches the incoming entity operation using reflection.
+        /// </summary>
+        /// <typeparam name="T">The class to use for entity instances.</typeparam>
+        /// <returns>A task that completes when the dispatched operation has finished.</returns>
+        /// <exception cref="AmbiguousMatchException">If there is more than one method with the given operation name.</exception>
+        /// <exception cref="MissingMethodException">If there is no method with the given operation name.</exception>
+        /// <exception cref="InvalidCastException">If the method has more than one argument.</exception>
+        /// <remarks>
+        /// If the entity's state is null, an object of type <typeparamref name="T"/> is created first. Then, reflection
+        /// is used to try to find a matching method. This match is based on the method name
+        /// (which is the operation name) and the argument list (which is the operation content, deserialized into
+        /// an object array).
+        /// </remarks>
+        public static async Task DispatchAsync<T>(this IDurableEntityContext context)
+            where T : new()
+        {
+            // find the method corresponding to the operation
+            // (may throw an AmbiguousMatchException)
+            var method = typeof(T).GetMethod(
+                context.OperationName,
+                System.Reflection.BindingFlags.IgnoreCase
+                | System.Reflection.BindingFlags.Public
+                | System.Reflection.BindingFlags.NonPublic
+                | System.Reflection.BindingFlags.Instance);
+
+            // check that the number of arguments is zero or one
+            var parameters = method.GetParameters();
+            if (parameters.Length > 1)
+            {
+                throw new InvalidCastException("only a single argument can be used for operation input");
+            }
+
+            object[] args;
+            if (parameters.Length == 1)
+            {
+                // determine the expected type of the operation input and deserialize
+                var inputType = method.GetParameters()[0].ParameterType;
+                var input = context.GetInput(inputType);
+                args = new object[1] { input };
+            }
+            else
+            {
+                args = Array.Empty<object>();
+            }
+
+            var state = context.GetState(() => new T());
+
+            object result = method.Invoke(state, args);
+
+            if (method.ReturnType != typeof(void))
+            {
+                if (result is Task task)
+                {
+                    await task;
+
+                    if (task.GetType().IsGenericType)
+                    {
+                        context.Return(task.GetType().GetProperty("Result").GetValue(task));
+                    }
+                }
+                else
+                {
+                    context.Return(result);
+                }
+            }
+        }
+    }
+}

--- a/src/WebJobs.Extensions.DurableTask/Listener/TaskEntityShim.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/TaskEntityShim.cs
@@ -310,6 +310,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             this.context.DestructOnExit = false;
             this.context.IsCompleted = false;
 
+            Entity.SetContext(this.context);
+
             this.Config.TraceHelper.FunctionStarting(
                 this.context.HubName,
                 this.context.Name,
@@ -356,6 +358,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     functionType: FunctionType.Entity,
                     isReplay: this.context.IsReplaying);
             }
+
+            Entity.SetContext(null);
 
             // read and clear context
             var response = this.context.CurrentOperationResponse;

--- a/src/WebJobs.Extensions.DurableTask/Listener/TaskEntityShim.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/TaskEntityShim.cs
@@ -310,6 +310,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             this.context.DestructOnExit = false;
             this.context.IsCompleted = false;
 
+            // set the async-local static context that is visible to the application code
             Entity.SetContext(this.context);
 
             this.Config.TraceHelper.FunctionStarting(
@@ -359,6 +360,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     isReplay: this.context.IsReplaying);
             }
 
+            // clear the async-local static context that is visible to the application code
             Entity.SetContext(null);
 
             // read and clear context

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
@@ -2119,19 +2119,9 @@
             Statically accessible context for entity operations.
             </summary>
         </member>
-        <member name="P:Microsoft.Azure.WebJobs.Entity.Context">
+        <member name="P:Microsoft.Azure.WebJobs.Entity.Current">
             <summary>
             The context of the currently executing entity.
-            </summary>
-        </member>
-        <member name="P:Microsoft.Azure.WebJobs.Entity.Key">
-            <summary>
-            The key of the currently executing entity.
-            </summary>
-        </member>
-        <member name="P:Microsoft.Azure.WebJobs.Entity.Self">
-            <summary>
-            The entity reference for the currently executing entity.
             </summary>
         </member>
         <member name="T:Microsoft.Azure.WebJobs.EntityCurrentOperationStatus">
@@ -2231,7 +2221,7 @@
             <returns>A task that completes when the dispatched operation has finished.</returns>
             <exception cref="T:System.Reflection.AmbiguousMatchException">If there is more than one method with the given operation name.</exception>
             <exception cref="T:System.MissingMethodException">If there is no method with the given operation name.</exception>
-            <exception cref="T:System.InvalidCastException">If the method has more than one argument.</exception>
+            <exception cref="T:System.InvalidOperationException">If the method has more than one argument.</exception>
             <remarks>
             If the entity's state is null, an object of type <typeparamref name="T"/> is created first. Then, reflection
             is used to try to find a matching method. This match is based on the method name

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
@@ -2114,6 +2114,26 @@
             The output as a <c>JArray</c> object or <c>null</c>.
             </value>
         </member>
+        <member name="T:Microsoft.Azure.WebJobs.Entity">
+            <summary>
+            Statically accessible context for entity operations.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.Entity.Context">
+            <summary>
+            The context of the currently executing entity.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.Entity.Key">
+            <summary>
+            The key of the currently executing entity.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.Entity.Self">
+            <summary>
+            The entity reference for the currently executing entity.
+            </summary>
+        </member>
         <member name="T:Microsoft.Azure.WebJobs.EntityCurrentOperationStatus">
             <summary>
             Information about the current status of an operation executing on an entity.
@@ -2197,6 +2217,27 @@
             <summary>
             The exception that is thrown when application code violates the locking rules.
             </summary>
+        </member>
+        <member name="T:Microsoft.Azure.WebJobs.TypedInvocationExtensions">
+            <summary>
+            Extends the durable entity context to support reflection-based invocation of entity operations.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.TypedInvocationExtensions.DispatchAsync``1(Microsoft.Azure.WebJobs.IDurableEntityContext)">
+            <summary>
+            Dynamically dispatches the incoming entity operation using reflection.
+            </summary>
+            <typeparam name="T">The class to use for entity instances.</typeparam>
+            <returns>A task that completes when the dispatched operation has finished.</returns>
+            <exception cref="T:System.Reflection.AmbiguousMatchException">If there is more than one method with the given operation name.</exception>
+            <exception cref="T:System.MissingMethodException">If there is no method with the given operation name.</exception>
+            <exception cref="T:System.InvalidCastException">If the method has more than one argument.</exception>
+            <remarks>
+            If the entity's state is null, an object of type <typeparamref name="T"/> is created first. Then, reflection
+            is used to try to find a matching method. This match is based on the method name
+            (which is the operation name) and the argument list (which is the operation content, deserialized into
+            an object array).
+            </remarks>
         </member>
         <member name="T:Microsoft.Azure.WebJobs.FunctionFailedException">
             <summary>

--- a/test/Common/DurableTaskEndToEndTests.cs
+++ b/test/Common/DurableTaskEndToEndTests.cs
@@ -2706,6 +2706,39 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             }
         }
 
+        /// <summary>
+        /// End-to-end test which validates basic use of the object dispatch feature.
+        /// </summary>
+        [Theory]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task DurableEntity_BasicObjects(bool extendedSessions)
+        {
+            string[] orchestratorFunctionNames =
+            {
+                nameof(TestOrchestrations.BasicObjects),
+            };
+            using (var host = TestHelpers.GetJobHost(
+                this.loggerProvider,
+                nameof(this.DurableEntity_BasicObjects),
+                extendedSessions))
+            {
+                await host.StartAsync();
+
+                var chatroom = new EntityId(nameof(TestEntityClasses.ChatRoom), Guid.NewGuid().ToString());
+
+                var client = await host.StartOrchestratorAsync(orchestratorFunctionNames[0], chatroom, this.output);
+
+                var status = await client.WaitForCompletionAsync(this.output);
+
+                Assert.Equal(OrchestrationRuntimeStatus.Completed, status?.RuntimeStatus);
+                Assert.Equal("ok", status?.Output);
+
+                await host.StopAsync();
+            }
+        }
+
         [Theory]
         [Trait("Category", PlatformSpecificHelpers.FlakeyTestCategory)]
         [MemberData(nameof(TestDataGenerator.GetExtendedSessionAndFullFeaturedStorageProviderOptions), MemberType = typeof(TestDataGenerator))]

--- a/test/Common/TestEntities.cs
+++ b/test/Common/TestEntities.cs
@@ -288,59 +288,5 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 return (int)response.StatusCode;
             }
         }
-
-        //-------------- an entity representing a chat room -----------------
-        // this example shows how to use reflection to define entities using a C# class.
-
-        public static void ChatRoomEntity([EntityTrigger(EntityName = "ChatRoom")] IDurableEntityContext context)
-        {
-            // if the entity is fresh call the constructor for the state
-            if (context.IsNewlyConstructed)
-            {
-                context.SetState(new ChatRoom(context));
-            }
-
-            // find the method corresponding to the operation
-            var method = typeof(ChatRoom).GetMethod(context.OperationName);
-
-            // determine the type of the operation content (= second method argument) and deserialize
-            var contentType = method.GetParameters()[1].ParameterType;
-            var content = context.GetInput(contentType);
-
-            // invoke the method and return the result;
-            var result = method.Invoke(context.GetState<ChatRoom>(), new object[2] { context, content });
-            context.Return(result);
-        }
-
-        public class ChatRoom
-        {
-            public ChatRoom(IDurableEntityContext ctx)
-            {
-                this.ChatEntries = new SortedDictionary<DateTime, string>();
-            }
-
-            public SortedDictionary<DateTime, string> ChatEntries { get; set; }
-
-            // an operation that adds a message to the chat
-            public DateTime Post(IDurableEntityContext ctx, string content)
-            {
-                var timestamp = DateTime.UtcNow;
-                this.ChatEntries.Add(timestamp, content);
-                return timestamp;
-            }
-
-            // an operation that reads all messages in the chat, within range
-            public List<KeyValuePair<DateTime, string>> Read(IDurableEntityContext ctx, DateTime? fromRange)
-            {
-                if (fromRange.HasValue)
-                {
-                    return this.ChatEntries.Where(kvp => kvp.Key >= fromRange.Value).ToList();
-                }
-                else
-                {
-                    return this.ChatEntries.ToList();
-                }
-            }
-        }
     }
 }

--- a/test/Common/TestEntityClasses.cs
+++ b/test/Common/TestEntityClasses.cs
@@ -1,0 +1,59 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
+{
+    public class TestEntityClasses
+    {
+        //-------------- an entity representing a chat room -----------------
+        // this example shows how to use the C# class API for entities.
+
+        public interface IChatRoom
+        {
+            DateTime Post(string content);
+
+            List<KeyValuePair<DateTime, string>> Get();
+        }
+
+        [JsonObject(MemberSerialization.OptIn)]
+        public class ChatRoom : IChatRoom
+        {
+            public ChatRoom()
+            {
+                this.ChatEntries = new SortedDictionary<DateTime, string>();
+            }
+
+            [JsonProperty("chatEntries")]
+            public SortedDictionary<DateTime, string> ChatEntries { get; set; }
+
+            // an operation that adds a message to the chat
+            public DateTime Post(string content)
+            {
+                var timestamp = DateTime.UtcNow;
+                this.ChatEntries.Add(timestamp, content);
+                return timestamp;
+            }
+
+            // an operation that reads all messages in the chat
+            public List<KeyValuePair<DateTime, string>> Get()
+            {
+                return this.ChatEntries.ToList();
+            }
+        }
+
+        [FunctionName(nameof(ChatRoom))]
+        public static Task ChatRoomFunction([EntityTrigger] IDurableEntityContext context)
+        {
+            return context.DispatchAsync<ChatRoom>();
+        }
+    }
+}

--- a/test/Common/TestHelpers.cs
+++ b/test/Common/TestHelpers.cs
@@ -117,6 +117,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 typeof(TestOrchestrations),
                 typeof(TestActivities),
                 typeof(TestEntities),
+                typeof(TestEntityClasses),
                 typeof(ClientFunctions),
             };
 

--- a/test/Common/TestOrchestrations.cs
+++ b/test/Common/TestOrchestrations.cs
@@ -797,5 +797,27 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
             var result = await ctx.CallEntityAsync<List<KeyValuePair<DateTime, string>>>(entity, "Get");
         }
+
+        public static async Task<string> BasicObjects([OrchestrationTrigger] IDurableOrchestrationContext ctx)
+        {
+            var chatroom = ctx.GetInput<EntityId>();
+
+            // signals
+            ctx.SignalEntity(chatroom, "post", "a");
+            ctx.SignalEntity(chatroom, "post", "b");
+
+            // call returning a task, but no result
+            await ctx.CallEntityAsync(chatroom, "post", "c");
+
+            // calls returning a result
+            var result = await ctx.CallEntityAsync<List<KeyValuePair<DateTime, string>>>(chatroom, "get");
+
+            if (string.Join(',', result.Select(kvp => kvp.Value)) != "a,b,c")
+            {
+                return "incorrect result1";
+            }
+
+            return "ok";
+        }
     }
 }


### PR DESCRIPTION
This PR adds a new feature that allows actors to be called or signaled using C# interfaces and reflection. 

On the actor side, incoming operations can be dispatched to the object type representing the actor using reflection, e.g.

```csharp
   ctx.Dispatch<Room>()
```

On the caller side, an operation is chosen by providing a delegate that performs the invocation on an interface, e.g.
```csharp
   ctx.SignalActor<IRoom>(actorId, r => r.MethodToBeCalled(typedArg1, typedArg2))
```
or
```csharp
   var result = await ctx.CallActorAsync<IRoom,int>(actorId, r => r.MethodReturningInteger())
```
