### PR TITLE
Provide sorting and deduplication for entity messages

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableCommonContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableCommonContext.cs
@@ -38,6 +38,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         {
             this.Config = config ?? throw new ArgumentNullException(nameof(config));
             this.FunctionName = functionName;
+            this.EntityMessageReorderWindow = TimeSpan.FromMinutes(config.Options.EntityMessageReorderWindowInMinutes);
         }
 
         internal DurableTaskExtension Config { get; }
@@ -81,7 +82,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
         internal string Name => this.FunctionName;
 
-        internal TimeSpan ReorderWindow => TimeSpan.FromMinutes(30);
+        internal TimeSpan EntityMessageReorderWindow { get; private set; }
 
         /// <inheritdoc/>
         DateTime IDeterministicExecutionContext.CurrentUtcDateTime => this.InnerContext.CurrentUtcDateTime;

--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableCommonContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableCommonContext.cs
@@ -81,6 +81,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
         internal string Name => this.FunctionName;
 
+        internal TimeSpan ReorderWindow => TimeSpan.FromMinutes(30);
+
         /// <inheritdoc/>
         DateTime IDeterministicExecutionContext.CurrentUtcDateTime => this.InnerContext.CurrentUtcDateTime;
 

--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableEntityContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableEntityContext.cs
@@ -161,7 +161,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             {
                 if (message is RequestMessage requestMessage)
                 {
-                    this.State.MessageSorter.LabelOutgoingMessage(requestMessage, target.InstanceId, DateTime.UtcNow, this.ReorderWindow);
+                    this.State.MessageSorter.LabelOutgoingMessage(requestMessage, target.InstanceId, DateTime.UtcNow, this.EntityMessageReorderWindow);
                 }
 
                 this.outbox.Add(new OutgoingMessage()

--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableEntityContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableEntityContext.cs
@@ -155,15 +155,20 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             }
         }
 
-        internal override void SendEntityMessage(OrchestrationInstance target, string eventName, object eventContent)
+        internal override void SendEntityMessage(OrchestrationInstance target, string eventName, object message)
         {
             lock (this.outbox)
             {
+                if (message is RequestMessage requestMessage)
+                {
+                    this.State.MessageSorter.LabelOutgoingMessage(requestMessage, target.InstanceId, DateTime.UtcNow, this.ReorderWindow);
+                }
+
                 this.outbox.Add(new OutgoingMessage()
                 {
                     Target = target,
                     EventName = eventName,
-                    EventContent = eventContent,
+                    EventContent = message,
                 });
             }
         }

--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableOrchestrationContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableOrchestrationContext.cs
@@ -388,7 +388,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         {
             if (eventContent is RequestMessage requestMessage)
             {
-                this.MessageSorter.LabelOutgoingMessage(requestMessage, target.InstanceId, this.InnerContext.CurrentUtcDateTime, this.ReorderWindow);
+                this.MessageSorter.LabelOutgoingMessage(
+                    requestMessage,
+                    target.InstanceId,
+                    this.InnerContext.CurrentUtcDateTime,
+                    TimeSpan.FromMinutes(this.Config.Options.EntityMessageReorderWindowInMinutes));
             }
 
             if (!this.IsReplaying)

--- a/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
@@ -386,15 +386,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
                             foreach (var message in deliverNow)
                             {
-                                if (entityContext.State.LockedBy == requestMessage.ParentInstanceId)
+                                if (entityContext.State.LockedBy == message.ParentInstanceId)
                                 {
                                     // operation requests from the lock holder are processed immediately
-                                    entityShim.AddOperationToBatch(requestMessage);
+                                    entityShim.AddOperationToBatch(message);
                                 }
                                 else
                                 {
                                     // others go to the back of the queue
-                                    entityContext.State.Enqueue(requestMessage);
+                                    entityContext.State.Enqueue(message);
                                 }
                             }
                         }

--- a/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
@@ -381,15 +381,21 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                             // we are receiving an operation request or a lock request
                             var requestMessage = JsonConvert.DeserializeObject<RequestMessage>(eventRaisedEvent.Input);
 
