### PR TITLE
Restore v1 Azure Storage default behavior to v2

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/Options/DurableTaskOptions.cs
+++ b/src/WebJobs.Extensions.DurableTask/Options/DurableTaskOptions.cs
@@ -227,6 +227,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 throw new InvalidOperationException($"A non-empty {nameof(this.HubName)} configuration is required.");
             }
 
+            if (this.StorageProvider == null)
+            {
+                this.StorageProvider = new StorageProviderOptions();
+            }
+
             this.StorageProvider.Validate();
 
             // Each storage provider may have its own limitations for task hub names due to provider naming restrictions

--- a/src/WebJobs.Extensions.DurableTask/Options/StorageProviderOptions.cs
+++ b/src/WebJobs.Extensions.DurableTask/Options/StorageProviderOptions.cs
@@ -31,12 +31,20 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Options
             {
                 var storageProviderOptions = new CommonStorageProviderOptions[] { this.AzureStorage, this.Emulator };
                 var activeProviders = storageProviderOptions.Where(provider => provider != null);
-                if (activeProviders.Count() != 1)
+                if (!activeProviders.Any())
                 {
-                    throw new InvalidOperationException("There must be exactly one storage provider configured.");
+                    // Assume azure storage with defaults
+                    this.AzureStorage = new AzureStorageOptions();
+                    this.configuredProvider = this.AzureStorage;
                 }
-
-                this.configuredProvider = activeProviders.First();
+                else if (activeProviders.Count() > 1)
+                {
+                    throw new InvalidOperationException("Only one storage provider can be configured per function application.");
+                }
+                else
+                {
+                    this.configuredProvider = activeProviders.First();
+                }
             }
 
             return this.configuredProvider;

--- a/test/Common/TestHelpers.cs
+++ b/test/Common/TestHelpers.cs
@@ -21,6 +21,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         public const string AzureStorageProviderType = "azure_storage";
         public const string EmulatorProviderType = "emulator";
         public const string LogCategory = "Host.Triggers.DurableTask";
+        public const string EmptyStorageProviderType = "empty";
 
         public static JobHost GetJobHost(
             ILoggerProvider loggerProvider,
@@ -41,7 +42,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         {
             var durableTaskOptions = new DurableTaskOptions
             {
-                StorageProvider = new StorageProviderOptions(),
+
                 HubName = GetTaskHubNameFromTestName(testName, enableExtendedSessions),
                 TraceInputsAndOutputs = true,
                 EventGridKeySettingName = eventGridKeySettingName,
@@ -55,17 +56,19 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 EventGridPublishEventTypes = eventGridPublishEventTypes,
             };
 
+            if (storageProviderType != null)
+            {
+                durableTaskOptions.StorageProvider = new StorageProviderOptions();
+            }
+
             if (string.Equals(storageProviderType, AzureStorageProviderType))
             {
+
                 durableTaskOptions.StorageProvider.AzureStorage = new AzureStorageOptions();
             }
             else if (string.Equals(storageProviderType, EmulatorProviderType))
             {
                 durableTaskOptions.StorageProvider.Emulator = new EmulatorStorageOptions();
-            }
-            else
-            {
-                throw new ArgumentException("Invalid storage provider type.", nameof(storageProviderType));
             }
 
             if (eventGridRetryCount.HasValue)
@@ -655,7 +658,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             }
         }
 
