### PR TITLE
Add WaitForExternalEvent with CancellationToken overloads

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/DurableOrchestrationContextBase.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableOrchestrationContextBase.cs
@@ -411,6 +411,22 @@ namespace Microsoft.Azure.WebJobs
         public virtual Task WaitForExternalEvent(string name, TimeSpan timeout) => this.WaitForExternalEvent<object>(name, timeout);
 
         /// <summary>
+        /// Waits asynchronously for an event to be raised with name <paramref name="name"/>.
+        /// </summary>
+        /// <remarks>
+        /// External clients can raise events to a waiting orchestration instance using
+        /// <see cref="DurableOrchestrationClient.RaiseEventAsync(string, string, object)"/> with the object parameter set to <c>null</c>.
+        /// </remarks>
+        /// <param name="name">The name of the event to wait for.</param>
+        /// <param name="timeout">The duration after which to throw a TimeoutException.</param>
+        /// <param name="cancelToken">The <c>CancellationToken</c> to use for cancelling the timer.</param>
+        /// <returns>A durable task that completes when the external event is received.</returns>
+        /// <exception cref="TimeoutException">
+        /// The external event was not received before the timeout expired.
+        /// </exception>
+        public virtual Task WaitForExternalEvent(string name, TimeSpan timeout, CancellationToken cancelToken) => throw new NotImplementedException();
+
+        /// <summary>
         /// Waits asynchronously for an event to be raised with name <paramref name="name"/> and returns the event data.
         /// </summary>
         /// <remarks>
@@ -434,12 +450,45 @@ namespace Microsoft.Azure.WebJobs
         /// <see cref="DurableOrchestrationClient.RaiseEventAsync(string, string, object)"/>.
         /// </remarks>
         /// <param name="name">The name of the event to wait for.</param>
+        /// <param name="timeout">The duration after which to throw a TimeoutException.</param>
+        /// <param name="cancelToken">The <c>CancellationToken</c> to use for cancelling the timer.</param>
+        /// <typeparam name="T">Any serializeable type that represents the JSON event payload.</typeparam>
+        /// <returns>A durable task that completes when the external event is received.</returns>
+        /// <exception cref="TimeoutException">
+        /// The external event was not received before the timeout expired.
+        /// </exception>
+        public virtual Task<T> WaitForExternalEvent<T>(string name, TimeSpan timeout, CancellationToken cancelToken) => throw new NotImplementedException();
+
+        /// <summary>
+        /// Waits asynchronously for an event to be raised with name <paramref name="name"/> and returns the event data.
+        /// </summary>
+        /// <remarks>
+        /// External clients can raise events to a waiting orchestration instance using
+        /// <see cref="DurableOrchestrationClient.RaiseEventAsync(string, string, object)"/>.
+        /// </remarks>
+        /// <param name="name">The name of the event to wait for.</param>
         /// <param name="timeout">The duration after which to return the value in the <paramref name="defaultValue"/> parameter.</param>
         /// <param name="defaultValue">The default value to return if the timeout expires before the external event is received.</param>
         /// <typeparam name="T">Any serializeable type that represents the JSON event payload.</typeparam>
         /// <returns>A durable task that completes when the external event is received, or returns the value of <paramref name="defaultValue"/>
         /// if the timeout expires.</returns>
         public abstract Task<T> WaitForExternalEvent<T>(string name, TimeSpan timeout, T defaultValue);
+
+        /// <summary>
+        /// Waits asynchronously for an event to be raised with name <paramref name="name"/> and returns the event data.
+        /// </summary>
+        /// <remarks>
+        /// External clients can raise events to a waiting orchestration instance using
+        /// <see cref="DurableOrchestrationClient.RaiseEventAsync(string, string, object)"/>.
+        /// </remarks>
+        /// <param name="name">The name of the event to wait for.</param>
+        /// <param name="timeout">The duration after which to return the value in the <paramref name="defaultValue"/> parameter.</param>
+        /// <param name="defaultValue">The default value to return if the timeout expires before the external event is received.</param>
+        /// <param name="cancelToken">The <c>CancellationToken</c> to use for cancelling the timer.</param>
+        /// <typeparam name="T">Any serializeable type that represents the JSON event payload.</typeparam>
+        /// <returns>A durable task that completes when the external event is received, or returns the value of <paramref name="defaultValue"/>
+        /// if the timeout expires.</returns>
+        public virtual Task<T> WaitForExternalEvent<T>(string name, TimeSpan timeout, T defaultValue, CancellationToken cancelToken) => throw new NotImplementedException();
 
         /// <summary>
         /// Restarts the orchestration by clearing its history.