-                            if (entityContext.State.LockedBy == requestMessage.ParentInstanceId)
+                            // run this through the message sorter to help with reordering and duplicate filtering
+                            var deliverNow = entityContext.State.MessageSorter.ReceiveInOrder(requestMessage, entityContext.ReorderWindow);
+
+                            foreach (var message in deliverNow)
                             {
-                                // operation requests from the lock holder are processed immediately
-                                entityShim.AddOperationToBatch(requestMessage);
-                            }
-                            else
-                            {
-                                // others go to the back of the queue
-                                entityContext.State.Enqueue(requestMessage);
+                                if (entityContext.State.LockedBy == requestMessage.ParentInstanceId)
+                                {
+                                    // operation requests from the lock holder are processed immediately
+                                    entityShim.AddOperationToBatch(requestMessage);
+                                }
+                                else
+                                {
+                                    // others go to the back of the queue
+                                    entityContext.State.Enqueue(requestMessage);
+                                }
                             }
                         }
                         else

--- a/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
@@ -382,7 +382,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                             var requestMessage = JsonConvert.DeserializeObject<RequestMessage>(eventRaisedEvent.Input);
 
                             // run this through the message sorter to help with reordering and duplicate filtering
-                            var deliverNow = entityContext.State.MessageSorter.ReceiveInOrder(requestMessage, entityContext.ReorderWindow);
+                            var deliverNow = entityContext.State.MessageSorter.ReceiveInOrder(requestMessage, entityContext.EntityMessageReorderWindow);
 
                             foreach (var message in deliverNow)
                             {

--- a/src/WebJobs.Extensions.DurableTask/EntityScheduler/MessageSorter.cs
+++ b/src/WebJobs.Extensions.DurableTask/EntityScheduler/MessageSorter.cs
@@ -1,0 +1,243 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Newtonsoft.Json;
+
+namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
+{
+    /// <summary>
+    /// provides message ordering and deduplication of request messages (operations or lock requests)
+    /// that are sent to entities, from other entities, or from orchestrations.
+    /// </summary>
+    [JsonObject(MemberSerialization.OptIn)]
+    internal class MessageSorter
+    {
+        // don't update the reorder window too often since the garbage collection incurs some overhead.
+        private static readonly TimeSpan MinIntervalBetweenCollections = TimeSpan.FromSeconds(10);
+
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public Dictionary<string, DateTime> Sent { get; set; }
+
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public Dictionary<string, ReceiveBuffer> Received { get; set; }
+
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public DateTime ReceiveHorizon { get; set; }
+
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public DateTime SendHorizon { get; set; }
+
+        public int NumberBufferedRequests =>
+            this.Received?.Select(kvp => kvp.Value.Buffered?.Count ?? 0).Sum() ?? 0;
+
+        /// <summary>
+        /// Called on the sending side, to fill in timestamp and predecessor fields.
+        /// </summary>
+        public void LabelOutgoingMessage(RequestMessage message, string destination, DateTime now, TimeSpan reorderWindow)
+        {
+            DateTime timestamp = now;
+
+            if (this.SendHorizon + reorderWindow + MinIntervalBetweenCollections < now)
+            {
+                this.SendHorizon = now - reorderWindow;
+
+                // clean out send clocks that are past the reorder window
+
+                if (this.Sent != null)
+                {
+                    List<string> expired = null;
+
+                    foreach (var kvp in this.Sent)
+                    {
+                        if (kvp.Value < this.SendHorizon)
+                        {
+                            (expired ?? (expired = new List<string>())).Add(kvp.Key);
+                        }
+                    }
+
+                    if (expired != null)
+                    {
+                        foreach (var t in expired)
+                        {
+                            this.Sent.Remove(t);
+                        }
+
+                        expired.Clear();
+                    }
+
+                    if (this.Sent.Count == 0)
+                    {
+                        this.Sent = null;
+                    }
+                }
+            }
+
+            if (this.Sent == null)
+            {
+                this.Sent = new Dictionary<string, DateTime>();
+            }
+            else if (this.Sent.TryGetValue(destination, out var last))
+            {
+                message.Predecessor = last;
+
+                // ensure timestamps are monotonic even if system clock is not
+                if (timestamp <= last)
+                {
+                    timestamp = new DateTime(last.Ticks + 1);
+                }
+            }
+
+            message.Timestamp = timestamp;
+            this.Sent[destination] = timestamp;
+        }
+
+        /// <summary>
+        /// Called on the receiving side, to reorder and deduplicate within the window.
+        /// </summary>
+        public IEnumerable<RequestMessage> ReceiveInOrder(RequestMessage message, TimeSpan reorderWindow)
+        {
+            // messages sent from clients are  not participating in the sorting.
+            if (message.ParentInstanceId == null)
+            {
+                // Just pass the message through.
+                yield return message;
+                yield break;
+            }
+
+            // advance the horizon based on the latest timestamp
+            if (this.ReceiveHorizon + reorderWindow + MinIntervalBetweenCollections < message.Timestamp)
+            {
+                this.ReceiveHorizon = message.Timestamp - reorderWindow;
+
+                // deliver any messages that were held in the receive buffers
+                // but are now past the reorder window
+
+                List<string> emptyReceiveBuffers = null;
+
+                if (this.Received != null)
+                {
+                    foreach (var kvp in this.Received)
+                    {
+                        if (kvp.Value.Last < this.ReceiveHorizon)
+                        {
+                            kvp.Value.Last = DateTime.MinValue;
+                        }
+
+                        while (this.DeliverNextMessage(kvp.Value, out var next))
+                        {
+                            yield return next;
+                        }
+
+                        if (kvp.Value.Last == DateTime.MinValue
+                            && (kvp.Value.Buffered == null || kvp.Value.Buffered.Count == 0))
+                        {
+                            (emptyReceiveBuffers ?? (emptyReceiveBuffers = new List<string>())).Add(kvp.Key);
+                        }
+                    }
+
+                    if (emptyReceiveBuffers != null)
+                    {
+                        foreach (var t in emptyReceiveBuffers)
+                        {
+                            this.Received.Remove(t);
+                        }
+                    }
+
+                    if (this.Received.Count == 0)
+                    {
+                        this.Received = null;
+                    }
+                }
+            }
+
+            // Messages older than the reorder window are not participating.
+            if (message.Timestamp < this.ReceiveHorizon)
+            {
+                // Just pass the message through.
+                yield return message;
+                yield break;
+            }
+
+            ReceiveBuffer receiveBuffer;
+
+            if (this.Received == null)
+            {
+                this.Received = new Dictionary<string, ReceiveBuffer>()
+                {
+                    { message.ParentInstanceId,  receiveBuffer = new ReceiveBuffer() },
+                };
+            }
+            else if (!this.Received.TryGetValue(message.ParentInstanceId, out receiveBuffer))
+            {
+                this.Received[message.ParentInstanceId] = receiveBuffer = new ReceiveBuffer();
+            }
+
+            if (message.Timestamp <= receiveBuffer.Last)
+            {
+                // This message was already delivered, it's a duplicate
+                yield break;
+            }
+
+            if (message.Predecessor > receiveBuffer.Last
+                && message.Predecessor >= this.ReceiveHorizon)
+            {
+                // this message is waiting for a non-delivered predecessor in the window, buffer it
+                if (receiveBuffer.Buffered == null)
+                {
+                    receiveBuffer.Buffered = new SortedDictionary<DateTime, RequestMessage>();
+                }
+
+                receiveBuffer.Buffered[message.Timestamp] = message;
+            }
+            else
+            {
+                yield return message;
+
+                receiveBuffer.Last = message.Timestamp >= this.ReceiveHorizon ? message.Timestamp : DateTime.MinValue;
+
+                while (this.DeliverNextMessage(receiveBuffer, out var next))
+                {
+                    yield return next;
+                }
+            }
+        }
+
+        private bool DeliverNextMessage(ReceiveBuffer buffer, out RequestMessage message)
+        {
+            if (buffer.Buffered != null)
+            {
+                using (var e = buffer.Buffered.GetEnumerator())
+                {
+                    if (e.MoveNext())
+                    {
+                        var pred = e.Current.Value.Predecessor;
+
+                        if (pred <= buffer.Last || pred < this.ReceiveHorizon)
+                        {
+                            message = e.Current.Value;
+
+                            buffer.Last = message.Timestamp >= this.ReceiveHorizon ? message.Timestamp : DateTime.MinValue;
+
+                            buffer.Buffered.Remove(message.Timestamp);
+
+                            return true;
+                        }
+                    }
+                }
+            }
+
+            message = null;
+            return false;
+        }
+
+        [JsonObject(MemberSerialization.OptOut)]
+        internal class ReceiveBuffer
+        {
+            public DateTime Last { get; set; }// last message delivered, or DateTime.Min if none
+
+            [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+            public SortedDictionary<DateTime, RequestMessage> Buffered { get; set; }
+        }
+    }
+}

--- a/src/WebJobs.Extensions.DurableTask/EntityScheduler/RequestMessage.cs
+++ b/src/WebJobs.Extensions.DurableTask/EntityScheduler/RequestMessage.cs
@@ -49,6 +49,18 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         public string ParentInstanceId { get; set; }
 
         /// <summary>
+        /// A timestamp for this request. 
+        /// Used for duplicate filtering and in-order delivery.
+        /// </summary>
+        public DateTime Timestamp { get; set; }
+
+        /// <summary>
+        /// A timestamp for the predecessor request in the stream, or DateTime.MinValue if none.
+        /// Used for duplicate filtering and in-order delivery.
+        /// </summary>
+        public DateTime Predecessor { get; set; }
+
+        /// <summary>
         /// For lock requests, the set of locks being acquired. Is sorted,
         /// contains at least one element, and has no repetitions.
         /// </summary>

--- a/src/WebJobs.Extensions.DurableTask/EntityScheduler/RequestMessage.cs
+++ b/src/WebJobs.Extensions.DurableTask/EntityScheduler/RequestMessage.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         public string ParentInstanceId { get; set; }
 
         /// <summary>
-        /// A timestamp for this request. 
+        /// A timestamp for this request.
         /// Used for duplicate filtering and in-order delivery.
         /// </summary>
         public DateTime Timestamp { get; set; }

--- a/src/WebJobs.Extensions.DurableTask/EntityScheduler/SchedulerState.cs
+++ b/src/WebJobs.Extensions.DurableTask/EntityScheduler/SchedulerState.cs
@@ -42,6 +42,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         [JsonProperty(PropertyName = "lockedBy", DefaultValueHandling = DefaultValueHandling.Ignore)]
         public string LockedBy { get; set; }
 
+        /// <summary>
+        /// The metadata used for reordering and deduplication of messages sent to entities.
+        /// </summary>
+        [JsonProperty(PropertyName = "sorter", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public MessageSorter MessageSorter { get; set; } = new MessageSorter();
+
         [JsonIgnore]
         public bool IsEmpty => !this.EntityExists && (this.Queue == null || this.Queue.Count == 0) && this.LockedBy == null;
 

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
@@ -300,6 +300,22 @@
             <param name="configure">An <see cref="T:System.Action`1"/> to configure the provided <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskOptions"/>.</param>
             <returns>Returns the modified <paramref name="builder"/> object.</returns>
         </member>
+        <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.MessageSorter">
+            <summary>
+            provides message ordering and deduplication of request messages (operations or lock requests)
+            that are sent to entities, from other entities, or from orchestrations.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.MessageSorter.LabelOutgoingMessage(Microsoft.Azure.WebJobs.Extensions.DurableTask.RequestMessage,System.String,System.DateTime,System.TimeSpan)">
+            <summary>
+            Called on the sending side, to fill in timestamp and predecessor fields.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.MessageSorter.ReceiveInOrder(Microsoft.Azure.WebJobs.Extensions.DurableTask.RequestMessage,System.TimeSpan)">
+            <summary>
+            Called on the receiving side, to reorder and deduplicate within the window.
+            </summary>
+        </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.RequestMessage">
             <summary>
             A message that represents an operation request or a lock request.
@@ -329,6 +345,18 @@
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.RequestMessage.ParentInstanceId">
             <summary>
             The parent instance that called this operation.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.RequestMessage.Timestamp">
+            <summary>
+            A timestamp for this request. 
+            Used for duplicate filtering and in-order delivery.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.RequestMessage.Predecessor">
+            <summary>
+            A timestamp for the predecessor request in the stream, or DateTime.MinValue if none.
+            Used for duplicate filtering and in-order delivery.
             </summary>
         </member>
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.RequestMessage.LockSet">
@@ -365,6 +393,11 @@
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.SchedulerState.LockedBy">
             <summary>
             The instance id of the orchestration that currently holds the lock of this entity.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.SchedulerState.MessageSorter">
+            <summary>
+            The metadata used for reordering and deduplication of messages sent to entities.
             </summary>
         </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.EtwEventSource">

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
@@ -306,6 +306,11 @@
             that are sent to entities, from other entities, or from orchestrations.
             </summary>
         </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.MessageSorter.NumberBufferedRequests">
+            <summary>
+            Used for testing purposes.
+            </summary>
+        </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.MessageSorter.LabelOutgoingMessage(Microsoft.Azure.WebJobs.Extensions.DurableTask.RequestMessage,System.String,System.DateTime,System.TimeSpan)">
             <summary>
             Called on the sending side, to fill in timestamp and predecessor fields.
@@ -349,7 +354,7 @@
         </member>
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.RequestMessage.Timestamp">
             <summary>
-            A timestamp for this request. 
+            A timestamp for this request.
             Used for duplicate filtering and in-order delivery.
             </summary>
         </member>
@@ -992,6 +997,11 @@
             <value>
             The number of seconds before an idle session times out.
             </value>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskOptions.EntityMessageReorderWindowInMinutes">
+            <summary>
+            Gets or sets the time window within which entity messages get deduplicated and reordered.
+            </summary>
         </member>
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskOptions.CustomLifeCycleNotificationHelperType">
             <summary>

--- a/src/WebJobs.Extensions.DurableTask/Options/DurableTaskOptions.cs
+++ b/src/WebJobs.Extensions.DurableTask/Options/DurableTaskOptions.cs
@@ -101,6 +101,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         public int ExtendedSessionIdleTimeoutInSeconds { get; set; } = 30;
 
         /// <summary>
+        /// Gets or sets the time window within which entity messages get deduplicated and reordered.
+        /// </summary>
+        public int EntityMessageReorderWindowInMinutes { get; set; } = 30;
+
+        /// <summary>
         /// Gets or sets the type name of a custom to use for handling lifecycle notification events.
         /// </summary>
         /// <value>Assembly qualified class name that implements <see cref="ILifeCycleNotificationHelper">ILifeCycleNotificationHelper</see>.</value>

--- a/test/Common/MessageSorterTests.cs
+++ b/test/Common/MessageSorterTests.cs
@@ -40,6 +40,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             Assert.Single(batch).Input.Equals("2");
             batch = receiverSorter.ReceiveInOrder(message3, ReorderWindow).ToList();
             Assert.Single(batch).Input.Equals("3");
+
+            Assert.Equal(0, receiverSorter.NumberBufferedRequests);
         }
 
         [Fact]
@@ -67,6 +69,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             Assert.Single(batch).Input.Equals("2");
             batch = receiverSorter.ReceiveInOrder(message3, ReorderWindow).ToList();
             Assert.Single(batch).Input.Equals("3");
+
+            Assert.Equal(0, receiverSorter.NumberBufferedRequests);
         }
 
         [Fact]
@@ -97,6 +101,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 first => first.Input.Equals("1"),
                 second => second.Input.Equals("2"),
                 third => third.Input.Equals("3"));
+
+            Assert.Equal(0, receiverSorter.NumberBufferedRequests);
         }
 
         [Fact]