-        private class TestNameResolver : INameResolver
+        public class TestNameResolver : INameResolver
         {
             private static readonly Dictionary<string, string> DefaultAppSettings = new Dictionary<string, string>(
                 StringComparer.OrdinalIgnoreCase)

--- a/test/Common/TestHelpers.cs
+++ b/test/Common/TestHelpers.cs
@@ -42,7 +42,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         {
             var durableTaskOptions = new DurableTaskOptions
             {
-
                 HubName = GetTaskHubNameFromTestName(testName, enableExtendedSessions),
                 TraceInputsAndOutputs = true,
                 EventGridKeySettingName = eventGridKeySettingName,
@@ -63,7 +62,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
             if (string.Equals(storageProviderType, AzureStorageProviderType))
             {
-
                 durableTaskOptions.StorageProvider.AzureStorage = new AzureStorageOptions();
             }
             else if (string.Equals(storageProviderType, EmulatorProviderType))
@@ -658,7 +656,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             }
         }
 
-        public class TestNameResolver : INameResolver
+        private class TestNameResolver : INameResolver
         {
             private static readonly Dictionary<string, string> DefaultAppSettings = new Dictionary<string, string>(
                 StringComparer.OrdinalIgnoreCase)

--- a/test/FunctionsV2/DurableOptionsConfigurationTests.cs
+++ b/test/FunctionsV2/DurableOptionsConfigurationTests.cs
@@ -1,0 +1,115 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.Azure.Storage;
+using Microsoft.Azure.Storage.Auth;
+using Microsoft.Azure.Storage.Blob;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests;
+using Microsoft.Azure.WebJobs.Host.TestCommon;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace WebJobs.Extensions.DurableTask.Tests.V2
+{
+    public class DurableOptionsConfigurationTests
+    {
+        private readonly ITestOutputHelper output;
+        private readonly TestLoggerProvider loggerProvider;
+
+        public DurableOptionsConfigurationTests(ITestOutputHelper output)
+        {
+            this.output = output;
+            this.loggerProvider = new TestLoggerProvider(output);
+        }
+
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public async Task EmptyStorageProviderUsesAzureStorageDefaults()
+        {
+            string testName = nameof(this.EmptyStorageProviderUsesAzureStorageDefaults).ToLowerInvariant();
+            string defaultConnectionString = TestHelpers.GetStorageConnectionString();
+
+            string blobLeaseContainerName = $"{testName}v2-leases";
+            CloudStorageAccount account = CloudStorageAccount.Parse(defaultConnectionString);
+            CloudBlobClient blobClient = account.CreateCloudBlobClient();
+            CloudBlobContainer blobContainer = blobClient.GetContainerReference(blobLeaseContainerName);
+
+            string[] orchestratorFunctionNames =
+            {
+                nameof(TestOrchestrations.SayHelloInline),
+            };
+
+            using (var host = TestHelpers.GetJobHost(
+                this.loggerProvider,
+                testName,
+                false,
+                storageProviderType: "empty_storage_provider"))
+            {
+                await host.StartAsync();
+
+                var client = await host.StartOrchestratorAsync(orchestratorFunctionNames[0], "World", this.output);
+                var status = await client.WaitForCompletionAsync(this.output);
+
+                Assert.Equal(OrchestrationRuntimeStatus.Completed, status?.RuntimeStatus);
+                Assert.Equal("World", status?.Input);
+                Assert.Equal("Hello, World!", status?.Output);
+
+                await host.StopAsync();
+            }
+
+            // Ensure blobs touched in the last 30 seconds
+            CloudBlockBlob blob = blobContainer.GetBlockBlobReference($"default/{testName}v2-control-00");
+            await blob.FetchAttributesAsync();
+            DateTimeOffset lastModified = blob.Properties.LastModified.Value;
+            DateTimeOffset expectedLastModifiedTimeThreshold = DateTimeOffset.UtcNow.AddSeconds(-30);
+            Assert.True(lastModified > expectedLastModifiedTimeThreshold);
+        }
+
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public async Task NullStorageProviderUsesAzureStorageDefaults()
+        {
+            string testName = nameof(this.NullStorageProviderUsesAzureStorageDefaults).ToLowerInvariant();
+            string defaultConnectionString = TestHelpers.GetStorageConnectionString();
+
+            string blobLeaseContainerName = $"{testName}v2-leases";
+            CloudStorageAccount account = CloudStorageAccount.Parse(defaultConnectionString);
+            CloudBlobClient blobClient = account.CreateCloudBlobClient();
+            CloudBlobContainer blobContainer = blobClient.GetContainerReference(blobLeaseContainerName);
+
+            string[] orchestratorFunctionNames =
+            {
+                nameof(TestOrchestrations.SayHelloInline),
+            };
+
+            using (var host = TestHelpers.GetJobHost(
+                this.loggerProvider,
+                testName,
+                false,
+                storageProviderType: null))
+            {
+                await host.StartAsync();
+
+                var client = await host.StartOrchestratorAsync(orchestratorFunctionNames[0], "World", this.output);
+                var status = await client.WaitForCompletionAsync(this.output);
+
+                Assert.Equal(OrchestrationRuntimeStatus.Completed, status?.RuntimeStatus);
+                Assert.Equal("World", status?.Input);
+                Assert.Equal("Hello, World!", status?.Output);
+
+                await host.StopAsync();
+            }
+
+            // Ensure blobs touched in the last 30 seconds
+            CloudBlockBlob blob = blobContainer.GetBlockBlobReference($"default/{testName}v2-control-00");
+            await blob.FetchAttributesAsync();
+            DateTimeOffset lastModified = blob.Properties.LastModified.Value;
+            DateTimeOffset expectedLastModifiedTimeThreshold = DateTimeOffset.UtcNow.AddSeconds(-30);
+            Assert.True(lastModified > expectedLastModifiedTimeThreshold);
+        }
+    }
+}

--- a/test/FunctionsV2/DurableOptionsConfigurationTests.cs
+++ b/test/FunctionsV2/DurableOptionsConfigurationTests.cs
@@ -2,14 +2,12 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
-using System.IO;
 using System.Threading.Tasks;
-using Microsoft.Azure.Storage;
-using Microsoft.Azure.Storage.Auth;
-using Microsoft.Azure.Storage.Blob;
 using Microsoft.Azure.WebJobs;
 using Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests;
 using Microsoft.Azure.WebJobs.Host.TestCommon;
+using Microsoft.WindowsAzure.Storage;
+using Microsoft.WindowsAzure.Storage.Blob;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -31,12 +29,6 @@ namespace WebJobs.Extensions.DurableTask.Tests.V2
         public async Task EmptyStorageProviderUsesAzureStorageDefaults()
         {
             string testName = nameof(this.EmptyStorageProviderUsesAzureStorageDefaults).ToLowerInvariant();
-            string defaultConnectionString = TestHelpers.GetStorageConnectionString();
-
-            string blobLeaseContainerName = $"{testName}v2-leases";
-            CloudStorageAccount account = CloudStorageAccount.Parse(defaultConnectionString);
-            CloudBlobClient blobClient = account.CreateCloudBlobClient();
-            CloudBlobContainer blobContainer = blobClient.GetContainerReference(blobLeaseContainerName);
 
             string[] orchestratorFunctionNames =
             {
@@ -62,11 +54,7 @@ namespace WebJobs.Extensions.DurableTask.Tests.V2
             }
 
             // Ensure blobs touched in the last 30 seconds
-            CloudBlockBlob blob = blobContainer.GetBlockBlobReference($"default/{testName}v2-control-00");
-            await blob.FetchAttributesAsync();
-            DateTimeOffset lastModified = blob.Properties.LastModified.Value;
-            DateTimeOffset expectedLastModifiedTimeThreshold = DateTimeOffset.UtcNow.AddSeconds(-30);
-            Assert.True(lastModified > expectedLastModifiedTimeThreshold);
+            await AssertTestUsedAzureStorageAsync(testName);
         }
 
         [Fact]
@@ -74,12 +62,6 @@ namespace WebJobs.Extensions.DurableTask.Tests.V2
         public async Task NullStorageProviderUsesAzureStorageDefaults()
         {
             string testName = nameof(this.NullStorageProviderUsesAzureStorageDefaults).ToLowerInvariant();
-            string defaultConnectionString = TestHelpers.GetStorageConnectionString();
-
-            string blobLeaseContainerName = $"{testName}v2-leases";
-            CloudStorageAccount account = CloudStorageAccount.Parse(defaultConnectionString);
-            CloudBlobClient blobClient = account.CreateCloudBlobClient();
-            CloudBlobContainer blobContainer = blobClient.GetContainerReference(blobLeaseContainerName);
 
             string[] orchestratorFunctionNames =
             {
@@ -104,7 +86,17 @@ namespace WebJobs.Extensions.DurableTask.Tests.V2
                 await host.StopAsync();
             }
 
+            await AssertTestUsedAzureStorageAsync(testName);
+        }
+
+        private static async Task AssertTestUsedAzureStorageAsync(string testName)
+        {
             // Ensure blobs touched in the last 30 seconds
+            string defaultConnectionString = TestHelpers.GetStorageConnectionString();
+            string blobLeaseContainerName = $"{testName}v2-leases";
+            CloudStorageAccount account = CloudStorageAccount.Parse(defaultConnectionString);
+            CloudBlobClient blobClient = account.CreateCloudBlobClient();
+            CloudBlobContainer blobContainer = blobClient.GetContainerReference(blobLeaseContainerName);
             CloudBlockBlob blob = blobContainer.GetBlockBlobReference($"default/{testName}v2-control-00");
             await blob.FetchAttributesAsync();
             DateTimeOffset lastModified = blob.Properties.LastModified.Value;

--- a/test/FunctionsV2/WebJobs.Extensions.DurableTask.Tests.V2.csproj
+++ b/test/FunctionsV2/WebJobs.Extensions.DurableTask.Tests.V2.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="4.19.4" />
     <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage" Version="1.6.0" />
+    <PackageReference Include="Microsoft.Azure.Storage.Blob" Version="10.0.1" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="3.0.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" Version="3.0.0" />

--- a/test/FunctionsV2/WebJobs.Extensions.DurableTask.Tests.V2.csproj
+++ b/test/FunctionsV2/WebJobs.Extensions.DurableTask.Tests.V2.csproj
@@ -11,7 +11,6 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="4.19.4" />
     <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage" Version="1.6.0" />
-    <PackageReference Include="Microsoft.Azure.Storage.Blob" Version="10.0.1" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="3.0.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" Version="3.0.0" />


### PR DESCRIPTION
This PR addresses stops throwing exceptions when the host.json either has `storageProvider` as `null` or `{}`.

The new behavior is to default to `Storage`, which is the same behavior as v1 if no connection string was provided.