### PR TITLE
Prevent sub-orchestrations from using the instance ID of the parent

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/DurableOrchestrationContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableOrchestrationContext.cs
@@ -438,6 +438,15 @@ namespace Microsoft.Azure.WebJobs
 
                     break;
                 case FunctionType.Orchestrator:
+                    // Instance IDs should not be reused when creating sub-orchestrations. This is a best-effort
+                    // check. We cannot easily check the full hierarchy, so we just look at the current orchestration
+                    // and the immediate parent.
+                    if (string.Equals(instanceId, this.InstanceId, StringComparison.OrdinalIgnoreCase) ||
+                        string.Equals(instanceId, this.ParentInstanceId, StringComparison.OrdinalIgnoreCase))
+                    {
+                        throw new ArgumentException("The instance ID of a sub-orchestration must be different than the instance ID of a parent orchestration.");
+                    }
+
                     if (retryOptions == null)
                     {
                         callTask = this.innerContext.CreateSubOrchestrationInstance<TResult>(

--- a/src/WebJobs.Extensions.DurableTask/DurableOrchestrationContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableOrchestrationContext.cs
@@ -442,7 +442,7 @@ namespace Microsoft.Azure.WebJobs
                     // check. We cannot easily check the full hierarchy, so we just look at the current orchestration
                     // and the immediate parent.
                     if (string.Equals(instanceId, this.InstanceId, StringComparison.OrdinalIgnoreCase) ||
-                        string.Equals(instanceId, this.ParentInstanceId, StringComparison.OrdinalIgnoreCase))
+                        (this.ParentInstanceId != null && string.Equals(instanceId, this.ParentInstanceId, StringComparison.OrdinalIgnoreCase)))
                     {
                         throw new ArgumentException("The instance ID of a sub-orchestration must be different than the instance ID of a parent orchestration.");
                     }


### PR DESCRIPTION
Resolves #747 