--- a/src/WebJobs.Extensions.DurableTask/DurableOrchestrationContextBase.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableOrchestrationContextBase.cs
@@ -396,7 +396,7 @@ namespace Microsoft.Azure.WebJobs
         public abstract Task<T> WaitForExternalEvent<T>(string name);
 
         /// <summary>
-        /// Waits asynchronously for an event to be raised with name <paramref name="name"/>.
+        /// Waits asynchronously for an event to be raised with name <paramref name="name"/> for duration <paramref name="timeout"/>.
         /// </summary>
         /// <remarks>
         /// External clients can raise events to a waiting orchestration instance using
@@ -411,7 +411,8 @@ namespace Microsoft.Azure.WebJobs
         public virtual Task WaitForExternalEvent(string name, TimeSpan timeout) => this.WaitForExternalEvent<object>(name, timeout);
 
         /// <summary>
-        /// Waits asynchronously for an event to be raised with name <paramref name="name"/>.
+        /// Waits asynchronously for an event to be raised with name <paramref name="name"/> for duration <paramref name="timeout"/>.
+        /// Cancelling <paramref name="cancelToken"/> allows stopping the duration timeout early.
         /// </summary>
         /// <remarks>
         /// External clients can raise events to a waiting orchestration instance using
@@ -419,7 +420,7 @@ namespace Microsoft.Azure.WebJobs
         /// </remarks>
         /// <param name="name">The name of the event to wait for.</param>
         /// <param name="timeout">The duration after which to throw a TimeoutException.</param>
-        /// <param name="cancelToken">The <c>CancellationToken</c> to use for cancelling the timer.</param>
+        /// <param name="cancelToken">The <c>CancellationToken</c> to use for cancelling <paramref name="timeout"/>'s internal timer.</param>
         /// <returns>A durable task that completes when the external event is received.</returns>
         /// <exception cref="TimeoutException">
         /// The external event was not received before the timeout expired.
@@ -427,7 +428,8 @@ namespace Microsoft.Azure.WebJobs
         public virtual Task WaitForExternalEvent(string name, TimeSpan timeout, CancellationToken cancelToken) => throw new NotImplementedException();
 
         /// <summary>
-        /// Waits asynchronously for an event to be raised with name <paramref name="name"/> and returns the event data.
+        /// Waits asynchronously for an event to be raised with name <paramref name="name"/> for duration <paramref name="timeout"/>
+        /// and returns the event data.
         /// </summary>
         /// <remarks>
         /// External clients can raise events to a waiting orchestration instance using
@@ -443,7 +445,8 @@ namespace Microsoft.Azure.WebJobs
         public abstract Task<T> WaitForExternalEvent<T>(string name, TimeSpan timeout);
 
         /// <summary>
-        /// Waits asynchronously for an event to be raised with name <paramref name="name"/> and returns the event data.
+        /// Waits asynchronously for an event to be raised with name <paramref name="name"/> for duration <paramref name="timeout"/>
+        /// and returns the event data.  Cancelling <paramref name="cancelToken"/> allows stopping the duration timeout early.
         /// </summary>
         /// <remarks>
         /// External clients can raise events to a waiting orchestration instance using
@@ -451,7 +454,7 @@ namespace Microsoft.Azure.WebJobs
         /// </remarks>
         /// <param name="name">The name of the event to wait for.</param>
         /// <param name="timeout">The duration after which to throw a TimeoutException.</param>
