### PR TITLE
Batch-processing of entity operations for out-of-proc support

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableCommonContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableCommonContext.cs
@@ -371,7 +371,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
                     if (functionType == FunctionType.Entity)
                     {
-                        this.Config.TraceHelper.OperationCompleted(
+                        this.Config.TraceHelper.OperationFailed(
                             this.Config.Options.HubName,
                             functionName,
                             this.InstanceId,
@@ -379,7 +379,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                             operationName,
                             input: "(replayed)",
                             output: "(replayed)",
-                            failed: true,
                             duration: 0,
                             isReplay: true);
                     }
@@ -411,20 +410,19 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                         operationName,
                         input: "(replayed)",
                         output: "(replayed)",
-                        failed: false,
                         duration: 0,
                         isReplay: true);
                 }
                 else
                 {
                     this.Config.TraceHelper.FunctionCompleted(
-                    this.Config.Options.HubName,
-                    functionName,
-                    this.InstanceId,
-                    output: "(replayed)",
-                    continuedAsNew: false,
-                    functionType: functionType,
-                    isReplay: true);
+                        this.Config.Options.HubName,
+                        functionName,
+                        this.InstanceId,
+                        output: "(replayed)",
+                        continuedAsNew: false,
+                        functionType: functionType,
+                        isReplay: true);
                 }
             }
 

--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableCommonContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableCommonContext.cs
@@ -75,11 +75,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
         internal string RawInput { get; set; }
 
-        internal bool IsCompleted { get; set; }
-
         internal OrchestrationContext InnerContext { get; set; }
-
-        internal ExceptionDispatchInfo OrchestrationException { get; set; }
 
         internal string HubName => this.Config.Options.HubName;
 

--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableCommonContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableCommonContext.cs
@@ -368,15 +368,31 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 {
                     // If this were not a replay, then the orchestrator/activity/entity function trigger would have already
                     // emitted a FunctionFailed trace with the full exception details.
-                    this.Config.TraceHelper.FunctionFailed(
-                        this.Config.Options.HubName,
-                        functionName,
-                        this.InstanceId,
-                        operationId,
-                        operationName,
-                        reason: $"(replayed {exception.GetType().Name})",
-                        functionType: functionType,
-                        isReplay: true);
+
+                    if (functionType == FunctionType.Entity)
+                    {
+                        this.Config.TraceHelper.OperationCompleted(
+                            this.Config.Options.HubName,
+                            functionName,
+                            this.InstanceId,
+                            operationId,
+                            operationName,
+                            input: "(replayed)",
+                            output: "(replayed)",
+                            failed: true,
+                            duration: 0,
+                            isReplay: true);
+                    }
+                    else
+                    {
+                        this.Config.TraceHelper.FunctionFailed(
+                            this.Config.Options.HubName,
+                            functionName,
+                            this.InstanceId,
+                            reason: $"(replayed {exception.GetType().Name})",
+                            functionType: functionType,
+                            isReplay: true);
+                    }
                 }
             }
 
@@ -384,16 +400,32 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             {
                 // If this were not a replay, then the orchestrator/activity/entity function trigger would have already
                 // emitted a FunctionCompleted trace with the actual output details.
-                this.Config.TraceHelper.FunctionCompleted(
+
+                if (functionType == FunctionType.Entity)
+                {
+                    this.Config.TraceHelper.OperationCompleted(
+                        this.Config.Options.HubName,
+                        functionName,
+                        this.InstanceId,
+                        operationId,
+                        operationName,
+                        input: "(replayed)",
+                        output: "(replayed)",
+                        failed: false,
+                        duration: 0,
+                        isReplay: true);
+                }
+                else
+                {
+                    this.Config.TraceHelper.FunctionCompleted(
                     this.Config.Options.HubName,
                     functionName,
                     this.InstanceId,
-                    operationId,
-                    operationName,
                     output: "(replayed)",
                     continuedAsNew: false,
                     functionType: functionType,
                     isReplay: true);
+                }
             }
 
             return output;

--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableEntityContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableEntityContext.cs
@@ -199,6 +199,5 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             public string EventName;
             public object EventContent;
         }
-
     }
 }

--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableEntityContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableEntityContext.cs
@@ -15,12 +15,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
     {
         private readonly EntityId self;
 
+        private readonly TaskEntityShim shim;
+
         private List<OutgoingMessage> outbox = new List<OutgoingMessage>();
 
-        public DurableEntityContext(DurableTaskExtension config, EntityId entity)
+        public DurableEntityContext(DurableTaskExtension config, EntityId entity, TaskEntityShim shim)
             : base(config, entity.EntityName)
         {
             this.self = entity;
+            this.shim = shim;
         }
 
         internal bool StateWasAccessed { get; set; }
@@ -46,6 +49,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         EntityId IDurableEntityContext.EntityId => this.self;
 
         internal override FunctionType FunctionType => FunctionType.Entity;
+
+        internal List<RequestMessage> OperationBatch => this.shim.OperationBatch;
+
+        internal EntityId Self => this.self;
 
         string IDurableEntityContext.OperationName
         {
@@ -192,5 +199,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             public string EventName;
             public object EventContent;
         }
+
     }
 }

--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableOrchestrationContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableOrchestrationContext.cs
@@ -42,6 +42,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
         internal bool ContinuedAsNew { get; private set; }
 
+        internal bool IsCompleted { get; set; }
+
+        internal ExceptionDispatchInfo OrchestrationException { get; set; }
+
         internal bool IsOutputSet => this.serializedOutput != null;
 
         private string OrchestrationName => this.FunctionName;

--- a/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
@@ -449,7 +449,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                             // 4. Run the DTFx orchestration to persist the effects,
                             // send the outbox, and continue as new
                             await next();
-
                         }
                         catch (Exception e)
                         {

--- a/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
@@ -3,14 +3,13 @@
 
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
-using System.Reflection;
 using System.Runtime.ExceptionServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using DurableTask.AzureStorage;
 using DurableTask.Core;
 using DurableTask.Core.Common;
 using DurableTask.Core.Exceptions;
@@ -23,6 +22,7 @@ using Microsoft.Azure.WebJobs.Host.Executors;
 using Microsoft.Azure.WebJobs.Logging;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
@@ -264,7 +264,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 return;
             }
 
-            DurableCommonContext context = shim.Context;
+            DurableOrchestrationContext context = (DurableOrchestrationContext)shim.Context;
 
             OrchestrationRuntimeState orchestrationRuntimeState = dispatchContext.GetProperty<OrchestrationRuntimeState>();
 
