### PR TITLE
fix NullReferenceException thrown during IDurableEntityContext.SignalEntity

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableCommonContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableCommonContext.cs
@@ -316,7 +316,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 this.InstanceId,
                 reason: sourceFunctionId,
                 functionType: functionType,
-                isReplay: this.InnerContext.IsReplaying);
+                isReplay: this.IsReplaying);
 
             TResult output;
             Exception exception = null;
@@ -359,7 +359,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             }
             finally
             {
-                if (exception != null && this.InnerContext.IsReplaying)
+                if (exception != null && this.IsReplaying)
                 {
                     // If this were not a replay, then the orchestrator/activity/entity function trigger would have already
                     // emitted a FunctionFailed trace with the full exception details.
@@ -375,7 +375,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 }
             }
 
-            if (this.InnerContext.IsReplaying)
+            if (this.IsReplaying)
             {
                 // If this were not a replay, then the orchestrator/activity/entity function trigger would have already
                 // emitted a FunctionCompleted trace with the actual output details.
@@ -447,7 +447,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                         this.FunctionName,
                         this.InstanceId,
                         reason: $"WaitFor{reason}:{name}",
-                        isReplay: this.InnerContext.IsReplaying);
+                        isReplay: this.IsReplaying);
                 }
 
                 return tcs.Task;

--- a/test/Common/DurableTaskEndToEndTests.cs
+++ b/test/Common/DurableTaskEndToEndTests.cs
@@ -2356,8 +2356,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         }
 
         /// <summary>
-        /// End-to-end test which validates a simple entity scenario which sends a signal, and then polls
-        /// until the signal is delivered.
+        /// End-to-end test which validates a simple entity scenario which sends a signal
+        /// to a relay which forwards it to counter, and polls until the signal is delivered.
         /// </summary>
         [Theory]
         [Trait("Category", PlatformSpecificHelpers.TestCategory)]
@@ -2377,11 +2377,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             {
                 await host.StartAsync();
 
-                var entityId = new EntityId("Counter", Guid.NewGuid().ToString());
+                var relayEntityId = new EntityId("Relay", "");
+                var counterEntityId = new EntityId("Counter", Guid.NewGuid().ToString());
 
-                var client = await host.StartOrchestratorAsync(orchestratorFunctionNames[0], entityId, this.output);
+                var client = await host.StartOrchestratorAsync(orchestratorFunctionNames[0], counterEntityId, this.output);
 
-                await client.InnerClient.SignalEntityAsync(entityId, "increment");
+                await client.InnerClient.SignalEntityAsync(relayEntityId, "", (counterEntityId, "increment"));
 
                 var status = await client.WaitForCompletionAsync(this.output);
 

--- a/test/Common/TestEntities.cs
+++ b/test/Common/TestEntities.cs
@@ -101,6 +101,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             }
         }
 
+        //-------------- An entity that forwards a signal -----------------
+
+        public static void RelayEntity([EntityTrigger(EntityName = "Relay")] IDurableEntityContext context)
+        {
+            var (destination, operation) = context.GetInput<(EntityId, string)>();
+
+            context.SignalEntity(destination, operation);
+        }
+
         //-------------- An entity representing a phone book, using an untyped json object -----------------
 
         public static void PhoneBookEntity([EntityTrigger(EntityName = "PhoneBook")] IDurableEntityContext context)


### PR DESCRIPTION
Fixes a bug where tracing functions throw an exception because `InnerContext` is null with the new scheduler.

This bug was missed by our tests (I found it while testing samples), so I modified one of the tests to catch future regressions.

