### PR TITLE
minor renaming in IDurableEntityContext

### DIFF
--- a/samples/v2/entitites-csharp/RideSharing/RideSharing/Entities/UserEntity.cs
+++ b/samples/v2/entitites-csharp/RideSharing/RideSharing/Entities/UserEntity.cs
@@ -18,7 +18,7 @@ namespace RideSharing
         {
             var state = context.GetState(() => new UserStatus()
             {
-                UserId = context.Key,
+                UserId = context.EntityKey,
             });
 
             switch (context.OperationName)
@@ -54,7 +54,7 @@ namespace RideSharing
                         if (state.CurrentRide != null
                             && state.CurrentRide.RideId == rideId)
                         {
-                            if (context.Key == state.CurrentRide.DriverId)
+                            if (context.EntityKey == state.CurrentRide.DriverId)
                             {
                                 // forward signal to rider
                                 context.SignalEntity(

--- a/src/WebJobs.Extensions.DurableTask/Bindings/EntityTriggerAttributeBindingProvider.cs
+++ b/src/WebJobs.Extensions.DurableTask/Bindings/EntityTriggerAttributeBindingProvider.cs
@@ -154,7 +154,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 // TODO figure out what exactly is needed here
                 var contextObject = new JObject(
                     new JProperty("history", history),
-                    new JProperty("entity", ((IDurableEntityContext)arg).Self),
+                    new JProperty("entity", ((IDurableEntityContext)arg).EntityId),
                     new JProperty("isReplaying", arg.IsReplaying));
 
                 return contextObject.ToString();

--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableEntityContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableEntityContext.cs
@@ -41,9 +41,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
         string IDurableEntityContext.EntityName => this.self.EntityName;
 
-        string IDurableEntityContext.Key => this.self.EntityKey;
+        string IDurableEntityContext.EntityKey => this.self.EntityKey;
 
-        EntityId IDurableEntityContext.Self => this.self;
+        EntityId IDurableEntityContext.EntityId => this.self;
 
         internal override FunctionType FunctionType => FunctionType.Entity;
 

--- a/src/WebJobs.Extensions.DurableTask/ContextInterfaces/IDurableEntityContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextInterfaces/IDurableEntityContext.cs
@@ -23,12 +23,12 @@ namespace Microsoft.Azure.WebJobs
         /// <summary>
         /// Gets the key of the currently executing entity.
         /// </summary>
-        string Key { get; }
+        string EntityKey { get; }
 
         /// <summary>
-        /// Gets an entity id for the currently executing entity.
+        /// Gets the id of the currently executing entity.
         /// </summary>
-        EntityId Self { get; }
+        EntityId EntityId { get; }
 
         /// <summary>
         /// Gets the name of the operation that was called.

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
@@ -1501,14 +1501,14 @@
             Gets the name of the currently executing entity.
             </summary>
         </member>
-        <member name="P:Microsoft.Azure.WebJobs.IDurableEntityContext.Key">
+        <member name="P:Microsoft.Azure.WebJobs.IDurableEntityContext.EntityKey">
             <summary>
             Gets the key of the currently executing entity.
             </summary>
         </member>
-        <member name="P:Microsoft.Azure.WebJobs.IDurableEntityContext.Self">
+        <member name="P:Microsoft.Azure.WebJobs.IDurableEntityContext.EntityId">
             <summary>
-            Gets an entity id for the currently executing entity.
+            Gets the id of the currently executing entity.
             </summary>
         </member>
         <member name="P:Microsoft.Azure.WebJobs.IDurableEntityContext.OperationName">

--- a/test/Common/TestEntities.cs
+++ b/test/Common/TestEntities.cs
@@ -228,7 +228,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             {
                 // try to load state from existing blob
                 var currentFileContent = await TestHelpers.LoadStringFromTextBlobAsync(
-                         context.Key);
+                         context.EntityKey);
                 context.SetState(new StringBuilder(currentFileContent ?? ""));
             }
 
@@ -251,7 +251,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 case "deactivate":
                     // first, store the current value in a blob
                     await TestHelpers.WriteStringToTextBlob(
-                        context.Key, state.ToString());
+                        context.EntityKey, state.ToString());
 
                     // then, destruct this entity (and all of its state)
                     context.DestructOnExit();


### PR DESCRIPTION
Use consistent naming of fields that give access to entity properties.

Before: (`EntityName`, `Key`, `Self`).
Proposed: (`EntityName`, `EntityKey`, `EntityId`).