@@ -318,7 +318,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
             if (!context.IsCompleted)
             {
-                shim.TraceAwait();
+                this.TraceHelper.FunctionAwaited(
+                    context.HubName,
+                    context.Name,
+                    context.FunctionType,
+                    context.InstanceId,
+                    context.IsReplaying);
             }
 
             if (context.IsCompleted &&
@@ -349,7 +354,83 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             entityContext.History = runtimeState.Events;
             entityContext.RawInput = runtimeState.Input;
 
-            // 1. Start the functions invocation pipeline (billing, logging, bindings, and timeout tracking).
+            // 1. First time through the history
+            // we count events, add any under-lock op to the batch, and process lock releases
+            foreach (HistoryEvent e in runtimeState.Events)
+            {
+                switch (e.EventType)
+                {
+                    case EventType.ExecutionStarted:
+                        entityShim.Rehydrate(runtimeState.Input);
+                        break;
+
+                    case EventType.EventRaised:
+                        EventRaisedEvent eventRaisedEvent = (EventRaisedEvent)e;
+
+                        this.TraceHelper.DeliveringEntityMessage(
+                            entityContext.InstanceId,
+                            entityContext.ExecutionId,
+                            e.EventId,
+                            eventRaisedEvent.Name,
+                            eventRaisedEvent.Input);
+
+                        entityShim.NumberEventsToReceive++;
+
+                        if (eventRaisedEvent.Name == "op")
+                        {
+                            // we are receiving an operation request or a lock request
+                            var requestMessage = JsonConvert.DeserializeObject<RequestMessage>(eventRaisedEvent.Input);
+
+                            if (entityContext.State.LockedBy == requestMessage.ParentInstanceId)
+                            {
+                                // operation requests from the lock holder are processed immediately
+                                entityShim.AddOperationToBatch(requestMessage);
+                            }
+                            else
+                            {
+                                // others go to the back of the queue
+                                entityContext.State.Enqueue(requestMessage);
+                            }
+                        }
+                        else
+                        {
+                            // we are receiving a lock release
+                            var message = JsonConvert.DeserializeObject<ReleaseMessage>(eventRaisedEvent.Input);
+
+                            if (entityContext.State.LockedBy == message.ParentInstanceId)
+                            {
+                                this.TraceHelper.EntityLockReleased(
+                                    entityContext.HubName,
+                                    entityContext.Name,
+                                    entityContext.InstanceId,
+                                    message.ParentInstanceId,
+                                    message.LockRequestId,
+                                    entityContext.IsReplaying);
+
+                                entityContext.State.LockedBy = null;
+                            }
+                        }
+
+                        break;
+                }
+            }
+
+            // 2. We add as many requests from the queue to the batch as possible (stopping at lock requests)
+            while (entityContext.State.LockedBy == null
+                && entityContext.State.TryDequeue(out var request))
+            {
+                if (request.IsLockRequest)
+                {
+                    entityShim.AddLockRequestToBatch(request);
+                    entityContext.State.LockedBy = request.ParentInstanceId;
+                }
+                else
+                {
+                    entityShim.AddOperationToBatch(request);
+                }
+            }
+
+            // 3. Start the functions invocation pipeline (billing, logging, bindings, and timeout tracking).
             FunctionResult result = await entityShim.GetFunctionInfo().Executor.TryExecuteAsync(
                 new TriggeredFunctionData
                 {
@@ -362,35 +443,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
                         try
                         {
-                            // 2. Load all the external events into the entity shim
-                            foreach (HistoryEvent e in runtimeState.Events)
-                            {
-                                switch (e.EventType)
-                                {
-                                    case EventType.OrchestratorStarted:
-                                        entityContext.CurrentOperationStartTime = e.Timestamp;
-                                        break;
-                                    case EventType.ExecutionStarted:
-                                        entityShim.Rehydrate(runtimeState.Input);
-                                        break;
-                                    case EventType.EventRaised:
-                                        EventRaisedEvent eventRaisedEvent = (EventRaisedEvent)e;
-                                        this.TraceHelper.DeliveringEntityMessage(
-                                            entityContext.InstanceId,
-                                            entityContext.ExecutionId,
-                                            e.EventId,
-                                            eventRaisedEvent.Name,
-                                            eventRaisedEvent.Input);
-                                        entityShim.ProcessMessage(eventRaisedEvent.Name, eventRaisedEvent.Input);
-                                        break;
-                                }
-                            }
+                            // 3. Run all the operations in the batch
+                            await entityShim.ExecuteBatch();
 
-                            // 3. Wait for all the queued entity operations to complete
-                            await entityShim.WaitForLastOperation();
-
-                            // 4. Run the scheduler orchestration so that state can be persisted.
+                            // 4. Run the DTFx orchestration to persist the effects,
+                            // send the outbox, and continue as new
                             await next();
+
                         }
                         catch (Exception e)
                         {
@@ -411,8 +470,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                             var entitySchedulerExceptions = new OrchestrationFailureException(
                                 $"Entity scheduler {entityShim.EntityId} failed: {e.Message}",
                                 Utils.SerializeCause(e, MessagePayloadDataConverter.ErrorConverter));
-
-                            entityContext.OrchestrationException = ExceptionDispatchInfo.Capture(entitySchedulerExceptions);
 
                             throw entitySchedulerExceptions;
                         }

--- a/src/WebJobs.Extensions.DurableTask/EndToEndTraceHelper.cs
+++ b/src/WebJobs.Extensions.DurableTask/EndToEndTraceHelper.cs
@@ -169,8 +169,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             string functionName,
             FunctionType functionType,
             string instanceId,
-            string operationId,
-            string operationName,
             bool isReplay)
         {
             EtwEventSource.Instance.FunctionAwaited(
@@ -179,28 +177,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 LocalSlotName,
                 functionName,
                 instanceId,
-                operationId,
-                operationName,
                 functionType.ToString(),
                 ExtensionVersion,
                 IsReplay: isReplay);
 
             if (this.ShouldLogEvent(isReplay))
             {
-                if (string.IsNullOrEmpty(operationName))
-                {
-                    this.logger.LogInformation(
-                        "{instanceId}: Function '{functionName} ({functionType})' awaited. IsReplay: {isReplay}. State: {state}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}. SequenceNumber: {sequenceNumber}.",
-                        instanceId, functionName, functionType, isReplay, FunctionState.Awaited, hubName, LocalAppName,
-                        LocalSlotName, ExtensionVersion, this.sequenceNumber++);
-                }
-                else
-                {
-                    this.logger.LogInformation(
-                        "{instanceId}: Function '{functionName} ({functionType})' awaited '{operationName}' operation {operationId}. IsReplay: {isReplay}. State: {state}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}. SequenceNumber: {sequenceNumber}.",
-                        instanceId, functionName, functionType, operationName, operationId, isReplay, FunctionState.Awaited, hubName, LocalAppName,
-                        LocalSlotName, ExtensionVersion, this.sequenceNumber++);
-                }
+                this.logger.LogInformation(
+                    "{instanceId}: Function '{functionName} ({functionType})' awaited. IsReplay: {isReplay}. State: {state}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}. SequenceNumber: {sequenceNumber}.",
+                    instanceId, functionName, functionType, isReplay, FunctionState.Awaited, hubName, LocalAppName,
+                    LocalSlotName, ExtensionVersion, this.sequenceNumber++);
             }
         }
 
@@ -431,7 +417,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             string eventName,
             object eventContent)
         {
-            this.logger.LogInformation(
+            this.logger.LogDebug(
                               "{instanceId}: delivering message: {eventName} {eventContent} EventId: {eventId} ExecutionId: {executionId} SequenceNumber: {sequenceNumber}.",
                               instanceId, eventName, eventContent, eventId, executionId, this.sequenceNumber++);
         }
@@ -444,7 +430,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             string eventName,
             object eventContent)
         {
-            this.logger.LogInformation(
+            this.logger.LogDebug(
                               "{instanceId}: sending message: {eventName} {eventContent}  TargetInstanceId: {targetInstanceId} ExecutionId: {executionId} SequenceNumber: {sequenceNumber}.",
                               instanceId, eventName, eventContent, targetInstanceId, executionId, this.sequenceNumber++);
         }

--- a/src/WebJobs.Extensions.DurableTask/EndToEndTraceHelper.cs
+++ b/src/WebJobs.Extensions.DurableTask/EndToEndTraceHelper.cs
@@ -126,8 +126,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             string hubName,
             string functionName,
             string instanceId,
-            string operationId,
-            string operationName,
             string input,
             FunctionType functionType,
             bool isReplay)
@@ -138,8 +136,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 LocalSlotName,
                 functionName,
                 instanceId,
-                operationId,
-                operationName,
                 input,
                 functionType.ToString(),
                 ExtensionVersion,
@@ -147,20 +143,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
             if (this.ShouldLogEvent(isReplay))
             {
-                if (string.IsNullOrEmpty(operationName))
-                {
-                    this.logger.LogInformation(
-                        "{instanceId}: Function '{functionName} ({functionType})' started. IsReplay: {isReplay}. Input: {input}. State: {state}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}. SequenceNumber: {sequenceNumber}.",
-                        instanceId, functionName, functionType, isReplay, input, FunctionState.Started, hubName,
-                        LocalAppName, LocalSlotName, ExtensionVersion, this.sequenceNumber++);
-                }
-                else
-                {
-                    this.logger.LogInformation(
-                        "{instanceId}: Function '{functionName} ({functionType})' started '{operationName}' operation {operationId}. IsReplay: {isReplay}. Input: {input}. State: {state}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}. SequenceNumber: {sequenceNumber}.",
-                        instanceId, functionName, functionType, operationName, operationId, isReplay, input, FunctionState.Started, hubName,
-                        LocalAppName, LocalSlotName, ExtensionVersion, this.sequenceNumber++);
-                }
+                this.logger.LogInformation(
+                    "{instanceId}: Function '{functionName} ({functionType})' started. IsReplay: {isReplay}. Input: {input}. State: {state}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}. SequenceNumber: {sequenceNumber}.",
+                    instanceId, functionName, functionType, isReplay, input, FunctionState.Started, hubName,
+                    LocalAppName, LocalSlotName, ExtensionVersion, this.sequenceNumber++);
             }
         }
 
