### PR TITLE
add optional initializer argument to GetState

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableEntityContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableEntityContext.cs
@@ -83,14 +83,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             return this.CurrentOperation.GetInput(argumentType);
         }
 
-        T IDurableEntityContext.GetState<T>()
+        T IDurableEntityContext.GetState<T>(Func<T> initializer)
         {
             this.ThrowIfInvalidAccess();
 
             if (!this.StateWasAccessed)
             {
                 var result = (this.State.EntityState == null)
-                    ? default(T)
+                    ? (initializer != null ? initializer() : default(T))
                     : MessagePayloadDataConverter.Default.Deserialize<T>(this.State.EntityState);
                 this.CurrentState = result;
                 this.StateWasAccessed = true;

--- a/src/WebJobs.Extensions.DurableTask/ContextInterfaces/IDurableEntityContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextInterfaces/IDurableEntityContext.cs
@@ -47,10 +47,11 @@ namespace Microsoft.Azure.WebJobs
         /// <summary>
         /// Gets the current state of this entity, for reading and/or updating.
         /// </summary>
-        /// <typeparam name="TState">The JSON-serializable type of the entity state.</typeparam>
+        /// <typeparam name="T">The JSON-serializable type of the entity state.</typeparam>
+        /// <param name="initializer">Provides an initial value to use for the state, instead of default(<typeparamref name="T"/>).</param>
         /// <returns>The current state of this entity.</returns>
         /// <exception cref="InvalidCastException">If the current state has an incompatible type.</exception>
-        TState GetState<TState>();
+        T GetState<T>(Func<T> initializer = null);
 
         /// <summary>
         /// Sets the current state of this entity.

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
@@ -1476,11 +1476,12 @@
             Whether this entity is freshly constructed, i.e. did not exist prior to this operation being called.
             </summary>
         </member>
-        <member name="M:Microsoft.Azure.WebJobs.IDurableEntityContext.GetState``1">
+        <member name="M:Microsoft.Azure.WebJobs.IDurableEntityContext.GetState``1(System.Func{``0})">
             <summary>
             Gets the current state of this entity, for reading and/or updating.
             </summary>
-            <typeparam name="TState">The JSON-serializable type of the entity state.</typeparam>
+            <typeparam name="T">The JSON-serializable type of the entity state.</typeparam>
+            <param name="initializer">Provides an initial value to use for the state, instead of default(<typeparamref name="T"/>).</param>
             <returns>The current state of this entity.</returns>
             <exception cref="T:System.InvalidCastException">If the current state has an incompatible type.</exception>
         </member>


### PR DESCRIPTION
Makes it very easy to specify an initial state for the entity when accessing it via `GetState<T>`.

For example, 

```csharp
   var state = context.GetState(() => new List<int>())
```