### PR TITLE
Actor scheduler overhaul

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/ActorScheduler/ReleaseMessage.cs
+++ b/src/WebJobs.Extensions.DurableTask/ActorScheduler/ReleaseMessage.cs
@@ -15,5 +15,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
         [JsonProperty(PropertyName = "id")]
         public string LockRequestId { get; set; }
+
+        public override string ToString()
+        {
+            return $"[Release lock {this.LockRequestId} by {this.ParentInstanceId}]";
+        }
     }
 }

--- a/src/WebJobs.Extensions.DurableTask/ActorScheduler/RequestMessage.cs
+++ b/src/WebJobs.Extensions.DurableTask/ActorScheduler/RequestMessage.cs
@@ -85,5 +85,17 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         {
             return JsonConvert.DeserializeObject(this.Content, contentType);
         }
+
+        public override string ToString()
+        {
+            if (this.IsLockMessage)
+            {
+                return $"[Request lock {this.Id} by {this.ParentInstanceId}, position {this.Position}]";
+            }
+            else
+            {
+                return $"[{(this.IsSignal ? "Signal" : "Call")} '{this.Operation}' operation {this.Id} by {this.ParentInstanceId}]";
+            }
+        }
     }
 }

--- a/src/WebJobs.Extensions.DurableTask/ActorScheduler/ResponseMessage.cs
+++ b/src/WebJobs.Extensions.DurableTask/ActorScheduler/ResponseMessage.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         public string ExceptionType { get; set; }
 
         [JsonIgnore]
-        public bool IsException => ExceptionType != null;
+        public bool IsException => this.ExceptionType != null;
 
         public void SetResult(object result)
         {
@@ -74,6 +74,18 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             else
             {
                 return MessagePayloadDataConverter.Default.Deserialize<T>(this.Result);
+            }
+        }
+
+        public override string ToString()
+        {
+            if (this.IsException)
+            {
+                return $"[ExceptionResponse {this.Result}]";
+            }
+            else
+            {
+                return $"[Response {this.Result}]";
             }
         }
     }

--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableActorContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableActorContext.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
+using System.Collections.Generic;
+using DurableTask.Core;
 using Newtonsoft.Json;
 
 namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
@@ -12,6 +14,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
     internal class DurableActorContext : DurableCommonContext, IDurableActorContext
     {
         private readonly ActorId self;
+
+        private List<OutgoingMessage> outbox;
 
         public DurableActorContext(DurableTaskExtension config, ActorId actor)
             : base(config, actor.ActorClass)
@@ -98,6 +102,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             return newView;
         }
 
+        void IDurableActorContext.SignalActor(ActorId actor, string operationName, object operationContent)
+        {
+            this.ThrowIfInvalidAccess();
+            var alreadyCompletedTask = this.CallDurableTaskFunctionAsync<object>(actor.ActorClass, FunctionType.Actor, true, ActorId.GetSchedulerIdFromActorId(actor), operationName, null, operationContent);
+            System.Diagnostics.Debug.Assert(alreadyCompletedTask.IsCompleted, "signalling actors is synchronous");
+            alreadyCompletedTask.Wait(); // just so we see exceptions during testing
+        }
+
         void IDurableActorContext.Return(object result)
         {
             this.ThrowIfInvalidAccess();
@@ -110,6 +122,56 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             {
                 throw new InvalidOperationException("No operation is being processed.");
             }
+        }
+
+        internal override void SendActorMessage(OrchestrationInstance target, string eventName, object eventContent)
+        {
+            lock (this)
+            {
+                if (this.outbox == null)
+                {
+                    this.outbox = new List<OutgoingMessage>();
+                }
+
+                this.outbox.Add(new OutgoingMessage()
+                {
+                    Target = target,
+                    EventName = eventName,
+                    EventContent = eventContent,
+                });
+            }
+        }
+
+        internal void SendOutbox(OrchestrationContext innerContext)
+        {
+            if (this.outbox != null)
+            {
+                foreach (var message in this.outbox)
+                {
+                    this.Config.TraceHelper.SendingActorMessage(
+                        this.InstanceId,
+                        this.ExecutionId,
+                        message.Target.InstanceId,
+                        message.EventName,
+                        message.EventContent);
+
+                    innerContext.SendEvent(message.Target, message.EventName, message.EventContent);
+                }
+
+                this.outbox.Clear();
+            }
+        }
+
+        internal override Guid NewGuid()
+        {
+            return Guid.NewGuid();
+        }
+
+        private struct OutgoingMessage
+        {
+            public OrchestrationInstance Target;
+            public string EventName;
+            public object EventContent;
         }
     }
 }