@@ -223,8 +209,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             string hubName,
             string functionName,
             string instanceId,
-            string operationId,
-            string operationName,
             string output,
             bool continuedAsNew,
             FunctionType functionType,
@@ -236,8 +220,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 LocalSlotName,
                 functionName,
                 instanceId,
-                operationId,
-                operationName,
                 output,
                 continuedAsNew,
                 functionType.ToString(),
@@ -246,20 +228,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
             if (this.ShouldLogEvent(isReplay))
             {
-                if (string.IsNullOrEmpty(operationName))
-                {
-                    this.logger.LogInformation(
-                        "{instanceId}: Function '{functionName} ({functionType})' completed. ContinuedAsNew: {continuedAsNew}. IsReplay: {isReplay}. Output: {output}. State: {state}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}. SequenceNumber: {sequenceNumber}.",
-                        instanceId, functionName, functionType, continuedAsNew, isReplay, output, FunctionState.Completed,
-                        hubName, LocalAppName, LocalSlotName, ExtensionVersion, this.sequenceNumber++);
-                }
-                else
-                {
-                    this.logger.LogInformation(
-                        "{instanceId}: Function '{functionName} ({functionType})' completed '{operationName}' operation {operationId}. ContinuedAsNew: {continuedAsNew}. IsReplay: {isReplay}. Output: {output}. State: {state}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}. SequenceNumber: {sequenceNumber}.",
-                        instanceId, functionName, functionType, operationName, operationId, continuedAsNew, isReplay, output, FunctionState.Completed,
-                        hubName, LocalAppName, LocalSlotName, ExtensionVersion, this.sequenceNumber++);
-                }
+                this.logger.LogInformation(
+                    "{instanceId}: Function '{functionName} ({functionType})' completed. ContinuedAsNew: {continuedAsNew}. IsReplay: {isReplay}. Output: {output}. State: {state}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}. SequenceNumber: {sequenceNumber}.",
+                    instanceId, functionName, functionType, continuedAsNew, isReplay, output, FunctionState.Completed,
+                    hubName, LocalAppName, LocalSlotName, ExtensionVersion, this.sequenceNumber++);
             }
         }
 
@@ -323,28 +295,82 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             string hubName,
             string functionName,
             string instanceId,