@@ -123,6 +129,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             Assert.Single(batch).Input.Equals("2");
             batch = receiverSorter.ReceiveInOrder(message3, ReorderWindow).ToList();
             Assert.Single(batch).Input.Equals("3");
+
+            Assert.Equal(0, receiverSorter.NumberBufferedRequests);
         }
 
         [Fact]
@@ -168,6 +176,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             Assert.Empty(batch);
             batch = receiverSorter.ReceiveInOrder(message1, ReorderWindow).ToList();
             Assert.Empty(batch);
+
+            Assert.Equal(0, receiverSorter.NumberBufferedRequests);
         }
 
         [Fact]
@@ -217,6 +227,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             {
                 Assert.Equal(i.ToString(), deliveredMessages[i].Input);
             }
+
+            Assert.Equal(0, receiverSorter.NumberBufferedRequests);
         }
 
         /// <summary>
@@ -272,6 +284,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
             // check that all messages were delivered
             Assert.Equal(messageCount + 1, deliveredMessages.Count());
+
+            Assert.Equal(0, receiverSorter.NumberBufferedRequests);
         }
 
         private static RequestMessage Send(string senderId, string receiverId, string input, MessageSorter sorter, DateTime now, TimeSpan? reorderWindow = null)

--- a/test/Common/MessageSorterTests.cs
+++ b/test/Common/MessageSorterTests.cs
@@ -1,0 +1,302 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using DurableTask.Core;
+using FluentAssertions;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
+{
+    public class MessageSorterTests
+    {
+        private static readonly TimeSpan ReorderWindow = TimeSpan.FromMinutes(30);
+
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public void SimpleInOrder()
+        {
+            var senderId = "A";
+            var receiverId = "B";
+
+            var senderSorter = new MessageSorter();
+
+            var message1 = Send(senderId, receiverId, "1", senderSorter, DateTime.UtcNow);
+            var message2 = Send(senderId, receiverId, "2", senderSorter, DateTime.UtcNow);
+            var message3 = Send(senderId, receiverId, "3", senderSorter, DateTime.UtcNow);
+
+            List<RequestMessage> batch;
+            MessageSorter receiverSorter = new MessageSorter();
+
+            // delivering the sequence in order produces 1 message each time
+            receiverSorter = new MessageSorter();
+            batch = receiverSorter.ReceiveInOrder(message1, ReorderWindow).ToList();
+            Assert.Single(batch).Input.Equals("1");
+            batch = receiverSorter.ReceiveInOrder(message2, ReorderWindow).ToList();
+            Assert.Single(batch).Input.Equals("2");
+            batch = receiverSorter.ReceiveInOrder(message3, ReorderWindow).ToList();
+            Assert.Single(batch).Input.Equals("3");
+        }
+
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public void WackySystemClock()
+        {
+            var senderId = "A";
+            var receiverId = "B";
+
+            var senderSorter = new MessageSorter();
+
+            // simulate system clock that goes backwards - mechanism should still guarantee monotonicitty
+            var message1 = Send(senderId, receiverId, "1", senderSorter, DateTime.UtcNow);
+            var message2 = Send(senderId, receiverId, "2", senderSorter, DateTime.UtcNow - TimeSpan.FromSeconds(1));
+            var message3 = Send(senderId, receiverId, "3", senderSorter, DateTime.UtcNow - TimeSpan.FromSeconds(2));
+
+            List<RequestMessage> batch;
+            MessageSorter receiverSorter = new MessageSorter();
+
+            // delivering the sequence in order produces 1 message each time
+            receiverSorter = new MessageSorter();
+            batch = receiverSorter.ReceiveInOrder(message1, ReorderWindow).ToList();
+            Assert.Single(batch).Input.Equals("1");
+            batch = receiverSorter.ReceiveInOrder(message2, ReorderWindow).ToList();
+            Assert.Single(batch).Input.Equals("2");
+            batch = receiverSorter.ReceiveInOrder(message3, ReorderWindow).ToList();
+            Assert.Single(batch).Input.Equals("3");
+        }
+
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public void DelayedElement()
+        {
+            var senderId = "A";
+            var receiverId = "B";
+
+            var senderSorter = new MessageSorter();
+
+            var message1 = Send(senderId, receiverId, "1", senderSorter, DateTime.UtcNow);
+            var message2 = Send(senderId, receiverId, "2", senderSorter, DateTime.UtcNow);
+            var message3 = Send(senderId, receiverId, "3", senderSorter, DateTime.UtcNow);
+
+            List<RequestMessage> batch;
+            MessageSorter receiverSorter;
+
+            // delivering first message last delays all messages until getting the first one
+            receiverSorter = new MessageSorter();
+            batch = receiverSorter.ReceiveInOrder(message2, ReorderWindow).ToList();
+            Assert.Empty(batch);
+            batch = receiverSorter.ReceiveInOrder(message3, ReorderWindow).ToList();
+            Assert.Empty(batch);
+            batch = receiverSorter.ReceiveInOrder(message1, ReorderWindow).ToList();
+            Assert.Collection(
+                batch,
+                first => first.Input.Equals("1"),
+                second => second.Input.Equals("2"),
+                third => third.Input.Equals("3"));
+        }
+
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public void Collection()
+        {
+            var senderId = "A";
+            var receiverId = "B";
+
+            var senderSorter = new MessageSorter();
+
+            var message1 = Send(senderId, receiverId, "1", senderSorter, DateTime.UtcNow);
+            var message2 = Send(senderId, receiverId, "2", senderSorter, DateTime.UtcNow + ReorderWindow + ReorderWindow);
+            var message3 = Send(senderId, receiverId, "3", senderSorter, DateTime.UtcNow + ReorderWindow + ReorderWindow + ReorderWindow + ReorderWindow);
+
+            List<RequestMessage> batch;
+            MessageSorter receiverSorter = new MessageSorter();
+
+            // delivering the sequence in order produces 1 message each time
+            receiverSorter = new MessageSorter();
+            batch = receiverSorter.ReceiveInOrder(message1, ReorderWindow).ToList();
+            Assert.Single(batch).Input.Equals("1");
+            batch = receiverSorter.ReceiveInOrder(message2, ReorderWindow).ToList();
+            Assert.Single(batch).Input.Equals("2");
+            batch = receiverSorter.ReceiveInOrder(message3, ReorderWindow).ToList();
+            Assert.Single(batch).Input.Equals("3");
+        }
+
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public void DuplicatedElements()
+        {
+            var senderId = "A";
+            var receiverId = "B";
+
+            var senderSorter = new MessageSorter();
+
+            var message1 = Send(senderId, receiverId, "1", senderSorter, DateTime.UtcNow);
+            var message2 = Send(senderId, receiverId, "2", senderSorter, DateTime.UtcNow);
+            var message3 = Send(senderId, receiverId, "3", senderSorter, DateTime.UtcNow);
+
+            List<RequestMessage> batch;
+            MessageSorter receiverSorter;
+
+            // delivering first message last delays all messages until getting the first one
+            receiverSorter = new MessageSorter();
+            batch = receiverSorter.ReceiveInOrder(message2, ReorderWindow).ToList();
+            Assert.Empty(batch);
+            batch = receiverSorter.ReceiveInOrder(message2, ReorderWindow).ToList();
+            Assert.Empty(batch);
+            batch = receiverSorter.ReceiveInOrder(message1, ReorderWindow).ToList();
+            Assert.Collection(
+                batch,
+                first => first.Input.Equals("1"),
+                second => second.Input.Equals("2"));
+            batch = receiverSorter.ReceiveInOrder(message2, ReorderWindow).ToList();
+            Assert.Empty(batch);
+            batch = receiverSorter.ReceiveInOrder(message1, ReorderWindow).ToList();
+            Assert.Empty(batch);
+            batch = receiverSorter.ReceiveInOrder(message2, ReorderWindow).ToList();
+            Assert.Empty(batch);
+            batch = receiverSorter.ReceiveInOrder(message1, ReorderWindow).ToList();
+            Assert.Empty(batch);
+            batch = receiverSorter.ReceiveInOrder(message3, ReorderWindow).ToList();
+            Assert.Single(batch).Input.Equals("3");
+            batch = receiverSorter.ReceiveInOrder(message3, ReorderWindow).ToList();
+            Assert.Empty(batch);
+            batch = receiverSorter.ReceiveInOrder(message2, ReorderWindow).ToList();
+            Assert.Empty(batch);
+            batch = receiverSorter.ReceiveInOrder(message1, ReorderWindow).ToList();
+            Assert.Empty(batch);
+        }
+
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public void RandomShuffleAndDuplication()
+        {
+            var senderId = "A";
+            var receiverId = "B";
+
+            var senderSorter = new MessageSorter();
+            var receiverSorter = new MessageSorter();
+
+            var messageCount = 100;
+            var duplicateCount = 100;
+
+            // create a ordered sequence of messages
+            var messages = new List<RequestMessage>();
+            for (int i = 0; i < messageCount; i++)
+            {
+                messages.Add(Send(senderId, receiverId, i.ToString(), senderSorter, DateTime.UtcNow));
+            }
+
+            // add some random duplicates
+            var random = new Random(0);
+            for (int i = 0; i < duplicateCount; i++)
+            {
+                messages.Add(messages[random.Next(messageCount)]);
+            }
+
+            // shuffle the messages
+            Shuffle(messages, random);
+
+            // deliver all the messages
+            var deliveredMessages = new List<RequestMessage>();
+
+            foreach (var msg in messages)
+            {
+                foreach (var deliveredMessage in receiverSorter.ReceiveInOrder(msg, ReorderWindow))
+                {
+                    deliveredMessages.Add(deliveredMessage);
+                }
+            }
+
+            // check that the delivered messages are the original sequence
+            Assert.Equal(messageCount, deliveredMessages.Count());
+            for (int i = 0; i < messageCount; i++)
+            {
+                Assert.Equal(i.ToString(), deliveredMessages[i].Input);
+            }
+        }
+
+        /// <summary>
+        /// Tests that if messages get reordered beyond the supported reorder window,
+        /// we still deliver them all but they may now be out of order.
+        /// </summary>
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public void RandomCollection()
+        {
+            var senderId = "A";
+            var receiverId = "B";
+
+            var senderSorter = new MessageSorter();
+            var receiverSorter = new MessageSorter();
+
+            var messageCount = 100;
+
+            var random = new Random(0);
+            var now = DateTime.UtcNow;
+
+            // create a ordered sequence of messages
+            var messages = new List<RequestMessage>();
+            for (int i = 0; i < messageCount; i++)
+            {
+                messages.Add(Send(senderId, receiverId, i.ToString(), senderSorter, now + TimeSpan.FromSeconds(i), TimeSpan.FromSeconds(10)));
+            }
+
+            // shuffle the messages
+            Shuffle(messages, random);
+
+            // add a final message
+            messages.Add(Send(senderId, receiverId, (messageCount + 1).ToString(), senderSorter, now + TimeSpan.FromSeconds(1000), TimeSpan.FromSeconds(10)));
+
+            // deliver all the messages
+            var deliveredMessages = new List<RequestMessage>();
+
+            for (int i = 0; i < messageCount; i++)
+            {
+                foreach (var deliveredMessage in receiverSorter.ReceiveInOrder(messages[i], TimeSpan.FromSeconds(10)))
+                {
+                    deliveredMessages.Add(deliveredMessage);
+                }
+
+                Assert.Equal(i + 1, deliveredMessages.Count + receiverSorter.NumberBufferedRequests);
+            }
+
+            // receive the final messages
+            foreach (var deliveredMessage in receiverSorter.ReceiveInOrder(messages[messageCount], TimeSpan.FromSeconds(10)))
+            {
+                deliveredMessages.Add(deliveredMessage);
+            }
+
+            // check that all messages were delivered
+            Assert.Equal(messageCount + 1, deliveredMessages.Count());
+        }
+
+        private static RequestMessage Send(string senderId, string receiverId, string input, MessageSorter sorter, DateTime now, TimeSpan? reorderWindow = null)
+        {
+            var msg = new RequestMessage()
+            {
+                Id = Guid.NewGuid(),
+                ParentInstanceId = senderId,
+                Input = input,
+            };
+            sorter.LabelOutgoingMessage(msg, receiverId, now, reorderWindow.HasValue ? reorderWindow.Value : ReorderWindow);
+            return msg;
+        }
+
+        private static void Shuffle<T>(IList<T> list, Random random)
+        {
+            int n = list.Count;
+            while (n > 1)
+            {
+                n--;
+                int k = random.Next(n + 1);
+                T value = list[k];
+                list[k] = list[n];
+                list[n] = value;
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR fixes the issue described in #762.

Our current implementation does not guarantee exactly-once and in-order delivery. Depending on various timing aspects messages can be delivered out of order. They can also be duplicated in some circumstances involving failures or lease timeouts.

The reordering of messages currently causes several of our tests to fail occasionally (DurableEntity_EntityProxy, DurableEntity_BasicObjects, DurableEntity_EntityProxy_NameResolution) because they expect signals and operations targeting an entity from an orchestration to be delivered in the same order as they appear in the orchestration. 

Also, several of our examples include operations (e.g. increment) that by design implicitly assume that each message is delivered exactly once.

This PR adds a mechanism for message sorting and deduplication. It adds two fields  (timestamp and predecessor) to each request message, and uses these to sort and deduplicate all messages for the same (sender instance, receiver instance) pair, where the sender instance is either an orchestration or an entity, and the receiver instance is an entity.

To keep the meta data from growing beyond bounds, this is a best-effort implementation; messages are reordered and deduplicated within a 30-minute window. Note that this window advances based on the timestamp of messages received, not the local clock of the receiver. So, this still works even if a receiver does not receive any messages for a period exceeding 30 minutes.

