### PR TITLE
Simple REST API for durable entities

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableCommonContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableCommonContext.cs
@@ -136,6 +136,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         void IDeterministicExecutionContext.SignalEntity(EntityId entity, string operationName, object operationInput)
         {
             this.ThrowIfInvalidAccess();
+            if (operationName == null)
+            {
+                throw new ArgumentNullException(nameof(operationName));
+            }
+
             var alreadyCompletedTask = this.CallDurableTaskFunctionAsync<object>(entity.EntityName, FunctionType.Entity, true, EntityId.GetSchedulerIdFromEntityId(entity), operationName, null, operationInput);
             System.Diagnostics.Debug.Assert(alreadyCompletedTask.IsCompleted, "signaling entities is synchronous");
             alreadyCompletedTask.Wait(); // just so we see exceptions during testing
@@ -250,7 +255,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     break;
 
                 case FunctionType.Entity:
-                    System.Diagnostics.Debug.Assert(!string.IsNullOrEmpty(operation), "The operation parameter is required.");
+                    System.Diagnostics.Debug.Assert(operation != null, "The operation parameter is required.");
                     System.Diagnostics.Debug.Assert(oneWay || !isEntity, "Entities cannot call entities");
                     System.Diagnostics.Debug.Assert(retryOptions == null, "Retries are not supported for entity calls.");
                     System.Diagnostics.Debug.Assert(instanceId != null, "Entity calls need to specify the target entity.");

--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableEntityContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableEntityContext.cs
@@ -124,6 +124,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         void IDurableEntityContext.SignalEntity(EntityId entity, string operationName, object operationInput)
         {
             this.ThrowIfInvalidAccess();
+            if (operationName == null)
+            {
+                throw new ArgumentNullException(nameof(operationName));
+            }
+
             var alreadyCompletedTask = this.CallDurableTaskFunctionAsync<object>(entity.EntityName, FunctionType.Entity, true, EntityId.GetSchedulerIdFromEntityId(entity), operationName, null, operationInput);
             System.Diagnostics.Debug.Assert(alreadyCompletedTask.IsCompleted, "signalling entities is synchronous");
             alreadyCompletedTask.Wait(); // just so we see exceptions during testing

--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableOrchestrationClient.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableOrchestrationClient.cs
@@ -180,7 +180,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
         private async Task SignalEntityAsync(TaskHubClient client, string hubName, EntityId entityId, string operationName, object operationInput)
         {
-            if (string.IsNullOrEmpty(operationName))
+            if (operationName == null)
             {
                 throw new ArgumentNullException(nameof(operationName));
             }

--- a/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
+++ b/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
@@ -188,28 +188,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     }
                 }
 
-                if (i >= 0 && request.Method == HttpMethod.Post)
-                {
-                    string functionName;
-                    string instanceId = string.Empty;
-
-                    i += OrchestratorsControllerSegment.Length;
-                    nextSlash = path.IndexOf('/', i);
-
-                    if (nextSlash < 0)
-                    {
-                        functionName = path.Substring(i);
-                    }
-                    else
-                    {
-                        functionName = path.Substring(i, nextSlash - i);
-                        i = nextSlash + 1;
-                        instanceId = path.Substring(i);
-                    }
-
-                    return await this.HandleStartOrchestratorRequestAsync(request, functionName, instanceId);
-                }
-
                 i = path.IndexOf(InstancesControllerSegment, StringComparison.OrdinalIgnoreCase);
                 if (i < 0)
                 {


### PR DESCRIPTION
A basic implementation of the feature request #733.

Entities have a path of the form 

- GET operations return the state of the entity, as JSON content, or 404 (NotFound) if the entity does not exist.

- POST operations send a signal to the entity and return 202 (Accepted). 
   - The operation name is given by the query argument `?op=opname`. It is optional and defaults to the empty string.
  - The operation content is retrieved from the content. If the content type is 'application/json', we parse it to make sure it is valid JSON before sending the signal. Otherwise, we consider it to be plain string.