-            string operationId,
-            string operationName,
             string reason,
             FunctionType functionType,
             bool isReplay)
         {
             EtwEventSource.Instance.FunctionFailed(hubName, LocalAppName, LocalSlotName, functionName,
-                instanceId, operationId, operationName, reason, functionType.ToString(), ExtensionVersion, isReplay);
+                instanceId, reason, functionType.ToString(), ExtensionVersion, isReplay);
             if (this.ShouldLogEvent(isReplay))
             {
-                if (string.IsNullOrEmpty(operationName))
+                this.logger.LogError(
+                    "{instanceId}: Function '{functionName} ({functionType})' failed with an error. Reason: {reason}. IsReplay: {isReplay}. State: {state}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}. SequenceNumber: {sequenceNumber}.",
+                    instanceId, functionName, functionType, reason, isReplay, FunctionState.Failed, hubName,
+                    LocalAppName, LocalSlotName, ExtensionVersion, this.sequenceNumber++);
+            }
+        }
+
+        public void OperationCompleted(
+           string hubName,
+           string functionName,
+           string instanceId,
+           string operationId,
+           string operationName,
+           string input,
+           string output,
+           bool failed,
+           double duration,
+           bool isReplay)
+        {
+            if (!failed)
+            {
+                EtwEventSource.Instance.OperationCompleted(
+                    hubName,
+                    LocalAppName,
+                    LocalSlotName,
+                    functionName,
+                    instanceId,
+                    operationId,
+                    operationName,
+                    input,
+                    output,
+                    duration,
+                    FunctionType.Entity.ToString(),
+                    ExtensionVersion,
+                    isReplay);
+            }
+            else
+            {
+                EtwEventSource.Instance.OperationFailed(
+                    hubName,
+                    LocalAppName,
+                    LocalSlotName,
+                    functionName,
+                    instanceId,
+                    operationId,
+                    operationName,
+                    input,
+                    output,
+                    duration,
+                    FunctionType.Entity.ToString(),
+                    ExtensionVersion,
+                    isReplay);
+            }
+
+            if (this.ShouldLogEvent(isReplay))
+            {
+                if (!failed)
                 {
-                    this.logger.LogError(
-                        "{instanceId}: Function '{functionName} ({functionType})' failed with an error. Reason: {reason}. IsReplay: {isReplay}. State: {state}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}. SequenceNumber: {sequenceNumber}.",
-                        instanceId, functionName, functionType, reason, isReplay, FunctionState.Failed, hubName,
-                        LocalAppName, LocalSlotName, ExtensionVersion, this.sequenceNumber++);
+                    this.logger.LogInformation(
+                    "{instanceId}: Function '{functionName} ({functionType})' completed '{operationName}' operation {operationId} in {duration}ms. IsReplay: {isReplay}. Input: {input}. Output: {output}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}. SequenceNumber: {sequenceNumber}.",
+                    instanceId, functionName, FunctionType.Entity, operationName, operationId, duration, isReplay, input, output,
+                    hubName, LocalAppName, LocalSlotName, ExtensionVersion, this.sequenceNumber++);
                 }
                 else
                 {
                     this.logger.LogError(
-                        "{instanceId}: Function '{functionName} ({functionType})' failed '{operationName}' operation {operationId} with an error. Reason: {reason}. IsReplay: {isReplay}. State: {state}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}. SequenceNumber: {sequenceNumber}.",
-                        instanceId, functionName, functionType, operationName, operationId, reason, isReplay, FunctionState.Failed, hubName,
+                        "{instanceId}: Function '{functionName} ({functionType})' failed '{operationName}' operation {operationId} after {duration}ms with exception {exception}. Input: {input}. IsReplay: {isReplay}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}. SequenceNumber: {sequenceNumber}.",
+                        instanceId, functionName, FunctionType.Entity, operationName, operationId, duration, output, input, isReplay, hubName,
                         LocalAppName, LocalSlotName, ExtensionVersion, this.sequenceNumber++);
                 }
             }

--- a/src/WebJobs.Extensions.DurableTask/EndToEndTraceHelper.cs
+++ b/src/WebJobs.Extensions.DurableTask/EndToEndTraceHelper.cs
@@ -318,61 +318,65 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
            string operationName,
            string input,
            string output,
-           bool failed,
            double duration,
            bool isReplay)
         {
-            if (!failed)
-            {
-                EtwEventSource.Instance.OperationCompleted(
-                    hubName,
-                    LocalAppName,
-                    LocalSlotName,
-                    functionName,
-                    instanceId,
-                    operationId,
-                    operationName,
-                    input,
-                    output,
-                    duration,
-                    FunctionType.Entity.ToString(),
-                    ExtensionVersion,
-                    isReplay);
-            }
-            else
-            {
-                EtwEventSource.Instance.OperationFailed(
-                    hubName,
-                    LocalAppName,
-                    LocalSlotName,
-                    functionName,
-                    instanceId,
-                    operationId,
-                    operationName,
-                    input,
-                    output,
-                    duration,
-                    FunctionType.Entity.ToString(),
-                    ExtensionVersion,
-                    isReplay);
-            }
+            EtwEventSource.Instance.OperationCompleted(
+                hubName,
+                LocalAppName,
+                LocalSlotName,
+                functionName,
+                instanceId,
+                operationId,
+                operationName,
+                input,
+                output,
+                duration,
+                FunctionType.Entity.ToString(),
+                ExtensionVersion,
+                isReplay);
 
             if (this.ShouldLogEvent(isReplay))
             {
-                if (!failed)
-                {
-                    this.logger.LogInformation(
-                    "{instanceId}: Function '{functionName} ({functionType})' completed '{operationName}' operation {operationId} in {duration}ms. IsReplay: {isReplay}. Input: {input}. Output: {output}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}. SequenceNumber: {sequenceNumber}.",
-                    instanceId, functionName, FunctionType.Entity, operationName, operationId, duration, isReplay, input, output,
-                    hubName, LocalAppName, LocalSlotName, ExtensionVersion, this.sequenceNumber++);
-                }
-                else
-                {
-                    this.logger.LogError(
-                        "{instanceId}: Function '{functionName} ({functionType})' failed '{operationName}' operation {operationId} after {duration}ms with exception {exception}. Input: {input}. IsReplay: {isReplay}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}. SequenceNumber: {sequenceNumber}.",
-                        instanceId, functionName, FunctionType.Entity, operationName, operationId, duration, output, input, isReplay, hubName,
-                        LocalAppName, LocalSlotName, ExtensionVersion, this.sequenceNumber++);
-                }
+                this.logger.LogInformation(
+                "{instanceId}: Function '{functionName} ({functionType})' completed '{operationName}' operation {operationId} in {duration}ms. IsReplay: {isReplay}. Input: {input}. Output: {output}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}. SequenceNumber: {sequenceNumber}.",
+                instanceId, functionName, FunctionType.Entity, operationName, operationId, duration, isReplay, input, output,
+                hubName, LocalAppName, LocalSlotName, ExtensionVersion, this.sequenceNumber++);
+            }
+        }
+
+        public void OperationFailed(
+           string hubName,
+           string functionName,
+           string instanceId,
+           string operationId,
+           string operationName,
+           string input,
+           string output,
+           double duration,
+           bool isReplay)
+        {
+            EtwEventSource.Instance.OperationFailed(
+                hubName,
+                LocalAppName,
+                LocalSlotName,
+                functionName,
+                instanceId,
+                operationId,
+                operationName,
+                input,
+                output,
+                duration,
+                FunctionType.Entity.ToString(),
+                ExtensionVersion,
+                isReplay);
+
+            if (this.ShouldLogEvent(isReplay))
+            {
+                this.logger.LogError(
+                    "{instanceId}: Function '{functionName} ({functionType})' failed '{operationName}' operation {operationId} after {duration}ms with exception {exception}. Input: {input}. IsReplay: {isReplay}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}. SequenceNumber: {sequenceNumber}.",
+                    instanceId, functionName, FunctionType.Entity, operationName, operationId, duration, output, input, isReplay, hubName,
+                    LocalAppName, LocalSlotName, ExtensionVersion, this.sequenceNumber++);
             }
         }
 

--- a/src/WebJobs.Extensions.DurableTask/EntityScheduler/RequestMessage.cs
+++ b/src/WebJobs.Extensions.DurableTask/EntityScheduler/RequestMessage.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         public int Position { get; set; }
 
         [JsonIgnore]
-        public bool IsLockMessage => this.LockSet != null;
+        public bool IsLockRequest => this.LockSet != null;
 
         public void SetInput(object obj)
         {
@@ -88,7 +88,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
         public override string ToString()
         {
-            if (this.IsLockMessage)
+            if (this.IsLockRequest)
             {
                 return $"[Request lock {this.Id} by {this.ParentInstanceId}, position {this.Position}]";
             }

--- a/src/WebJobs.Extensions.DurableTask/EtwEventSource.cs
+++ b/src/WebJobs.Extensions.DurableTask/EtwEventSource.cs
@@ -51,20 +51,18 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             this.WriteEvent(202, TaskHub, AppName, SlotName, FunctionName, InstanceId, OperationId, OperationName, Input ?? "(null)", FunctionType, ExtensionVersion, IsReplay);
         }
 
-        [Event(203, Level = EventLevel.Informational, Version = 3)]
+        [Event(203, Level = EventLevel.Informational, Version = 4)]
         public void FunctionAwaited(
             string TaskHub,
             string AppName,
             string SlotName,
             string FunctionName,
             string InstanceId,
-            string OperationId,
-            string OperationName,
             string FunctionType,
             string ExtensionVersion,
             bool IsReplay)
         {
-            this.WriteEvent(203, TaskHub, AppName, SlotName, FunctionName, InstanceId, OperationId, OperationName, FunctionType, ExtensionVersion, IsReplay);
+            this.WriteEvent(203, TaskHub, AppName, SlotName, FunctionName, InstanceId, FunctionType, ExtensionVersion, IsReplay);
         }
 
         [Event(204, Level = EventLevel.Informational, Version = 2)]

--- a/src/WebJobs.Extensions.DurableTask/EtwEventSource.cs
+++ b/src/WebJobs.Extensions.DurableTask/EtwEventSource.cs
@@ -348,8 +348,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             string FunctionType,
             string ExtensionVersion,
             bool IsReplay)