-        /// <param name="cancelToken">The <c>CancellationToken</c> to use for cancelling the timer.</param>
+        /// <param name="cancelToken">The <c>CancellationToken</c> to use for cancelling <paramref name="timeout"/>'s internal timer.</param>
         /// <typeparam name="T">Any serializeable type that represents the JSON event payload.</typeparam>
         /// <returns>A durable task that completes when the external event is received.</returns>
         /// <exception cref="TimeoutException">
@@ -460,7 +463,8 @@ namespace Microsoft.Azure.WebJobs
         public virtual Task<T> WaitForExternalEvent<T>(string name, TimeSpan timeout, CancellationToken cancelToken) => throw new NotImplementedException();
 
         /// <summary>
-        /// Waits asynchronously for an event to be raised with name <paramref name="name"/> and returns the event data.
+        /// Waits asynchronously for an event to be raised with name <paramref name="name"/> for duration <paramref name="timeout"/>
+        /// and returns the event data.
         /// </summary>
         /// <remarks>
         /// External clients can raise events to a waiting orchestration instance using
@@ -475,7 +479,8 @@ namespace Microsoft.Azure.WebJobs
         public abstract Task<T> WaitForExternalEvent<T>(string name, TimeSpan timeout, T defaultValue);
 
         /// <summary>
-        /// Waits asynchronously for an event to be raised with name <paramref name="name"/> and returns the event data.
+        /// Waits asynchronously for an event to be raised with name <paramref name="name"/> for duration <paramref name="timeout"/>
+        /// and returns the event data.  Cancelling <paramref name="cancelToken"/> allows stopping the duration timeout early.
         /// </summary>
         /// <remarks>
         /// External clients can raise events to a waiting orchestration instance using
@@ -484,7 +489,7 @@ namespace Microsoft.Azure.WebJobs
         /// <param name="name">The name of the event to wait for.</param>
         /// <param name="timeout">The duration after which to return the value in the <paramref name="defaultValue"/> parameter.</param>
         /// <param name="defaultValue">The default value to return if the timeout expires before the external event is received.</param>
-        /// <param name="cancelToken">The <c>CancellationToken</c> to use for cancelling the timer.</param>
+        /// <param name="cancelToken">The <c>CancellationToken</c> to use for cancelling <paramref name="timeout"/>'s internal timer.</param>
         /// <typeparam name="T">Any serializeable type that represents the JSON event payload.</typeparam>
         /// <returns>A durable task that completes when the external event is received, or returns the value of <paramref name="defaultValue"/>
         /// if the timeout expires.</returns>

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
@@ -1036,10 +1036,19 @@
         <member name="M:Microsoft.Azure.WebJobs.DurableOrchestrationContext.WaitForExternalEvent``1(System.String)">
             <inheritdoc />
         </member>
+        <member name="M:Microsoft.Azure.WebJobs.DurableOrchestrationContext.WaitForExternalEvent(System.String,System.TimeSpan,System.Threading.CancellationToken)">
+            <inheritdoc/>
+        </member>
         <member name="M:Microsoft.Azure.WebJobs.DurableOrchestrationContext.WaitForExternalEvent``1(System.String,System.TimeSpan)">
             <inheritdoc/>
         </member>
+        <member name="M:Microsoft.Azure.WebJobs.DurableOrchestrationContext.WaitForExternalEvent``1(System.String,System.TimeSpan,System.Threading.CancellationToken)">
+            <inheritdoc/>
+        </member>
         <member name="M:Microsoft.Azure.WebJobs.DurableOrchestrationContext.WaitForExternalEvent``1(System.String,System.TimeSpan,``0)">
+            <inheritdoc/>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.DurableOrchestrationContext.WaitForExternalEvent``1(System.String,System.TimeSpan,``0,System.Threading.CancellationToken)">
             <inheritdoc/>
         </member>
         <member name="M:Microsoft.Azure.WebJobs.DurableOrchestrationContext.ContinueAsNew(System.Object)">
