### PR TITLE
Fix warnings and make warnings fail on Release builds

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
@@ -724,7 +724,7 @@
         </member>
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.Options.EventGridNotificationOptions.PublishEventTypes">
             <summary>
-            Gets or sets the event types that will be published to Event Grid. 
+            Gets or sets the event types that will be published to Event Grid.
             </summary>
             <value>
             A list of strings. Possible values 'Started', 'Completed', 'Failed', 'Terminated'.
@@ -2174,6 +2174,12 @@
             <summary>
             The context of the currently executing entity.
             </summary>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Entity.SetMockContext(Microsoft.Azure.WebJobs.IDurableEntityContext)">
+            <summary>
+            Sets the current context to a mocked context for unit testing.
+            </summary>
+            <param name="mockContext">The mocked context.</param>
         </member>
         <member name="T:Microsoft.Azure.WebJobs.EntityCurrentOperationStatus">
             <summary>

--- a/src/WebJobs.Extensions.DurableTask/Options/EventGridNotificationOptions.cs
+++ b/src/WebJobs.Extensions.DurableTask/Options/EventGridNotificationOptions.cs
@@ -1,5 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
 using System.Text;
 
 namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Options
@@ -51,7 +53,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Options
         public int[] PublishRetryHttpStatus { get; set; }
 
         /// <summary>
-        /// Gets or sets the event types that will be published to Event Grid. 
+        /// Gets or sets the event types that will be published to Event Grid.
         /// </summary>
         /// <value>
         /// A list of strings. Possible values 'Started', 'Completed', 'Failed', 'Terminated'.

--- a/src/WebJobs.Extensions.DurableTask/Options/NotificationOptions.cs
+++ b/src/WebJobs.Extensions.DurableTask/Options/NotificationOptions.cs
@@ -1,5 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
 using System.Text;
 
 namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Options

--- a/src/WebJobs.Extensions.DurableTask/Options/TraceOptions.cs
+++ b/src/WebJobs.Extensions.DurableTask/Options/TraceOptions.cs
@@ -1,5 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
 using System.Text;
 
 namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Options

--- a/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
+++ b/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
@@ -20,14 +20,17 @@
     <DebugType>embedded</DebugType>
     <IncludeSymbols>false</IncludeSymbols>
   </PropertyGroup>
-  
+
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netstandard2.0|AnyCPU'">
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <WarningsAsErrors />
+    <StyleCopTreatErrorsAsWarnings>true</StyleCopTreatErrorsAsWarnings>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.WebApiCompatShim" Version="2.2.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-*" PrivateAssets="All" />
-  </ItemGroup>
-  
-  <ItemGroup Condition="'$(Configuration)' == 'Debug'">
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.1-*" PrivateAssets="All" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.*" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Common/TestEntityClasses.cs
+++ b/test/Common/TestEntityClasses.cs
@@ -3,12 +3,9 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 {
@@ -22,6 +19,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             DateTime Post(string content);
 
             List<KeyValuePair<DateTime, string>> Get();
+        }
+
+        [FunctionName(nameof(ChatRoom))]
+        public static Task ChatRoomFunction([EntityTrigger] IDurableEntityContext context)
+        {
+            return context.DispatchAsync<ChatRoom>();
         }
 
         [JsonObject(MemberSerialization.OptIn)]
@@ -48,12 +51,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             {
                 return this.ChatEntries.ToList();
             }
-        }
-
-        [FunctionName(nameof(ChatRoom))]
-        public static Task ChatRoomFunction([EntityTrigger] IDurableEntityContext context)
-        {
-            return context.DispatchAsync<ChatRoom>();
         }
     }
 }

--- a/test/FunctionsV2/WebJobs.Extensions.DurableTask.Tests.V2.csproj
+++ b/test/FunctionsV2/WebJobs.Extensions.DurableTask.Tests.V2.csproj
@@ -8,6 +8,12 @@
     <AssemblyOriginatorKeyFile>..\..\sign.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netcoreapp2.0|AnyCPU'">
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <WarningsAsErrors />
+    <StyleCopTreatErrorsAsWarnings>true</StyleCopTreatErrorsAsWarnings>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="4.19.4" />
     <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage" Version="1.6.0" />


### PR DESCRIPTION
I fixed some warnings in the build, and added some settings to make it so Release builds fail on any warnings from Roslyn or StyleCop. This means CIs should catch any warnings before they get introduced into our codebase, without blocking developers from rapidly prototyping and being bogged down by documentation and other style-based warnings.

The only downside to this approach I see is the annoyance of having a build pass locally but fail in the CI. Maybe I could add something to the contribution guidelines recommending a local "Release" build before opening a PR?