-                {
-            this.WriteEvent(206, TaskHub, AppName, SlotName, FunctionName, InstanceId, OperationId, OperationName, Input ?? "(null)", Output ?? "(null)", Duration, FunctionType, ExtensionVersion, IsReplay);
+        {
+            this.WriteEvent(221, TaskHub, AppName, SlotName, FunctionName, InstanceId, OperationId, OperationName, Input ?? "(null)", Output ?? "(null)", Duration, FunctionType, ExtensionVersion, IsReplay);
         }
 
         [Event(222, Level = EventLevel.Error)]
@@ -368,7 +368,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             string ExtensionVersion,
             bool IsReplay)
         {
-            this.WriteEvent(206, TaskHub, AppName, SlotName, FunctionName, InstanceId, OperationId, OperationName, Input ?? "(null)", Exception, Duration, FunctionType, ExtensionVersion, IsReplay);
+            this.WriteEvent(222, TaskHub, AppName, SlotName, FunctionName, InstanceId, OperationId, OperationName, Input ?? "(null)", Exception, Duration, FunctionType, ExtensionVersion, IsReplay);
         }
 
 #pragma warning restore SA1313 // Parameter names should begin with lower-case letter

--- a/src/WebJobs.Extensions.DurableTask/EtwEventSource.cs
+++ b/src/WebJobs.Extensions.DurableTask/EtwEventSource.cs
@@ -34,21 +34,19 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             this.WriteEvent(201, TaskHub, AppName, SlotName, FunctionName, InstanceId, Reason, FunctionType, ExtensionVersion, IsReplay);
         }
 
-        [Event(202, Level = EventLevel.Informational, Version = 3)]
+        [Event(202, Level = EventLevel.Informational, Version = 4)]
         public void FunctionStarting(
             string TaskHub,
             string AppName,
             string SlotName,
             string FunctionName,
             string InstanceId,
-            string OperationId,
-            string OperationName,
             string Input,
             string FunctionType,
             string ExtensionVersion,
             bool IsReplay)
         {
-            this.WriteEvent(202, TaskHub, AppName, SlotName, FunctionName, InstanceId, OperationId, OperationName, Input ?? "(null)", FunctionType, ExtensionVersion, IsReplay);
+            this.WriteEvent(202, TaskHub, AppName, SlotName, FunctionName, InstanceId, Input ?? "(null)", FunctionType, ExtensionVersion, IsReplay);
         }
 
         [Event(203, Level = EventLevel.Informational, Version = 4)]
@@ -96,22 +94,20 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             this.WriteEvent(205, TaskHub, AppName, SlotName, FunctionName, InstanceId, EventName, Input ?? "(null)", FunctionType, ExtensionVersion, IsReplay);
         }
 
-        [Event(206, Level = EventLevel.Informational, Version = 3)]
+        [Event(206, Level = EventLevel.Informational, Version = 4)]
         public void FunctionCompleted(
             string TaskHub,
             string AppName,
             string SlotName,
             string FunctionName,
             string InstanceId,
-            string OperationId,
-            string OperationName,
             string Output,
             bool ContinuedAsNew,
             string FunctionType,
             string ExtensionVersion,
             bool IsReplay)
         {
-            this.WriteEvent(206, TaskHub, AppName, SlotName, FunctionName, InstanceId, OperationId, OperationName, Output ?? "(null)", ContinuedAsNew, FunctionType, ExtensionVersion, IsReplay);
+            this.WriteEvent(206, TaskHub, AppName, SlotName, FunctionName, InstanceId, Output ?? "(null)", ContinuedAsNew, FunctionType, ExtensionVersion, IsReplay);
         }
 
         [Event(207, Level = EventLevel.Warning, Version = 2)]
@@ -136,14 +132,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             string SlotName,
             string FunctionName,
             string InstanceId,
-            string OperationId,
-            string OperationName,
             string Reason,
             string FunctionType,
             string ExtensionVersion,
             bool IsReplay)
         {
-            this.WriteEvent(208, TaskHub, AppName, SlotName, FunctionName, InstanceId, OperationId, OperationName, Reason, FunctionType, ExtensionVersion, IsReplay);
+            this.WriteEvent(208, TaskHub, AppName, SlotName, FunctionName, InstanceId, Reason, FunctionType, ExtensionVersion, IsReplay);
         }
 
         [Event(209, Level = EventLevel.Informational, Version = 2)]
@@ -337,6 +331,44 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             bool IsReplay)
         {
             this.WriteEvent(220, TaskHub, AppName, SlotName, FunctionName, InstanceId, RequestingInstance, RequestId, FunctionType, ExtensionVersion, IsReplay);
+        }
+
+        [Event(221, Level = EventLevel.Informational)]
+        public void OperationCompleted(
+            string TaskHub,
+            string AppName,
+            string SlotName,
+            string FunctionName,
+            string InstanceId,
+            string OperationId,
+            string OperationName,
+            string Input,
+            string Output,
+            double Duration,
+            string FunctionType,
+            string ExtensionVersion,
+            bool IsReplay)
+                {
+            this.WriteEvent(206, TaskHub, AppName, SlotName, FunctionName, InstanceId, OperationId, OperationName, Input ?? "(null)", Output ?? "(null)", Duration, FunctionType, ExtensionVersion, IsReplay);
+        }
+
+        [Event(222, Level = EventLevel.Error)]
+        public void OperationFailed(
+            string TaskHub,
+            string AppName,
+            string SlotName,
+            string FunctionName,
+            string InstanceId,
+            string OperationId,
+            string OperationName,
+            string Input,
+            string Exception,
+            double Duration,
+            string FunctionType,
+            string ExtensionVersion,
+            bool IsReplay)
+        {
+            this.WriteEvent(206, TaskHub, AppName, SlotName, FunctionName, InstanceId, OperationId, OperationName, Input ?? "(null)", Exception, Duration, FunctionType, ExtensionVersion, IsReplay);
         }
 
 #pragma warning restore SA1313 // Parameter names should begin with lower-case letter

--- a/src/WebJobs.Extensions.DurableTask/Listener/TaskActivityShim.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/TaskActivityShim.cs
@@ -50,8 +50,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 this.config.Options.HubName,
                 this.activityName,
                 instanceId,
-                string.Empty,
-                string.Empty,
                 this.config.GetIntputOutputTrace(rawInput),
                 functionType: FunctionType.Activity,
                 isReplay: false);
@@ -67,8 +65,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     this.config.Options.HubName,
                     this.activityName,
                     instanceId,
-                    string.Empty,
-                    string.Empty,
                     exceptionToReport?.ToString() ?? string.Empty,
                     functionType: FunctionType.Activity,
                     isReplay: false);
@@ -86,8 +82,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 this.config.Options.HubName,
                 this.activityName,
                 instanceId,
-                string.Empty,
-                string.Empty,
                 this.config.GetIntputOutputTrace(serializedOutput),
                 continuedAsNew: false,
                 functionType: FunctionType.Activity,