@@ -1420,6 +1429,22 @@
             The external event was not received before the timeout expired.
             </exception>
         </member>
+        <member name="M:Microsoft.Azure.WebJobs.DurableOrchestrationContextBase.WaitForExternalEvent(System.String,System.TimeSpan,System.Threading.CancellationToken)">
+            <summary>
+            Waits asynchronously for an event to be raised with name <paramref name="name"/>.
+            </summary>
+            <remarks>
+            External clients can raise events to a waiting orchestration instance using
+            <see cref="M:Microsoft.Azure.WebJobs.DurableOrchestrationClient.RaiseEventAsync(System.String,System.String,System.Object)"/> with the object parameter set to <c>null</c>.
+            </remarks>
+            <param name="name">The name of the event to wait for.</param>
+            <param name="timeout">The duration after which to throw a TimeoutException.</param>
+            <param name="cancelToken">The <c>CancellationToken</c> to use for cancelling the timer.</param>
+            <returns>A durable task that completes when the external event is received.</returns>
+            <exception cref="T:System.TimeoutException">
+            The external event was not received before the timeout expired.
+            </exception>
+        </member>
         <member name="M:Microsoft.Azure.WebJobs.DurableOrchestrationContextBase.WaitForExternalEvent``1(System.String,System.TimeSpan)">
             <summary>
             Waits asynchronously for an event to be raised with name <paramref name="name"/> and returns the event data.
@@ -1430,6 +1455,23 @@
             </remarks>
             <param name="name">The name of the event to wait for.</param>
             <param name="timeout">The duration after which to throw a TimeoutException.</param>
+            <typeparam name="T">Any serializeable type that represents the JSON event payload.</typeparam>
+            <returns>A durable task that completes when the external event is received.</returns>
+            <exception cref="T:System.TimeoutException">
+            The external event was not received before the timeout expired.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.DurableOrchestrationContextBase.WaitForExternalEvent``1(System.String,System.TimeSpan,System.Threading.CancellationToken)">
+            <summary>
+            Waits asynchronously for an event to be raised with name <paramref name="name"/> and returns the event data.
+            </summary>
+            <remarks>
+            External clients can raise events to a waiting orchestration instance using
+            <see cref="M:Microsoft.Azure.WebJobs.DurableOrchestrationClient.RaiseEventAsync(System.String,System.String,System.Object)"/>.
+            </remarks>
+            <param name="name">The name of the event to wait for.</param>
+            <param name="timeout">The duration after which to throw a TimeoutException.</param>
+            <param name="cancelToken">The <c>CancellationToken</c> to use for cancelling the timer.</param>
             <typeparam name="T">Any serializeable type that represents the JSON event payload.</typeparam>
             <returns>A durable task that completes when the external event is received.</returns>
             <exception cref="T:System.TimeoutException">
@@ -1447,6 +1489,22 @@
             <param name="name">The name of the event to wait for.</param>
             <param name="timeout">The duration after which to return the value in the <paramref name="defaultValue"/> parameter.</param>
             <param name="defaultValue">The default value to return if the timeout expires before the external event is received.</param>
+            <typeparam name="T">Any serializeable type that represents the JSON event payload.</typeparam>
+            <returns>A durable task that completes when the external event is received, or returns the value of <paramref name="defaultValue"/>
+            if the timeout expires.</returns>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.DurableOrchestrationContextBase.WaitForExternalEvent``1(System.String,System.TimeSpan,``0,System.Threading.CancellationToken)">
+            <summary>
+            Waits asynchronously for an event to be raised with name <paramref name="name"/> and returns the event data.
+            </summary>
+            <remarks>
+            External clients can raise events to a waiting orchestration instance using
+            <see cref="M:Microsoft.Azure.WebJobs.DurableOrchestrationClient.RaiseEventAsync(System.String,System.String,System.Object)"/>.
+            </remarks>
+            <param name="name">The name of the event to wait for.</param>
+            <param name="timeout">The duration after which to return the value in the <paramref name="defaultValue"/> parameter.</param>
+            <param name="defaultValue">The default value to return if the timeout expires before the external event is received.</param>
+            <param name="cancelToken">The <c>CancellationToken</c> to use for cancelling the timer.</param>
             <typeparam name="T">Any serializeable type that represents the JSON event payload.</typeparam>
             <returns>A durable task that completes when the external event is received, or returns the value of <paramref name="defaultValue"/>
             if the timeout expires.</returns>

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
@@ -1416,7 +1416,7 @@
         </member>
         <member name="M:Microsoft.Azure.WebJobs.DurableOrchestrationContextBase.WaitForExternalEvent(System.String,System.TimeSpan)">
             <summary>
