### PR TITLE
Add legacy compatibility for abstract base classes

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableActivityContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableActivityContext.cs
@@ -10,7 +10,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
     /// <summary>
     /// The default parameter type for activity functions.
     /// </summary>
-    internal class DurableActivityContext : IDurableActivityContext
+    internal class DurableActivityContext : IDurableActivityContext,
+#pragma warning disable 618
+        DurableActivityContextBase // for v1 legacy compatibility.
+#pragma warning restore 618
     {
         private readonly string serializedInput;
 

--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableOrchestrationClient.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableOrchestrationClient.cs
@@ -22,7 +22,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
     /// <summary>
     /// Client for starting, querying, terminating, and raising events to orchestration instances.
     /// </summary>
-    internal class DurableOrchestrationClient : IDurableOrchestrationClient
+    internal class DurableOrchestrationClient : IDurableOrchestrationClient,
+#pragma warning disable 618
+        DurableOrchestrationClientBase // for v1 legacy compatibility.
+#pragma warning restore 618
     {
         private const string DefaultVersion = "";
         private const int MaxInstanceIdLength = 256;

--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableOrchestrationContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableOrchestrationContext.cs
@@ -21,7 +21,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
     /// <summary>
     /// Parameter data for orchestration bindings that can be used to schedule function-based activities.
     /// </summary>
-    internal class DurableOrchestrationContext : DurableCommonContext, IDurableOrchestrationContext
+    internal class DurableOrchestrationContext : DurableCommonContext, IDurableOrchestrationContext,
+#pragma warning disable 618
+        DurableOrchestrationContextBase // for v1 legacy compatibility.
+#pragma warning restore 618
     {
         private const int MaxTimerDurationInDays = 6;
 

--- a/src/WebJobs.Extensions.DurableTask/ContextInterfaces/LegacyCompatibility.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextInterfaces/LegacyCompatibility.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Text;
+
+namespace Microsoft.Azure.WebJobs.Extensions
+{
+    /// <summary>
+    /// Formerly, the abstract base class for DurableOrchestrationContext.
+    /// Now obsolete: use <see cref="IDurableOrchestrationContext"/> instead.
+    /// </summary>
+    [SuppressMessage("StyleCop.CSharp.NamingRules", "SA1302", Justification = "Engineered for v1 legacy compatibility.")]
+    [SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1649", Justification = "Engineered for v1 legacy compatibility.")]
+    [Obsolete("Use IDurableOrchestrationContext instead.")]
+    public interface DurableOrchestrationContextBase : IDurableOrchestrationContext
+    {
+    }
+
+    /// <summary>
+    /// Formerly, the abstract base class for DurableActivityContext.
+    /// Now obsolete: use <see cref="IDurableActivityContext"/> instead.
+    /// </summary>
+    [SuppressMessage("StyleCop.CSharp.NamingRules", "SA1302", Justification = "Engineered for v1 legacy compatibility.")]
+    [Obsolete("Use IDurableOrchestrationContext instead.")]
+    public interface DurableActivityContextBase : IDurableActivityContext
+    {
+    }
+
+    /// <summary>
+    /// Formerly, the abstract base class for DurableOrchestrationClient.
+    /// Now obsolete: use <see cref="IDurableOrchestrationClient"/> instead.
+    /// </summary>
+    [SuppressMessage("StyleCop.CSharp.NamingRules", "SA1302", Justification = "Engineered for v1 legacy compatibility.")]
+    [Obsolete("Use IDurableOrchestrationContext instead.")]
+    public interface DurableOrchestrationClientBase : IDurableOrchestrationClient
+    {
+    }
+}

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
@@ -986,6 +986,24 @@
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.WebJobsConnectionStringProvider.Resolve(System.String)">
             <inheritdoc />
         </member>
+        <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableOrchestrationContextBase">
+            <summary>
+            Formerly, the abstract base class for DurableOrchestrationContext.
+            Now obsolete: use <see cref="T:Microsoft.Azure.WebJobs.IDurableOrchestrationContext"/> instead.
+            </summary>
+        </member>
+        <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableActivityContextBase">
+            <summary>
+            Formerly, the abstract base class for DurableActivityContext.
+            Now obsolete: use <see cref="T:Microsoft.Azure.WebJobs.IDurableActivityContext"/> instead.
+            </summary>
+        </member>
+        <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableOrchestrationClientBase">
+            <summary>
+            Formerly, the abstract base class for DurableOrchestrationClient.
+            Now obsolete: use <see cref="T:Microsoft.Azure.WebJobs.IDurableOrchestrationClient"/> instead.
+            </summary>
+        </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.EntityStatus">
             <summary>
             Information about the current status of an entity. Excludes potentially large data

--- a/test/Common/DurableTaskEndToEndTests.cs
+++ b/test/Common/DurableTaskEndToEndTests.cs
@@ -2286,6 +2286,30 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         }
 
         /// <summary>
+        /// End-to-end test which validates legacy compatibility of orchestration and activity bindings.
+        /// </summary>
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public async Task LegacyBaseClasses()
+        {
+            using (var host = TestHelpers.GetJobHost(
+                this.loggerProvider,
+                nameof(this.LegacyBaseClasses),
+                false))
+            {
+                await host.StartAsync();
+
+                var client = await host.StartOrchestratorAsync(nameof(TestOrchestrations.LegacyOrchestration), null, this.output);
+                var status = await client.WaitForCompletionAsync(this.output);
+
+                Assert.Equal(OrchestrationRuntimeStatus.Completed, status?.RuntimeStatus);
+                Assert.Equal("ok", (string)status?.Output);
+
+                await host.StopAsync();
+            }
+        }
+
+        /// <summary>
         /// End-to-end test which validates a simple entity scenario involving a signal and two calls.
         /// </summary>
         [Theory]

--- a/test/Common/TestActivities.cs
+++ b/test/Common/TestActivities.cs
@@ -136,6 +136,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             return Guid.NewGuid();
         }
 
+#pragma warning disable 618
+        public static Task<string> LegacyActivity([ActivityTrigger] DurableActivityContextBase ctx)
+        {
+            return Task.FromResult("ok");
+        }
+#pragma warning restore 618
+
         public class PlainOldClrObject
         {
             public string Foo { get; set; }

--- a/test/Common/TestOrchestrations.cs
+++ b/test/Common/TestOrchestrations.cs
@@ -518,6 +518,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             return sum;
         }
 
+#pragma warning disable 618
+        public static Task<string> LegacyOrchestration([OrchestrationTrigger] DurableOrchestrationContextBase ctx)
+        {
+            return ctx.CallActivityAsync<string>(nameof(TestActivities.LegacyActivity), null);
+        }
+#pragma warning restore 618
+
         public static async Task<string> SignalAndCallStringStore([OrchestrationTrigger] IDurableOrchestrationContext ctx)
         {
             // construct entity id from entity name and a supplied GUID


### PR DESCRIPTION
This is a little change meant to ease the transition to v2.

Rather than breaking v1 orchestration triggers based on `DurableOrchestrationContextBase` and `DurableActivityContextBase`, this change keeps them defined and functional, but marked as obsolete. So users get warnings that tell them what to do, that they can fix at their leisure.

I think this is better than reverting back to the old scheme because I think public interfaces are usually preferable to public base classes as they keep the options open for how things are implemented internally. 