--- a/src/WebJobs.Extensions.DurableTask/Listener/TaskCommonShim.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/TaskCommonShim.cs
@@ -39,7 +39,5 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         }
 
         public abstract RegisteredFunctionInfo GetFunctionInfo();
-
-        public abstract void TraceAwait();
     }
 }

--- a/src/WebJobs.Extensions.DurableTask/Listener/TaskEntityShim.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/TaskEntityShim.cs
@@ -26,20 +26,17 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         private readonly TaskCompletionSource<object> doneProcessingMessages
             = new TaskCompletionSource<object>();
 
-        private object lockable = new object();
-
-        private Task lastStartedOperation = Task.CompletedTask;
-
-        private int numberOperationsStarted = 0;
-
-        private int numberMessagesToReceive;
+        // a batch always consists of a (possibly empty) sequence of operations
+        // followed by zero or one lock request
+        private readonly List<RequestMessage> operationBatch = new List<RequestMessage>();
+        private RequestMessage lockRequest = null;
 
         public TaskEntityShim(DurableTaskExtension config, string schedulerId)
             : base(config)
         {
             this.SchedulerId = schedulerId;
             this.EntityId = EntityId.GetEntityIdFromSchedulerId(schedulerId);
-            this.context = new DurableEntityContext(config, this.EntityId);
+            this.context = new DurableEntityContext(config, this.EntityId, this);
         }
 
         public override DurableCommonContext Context => this.context;
@@ -47,6 +44,20 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         public string SchedulerId { get; private set; }
 
         public EntityId EntityId { get; private set; }
+
+        public int NumberEventsToReceive { get; set; }
+    
+        internal List<RequestMessage> OperationBatch => this.operationBatch;
+
+        public void AddOperationToBatch(RequestMessage operationMessage)
+        {
+            this.operationBatch.Add(operationMessage);
+        }
+
+        public void AddLockRequestToBatch(RequestMessage lockRequest)
+        {
+            this.lockRequest = lockRequest;
+        }
 
         public override RegisteredFunctionInfo GetFunctionInfo()
         {
@@ -82,104 +93,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             });
         }
 
-        internal void ProcessMessage(string eventName, string serializedEventData)
-        {
-            this.numberMessagesToReceive++;
-
-            if (eventName == "op")
-            {
-                var operationMessage = JsonConvert.DeserializeObject<RequestMessage>(serializedEventData);
-
-                lock (this.lockable)
-                {
-                    // the operation gets processed if either
-                    // - it was sent by the lock holder (the latter issues only one at a time, so no need to for queueing)
-                    // - there is no lock holder, no current operation being processed, and we have not reached the limit
-                    if ((this.context.State.LockedBy != null
-                         && this.context.State.LockedBy == operationMessage.ParentInstanceId)
-                      || (this.context.State.LockedBy == null
-                          && this.lastStartedOperation.IsCompleted))
-                    {
-                        this.numberOperationsStarted++;
-                        this.lastStartedOperation = this.ProcessRequestAsync(operationMessage);
-                    }
-                    else
-                    {
-                        this.Config.TraceHelper.EntityOperationQueued(
-                            this.Context.HubName,
-                            this.Context.Name,
-                            this.Context.InstanceId,
-                            operationMessage.Id.ToString(),
-                            operationMessage.Operation ?? "LockRequest",
-                            this.Context.IsReplaying);
-
-                        this.context.State.Enqueue(operationMessage);
-                    }
-                }
-            }
-            else if (eventName == "release")
-            {
-                var message = JsonConvert.DeserializeObject<ReleaseMessage>(serializedEventData);
-
-                if (this.context.State.LockedBy == message.ParentInstanceId)
-                {
-                    lock (this.lockable)
-                    {
-                        this.Config.TraceHelper.EntityLockReleased(
-                            this.Context.HubName,
-                            this.Context.Name,
-                            this.Context.InstanceId,
-                            message.ParentInstanceId,
-                            message.LockRequestId,
-                            this.Context.IsReplaying);
-
-                        this.context.State.LockedBy = null;
-
-                        if (this.lastStartedOperation.IsCompleted
-                         && this.context.State.TryDequeue(out var operationMessage))
-                        {
-                            this.numberOperationsStarted++;
-                            this.lastStartedOperation = this.ProcessRequestAsync(operationMessage);
-                        }
-                    }
-                }
-            }
-            else // it's a response
-            {
-                this.Context.RaiseEvent(eventName, serializedEventData);
-            }
-        }
-
-        internal async Task WaitForLastOperation()
-        {
-            Task waitFor;
-            lock (this.lockable)
-            {
-                waitFor = this.lastStartedOperation;
-            }
-
-            while (true)
-            {
-                await waitFor;
-
-                lock (this.lockable)
-                {
-                    if (waitFor == this.lastStartedOperation)
-                    {
-                        return;
-                    }
-                    else
-                    {
-                        waitFor = this.lastStartedOperation;
-                    }
-                }
-            }
-        }
-
         public override void RaiseEvent(OrchestrationContext unused, string eventName, string serializedEventData)
         {
             // no-op: the events were already processed outside of the DTFx context
-            if (--this.numberMessagesToReceive == 0)
+            if (--this.NumberEventsToReceive == 0)
             {
                 // signal the main orchestration thread that it can now safely terminate.
                 this.doneProcessingMessages.SetResult(null);
@@ -204,7 +121,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 this.context.State = JsonConvert.DeserializeObject<SchedulerState>(serializedInput, MessagePayloadDataConverter.MessageSettings);
             }
 
-            if (!this.context.State.EntityExists)
+            if (serializedInput == null)
             {
                 this.context.AddDeferredTask(() => this.Config.LifeCycleNotificationHelper.OrchestratorStartingAsync(
                     this.context.HubName,
@@ -212,33 +129,21 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     this.context.InstanceId,
                     this.context.IsReplaying));
             }
-
-            // restart the processing if needed
-            lock (this.lockable)
-            {
-                if (this.context.State.LockedBy == null && this.context.State.TryDequeue(out var request))
-                {
-                    this.numberOperationsStarted++;
-                    this.lastStartedOperation = this.ProcessRequestAsync(request);
-                }
-            }
         }
 
         public override async Task<string> Execute(OrchestrationContext innerContext, string serializedInput)
         {
-            // Wait until all the entity events have been processed.
-
-            if (this.numberOperationsStarted == 0)
+            if (this.operationBatch.Count == 0 && this.lockRequest == null)
             {
-                // we are idle after a ContinueAsNew - no messages yet to process.
+                // we are idle after a ContinueAsNew - the batch is empty.
                 // Wait for more messages to get here (via extended sessions)
                 await this.doneProcessingMessages.Task;
             }
 
-            // Send all buffered outgoing messages (signals, responses, and fire-and-forget orchestrations)
+            // Send all buffered outgoing messages
             this.context.SendOutbox(innerContext);
 
-            if (this.numberMessagesToReceive > 0)
+            if (this.NumberEventsToReceive > 0)
             {
                 await this.doneProcessingMessages.Task;
             }
@@ -254,19 +159,30 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             return string.Empty;
         }
 