-            Waits asynchronously for an event to be raised with name <paramref name="name"/>.
+            Waits asynchronously for an event to be raised with name <paramref name="name"/> for duration <paramref name="timeout"/>.
             </summary>
             <remarks>
             External clients can raise events to a waiting orchestration instance using
@@ -1431,7 +1431,8 @@
         </member>
         <member name="M:Microsoft.Azure.WebJobs.DurableOrchestrationContextBase.WaitForExternalEvent(System.String,System.TimeSpan,System.Threading.CancellationToken)">
             <summary>
-            Waits asynchronously for an event to be raised with name <paramref name="name"/>.
+            Waits asynchronously for an event to be raised with name <paramref name="name"/> for duration <paramref name="timeout"/>.
+            Cancelling <paramref name="cancelToken"/> allows stopping the duration timeout early.
             </summary>
             <remarks>
             External clients can raise events to a waiting orchestration instance using
@@ -1439,7 +1440,7 @@
             </remarks>
             <param name="name">The name of the event to wait for.</param>
             <param name="timeout">The duration after which to throw a TimeoutException.</param>
-            <param name="cancelToken">The <c>CancellationToken</c> to use for cancelling the timer.</param>
+            <param name="cancelToken">The <c>CancellationToken</c> to use for cancelling <paramref name="timeout"/>'s internal timer.</param>
             <returns>A durable task that completes when the external event is received.</returns>
             <exception cref="T:System.TimeoutException">
             The external event was not received before the timeout expired.
@@ -1447,7 +1448,8 @@
         </member>
         <member name="M:Microsoft.Azure.WebJobs.DurableOrchestrationContextBase.WaitForExternalEvent``1(System.String,System.TimeSpan)">
             <summary>
-            Waits asynchronously for an event to be raised with name <paramref name="name"/> and returns the event data.
+            Waits asynchronously for an event to be raised with name <paramref name="name"/> for duration <paramref name="timeout"/>
+            and returns the event data.
             </summary>
             <remarks>
             External clients can raise events to a waiting orchestration instance using
@@ -1463,7 +1465,8 @@
         </member>
         <member name="M:Microsoft.Azure.WebJobs.DurableOrchestrationContextBase.WaitForExternalEvent``1(System.String,System.TimeSpan,System.Threading.CancellationToken)">
             <summary>
-            Waits asynchronously for an event to be raised with name <paramref name="name"/> and returns the event data.
+            Waits asynchronously for an event to be raised with name <paramref name="name"/> for duration <paramref name="timeout"/>
+            and returns the event data.  Cancelling <paramref name="cancelToken"/> allows stopping the duration timeout early.
             </summary>
             <remarks>
             External clients can raise events to a waiting orchestration instance using
@@ -1471,7 +1474,7 @@
             </remarks>
             <param name="name">The name of the event to wait for.</param>
             <param name="timeout">The duration after which to throw a TimeoutException.</param>
-            <param name="cancelToken">The <c>CancellationToken</c> to use for cancelling the timer.</param>
+            <param name="cancelToken">The <c>CancellationToken</c> to use for cancelling <paramref name="timeout"/>'s internal timer.</param>
             <typeparam name="T">Any serializeable type that represents the JSON event payload.</typeparam>
             <returns>A durable task that completes when the external event is received.</returns>
             <exception cref="T:System.TimeoutException">