--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableActorContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableActorContext.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
     {
         private readonly ActorId self;
 
-        private List<OutgoingMessage> outbox;
+        private List<OutgoingMessage> outbox = new List<OutgoingMessage>();
 
         public DurableActorContext(DurableTaskExtension config, ActorId actor)
             : base(config, actor.ActorClass)
@@ -126,13 +126,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
         internal override void SendActorMessage(OrchestrationInstance target, string eventName, object eventContent)
         {
-            lock (this)
+            lock (this.outbox)
             {
-                if (this.outbox == null)
-                {
-                    this.outbox = new List<OutgoingMessage>();
-                }
-
                 this.outbox.Add(new OutgoingMessage()
                 {
                     Target = target,
@@ -144,7 +139,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
         internal void SendOutbox(OrchestrationContext innerContext)
         {
-            if (this.outbox != null)
+            lock (this.outbox)
             {
                 foreach (var message in this.outbox)
                 {

--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableCommonContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableCommonContext.cs
@@ -32,8 +32,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         private readonly List<Func<Task>> deferredTasks
             = new List<Func<Task>>();
 
-        private int newGuidCounter = 0;
-
         private bool isReplaying;
 
         internal DurableCommonContext(DurableTaskExtension config, string functionName)
@@ -68,6 +66,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         }
 
         internal string InstanceId { get; set; }
+
+        internal string ExecutionId { get; set; }
 
         internal string ParentInstanceId { get; set; }
 
@@ -150,20 +150,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             return alreadyCompletedTask.Result;
         }
 
-        internal Guid NewGuid()
-        {
-            // The name is a combination of the instance ID, the current orchestrator date/time, and a counter.
-            string guidNameValue = string.Concat(
-                this.InstanceId,
-                "_",
-                this.InnerContext.CurrentUtcDateTime.ToString("o"),
-                "_",
-                this.newGuidCounter.ToString());
-
-            this.newGuidCounter++;
-
-            return GuidManager.CreateDeterministicGuid(GuidManager.UrlNamespaceValue, guidNameValue);
-        }
+        internal abstract Guid NewGuid();
 
         internal virtual void ThrowIfInvalidAccess()
         {
@@ -198,6 +185,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             ActorId? lockToUse = null;
             string operationId = string.Empty;
             string operationName = string.Empty;
+            bool isActor = this is DurableActorContext;
 
             switch (functionType)
             {
@@ -205,6 +193,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     System.Diagnostics.Debug.Assert(instanceId == null, "The instanceId parameter should not be used for activity functions.");
                     System.Diagnostics.Debug.Assert(operation == null, "The operation parameter should not be used for activity functions.");
                     System.Diagnostics.Debug.Assert(!oneWay, "The oneWay parameter should not be used for activity functions.");
+                    System.Diagnostics.Debug.Assert(!isActor, "Actors cannot call activities");
                     if (retryOptions == null)
                     {
                         callTask = this.InnerContext.ScheduleTask<TResult>(functionName, version, input);
@@ -222,6 +211,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
                 case FunctionType.Orchestrator:
                     System.Diagnostics.Debug.Assert(operation == null, "The operation parameter should not be used for activity functions.");
+                    System.Diagnostics.Debug.Assert(oneWay || !isActor, "Actors cannot call orchestrations");
                     if (instanceId != null && instanceId.StartsWith("@"))
                     {
                         throw new ArgumentException(nameof(instanceId), "Orchestration instance ids must not start with @");
@@ -263,6 +253,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     System.Diagnostics.Debug.Assert(!string.IsNullOrEmpty(operation), "The operation parameter is required.");
                     System.Diagnostics.Debug.Assert(retryOptions == null, "Retries are not supported for actor calls.");
                     System.Diagnostics.Debug.Assert(instanceId != null, "Actor calls need to specify the target actor.");
+                    System.Diagnostics.Debug.Assert(oneWay || !isActor, "Actors cannot call actors");
 
                     if (this.ContextLocks != null)
                     {
@@ -299,8 +290,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                         request.SetContent(input);
                     }
 
-                    var jrequest = JToken.FromObject(request, MessagePayloadDataConverter.DefaultSerializer);
-                    this.InnerContext.SendEvent(target, "op", jrequest);
+                    this.SendActorMessage(target, "op", request);
 
                     if (!oneWay)
                     {
@@ -399,6 +389,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             return output;
         }
 
+        internal abstract void SendActorMessage(OrchestrationInstance target, string eventName, object eventContent);
+
         internal Task<T> WaitForExternalEvent<T>(string name, string reason)
         {
             lock (this.pendingExternalEvents)
@@ -459,8 +451,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
         internal async Task<TResult> WaitForActorResponse<TResult>(Guid guid, ActorId? lockToUse)
         {
-            string reason = $"WaitForActorResponse:{guid.ToString()}";
-            var response = await this.WaitForExternalEvent<ResponseMessage>(guid.ToString(), reason);
+            var response = await this.WaitForExternalEvent<ResponseMessage>(guid.ToString(), "ActorResponse");
 
             if (lockToUse.HasValue)
             {
@@ -497,6 +488,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                         this.Config.TraceHelper.ActorResponseReceived(
                             this.HubName,
                             this.Name,
+                            this.FunctionType,
                             this.InstanceId,
                             name,
                             this.Config.GetIntputOutputTrace(responseMessage.Result),

--- a/src/WebJobs.Extensions.DurableTask/ContextInterfaces/IDurableActorContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextInterfaces/IDurableActorContext.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Azure.WebJobs
     /// <summary>
     /// Provides functionality for application code implementing an actor operation.
     /// </summary>
-    public interface IDurableActorContext : IDeterministicExecutionContext
+    public interface IDurableActorContext
     {
         /// <summary>
         /// Gets the class of the currently executing actor.
@@ -86,5 +86,13 @@ namespace Microsoft.Azure.WebJobs
         /// Deletes this actor after this operation completes.
         /// </summary>
         void DestructOnExit();
+
+        /// <summary>
+        /// Signals an actor to perform an operation, without waiting for a response. Any result or exception is ignored (fire and forget).
+        /// </summary>
+        /// <param name="actor">The target actor.</param>
+        /// <param name="operationName">The name of the operation.</param>
+        /// <param name="operationContent">The content for the operation.</param>
+        void SignalActor(ActorId actor, string operationName, object operationContent = null);
     }
 }

--- a/src/WebJobs.Extensions.DurableTask/EndToEndTraceHelper.cs
+++ b/src/WebJobs.Extensions.DurableTask/EndToEndTraceHelper.cs
@@ -157,8 +157,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 else
                 {
                     this.logger.LogInformation(
-                        "{instanceId}: Function '{functionName} ({functionType})' started. IsReplay: {isReplay}. OperationName: {operationName}. OperationId: {operationId}. Input: {input}. State: {state}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}. SequenceNumber: {sequenceNumber}.",
-                        instanceId, functionName, functionType, isReplay, operationName, operationId, input, FunctionState.Started, hubName,
+                        "{instanceId}: Function '{functionName} ({functionType})' started '{operationName}' operation {operationId}. IsReplay: {isReplay}. Input: {input}. State: {state}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}. SequenceNumber: {sequenceNumber}.",
+                        instanceId, functionName, functionType, operationName, operationId, isReplay, input, FunctionState.Started, hubName,
                         LocalAppName, LocalSlotName, ExtensionVersion, this.sequenceNumber++);
                 }
             }
@@ -197,8 +197,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 else
                 {
                     this.logger.LogInformation(
-                        "{instanceId}: Function '{functionName} ({functionType})' awaited. IsReplay: {isReplay}. OperationName: {operationName}. OperationId: {operationId}. State: {state}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}. SequenceNumber: {sequenceNumber}.",
-                        instanceId, functionName, functionType, isReplay, operationName, operationId, FunctionState.Awaited, hubName, LocalAppName,
+                        "{instanceId}: Function '{functionName} ({functionType})' awaited '{operationName}' operation {operationId}. IsReplay: {isReplay}. State: {state}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}. SequenceNumber: {sequenceNumber}.",
+                        instanceId, functionName, functionType, operationName, operationId, isReplay, FunctionState.Awaited, hubName, LocalAppName,
                         LocalSlotName, ExtensionVersion, this.sequenceNumber++);
                 }
             }
@@ -270,7 +270,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 else
                 {
                     this.logger.LogInformation(
-                        "{instanceId}: Function '{functionName} ({functionType})' completed. OperationName: {operationName}. OperationId: {operationId}. ContinuedAsNew: {continuedAsNew}. IsReplay: {isReplay}. Output: {output}. State: {state}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}. SequenceNumber: {sequenceNumber}.",
+                        "{instanceId}: Function '{functionName} ({functionType})' completed '{operationName}' operation {operationId}. ContinuedAsNew: {continuedAsNew}. IsReplay: {isReplay}. Output: {output}. State: {state}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}. SequenceNumber: {sequenceNumber}.",
                         instanceId, functionName, functionType, operationName, operationId, continuedAsNew, isReplay, output, FunctionState.Completed,
                         hubName, LocalAppName, LocalSlotName, ExtensionVersion, this.sequenceNumber++);
                 }
@@ -357,8 +357,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 else
                 {
                     this.logger.LogError(
-                        "{instanceId}: Function '{functionName} ({functionType})' failed with an error. Reason: {reason}. OperationName: {operationName}. OperationId: {operationId}. IsReplay: {isReplay}. State: {state}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}. SequenceNumber: {sequenceNumber}.",
-                        instanceId, functionName, functionType, reason, operationName, operationId, isReplay, FunctionState.Failed, hubName,
+                        "{instanceId}: Function '{functionName} ({functionType})' failed '{operationName}' operation {operationId} with an error. Reason: {reason}. IsReplay: {isReplay}. State: {state}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}. SequenceNumber: {sequenceNumber}.",
+                        instanceId, functionName, functionType, operationName, operationId, reason, isReplay, FunctionState.Failed, hubName,
                         LocalAppName, LocalSlotName, ExtensionVersion, this.sequenceNumber++);
                 }
             }
@@ -423,6 +423,32 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             }
         }
 
+        [System.Diagnostics.Conditional("DEBUG")]
+        public void DeliveringActorMessage(
+            string instanceId,
+            string executionId,
+            int eventId,
+            string eventName,
+            object eventContent)
+        {
+            this.logger.LogInformation(
+                              "{instanceId}: delivering message: {eventName} {eventContent} EventId: {eventId} ExecutionId: {executionId} SequenceNumber: {sequenceNumber}.",
+                              instanceId, eventName, eventContent, eventId, executionId, this.sequenceNumber++);
+        }
+
+        [System.Diagnostics.Conditional("DEBUG")]
+        public void SendingActorMessage(
+            string instanceId,
+            string executionId,
+            string targetInstanceId,
+            string eventName,
+            object eventContent)
+        {
+            this.logger.LogInformation(
+                              "{instanceId}: sending message: {eventName} {eventContent}  TargetInstanceId: {targetInstanceId} ExecutionId: {executionId} SequenceNumber: {sequenceNumber}.",
+                              instanceId, eventName, eventContent, targetInstanceId, executionId, this.sequenceNumber++);
+        }
+
         public void ActorOperationQueued(
             string hubName,
             string functionName,
@@ -448,7 +474,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             if (this.ShouldLogEvent(isReplay: isReplay))
             {
                 this.logger.LogInformation(
-                    "{instanceId}: Function '{functionName} ({functionType})' queued '{operationName}' operation. OperationId: {operationId}. State: {state}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}. SequenceNumber: {sequenceNumber}.",
+                    "{instanceId}: Function '{functionName} ({functionType})' queued '{operationName}' operation {operationId}. State: {state}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}. SequenceNumber: {sequenceNumber}.",
                     instanceId, functionName, functionType, operationName, operationId, FunctionState.ExternalEventRaised, hubName,
                     LocalAppName, LocalSlotName, ExtensionVersion, this.sequenceNumber++);
             }
@@ -457,13 +483,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         public void ActorResponseReceived(
             string hubName,
             string functionName,
+            FunctionType functionType,
             string instanceId,
             string operationId,
             string result,
             bool isReplay)
         {
-            FunctionType functionType = FunctionType.Actor;
-
             EtwEventSource.Instance.ActorResponseReceived(
                 hubName,
                 LocalAppName,

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
@@ -1609,6 +1609,14 @@
             Deletes this actor after this operation completes.
             </summary>
         </member>
+        <member name="M:Microsoft.Azure.WebJobs.IDurableActorContext.SignalActor(Microsoft.Azure.WebJobs.ActorId,System.String,System.Object)">
+            <summary>
+            Signals an actor to perform an operation, without waiting for a response. Any result or exception is ignored (fire and forget).
+            </summary>
+            <param name="actor">The target actor.</param>
+            <param name="operationName">The name of the operation.</param>
+            <param name="operationContent">The content for the operation.</param>
+        </member>
         <member name="T:Microsoft.Azure.WebJobs.IDurableOrchestrationClient">
             <summary>
             Provides functionality available to durable orchestration clients.

--- a/test/Common/TestActors.cs
+++ b/test/Common/TestActors.cs
@@ -314,7 +314,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             // an operation that adds a message to the chat
             public DateTime Post(IDurableActorContext ctx, string content)
             {
-                var timestamp = ctx.CurrentUtcDateTime;
+                var timestamp = DateTime.UtcNow;
                 this.ChatEntries.Add(timestamp, content);
                 return timestamp;
             }


### PR DESCRIPTION
Several fixes and improvements to the new actor scheduler.
- add locks to fix race condition between finishing/queueing operations
- keep list of outgoing messages instead of list of orchestrator actions
- change continue-as-new logic so it always processes exactly the batch of messages being delivered
- remove operation limit
- fix the counting of messages, and the waiting for pending operations

Also, some other changes:
- remove `IDeterministicExecutionContext` from `IDurableActorContext` (since it is not deterministic anymore)
- add more precise tracing for actor messages