-        private async Task ProcessRequestAsync(RequestMessage request)
+        public async Task ExecuteBatch()
         {
-            if (request.IsLockMessage)
+            if (this.GetFunctionInfo().IsOutOfProc)
             {
-                this.ProcessLockRequest(request);
+                // process all operations in the batch using a single function call
+                await this.ExecuteOutOfProcBatch();
             }
             else
             {
-                await this.ProcessOperationRequestAsync(request);
+                // call the function once per operation in the batch
+                foreach (var request in this.operationBatch)
+                {
+                    await this.ProcessOperationRequestAsync(request);
+                }
+            }
+
+            // process the lock request, if any
+            if (this.lockRequest != null)
+            {
+                this.ProcessLockRequest(this.lockRequest);
             }
         }
 
-        private void ProcessLockRequest(RequestMessage request)
+        public void ProcessLockRequest(RequestMessage request)
         {
             this.Config.TraceHelper.EntityLockAcquired(
                 this.context.HubName,
@@ -276,8 +192,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 request.Id.ToString(),
                 this.context.IsReplaying);
 
-            System.Diagnostics.Debug.Assert(this.context.State.LockedBy == null, "Lock not held already.");
-            this.context.State.LockedBy = request.ParentInstanceId;
+            System.Diagnostics.Debug.Assert(this.context.State.LockedBy == request.ParentInstanceId, "Lock was set.");
 
             System.Diagnostics.Debug.Assert(request.LockSet[request.Position].Equals(this.EntityId), "position is correct");
             request.Position++;
@@ -308,7 +223,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             this.context.IsNewlyConstructed = !this.context.State.EntityExists;
             this.context.State.EntityExists = true;
             this.context.DestructOnExit = false;
-            this.context.IsCompleted = false;
 
             // set the async-local static context that is visible to the application code
             Entity.SetContext(this.context);
@@ -340,15 +254,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 // exception must be sent with response back to caller
                 this.context.CurrentOperationResponse.SetExceptionResult(e, this.context.CurrentOperation.Operation, this.EntityId);
 
-                // the first exception is also handed over to the functions runtime
-                if (this.context.OrchestrationException == null)
-                {
-                    var operationException = new OrchestrationFailureException(
-                        $"Operation '{request.Operation}' on entity {this.EntityId} failed: {e.Message}",
-                        Utils.SerializeCause(e, MessagePayloadDataConverter.ErrorConverter));
-                    this.context.OrchestrationException = ExceptionDispatchInfo.Capture(operationException);
-                }
-
                 this.Config.TraceHelper.FunctionFailed(
                     this.context.HubName,
                     this.context.Name,
@@ -368,10 +273,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             var destructOnExit = this.context.DestructOnExit;
             this.context.CurrentOperation = null;
             this.context.CurrentOperationResponse = null;
-            this.context.IsCompleted = true;
 
             // send response
-            // TODO think about how to handle exceptions in signals
             if (!request.IsSignal)
             {
                 var target = new OrchestrationInstance() { InstanceId = request.ParentInstanceId };
@@ -389,59 +292,118 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 this.context.StateWasAccessed = false;
             }
 
-            // if there are requests waiting in the queue that we can process now, and
-            // we have not yet reached the limit, do that now; else continue as new
+            this.Config.TraceHelper.FunctionCompleted(
+                this.context.HubName,
+                this.context.Name,
+                this.context.InstanceId,
+                request.Id.ToString(),
+                request.Operation,
+                this.Config.GetIntputOutputTrace(response.Result),
+                continuedAsNew: false,
+                functionType: FunctionType.Entity,
+                isReplay: this.context.IsReplaying);
+        }
 
-            lock (this.lockable)
+        private async Task ExecuteOutOfProcBatch()
+        {
+            object outOfProcResults = null;
+
+            Task invokeTask = this.FunctionInvocationCallback();
+            if (invokeTask is Task<object> resultTask)
             {
-                if (this.context.State.LockedBy == null
-                    && this.context.State.TryDequeue(out var operationMessage))
-                {
-                    this.Config.TraceHelper.FunctionCompleted(
-                        this.context.HubName,
-                        this.context.Name,
-                        this.context.InstanceId,
-                        request.Id.ToString(),
-                        request.Operation,
-                        this.Config.GetIntputOutputTrace(response.Result),
-                        continuedAsNew: false,
-                        functionType: FunctionType.Entity,
-                        isReplay: this.context.IsReplaying);
+                outOfProcResults = await resultTask;
+            }
+            else
+            {
+                throw new InvalidOperationException("The WebJobs runtime returned a invocation task that does not support return values!");
+            }
 
-                    this.numberOperationsStarted++;
-                    this.lastStartedOperation = this.ProcessRequestAsync(operationMessage);
-                }
-                else
+            var jObj = outOfProcResults as JObject;
+            if (jObj == null)
+            {
+                throw new ArgumentException("Out of proc orchestrators must return a valid JSON schema.");
+            }
+
+            var result = jObj.ToObject<OutOfProcResult>();
+
+            // update the state
+            this.context.State.EntityExists = result.EntityExists;
+            this.context.State.EntityState = result.EntityState;
+
+            // send response messages
+            int position = 0;
+            foreach (var request in this.OperationBatch)
+            {
+                if (!request.IsSignal)
                 {
-                    this.Config.TraceHelper.FunctionCompleted(
-                        this.context.HubName,
-                        this.context.Name,
-                        this.context.InstanceId,
-                        request.Id.ToString(),
-                        request.Operation,
-                        this.Config.GetIntputOutputTrace(response.Result),
-                        continuedAsNew: true,
-                        functionType: FunctionType.Entity,
-                        isReplay: this.context.IsReplaying);
+                    var response = result.Responses[position++];
+
+                    var target = new OrchestrationInstance()
+                    {
+                        InstanceId = request.ParentInstanceId,
+                    };
+                    var responseMessage = new ResponseMessage()
+                    {
+                        Result = response.Result,
+                        ExceptionType = response.IsError ? "Error" : null,
+                    };
+                    var guid = request.Id.ToString();
+                    this.context.SendEntityMessage(target, guid, responseMessage);
                 }
+            }
+
+            // send signal messages
+            foreach (var signal in result.Signals)
+            {
+                var request = new RequestMessage()
+                {
+                    ParentInstanceId = this.context.InstanceId,
+                    Id = Guid.NewGuid(),
+                    IsSignal = true,
+                    Operation = signal.Name,
+                    Input = signal.Input,
+                };
+                var target = new OrchestrationInstance()
+                {
+                    InstanceId = EntityId.GetSchedulerIdFromEntityId(signal.Target),
+                };
+                this.context.SendEntityMessage(target, "op", request);
             }
         }
 
-        public override void TraceAwait()
+        internal class OutOfProcResult
         {
-            // we only trace the awaits that are happening inside an operation,
-            // not the awaits that come from the scheduler loop
+            [JsonProperty("entityExists")]
+            public bool EntityExists { get; set; }
 
-            if (this.context.CurrentOperation != null)
+            [JsonProperty("entityState")]
+            public string EntityState { get; set; }
+
+            [JsonProperty("responses")]
+            public List<Response> Responses { get; set; }
+
+            [JsonProperty("signals")]
+            public List<Signal> Signals { get; set; }
+
+            public struct Response
             {
-                this.Config.TraceHelper.FunctionAwaited(
-                    this.context.HubName,
-                    this.context.Name,
-                    this.context.FunctionType,
-                    this.context.InstanceId,
-                    this.context.CurrentOperation?.Id.ToString() ?? string.Empty,
-                    this.context.CurrentOperation?.Operation ?? string.Empty,
-                    this.context.IsReplaying);
+                [JsonProperty("result")]
+                public string Result { get; set; }
+
+                [JsonProperty("isError")]
+                public bool IsError { get; set; }
+            }
+
+            public struct Signal
+            {
+                [JsonProperty("target")]
+                public EntityId Target { get; set; }
+
+                [JsonProperty("name")]
+                public string Name { get; set; }
+
+                [JsonProperty("input")]
+                public string Input { get; set; }
             }
         }
     }