@@ -1480,7 +1483,8 @@
         </member>
         <member name="M:Microsoft.Azure.WebJobs.DurableOrchestrationContextBase.WaitForExternalEvent``1(System.String,System.TimeSpan,``0)">
             <summary>
-            Waits asynchronously for an event to be raised with name <paramref name="name"/> and returns the event data.
+            Waits asynchronously for an event to be raised with name <paramref name="name"/> for duration <paramref name="timeout"/>
+            and returns the event data.
             </summary>
             <remarks>
             External clients can raise events to a waiting orchestration instance using
@@ -1495,7 +1499,8 @@
         </member>
         <member name="M:Microsoft.Azure.WebJobs.DurableOrchestrationContextBase.WaitForExternalEvent``1(System.String,System.TimeSpan,``0,System.Threading.CancellationToken)">
             <summary>
-            Waits asynchronously for an event to be raised with name <paramref name="name"/> and returns the event data.
+            Waits asynchronously for an event to be raised with name <paramref name="name"/> for duration <paramref name="timeout"/>
+            and returns the event data.  Cancelling <paramref name="cancelToken"/> allows stopping the duration timeout early.
             </summary>
             <remarks>
             External clients can raise events to a waiting orchestration instance using
@@ -1504,7 +1509,7 @@
             <param name="name">The name of the event to wait for.</param>
             <param name="timeout">The duration after which to return the value in the <paramref name="defaultValue"/> parameter.</param>
             <param name="defaultValue">The default value to return if the timeout expires before the external event is received.</param>
-            <param name="cancelToken">The <c>CancellationToken</c> to use for cancelling the timer.</param>
+            <param name="cancelToken">The <c>CancellationToken</c> to use for cancelling <paramref name="timeout"/>'s internal timer.</param>
             <typeparam name="T">Any serializeable type that represents the JSON event payload.</typeparam>
             <returns>A durable task that completes when the external event is received, or returns the value of <paramref name="defaultValue"/>
             if the timeout expires.</returns>

--- a/test/Common/DurableTaskEndToEndTests.cs
+++ b/test/Common/DurableTaskEndToEndTests.cs
@@ -1028,6 +1028,36 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         }
 
         /// <summary>
+        /// End-to-end test which validates a CancellationToken-providing overload of WaitForExternalEvent.
+        /// </summary>
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public async Task WaitForExternalEventWithCancellationToken()
+        {
+            var orchestratorFunctionNames = new[] { nameof(TestOrchestrations.ApprovalWithCancellationToken) };
+            var extendedSessions = false;
+            using (JobHost host = TestHelpers.GetJobHost(
+                this.loggerProvider,
+                nameof(this.WaitForExternalEventWithCancellationToken),
+                extendedSessions))
+            {
+                await host.StartAsync();
+
+                var timeout = TimeSpan.FromSeconds(10);
+                var client = await host.StartOrchestratorAsync(orchestratorFunctionNames[0], timeout, this.output);
+                await client.WaitForStartupAsync(this.output);
+
+                await client.RaiseEventAsync("approval", this.output);
+
+                var status = await client.WaitForCompletionAsync(this.output);
+                Assert.Equal(OrchestrationRuntimeStatus.Completed, status?.RuntimeStatus);
+                Assert.InRange(status.LastUpdatedTime - status.CreatedTime, TimeSpan.Zero, timeout);
+
+                await host.StopAsync();
+            }
+        }
+
+        /// <summary>
         /// End-to-end test which validates correct exceptions for invalid timeout values.
         /// </summary>
         [Fact]


### PR DESCRIPTION
Previously, `WaitForExternalEvent` when invoked with a specified timeout value would create a Timer instance that was uncancelable by the surrounding orchestration.  This could have the practical effect of making orchestrations hang until either the event was received (causing the timer to be cancelled) or the timeout was reached (because the timer expired).

This change adds overloads for `TimeSpan`-accepting overloads of `WaitForExternalEvent` that allow providing a `CancellationToken`, which the calling orchestration can cancel if it no longer intends to wait for the event to be raised.

Fixes #816