--- a/src/WebJobs.Extensions.DurableTask/Listener/TaskOrchestrationShim.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/TaskOrchestrationShim.cs
@@ -72,8 +72,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 this.context.HubName,
                 this.context.Name,
                 this.context.InstanceId,
-                string.Empty,
-                string.Empty,
                 this.Config.GetIntputOutputTrace(serializedInput),
                 FunctionType.Orchestrator,
                 this.context.IsReplaying);
@@ -111,8 +109,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     this.context.HubName,
                     this.context.Name,
                     this.context.InstanceId,
-                    string.Empty,
-                    string.Empty,
                     exceptionDetails,
                     FunctionType.Orchestrator,
                     this.context.IsReplaying);
@@ -170,8 +166,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 this.context.HubName,
                 this.context.Name,
                 this.context.InstanceId,
-                string.Empty,
-                string.Empty,
                 this.Config.GetIntputOutputTrace(serializedOutput),
                 this.context.ContinuedAsNew,
                 FunctionType.Orchestrator,

--- a/src/WebJobs.Extensions.DurableTask/Listener/TaskOrchestrationShim.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/TaskOrchestrationShim.cs
@@ -53,18 +53,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             return this.context.GetSerializedCustomStatus();
         }
 
-        public override void TraceAwait()
-        {
-            this.Config.TraceHelper.FunctionAwaited(
-                this.context.HubName,
-                this.context.Name,
-                this.context.FunctionType,
-                this.context.InstanceId,
-                string.Empty,
-                string.Empty,
-                this.context.IsReplaying);
-        }
-
         public override void RaiseEvent(OrchestrationContext unused, string eventName, string serializedEventData)
         {
             this.Context.RaiseEvent(eventName, serializedEventData);

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
@@ -2296,6 +2296,19 @@
             about the failed sub-orchestrator or activity function.
             </remarks>
         </member>
+        <member name="M:Microsoft.Azure.WebJobs.FunctionFailedException.#ctor(System.String)">
+            <summary>
+            Initializes a new instance of a <see cref="T:Microsoft.Azure.WebJobs.FunctionFailedException"/>.
+            </summary>
+            <param name="message">A message describing where to look for more details.</param>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.FunctionFailedException.#ctor(System.String,System.Exception)">
+            <summary>
+            Initializes a new instance of a <see cref="T:Microsoft.Azure.WebJobs.FunctionFailedException"/>.
+            </summary>
+            <param name="message">A message describing where to look for more details.</param>
+            <param name="innerException">The exception that caused the function to fail.</param>
+        </member>
         <member name="T:Microsoft.Azure.WebJobs.FunctionName">
             <summary>
             The name of a durable function.

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
@@ -551,6 +551,75 @@
             The orchestration calls ContinueAsNew when it is idle, but not deleted.
             </summary>
         </member>
+        <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.TaskEntityShim.OutOfProcResult">
+            <summary>
+            The results of executing a batch of operations on the entity out of process.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.TaskEntityShim.OutOfProcResult.EntityExists">
+            <summary>
+            Whether the entity exists after executing the batch.
+            This is false if the last operation in the batch deletes the entity,
+            and true otherwise.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.TaskEntityShim.OutOfProcResult.EntityState">
+            <summary>
+            The state of the entity after executing the batch.
+            Should be null if <see cref="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.TaskEntityShim.OutOfProcResult.EntityExists"/> is false.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.TaskEntityShim.OutOfProcResult.Results">
+            <summary>
+            The results of executing the operations. The length of this list must always match
+            the size of the batch, even if there were exceptions.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.TaskEntityShim.OutOfProcResult.Signals">
+            <summary>
+            The list of signals sent by the entity. Can be empty.
+            </summary>
+        </member>
+        <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.TaskEntityShim.OutOfProcResult.OperationResult">
+            <summary>
+            The results of executing an operation.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.TaskEntityShim.OutOfProcResult.OperationResult.Result">
+            <summary>
+            The returned value or error/exception.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.TaskEntityShim.OutOfProcResult.OperationResult.IsError">
+            <summary>
+            Determines whether <see cref="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.TaskEntityShim.OutOfProcResult.OperationResult.Result"/> is a normal result, or an error/exception.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.TaskEntityShim.OutOfProcResult.OperationResult.DurationInMilliseconds">
+            <summary>
+            The measured duration of this operation's execution, in milliseconds.
+            </summary>
+        </member>
+        <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.TaskEntityShim.OutOfProcResult.Signal">
+            <summary>
+            Describes a signal that was emitted by one of the operations in the batch.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.TaskEntityShim.OutOfProcResult.Signal.Target">
+            <summary>
+            The destination of the signal.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.TaskEntityShim.OutOfProcResult.Signal.Name">
+            <summary>
+            The name of the operation being signaled.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.TaskEntityShim.OutOfProcResult.Signal.Input">
+            <summary>
+            The input of the operation being signaled.
+            </summary>
+        </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.TaskOrchestrationShim">
             <summary>
             Task orchestration implementation which delegates the orchestration implementation to a function.

--- a/test/Common/DurableTaskEndToEndTests.cs
+++ b/test/Common/DurableTaskEndToEndTests.cs
@@ -2569,7 +2569,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 }
 
                 Assert.Equal(OrchestrationRuntimeStatus.Completed, status?.RuntimeStatus);
-                Assert.Equal("ok", status?.Output);
+                Assert.Equal("ok", (string)status?.Output);
 
                 await host.StopAsync();
             }


### PR DESCRIPTION
For out-of-proc, we need to batch multiple operations into a single call (since we cannot change any of the parameters after the binding has taken place, and can therefore not call the function multiple times). 

To support this 

 - I rewrote the scheduler a bit. It now collects all the operations to execute, before executing any of them. This is actually cleaner than what we had before, it gets rid of the concurrency control (no more locking needed).
- I modified the JSON fields on the context object passed to the out-of-proc function:
   - 'batch' is an array of objects describing the operations to execute
   - 'exists' is a boolean indicating whether the entity exists 
   - 'state' is the state of the entity as a string (if `exists`)

- I modified the JSON fields on the result object returned from the out-of-proc function:
   - 'entityExists' indicates whether the entity exists. This is true unless the last operation deleted it.
   - 'entityState' is the state of the entity as a string
   - 'signals' is an array of outgoing signals
   - 'responses' is an array of outgoing responses (one per operation that is not a signal)

I also changed some of the tracing calls: since the entity scheduler (unlike general orchestrations) does not return until the entity function has completed, we do not need the `TraceAwait`. And I lowered the log level for delivery tracing to 'Debug' so it can be suppressed via configuration.