### PR TITLE
Adding first class support for HTTP calls in Orchestration functions.

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/ContextInterfaces/IDurableOrchestrationContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextInterfaces/IDurableOrchestrationContext.cs
@@ -3,9 +3,12 @@
 
 using System;
 using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Extensions.DurableTask;
+using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.Azure.WebJobs
 {
@@ -73,5 +76,21 @@ namespace Microsoft.Azure.WebJobs
         /// </remarks>
         /// <param name="customStatusObject">The JSON-serializeable value to use as the orchestrator function's custom status.</param>
         void SetCustomStatus(object customStatusObject);
+
+        /// <summary>
+        /// Makes an HTTP call to the specified uri.
+        /// </summary>
+        /// <param name="method">HttpMethod used for api call.</param>
+        /// <param name="uri">uri used to make the HTTP call.</param>
+        /// <param name="content">Content passed in the HTTP request.</param>
+        /// <returns>A <see cref="Task{DurableHttpResponse}"/>Result of the HTTP call.</returns>
+        Task<DurableHttpResponse> CallHttpAsync(HttpMethod method, Uri uri, string content = null);
+
+        /// <summary>
+        /// Makes an HTTP call using the information in the DurableHttpRequest.
+        /// </summary>
+        /// <param name="req">The DurableHttpRequest used to make the HTTP call.</param>
+        /// <returns>A <see cref="Task{DurableHttpResponse}"/>Result of the HTTP call.</returns>
+        Task<DurableHttpResponse> CallHttpAsync(DurableHttpRequest req);
     }
 }

--- a/src/WebJobs.Extensions.DurableTask/DurableHttpClientFactory.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableHttpClientFactory.cs
@@ -1,0 +1,44 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+using System.Diagnostics;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Reflection;
+
+namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
+{
+    internal class DurableHttpClientFactory
+    {
+        private HttpClient durableHttpClient;
+
+        public HttpClient GetClient(IDurableHttpMessageHandlerFactory handler)
+        {
+            if (this.durableHttpClient == null)
+            {
+                this.durableHttpClient = new HttpClient(handler.CreateHttpMessageHandler());
+
+                var assembly = typeof(DurableTaskExtension).Assembly;
+                Version assemblyVersion = GetAssemblyVersion(assembly);
+
+                this.durableHttpClient.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue(
+                    assembly.GetName().Name,
+                    assemblyVersion.ToString()));
+            }
+
+            return this.durableHttpClient;
+        }
+
+        private static Version GetAssemblyVersion(Assembly assembly)
+        {
+            var assemblyInfo = FileVersionInfo.GetVersionInfo(assembly.Location);
+            var assemblyVersion = new Version(
+                assemblyInfo.FileMajorPart,
+                assemblyInfo.FileMinorPart,
+                assemblyInfo.FileBuildPart);
+
+            return assemblyVersion;
+        }
+    }
+}

--- a/src/WebJobs.Extensions.DurableTask/DurableHttpMessageHandlerFactory.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableHttpMessageHandlerFactory.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Net.Http;
+
+namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
+{
+    internal class DurableHttpMessageHandlerFactory : IDurableHttpMessageHandlerFactory
+    {
+        private HttpMessageHandler httpClientHandler;
+
+        public DurableHttpMessageHandlerFactory()
+        {
+        }
+
+        internal DurableHttpMessageHandlerFactory(HttpMessageHandler handler)
+        {
+            this.httpClientHandler = handler;
+        }
+
+        public HttpMessageHandler CreateHttpMessageHandler()
+        {
+            if (this.httpClientHandler == null)
+            {
+                this.httpClientHandler = new HttpClientHandler();
+            }
+
+            return this.httpClientHandler;
+        }
+    }
+}

--- a/src/WebJobs.Extensions.DurableTask/DurableHttpRequest.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableHttpRequest.cs
@@ -105,9 +105,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         private static Dictionary<string, StringValues> CreateDictionaryCopy(IDictionary<string, StringValues> headers)
         {
             Dictionary<string, StringValues> newDictionary = new Dictionary<string, StringValues>(StringComparer.OrdinalIgnoreCase);
-            foreach (KeyValuePair<string, StringValues> pair in headers)
+            if (headers != null)
             {
-                newDictionary.Add(pair.Key, pair.Value);
+                foreach (KeyValuePair<string, StringValues> pair in headers)
+                {
+                    newDictionary.Add(pair.Key, pair.Value);
+                }
             }
 
             return newDictionary;

--- a/src/WebJobs.Extensions.DurableTask/DurableHttpRequest.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableHttpRequest.cs
@@ -1,0 +1,116 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Runtime.Serialization;
+using Microsoft.Azure.WebJobs.Extensions.DurableTask.Listener;
+using Microsoft.Extensions.Primitives;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
+{
+    /// <summary>
+    /// Request used to make an HTTP call through Durable Functions.
+    /// </summary>
+    public class DurableHttpRequest
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DurableHttpRequest"/> class.
+        /// </summary>
+        /// <param name="method">Method used for HTTP request.</param>
+        /// <param name="uri">Uri used to make the HTTP request.</param>
+        /// <param name="headers">Headers added to the HTTP request.</param>
+        /// <param name="content">Content added to the body of the HTTP request.</param>
+        /// <param name="tokenSource">AAD authentication attached to the HTTP request.</param>
+        /// <param name="asynchronousPatternEnabled">Specifies whether the DurableHttpRequest should handle the asynchronous pattern.</param>
+        public DurableHttpRequest(
+            HttpMethod method,
+            Uri uri,
+            IDictionary<string, StringValues> headers = null,
+            string content = null,
+            ITokenSource tokenSource = null,
+            bool asynchronousPatternEnabled = true)
+        {
+            this.Method = method;
+            this.Uri = uri;
+            this.Headers = CreateDictionaryCopy(headers);
+            this.Content = content;
+            this.TokenSource = tokenSource;
+            this.AsynchronousPatternEnabled = asynchronousPatternEnabled;
+        }
+
+        internal DurableHttpRequest(JObject jObject)
+        {
+            this.Method = jObject["Method"].ToObject<HttpMethod>();
+            this.Uri = jObject["Uri"].ToObject<Uri>();
+
+            Dictionary<string, StringValues> headerDictStringValues = new Dictionary<string, StringValues>();
+            Dictionary<string, IEnumerable<string>> headersDictEnumerable = jObject["Headers"].ToObject<Dictionary<string, IEnumerable<string>>>();
+            foreach (var header in headersDictEnumerable)
+            {
+                string key = header.Key;
+                string[] headerValues = header.Value.ToArray<string>();
+                StringValues values = new StringValues(headerValues);
+                headerDictStringValues.Add(key, values);
+            }
+
+            this.Headers = headerDictStringValues;
+
+            this.Content = jObject["Content"].Value<string>();
+
+            JsonSerializerSettings serializer = new JsonSerializerSettings();
+            serializer.TypeNameHandling = TypeNameHandling.Auto;
+            string tokenSource = JsonConvert.SerializeObject(jObject["TokenSource"], serializer);
+
+            this.TokenSource = JsonConvert.DeserializeObject<ITokenSource>(tokenSource, serializer);
+            this.AsynchronousPatternEnabled = jObject["AsynchronousPatternEnabled"].Value<bool>();
+        }
+
+        /// <summary>
+        /// HttpMethod used in the HTTP request made by the Durable Function.
+        /// </summary>
+        public HttpMethod Method { get; }
+
+        /// <summary>
+        /// Uri used in the HTTP request made by the Durable Function.
+        /// </summary>
+        public Uri Uri { get; }
+
+        /// <summary>
+        /// Headers passed with the HTTP request made by the Durable Function.
+        /// </summary>
+        public IDictionary<string, StringValues> Headers { get; }
+
+        /// <summary>
+        /// Content passed with the HTTP request made by the Durable Function.
+        /// </summary>
+        public string Content { get; }
+
+        /// <summary>
+        /// Information needed to get a token for a specified service.
+        /// </summary>
+        [JsonProperty(TypeNameHandling = TypeNameHandling.Auto)]
+        public ITokenSource TokenSource { get; }
+
+        /// <summary>
+        /// Specifies whether the Durable HTTP APIs should automatically
+        /// handle the asynchronous HTTP pattern.
+        /// </summary>
+        public bool AsynchronousPatternEnabled { get; } = true;
+
+        private static Dictionary<string, StringValues> CreateDictionaryCopy(IDictionary<string, StringValues> headers)
+        {
+            Dictionary<string, StringValues> newDictionary = new Dictionary<string, StringValues>(StringComparer.OrdinalIgnoreCase);
+            foreach (KeyValuePair<string, StringValues> pair in headers)
+            {
+                newDictionary.Add(pair.Key, pair.Value);
+            }
+
+            return newDictionary;
+        }
+    }
+}

--- a/src/WebJobs.Extensions.DurableTask/DurableHttpRequest.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableHttpRequest.cs
@@ -109,7 +109,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             {
                 foreach (KeyValuePair<string, StringValues> pair in headers)
                 {
-                    newDictionary.Add(pair.Key, pair.Value);
+                    newDictionary[pair.Key] = pair.Value;
                 }
             }
 

--- a/src/WebJobs.Extensions.DurableTask/DurableHttpRequestJsonConverter.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableHttpRequestJsonConverter.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+using System.Linq;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
+{
+    internal class DurableHttpRequestJsonConverter : JsonConverter
+    {
+        public override bool CanRead
+        {
+            get { return true; }
+        }
+
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType == typeof(DurableHttpRequest);
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            var jObject = JObject.Load(reader);
+            return new DurableHttpRequest(jObject);
+        }
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/WebJobs.Extensions.DurableTask/DurableHttpResponse.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableHttpResponse.cs
@@ -1,0 +1,94 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Extensions.DurableTask.Listener;
+using Microsoft.Extensions.Primitives;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
+{
+    /// <summary>
+    /// Response received from the HTTP request made by the Durable Function.
+    /// </summary>
+    // [JsonConverter(typeof(DurableHttpResponseJsonConverter))]
+    public class DurableHttpResponse
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DurableHttpResponse"/> class.
+        /// </summary>
+        /// <param name="statusCode">HTTP Status code returned from the HTTP call.</param>
+        /// <param name="headers">Headers returned from the HTTP call.</param>
+        /// <param name="content">Content returned from the HTTP call.</param>
+        [JsonConstructor]
+        public DurableHttpResponse(
+            HttpStatusCode statusCode,
+            IDictionary<string, StringValues> headers = null,
+            string content = null)
+        {
+            this.StatusCode = statusCode;
+            this.Headers = headers ?? new Dictionary<string, StringValues>(StringComparer.OrdinalIgnoreCase);
+            this.Content = content;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DurableHttpResponse"/> class.
+        /// </summary>
+        /// <param name="jObject">JObject containing information from HttpResponseMessage.</param>
+        public DurableHttpResponse(JObject jObject)
+        {
+            int codeInt = int.Parse(jObject["StatusCode"].Value<string>());
+            HttpStatusCode statusCode = (HttpStatusCode)codeInt;
+
+            Dictionary<string, StringValues> headerDictStringValues = new Dictionary<string, StringValues>(StringComparer.OrdinalIgnoreCase);
+            Dictionary<string, IEnumerable<string>> headersDictEnumerable = jObject["Headers"].ToObject<Dictionary<string, IEnumerable<string>>>();
+            foreach (var header in headersDictEnumerable)
+            {
+                string key = header.Key;
+                string[] headerValues = header.Value.ToArray<string>();
+                StringValues values = new StringValues(headerValues);
+                headerDictStringValues.Add(key, values);
+            }
+
+            this.StatusCode = statusCode;
+            this.Headers = headerDictStringValues;
+            this.Content = jObject["Content"].Value<string>();
+        }
+
+        /// <summary>
+        /// Status code returned from an HTTP request.
+        /// </summary>
+        public HttpStatusCode StatusCode { get; }
+
+        /// <summary>
+        /// Headers in the response from an HTTP request.
+        /// </summary>
+        public IDictionary<string, StringValues> Headers { get; }
+
+        /// <summary>
+        /// Content returned from an HTTP request.
+        /// </summary>
+        public string Content { get; }
+
+        /// <summary>
+        /// Creates a DurableHttpResponse from an HttpResponseMessage.
+        /// </summary>
+        /// <param name="httpResponseMessage">HttpResponseMessage returned from the HTTP call.</param>
+        /// <returns>A <see cref="Task{TResult}"/> representing the result of the asynchronous operation.</returns>
+        public static async Task<DurableHttpResponse> CreateDurableHttpResponseWithHttpResponseMessage(HttpResponseMessage httpResponseMessage)
+        {
+            DurableHttpResponse durableHttpResponse = new DurableHttpResponse(
+                statusCode: httpResponseMessage.StatusCode,
+                headers: TaskHttpActivityShim.CreateStringValuesHeaderDictionary(httpResponseMessage.Headers),
+                content: await httpResponseMessage.Content.ReadAsStringAsync());
+
+            return durableHttpResponse;
+        }
+    }
+}

--- a/src/WebJobs.Extensions.DurableTask/DurableHttpResponseJsonConverter.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableHttpResponseJsonConverter.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using Microsoft.Extensions.Primitives;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
+{
+    /// <summary>
+    /// This custom JsonConverter is used to deserialize DurableHttpResponse
+    /// messages and keep the Header's StringValues. StringValues otherwise cannot
+    /// be deserialized without losing their values.
+    /// </summary>
+    internal class DurableHttpResponseJsonConverter : JsonConverter
+    {
+        public override bool CanRead
+        {
+            get { return true; }
+        }
+
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType == typeof(DurableHttpResponse);
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            var jObject = JObject.Load(reader);
+            return new DurableHttpResponse(jObject);
+        }
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/WebJobs.Extensions.DurableTask/DurableTaskJobHostConfigurationExtensions.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskJobHostConfigurationExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
+using System.Net.Http;
 #if NETSTANDARD2_0
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
@@ -33,7 +34,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             builder.AddExtension<DurableTaskExtension>()
                 .BindOptions<DurableTaskOptions>()
                 .Services.AddSingleton<IConnectionStringResolver, WebJobsConnectionStringProvider>()
-                         .AddSingleton<IOrchestrationServiceFactory, OrchestrationServiceFactory>();
+                         .AddSingleton<IOrchestrationServiceFactory, OrchestrationServiceFactory>()
+                         .AddSingleton<IDurableHttpMessageHandlerFactory, DurableHttpMessageHandlerFactory>();
 
             return builder;
         }

--- a/src/WebJobs.Extensions.DurableTask/IDurableHttpMessageHandlerFactory.cs
+++ b/src/WebJobs.Extensions.DurableTask/IDurableHttpMessageHandlerFactory.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Net.Http;
+
+namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
+{
+    /// <summary>
+    /// Interface used for testing Durable HTTP.
+    /// </summary>
+    public interface IDurableHttpMessageHandlerFactory
+    {
+        /// <summary>
+        /// Creates an HttpClientHandler and returns it.
+        /// </summary>
+        /// <returns>Returns an HttpClientHandler.</returns>
+        HttpMessageHandler CreateHttpMessageHandler();
+    }
+}

--- a/src/WebJobs.Extensions.DurableTask/ITokenSource.cs
+++ b/src/WebJobs.Extensions.DurableTask/ITokenSource.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Threading.Tasks;
+
+namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
+{
+    /// <summary>
+    /// Provides functionality available to sources of tokens.
+    /// Custom implementation of this interface must include the use
+    /// of [DataContract] and [DataMember] for serialization.
+    /// </summary>
+    public interface ITokenSource
+    {
+        /// <summary>
+        /// Gets a token for a resource.
+        /// </summary>
+        /// <returns>A <see cref="Task{TResult}"/> representing the result of the asynchronous operation.</returns>
+        Task<string> GetTokenAsync();
+    }
+}

--- a/src/WebJobs.Extensions.DurableTask/Listener/TaskHttpActivityShim.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/TaskHttpActivityShim.cs
@@ -1,0 +1,141 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Threading.Tasks;
+using DurableTask.Core;
+using Microsoft.Extensions.Primitives;
+using Newtonsoft.Json;
+
+namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Listener
+{
+    internal class TaskHttpActivityShim : TaskActivity
+    {
+        private readonly HttpClient httpClient;
+        private readonly DurableTaskExtension config;
+        private static JsonSerializerSettings serializerSettings = CreateDurableHttpResponseSerializerSettings();
+
+        public TaskHttpActivityShim(
+            DurableTaskExtension config,
+            HttpClient httpClientFactory)
+        {
+            this.config = config ?? throw new ArgumentNullException(nameof(config));
+            this.httpClient = httpClientFactory ?? throw new ArgumentNullException(nameof(httpClientFactory));
+        }
+
+        public override string Run(TaskContext context, string input)
+        {
+            // This won't get called as long as we've implemented RunAsync.
+            throw new NotImplementedException();
+        }
+
+        public async override Task<string> RunAsync(TaskContext context, string rawInput)
+        {
+            HttpRequestMessage requestMessage = await this.ReconstructHttpRequestMessage(rawInput);
+            HttpResponseMessage response = await this.httpClient.SendAsync(requestMessage);
+            DurableHttpResponse durableHttpResponse = await DurableHttpResponse.CreateDurableHttpResponseWithHttpResponseMessage(response);
+
+            return MessagePayloadDataConverter.HttpConverter.Serialize(value: durableHttpResponse, formatted: true);
+        }
+
+        private static JsonSerializerSettings CreateDurableHttpResponseSerializerSettings()
+        {
+            JsonSerializerSettings serializerSettings = new JsonSerializerSettings();
+            serializerSettings.TypeNameHandling = TypeNameHandling.Objects;
+            serializerSettings.Converters.Add(new DurableHttpRequestJsonConverter());
+            return serializerSettings;
+        }
+
+        private static async Task<DurableHttpResponse> CopyDurableHttpResponseAsync(HttpResponseMessage response)
+        {
+            DurableHttpResponse durableHttpResponse = new DurableHttpResponse(
+                statusCode: response.StatusCode,
+                headers: CreateStringValuesHeaderDictionary(response.Headers),
+                content: await response.Content.ReadAsStringAsync());
+
+            return durableHttpResponse;
+        }
+
+        internal static IDictionary<string, StringValues> CreateStringValuesHeaderDictionary(IEnumerable<KeyValuePair<string, IEnumerable<string>>> headers)
+        {
+            IDictionary<string, StringValues> newHeaders = new Dictionary<string, StringValues>(StringComparer.OrdinalIgnoreCase);
+            if (headers != null)
+            {
+                foreach (var header in headers)
+                {
+                    newHeaders[header.Key] = new StringValues(header.Value.ToArray());
+                }
+            }
+
+            return newHeaders;
+        }
+
+        private async Task<HttpRequestMessage> ReconstructHttpRequestMessage(string serializedRequest)
+        {
+            // DeserializeObject deserializes into a List and then the first element
+            // of that list is the serialized DurableHttpRequest
+            IList<string> input = JsonConvert.DeserializeObject<List<string>>(serializedRequest, serializerSettings);
+            string durableHttpRequestString = input.First();
+
+            DurableHttpRequest durableHttpRequest = JsonConvert.DeserializeObject<DurableHttpRequest>(durableHttpRequestString, serializerSettings);
+
+            string contentType = "";
+            HttpRequestMessage requestMessage = new HttpRequestMessage(durableHttpRequest.Method, durableHttpRequest.Uri);
+            if (durableHttpRequest.Headers != null)
+            {
+                foreach (KeyValuePair<string, StringValues> entry in durableHttpRequest.Headers)
+                {
+                    if (entry.Key == "Content-Type")
+                    {
+                        foreach (string value in entry.Value)
+                        {
+                            if (value.Contains("multipart"))
+                            {
+                                throw new FunctionFailedException("Multipart content is not supported with CallHttpAsync.");
+                            }
+                            else
+                            {
+                                contentType = value;
+                            }
+                        }
+                    }
+                    else
+                    {
+                        requestMessage.Headers.Add(entry.Key, (IEnumerable<string>)entry.Value);
+                    }
+                }
+            }
+
+            if (durableHttpRequest.Content != null)
+            {
+                if (contentType == "")
+                {
+                    contentType = "text/plain";
+                }
+
+                if (contentType == "application/x-www-form-urlencoded")
+                {
+                    requestMessage.Content = new StringContent(durableHttpRequest.Content, Encoding.UTF8, contentType);
+                }
+                else
+                {
+                    requestMessage.Content = new StringContent(durableHttpRequest.Content);
+                    requestMessage.Content.Headers.ContentType = new MediaTypeHeaderValue(contentType);
+                }
+            }
+
+            if (durableHttpRequest.TokenSource != null)
+            {
+                string accessToken = await durableHttpRequest.TokenSource.GetTokenAsync();
+                requestMessage.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+            }
+
+            return requestMessage;
+        }
+    }
+}

--- a/src/WebJobs.Extensions.DurableTask/ManagedIdentityTokenSource.cs
+++ b/src/WebJobs.Extensions.DurableTask/ManagedIdentityTokenSource.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Runtime.Serialization;
+using System.Threading.Tasks;
+using Microsoft.Azure.Services.AppAuthentication;
+
+namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
+{
+    /// <summary>
+    /// Token Source implementation specific to Managed Identity Service.
+    /// </summary>
+    [DataContract]
+    public class ManagedIdentityTokenSource : ITokenSource
+    {
+        [DataMember]
+        private readonly string resourceURL;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ManagedIdentityTokenSource"/> class.
+        /// </summary>
+        /// <param name="resource">The reource url given by the user.</param>
+        public ManagedIdentityTokenSource(string resource)
+        {
+            this.resourceURL = resource;
+        }
+
+        /// <inheritdoc/>
+        public async Task<string> GetTokenAsync()
+        {
+            var azureServiceTokenProvider = new AzureServiceTokenProvider();
+            string accessToken = await azureServiceTokenProvider.GetAccessTokenAsync(this.resourceURL);
+            return accessToken;
+        }
+    }
+}

--- a/src/WebJobs.Extensions.DurableTask/MessagePayloadDataConverter.cs
+++ b/src/WebJobs.Extensions.DurableTask/MessagePayloadDataConverter.cs
@@ -27,9 +27,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             TypeNameHandling = TypeNameHandling.Objects,
         };
 
+        private static readonly JsonSerializerSettings HttpSettings = new JsonSerializerSettings
+        {
+            TypeNameHandling = TypeNameHandling.Objects,
+        };
+
         // Default singleton instances
         public static readonly MessagePayloadDataConverter Default = new MessagePayloadDataConverter(MessageSettings);
         public static readonly MessagePayloadDataConverter ErrorConverter = new MessagePayloadDataConverter(ErrorSettings);
+        public static readonly MessagePayloadDataConverter HttpConverter = new MessagePayloadDataConverter(HttpSettings);
         public static readonly JsonSerializer DefaultSerializer = JsonSerializer.Create(MessageSettings);
 
         public MessagePayloadDataConverter(JsonSerializerSettings settings)

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
@@ -208,6 +208,101 @@
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableOrchestrationContext.Microsoft#Azure#WebJobs#IInterleavingContext#LockAsync(Microsoft.Azure.WebJobs.EntityId[])">
             <inheritdoc/>
         </member>
+        <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableHttpRequest">
+            <summary>
+            Request used to make an HTTP call through Durable Functions.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableHttpRequest.#ctor(System.Net.Http.HttpMethod,System.Uri,System.Collections.Generic.IDictionary{System.String,Microsoft.Extensions.Primitives.StringValues},System.String,Microsoft.Azure.WebJobs.Extensions.DurableTask.ITokenSource,System.Boolean)">
+            <summary>
+            Initializes a new instance of the <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableHttpRequest"/> class.
+            </summary>
+            <param name="method">Method used for HTTP request.</param>
+            <param name="uri">Uri used to make the HTTP request.</param>
+            <param name="headers">Headers added to the HTTP request.</param>
+            <param name="content">Content added to the body of the HTTP request.</param>
+            <param name="tokenSource">AAD authentication attached to the HTTP request.</param>
+            <param name="asynchronousPatternEnabled">Specifies whether the DurableHttpRequest should handle the asynchronous pattern.</param>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableHttpRequest.Method">
+            <summary>
+            HttpMethod used in the HTTP request made by the Durable Function.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableHttpRequest.Uri">
+            <summary>
+            Uri used in the HTTP request made by the Durable Function.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableHttpRequest.Headers">
+            <summary>
+            Headers passed with the HTTP request made by the Durable Function.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableHttpRequest.Content">
+            <summary>
+            Content passed with the HTTP request made by the Durable Function.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableHttpRequest.TokenSource">
+            <summary>
+            Information needed to get a token for a specified service.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableHttpRequest.AsynchronousPatternEnabled">
+            <summary>
+            Specifies whether the Durable HTTP APIs should automatically
+            handle the asynchronous HTTP pattern.
+            </summary>
+        </member>
+        <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableHttpResponse">
+            <summary>
+            Response received from the HTTP request made by the Durable Function.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableHttpResponse.#ctor(System.Net.HttpStatusCode,System.Collections.Generic.IDictionary{System.String,Microsoft.Extensions.Primitives.StringValues},System.String)">
+            <summary>
+            Initializes a new instance of the <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableHttpResponse"/> class.
+            </summary>
+            <param name="statusCode">HTTP Status code returned from the HTTP call.</param>
+            <param name="headers">Headers returned from the HTTP call.</param>
+            <param name="content">Content returned from the HTTP call.</param>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableHttpResponse.#ctor(Newtonsoft.Json.Linq.JObject)">
+            <summary>
+            Initializes a new instance of the <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableHttpResponse"/> class.
+            </summary>
+            <param name="jObject">JObject containing information from HttpResponseMessage.</param>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableHttpResponse.StatusCode">
+            <summary>
+            Status code returned from an HTTP request.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableHttpResponse.Headers">
+            <summary>
+            Headers in the response from an HTTP request.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableHttpResponse.Content">
+            <summary>
+            Content returned from an HTTP request.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableHttpResponse.CreateDurableHttpResponseWithHttpResponseMessage(System.Net.Http.HttpResponseMessage)">
+            <summary>
+            Creates a DurableHttpResponse from an HttpResponseMessage.
+            </summary>
+            <param name="httpResponseMessage">HttpResponseMessage returned from the HTTP call.</param>
+            <returns>A <see cref="T:System.Threading.Tasks.Task`1"/> representing the result of the asynchronous operation.</returns>
+        </member>
+        <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableHttpResponseJsonConverter">
+            <summary>
+            This custom JsonConverter is used to deserialize DurableHttpResponse
+            messages and keep the Header's StringValues. StringValues otherwise cannot
+            be deserialized without losing their values.
+            </summary>
+        </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension">
             <summary>
             Configuration for the Durable Functions extension.
@@ -218,7 +313,7 @@
             Obsolete. Please use an alternate constructor overload.
             </summary>
         </member>
-        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.#ctor(Microsoft.Extensions.Options.IOptions{Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskOptions},Microsoft.Extensions.Logging.ILoggerFactory,Microsoft.Azure.WebJobs.INameResolver,Microsoft.Azure.WebJobs.Extensions.DurableTask.IOrchestrationServiceFactory)">
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.#ctor(Microsoft.Extensions.Options.IOptions{Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskOptions},Microsoft.Extensions.Logging.ILoggerFactory,Microsoft.Azure.WebJobs.INameResolver,Microsoft.Azure.WebJobs.Extensions.DurableTask.IOrchestrationServiceFactory,Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableHttpMessageHandlerFactory)">
             <summary>
             Initializes a new instance of the <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension"/>.
             </summary>
@@ -226,6 +321,7 @@
             <param name="loggerFactory">The logger factory used for extension-specific logging and orchestration tracking.</param>
             <param name="nameResolver">The name resolver to use for looking up application settings.</param>
             <param name="orchestrationServiceFactory">The factory used to create orchestration service based on the configured storage provider.</param>
+            <param name="durableHttpMessageHandlerFactory">The HTTP message handler that handles HTTP requests and HTTP responses.</param>
         </member>
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.HubName">
             <summary>
@@ -506,6 +602,17 @@
             <param name="connectionStringName">The name of the connection string.</param>
             <returns>Returns the resolved connection string value.</returns>
         </member>
+        <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableHttpMessageHandlerFactory">
+            <summary>
+            Interface used for testing Durable HTTP.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableHttpMessageHandlerFactory.CreateHttpMessageHandler">
+            <summary>
+            Creates an HttpClientHandler and returns it.
+            </summary>
+            <returns>Returns an HttpClientHandler.</returns>
+        </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.ILifeCycleNotificationHelper">
             <summary>
             Interface defining methods to life cycle notifications.
@@ -570,6 +677,19 @@
             </summary>
             <param name="attribute">An orchestration client attribute with parameters for the orchestration client.</param>
             <returns>An orchestration service client to be used by a function.</returns>
+        </member>
+        <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.ITokenSource">
+            <summary>
+            Provides functionality available to sources of tokens.
+            Custom implementation of this interface must include the use
+            of [DataContract] and [DataMember] for serialization.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.ITokenSource.GetTokenAsync">
+            <summary>
+            Gets a token for a resource.
+            </summary>
+            <returns>A <see cref="T:System.Threading.Tasks.Task`1"/> representing the result of the asynchronous operation.</returns>
         </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.TaskActivityShim">
             <summary>
@@ -662,6 +782,20 @@
             <summary>
             Task orchestration implementation which delegates the orchestration implementation to a function.
             </summary>
+        </member>
+        <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.ManagedIdentityTokenSource">
+            <summary>
+            Token Source implementation specific to Managed Identity Service.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.ManagedIdentityTokenSource.#ctor(System.String)">
+            <summary>
+            Initializes a new instance of the <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.ManagedIdentityTokenSource"/> class.
+            </summary>
+            <param name="resource">The reource url given by the user.</param>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.ManagedIdentityTokenSource.GetTokenAsync">
+            <inheritdoc/>
         </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.MessagePayloadDataConverter.Serialize(System.Object)">
             <summary>
@@ -844,6 +978,21 @@
             A list of strings. Possible values 'Started', 'Completed', 'Failed', 'Terminated'.
             </value>
         </member>
+        <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.Options.HttpOptions">
+            <summary>
+            Used for Durable HTTP functionality.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Azure.WebJobs.Extensions.DurableTask.Options.HttpOptions.HttpTaskActivityReservedName">
+            <summary>
+            Reserved name to know when a TaskActivity should be an HTTP activity.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.Options.HttpOptions.DefaultAsyncRequestSleepTimeMilliseconds">
+            <summary>
+            Gets or sets the default number of milliseconds between async HTTP status poll requests.
+            </summary>
+        </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.Options.NotificationOptions">
             <summary>
             Configuration of the notification options
@@ -916,6 +1065,11 @@
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskOptions">
             <summary>
             Configuration options for the Durable Task extension.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskOptions.HttpSettings">
+            <summary>
+            Settings used for Durable HTTP functionality.
             </summary>
         </member>
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskOptions.HubName">
@@ -2010,6 +2164,22 @@
             value must not exceed 16 KB of UTF-16 encoded text.
             </remarks>
             <param name="customStatusObject">The JSON-serializeable value to use as the orchestrator function's custom status.</param>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.IDurableOrchestrationContext.CallHttpAsync(System.Net.Http.HttpMethod,System.Uri,System.String)">
+            <summary>
+            Makes an HTTP call to the specified uri.
+            </summary>
+            <param name="method">HttpMethod used for api call.</param>
+            <param name="uri">uri used to make the HTTP call.</param>
+            <param name="content">Content passed in the HTTP request.</param>
+            <returns>A <see cref="T:System.Threading.Tasks.Task`1"/>Result of the HTTP call.</returns>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.IDurableOrchestrationContext.CallHttpAsync(Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableHttpRequest)">
+            <summary>
+            Makes an HTTP call using the information in the DurableHttpRequest.
+            </summary>
+            <param name="req">The DurableHttpRequest used to make the HTTP call.</param>
+            <returns>A <see cref="T:System.Threading.Tasks.Task`1"/>Result of the HTTP call.</returns>
         </member>
         <member name="T:Microsoft.Azure.WebJobs.IInterleavingContext">
             <summary>

--- a/src/WebJobs.Extensions.DurableTask/Options/DurableTaskOptions.cs
+++ b/src/WebJobs.Extensions.DurableTask/Options/DurableTaskOptions.cs
@@ -14,6 +14,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
     public class DurableTaskOptions
     {
         /// <summary>
+        /// Settings used for Durable HTTP functionality.
+        /// </summary>
+        public HttpOptions HttpSettings { get; set; }
+
+        /// <summary>
         /// Gets or sets default task hub name to be used by all <see cref="DurableOrchestrationClient"/>,
         /// <see cref="DurableOrchestrationContext"/>, and <see cref="DurableActivityContext"/> instances.
         /// </summary>

--- a/src/WebJobs.Extensions.DurableTask/Options/HttpOptions.cs
+++ b/src/WebJobs.Extensions.DurableTask/Options/HttpOptions.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Options
+{
+    /// <summary>
+    /// Used for Durable HTTP functionality.
+    /// </summary>
+    public class HttpOptions
+    {
+        /// <summary>
+        /// Reserved name to know when a TaskActivity should be an HTTP activity.
+        /// </summary>
+        internal const string HttpTaskActivityReservedName = "Durable:Http:Async:Activity:Function";
+
+        /// <summary>
+        /// Gets or sets the default number of milliseconds between async HTTP status poll requests.
+        /// </summary>
+        public int DefaultAsyncRequestSleepTimeMilliseconds { get; set; } = 30000;
+    }
+}

--- a/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
+++ b/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
@@ -42,6 +42,7 @@
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.WebApiCompatShim" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Routing" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>
@@ -58,6 +59,7 @@
     <PackageReference Include="Microsoft.Azure.DurableTask.Redis" Version="0.1.0-alpha" />
     <PackageReference Include="Microsoft.Azure.DurableTask.Emulator" Version="2.1.1" />
     <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage" Version="1.6.3" />
+    <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.0.3" />
   </ItemGroup>
 
   <!-- NuGet Publishing Metadata -->

--- a/test/Common/DurableOrchestrationClientBaseTests.cs
+++ b/test/Common/DurableOrchestrationClientBaseTests.cs
@@ -222,7 +222,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 wrappedOptions,
                 new LoggerFactory(),
                 TestHelpers.GetTestNameResolver(),
-                new OrchestrationServiceFactory(wrappedOptions, connectionStringResolver));
+                new OrchestrationServiceFactory(wrappedOptions, connectionStringResolver),
+                new DurableHttpMessageHandlerFactory());
         }
     }
 }

--- a/test/Common/HttpApiHandlerTests.cs
+++ b/test/Common/HttpApiHandlerTests.cs
@@ -1019,7 +1019,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                     new OptionsWrapper<DurableTaskOptions>(options),
                     new LoggerFactory(),
                     TestHelpers.GetTestNameResolver(),
-                    new OrchestrationServiceFactory(new OptionsWrapper<DurableTaskOptions>(options), new TestConnectionStringResolver()))
+                    new OrchestrationServiceFactory(new OptionsWrapper<DurableTaskOptions>(options), new TestConnectionStringResolver()),
+                    new DurableHttpMessageHandlerFactory())
             {
             }
 

--- a/test/Common/TestDurableHttpRequest.cs
+++ b/test/Common/TestDurableHttpRequest.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Runtime.Serialization;
+using Newtonsoft.Json;
+
+namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
+{
+    /// <summary>
+    /// This class is provides the header values as strings,
+    /// instead of StringValues because StringValues lose their data when
+    /// deserialized. The header value are changed to StringValues before
+    /// the request is sent.
+    /// </summary>
+    [DataContract]
+    public class TestDurableHttpRequest
+    {
+        public TestDurableHttpRequest(HttpMethod httpMethod, string uri = "https://www.dummy-url.com", IDictionary<string, string> headers = null, string content = null, ITokenSource tokenSource = null)
+        {
+            this.HttpMethod = httpMethod;
+            this.Uri = uri;
+            this.Headers = headers;
+            this.Content = content;
+            this.TokenSource = tokenSource;
+        }
+
+        [DataMember]
+        public HttpMethod HttpMethod { get; set; }
+
+        [DataMember]
+        public string Uri { get; set; }
+
+        [DataMember]
+        public IDictionary<string, string> Headers { get; set; }
+
+        [DataMember]
+        public string Content { get; set; }
+
+        /// <summary>
+        /// Information needed to get a token for a specified service.
+        /// </summary>
+        [JsonProperty(TypeNameHandling = TypeNameHandling.Auto)]
+        public ITokenSource TokenSource { get; set; }
+
+        [DataMember]
+        public bool AsynchronousPatternEnabled { get; set; } = true;
+    }
+}

--- a/test/Common/TestHelpers.cs
+++ b/test/Common/TestHelpers.cs
@@ -43,7 +43,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             TimeSpan? maxQueuePollingInterval = null,
             string[] eventGridPublishEventTypes = null,
             string storageProviderType = AzureStorageProviderType,
-            bool autoFetchLargeMessages = true)
+            bool autoFetchLargeMessages = true,
+            int httpAsyncSleepTime = 5000,
+            IDurableHttpMessageHandlerFactory durableHttpMessageHandler = null)
         {
             var durableTaskOptions = new DurableTaskOptions
             {
@@ -61,6 +63,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                         TopicEndpoint = eventGridTopicEndpoint,
                         PublishEventTypes = eventGridPublishEventTypes,
                     },
+                },
+                HttpSettings = new HttpOptions()
+                {
+                    DefaultAsyncRequestSleepTimeMilliseconds = httpAsyncSleepTime,
                 },
                 NotificationUrl = notificationUrl,
                 ExtendedSessionsEnabled = enableExtendedSessions,
@@ -113,7 +119,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
             var optionsWrapper = new OptionsWrapper<DurableTaskOptions>(durableTaskOptions);
             var testNameResolver = new TestNameResolver(nameResolver);
-            return PlatformSpecificHelpers.CreateJobHost(optionsWrapper, loggerProvider, testNameResolver);
+            if (durableHttpMessageHandler == null)
+            {
+                durableHttpMessageHandler = new DurableHttpMessageHandlerFactory();
+            }
+
+            return PlatformSpecificHelpers.CreateJobHost(optionsWrapper, loggerProvider, testNameResolver, durableHttpMessageHandler);
         }
 
         public static string GetTaskHubNameFromTestName(string testName, bool enableExtendedSessions)

--- a/test/FunctionsV1/PlatformSpecificHelpers.FunctionsV1.cs
+++ b/test/FunctionsV1/PlatformSpecificHelpers.FunctionsV1.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System.Net.Http;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
@@ -19,7 +20,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         public static JobHost CreateJobHost(
             IOptions<DurableTaskOptions> options,
             ILoggerProvider loggerProvider,
-            INameResolver nameResolver)
+            INameResolver nameResolver,
+            IDurableHttpMessageHandlerFactory durableHttpMessageHandler)
         {
             var config = new JobHostConfiguration { HostId = "durable-task-host" };
             config.TypeLocator = TestHelpers.GetTypeLocator();
@@ -31,7 +33,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
             IOrchestrationServiceFactory orchestrationServiceFactory = new OrchestrationServiceFactory(options, connectionResolver);
 
-            var extension = new DurableTaskExtension(options, loggerFactory, nameResolver, orchestrationServiceFactory);
+            var extension = new DurableTaskExtension(options, loggerFactory, nameResolver, orchestrationServiceFactory, durableHttpMessageHandler);
             config.UseDurableTask(extension);
 
             // Mock INameResolver for not setting EnvironmentVariables.

--- a/test/FunctionsV2/DurableHttpTests.cs
+++ b/test/FunctionsV2/DurableHttpTests.cs
@@ -1,0 +1,1252 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Runtime.InteropServices;
+using System.Runtime.Serialization;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Host.TestCommon;
+using Microsoft.Diagnostics.Tracing;
+using Microsoft.Extensions.Primitives;
+using Moq;
+using Moq.Protected;
+using Newtonsoft.Json;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
+{
+    public class DurableHttpTests : IDisposable
+    {
+        private readonly ITestOutputHelper output;
+
+        private readonly TestLoggerProvider loggerProvider;
+        private readonly bool useTestLogger = IsLogFriendlyPlatform();
+        private readonly LogEventTraceListener eventSourceListener;
+
+        public DurableHttpTests(ITestOutputHelper output)
+        {
+            this.output = output;
+            this.loggerProvider = new TestLoggerProvider(output);
+            this.eventSourceListener = new LogEventTraceListener();
+            this.StartLogCapture();
+        }
+
+        public void Dispose()
+        {
+            this.eventSourceListener.Dispose();
+        }
+
+        private void OnEventSourceListenerTraceLog(object sender, LogEventTraceListener.TraceLogEventArgs e)
+        {
+            this.output.WriteLine($"      ETW: {e.ProviderName} [{e.Level}] : {e.Message}");
+        }
+
+        private void StartLogCapture()
+        {
+            if (this.useTestLogger)
+            {
+                var traceConfig = new Dictionary<string, TraceEventLevel>
+                {
+                    { "DurableTask-AzureStorage", TraceEventLevel.Informational },
+                    { "7DA4779A-152E-44A2-A6F2-F80D991A5BEE", TraceEventLevel.Warning }, // DurableTask.Core
+                };
+
+                this.eventSourceListener.OnTraceLog += this.OnEventSourceListenerTraceLog;
+
+                string sessionName = "DTFxTrace" + Guid.NewGuid().ToString("N");
+                this.eventSourceListener.CaptureLogs(sessionName, traceConfig);
+            }
+        }
+
+        private static bool IsLogFriendlyPlatform()
+        {
+            return !RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
+        }
+
+        /// <summary>
+        /// End-to-end test which checks if the CallHttpAsync Orchestrator returns an OK (200) status code.
+        /// </summary>
+        [Theory]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        [MemberData(nameof(TestDataGenerator.GetFullFeaturedStorageProviderOptions), MemberType = typeof(TestDataGenerator))]
+        public async Task DurableHttpAsync_SynchronousAPI_Returns200(string storageProvider)
+        {
+            HttpResponseMessage testHttpResponseMessage = CreateTestHttpResponseMessage(HttpStatusCode.OK);
+            HttpMessageHandler httpMessageHandler = MockSynchronousHttpMessageHandler(testHttpResponseMessage);
+
+            using (JobHost host = TestHelpers.GetJobHost(
+                this.loggerProvider,
+                nameof(this.DurableHttpAsync_SynchronousAPI_Returns200),
+                enableExtendedSessions: false,
+                storageProviderType: storageProvider,
+                durableHttpMessageHandler: new DurableHttpMessageHandlerFactory(httpMessageHandler)))
+            {
+                await host.StartAsync();
+
+                Dictionary<string, string> headers = new Dictionary<string, string>();
+                headers.Add("Accept", "application/json");
+                TestDurableHttpRequest testRequest = new TestDurableHttpRequest(
+                    httpMethod: HttpMethod.Get,
+                    headers: headers);
+
+                string functionName = nameof(TestOrchestrations.CallHttpAsyncOrchestrator);
+                var client = await host.StartOrchestratorAsync(functionName, testRequest, this.output);
+                var status = await client.WaitForCompletionAsync(this.output, timeout: TimeSpan.FromSeconds(400));
+
+                var output = status?.Output;
+                JsonSerializer serializer = new JsonSerializer();
+                serializer.Converters.Add(new DurableHttpResponseJsonConverter());
+                DurableHttpResponse response = output.ToObject<DurableHttpResponse>(serializer);
+                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+                await host.StopAsync();
+            }
+        }
+
+        /// <summary>
+        /// End-to-end test which checks if the UserAgent header is set in the HttpResponseMessage.
+        /// </summary>
+        [Theory]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        [MemberData(nameof(TestDataGenerator.GetFullFeaturedStorageProviderOptions), MemberType = typeof(TestDataGenerator))]
+        public async Task DurableHttpAsync_CheckUserAgentHeader(string storageProvider)
+        {
+            HttpMessageHandler httpMessageHandler = MockHttpMessageHandlerCheckUserAgent();
+
+            using (JobHost host = TestHelpers.GetJobHost(
+                this.loggerProvider,
+                nameof(this.DurableHttpAsync_CheckUserAgentHeader),
+                enableExtendedSessions: false,
+                storageProviderType: storageProvider,
+                durableHttpMessageHandler: new DurableHttpMessageHandlerFactory(httpMessageHandler)))
+            {
+                await host.StartAsync();
+
+                Dictionary<string, string> headers = new Dictionary<string, string>();
+                headers.Add("Accept", "application/json");
+                TestDurableHttpRequest testRequest = new TestDurableHttpRequest(
+                    httpMethod: HttpMethod.Get,
+                    headers: headers);
+
+                string functionName = nameof(TestOrchestrations.CallHttpAsyncOrchestrator);
+                var client = await host.StartOrchestratorAsync(functionName, testRequest, this.output);
+                var status = await client.WaitForCompletionAsync(this.output, timeout: TimeSpan.FromSeconds(400));
+
+                var output = status?.Output;
+                JsonSerializer serializer = new JsonSerializer();
+                serializer.Converters.Add(new DurableHttpResponseJsonConverter());
+                DurableHttpResponse response = output.ToObject<DurableHttpResponse>(serializer);
+                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+                await host.StopAsync();
+            }
+        }
+
+        /// <summary>
+        /// End-to-end test which checks if the UserAgent header is set in the HttpResponseMessage.
+        /// </summary>
+        [Theory]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        [MemberData(nameof(TestDataGenerator.GetFullFeaturedStorageProviderOptions), MemberType = typeof(TestDataGenerator))]
+        public async Task DurableHttpAsync_CheckRequestAcceptHeaders(string storageProvider)
+        {
+            HttpMessageHandler httpMessageHandler = MockHttpMessageHandlerCheckAcceptHeader();
+
+            using (JobHost host = TestHelpers.GetJobHost(
+                this.loggerProvider,
+                nameof(this.DurableHttpAsync_CheckUserAgentHeader),
+                enableExtendedSessions: false,
+                storageProviderType: storageProvider,
+                durableHttpMessageHandler: new DurableHttpMessageHandlerFactory(httpMessageHandler)))
+            {
+                await host.StartAsync();
+
+                Dictionary<string, string> headers = new Dictionary<string, string>();
+                headers.Add("Accept", "application/json");
+                TestDurableHttpRequest testRequest = new TestDurableHttpRequest(
+                    httpMethod: HttpMethod.Get,
+                    headers: headers);
+
+                string functionName = nameof(TestOrchestrations.CallHttpAsyncOrchestrator);
+                var client = await host.StartOrchestratorAsync(functionName, testRequest, this.output);
+                var status = await client.WaitForCompletionAsync(this.output, timeout: TimeSpan.FromSeconds(400));
+
+                var output = status?.Output;
+                JsonSerializer serializer = new JsonSerializer();
+                serializer.Converters.Add(new DurableHttpResponseJsonConverter());
+                DurableHttpResponse response = output.ToObject<DurableHttpResponse>(serializer);
+                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+                await host.StopAsync();
+            }
+        }
+
+        /// <summary>
+        /// End-to-end test which checks if the CallHttpAsync Orchestrator returns an Accepted (202)
+        /// when the asynchronous pattern is disabled.
+        /// </summary>
+        [Theory]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        [MemberData(nameof(TestDataGenerator.GetFullFeaturedStorageProviderOptions), MemberType = typeof(TestDataGenerator))]
+        public async Task DurableHttpAsync_AsynchronousPatternDisabled(string storageProvider)
+        {
+            HttpResponseMessage testHttpResponseMessage = CreateTestHttpResponseMessage(HttpStatusCode.Accepted);
+            HttpMessageHandler httpMessageHandler = MockSynchronousHttpMessageHandler(testHttpResponseMessage);
+
+            using (JobHost host = TestHelpers.GetJobHost(
+                this.loggerProvider,
+                nameof(this.DurableHttpAsync_AsynchronousPatternDisabled),
+                enableExtendedSessions: false,
+                storageProviderType: storageProvider,
+                durableHttpMessageHandler: new DurableHttpMessageHandlerFactory(httpMessageHandler)))
+            {
+                await host.StartAsync();
+
+                Dictionary<string, string> headers = new Dictionary<string, string>();
+                headers.Add("Accept", "application/json");
+                TestDurableHttpRequest testRequest = new TestDurableHttpRequest(
+                    httpMethod: HttpMethod.Get,
+                    headers: headers);
+                testRequest.AsynchronousPatternEnabled = false;
+
+                string functionName = nameof(TestOrchestrations.CallHttpAsyncOrchestrator);
+                var client = await host.StartOrchestratorAsync(functionName, testRequest, this.output);
+                var status = await client.WaitForCompletionAsync(this.output, timeout: TimeSpan.FromSeconds(400));
+
+                var output = status?.Output;
+                JsonSerializer serializer = new JsonSerializer();
+                serializer.Converters.Add(new DurableHttpResponseJsonConverter());
+                DurableHttpResponse response = output.ToObject<DurableHttpResponse>(serializer);
+                Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
+
+                await host.StopAsync();
+            }
+        }
+
+        /// <summary>
+        /// End-to-end test which checks if the CallHttpAsync Orchestrator returns a Not Found (404) status code.
+        /// </summary>
+        [Theory]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        [MemberData(nameof(TestDataGenerator.GetFullFeaturedStorageProviderOptions), MemberType = typeof(TestDataGenerator))]
+        public async Task DurableHttpAsync_SynchronousAPI_ReturnsNotFound(string storageProvider)
+        {
+            HttpResponseMessage testHttpResponseMessage = CreateTestHttpResponseMessage(HttpStatusCode.NotFound);
+            HttpMessageHandler httpMessageHandler = MockSynchronousHttpMessageHandler(testHttpResponseMessage);
+
+            using (JobHost host = TestHelpers.GetJobHost(
+                this.loggerProvider,
+                nameof(this.DurableHttpAsync_SynchronousAPI_ReturnsNotFound),
+                enableExtendedSessions: false,
+                storageProviderType: storageProvider,
+                durableHttpMessageHandler: new DurableHttpMessageHandlerFactory(httpMessageHandler)))
+            {
+                await host.StartAsync();
+
+                Dictionary<string, string> headers = new Dictionary<string, string>();
+                headers.Add("Accept", "application/json");
+                TestDurableHttpRequest testRequest = new TestDurableHttpRequest(
+                    httpMethod: HttpMethod.Get,
+                    headers: headers);
+
+                string functionName = nameof(TestOrchestrations.CallHttpAsyncOrchestrator);
+                var client = await host.StartOrchestratorAsync(functionName, testRequest, this.output);
+                var status = await client.WaitForCompletionAsync(this.output, timeout: TimeSpan.FromSeconds(40));
+
+                var output = status?.Output;
+                DurableHttpResponse response = output.ToObject<DurableHttpResponse>();
+                Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+
+                await host.StopAsync();
+            }
+        }
+
+        /// <summary>
+        /// End-to-end test which checks if the CallHttpAsync Orchestrator Headers and Content.
+        /// from the response have relevant information. This test has multiple response
+        /// header values.
+        /// </summary>
+        [Theory]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        [MemberData(nameof(TestDataGenerator.GetFullFeaturedStorageProviderOptions), MemberType = typeof(TestDataGenerator))]
+        public async Task DurableHttpAsync_MultipleHeadersAndContentTest(string storageProvider)
+        {
+            string[] httpResponseHeaders = { "test.host.com", "test.response.com" };
+            StringValues stringValues = new StringValues(httpResponseHeaders);
+            Dictionary<string, StringValues> testHeaders = new Dictionary<string, StringValues>();
+            testHeaders.Add("Host", stringValues);
+
+            HttpResponseMessage testHttpResponseMessage = CreateTestHttpResponseMessageMultHeaders(
+                                                                                        statusCode: HttpStatusCode.OK,
+                                                                                        headers: testHeaders,
+                                                                                        content: "test content");
+
+            HttpMessageHandler httpMessageHandler = MockSynchronousHttpMessageHandler(testHttpResponseMessage);
+
+            using (JobHost host = TestHelpers.GetJobHost(
+                this.loggerProvider,
+                nameof(this.DurableHttpAsync_MultipleHeadersAndContentTest),
+                enableExtendedSessions: false,
+                storageProviderType: storageProvider,
+                durableHttpMessageHandler: new DurableHttpMessageHandlerFactory(httpMessageHandler)))
+            {
+                await host.StartAsync();
+
+                // Uri uri = new Uri("https://dummy-test-url.com");
+                // var request = new DurableHttpRequest(HttpMethod.Get, uri);
+                // StringValues stringValues = new StringValues("application/json");
+                // request.Headers.Add("Accept", stringValues);
+
+                Dictionary<string, string> headers = new Dictionary<string, string>();
+                headers.Add("Accept", "application/json");
+
+                TestDurableHttpRequest testRequest = new TestDurableHttpRequest(
+                    httpMethod: HttpMethod.Get,
+                    headers: headers);
+
+                var client = await host.StartOrchestratorAsync(nameof(TestOrchestrations.CallHttpAsyncOrchestrator), testRequest, this.output);
+                var status = await client.WaitForCompletionAsync(this.output, timeout: TimeSpan.FromSeconds(Debugger.IsAttached ? 3000 : 90));
+
+                var output = status?.Output;
+
+                JsonSerializer serializer = new JsonSerializer();
+                serializer.Converters.Add(new DurableHttpResponseJsonConverter());
+                DurableHttpResponse response = output.ToObject<DurableHttpResponse>(serializer);
+
+                var hostHeaders = response.Headers["Host"];
+                bool hasHostValueOne = response.Headers["Host"].Contains("test.host.com");
+                bool hasHostValueTwo = response.Headers["Host"].Contains("test.response.com");
+
+                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+                Assert.True(hasHostValueOne && hasHostValueTwo);
+                Assert.Contains("test content", response.Content);
+
+                await host.StopAsync();
+            }
+        }
+
+        /// <summary>
+        /// End-to-end test which checks if the CallHttpAsync Orchestrator Headers and Content.
+        /// from the response have relevant information. This test has multiple response
+        /// headers with varying amount of header values.
+        /// </summary>
+        [Theory]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        [MemberData(nameof(TestDataGenerator.GetFullFeaturedStorageProviderOptions), MemberType = typeof(TestDataGenerator))]
+        public async Task DurableHttpAsync_MultipleHeaderValuesTest(string storageProvider)
+        {
+            Dictionary<string, StringValues> testHeaders = new Dictionary<string, StringValues>();
+
+            string[] httpResponseHeaders = { "test.host.com", "test.response.com" };
+            StringValues stringValues = new StringValues(httpResponseHeaders);
+            testHeaders.Add("Host", stringValues);
+
+            string[] cacheResponseHeaders = { "GET", "POST", "HEAD", "OPTIONS" };
+            StringValues cacheStringValues = new StringValues(cacheResponseHeaders);
+            testHeaders.Add("Cache-Control", cacheStringValues);
+
+            string[] accessControlHeaders = { "X-customHeader1", "X-customHeader2", "X-customHeader3", "X-customHeader4", "X-customHeader5" };
+            StringValues accessControlStringValues = new StringValues(accessControlHeaders);
+            testHeaders.Add("Access-Control-Expose-Headers", accessControlStringValues);
+
+            HttpResponseMessage testHttpResponseMessage = CreateTestHttpResponseMessageMultHeaders(
+                                                                                        statusCode: HttpStatusCode.OK,
+                                                                                        headers: testHeaders,
+                                                                                        content: "test content");
+
+            HttpMessageHandler httpMessageHandler = MockSynchronousHttpMessageHandler(testHttpResponseMessage);
+
+            using (JobHost host = TestHelpers.GetJobHost(
+                this.loggerProvider,
+                nameof(this.DurableHttpAsync_MultipleHeaderValuesTest),
+                enableExtendedSessions: false,
+                storageProviderType: storageProvider,
+                durableHttpMessageHandler: new DurableHttpMessageHandlerFactory(httpMessageHandler)))
+            {
+                await host.StartAsync();
+
+                Dictionary<string, string> headers = new Dictionary<string, string>();
+                headers.Add("Accept", "application/json");
+
+                TestDurableHttpRequest testRequest = new TestDurableHttpRequest(
+                    httpMethod: HttpMethod.Get,
+                    headers: headers);
+
+                var client = await host.StartOrchestratorAsync(nameof(TestOrchestrations.CallHttpAsyncOrchestrator), testRequest, this.output);
+                var status = await client.WaitForCompletionAsync(this.output, timeout: TimeSpan.FromSeconds(Debugger.IsAttached ? 3000 : 90));
+
+                var output = status?.Output;
+
+                JsonSerializer serializer = new JsonSerializer();
+                serializer.Converters.Add(new DurableHttpResponseJsonConverter());
+                DurableHttpResponse response = output.ToObject<DurableHttpResponse>(serializer);
+
+                var hostHeaders = response.Headers["Host"];
+                bool hasHostValueOne = hostHeaders.Contains("test.host.com");
+                bool hasHostValueTwo = hostHeaders.Contains("test.response.com");
+
+                var cacheHeaders = response.Headers["Cache-Control"].First();
+                bool hasCacheValueOne = cacheHeaders.Contains("GET");
+                bool hasCacheValueTwo = cacheHeaders.Contains("POST");
+                bool hasCacheValueThree = cacheHeaders.Contains("HEAD");
+                bool hasCacheValueFour = cacheHeaders.Contains("OPTIONS");
+
+                var accessHeaders = response.Headers["Access-Control-Expose-Headers"];
+                bool hasAccessValueOne = accessHeaders.Contains("X-customHeader1");
+                bool hasAccessValueTwo = accessHeaders.Contains("X-customHeader2");
+                bool hasAccessValueThree = accessHeaders.Contains("X-customHeader3");
+                bool hasAccessValueFour = accessHeaders.Contains("X-customHeader4");
+                bool hasAccessValueFive = accessHeaders.Contains("X-customHeader5");
+
+                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+                Assert.True(hasHostValueOne && hasHostValueTwo);
+                Assert.True(hasCacheValueOne && hasCacheValueTwo && hasCacheValueThree && hasCacheValueFour);
+                Assert.True(hasAccessValueOne && hasAccessValueTwo && hasAccessValueThree && hasAccessValueFour && hasAccessValueFive);
+
+                Assert.Contains("test content", response.Content);
+
+                await host.StopAsync();
+            }
+        }
+
+        /// <summary>
+        /// End-to-end test which checks if the CallHttpAsync Orchestrator Headers and Content.
+        /// from the response have relevant information. This test has one response header
+        /// with one response header value.
+        /// </summary>
+        [Theory]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        [MemberData(nameof(TestDataGenerator.GetFullFeaturedStorageProviderOptions), MemberType = typeof(TestDataGenerator))]
+        public async Task DurableHttpAsync_OneHeaderAndContentTest(string storageProvider)
+        {
+            string[] httpResponseHeaders = { "test.host.com" };
+            StringValues stringValues = new StringValues(httpResponseHeaders);
+            Dictionary<string, StringValues> testHeaders = new Dictionary<string, StringValues>();
+            testHeaders.Add("Host", stringValues);
+
+            HttpResponseMessage testHttpResponseMessage = CreateTestHttpResponseMessageMultHeaders(
+                                                                                        statusCode: HttpStatusCode.OK,
+                                                                                        headers: testHeaders,
+                                                                                        content: "test content");
+
+            HttpMessageHandler httpMessageHandler = MockSynchronousHttpMessageHandler(testHttpResponseMessage);
+
+            using (JobHost host = TestHelpers.GetJobHost(
+                this.loggerProvider,
+                nameof(this.DurableHttpAsync_OneHeaderAndContentTest),
+                enableExtendedSessions: false,
+                storageProviderType: storageProvider,
+                durableHttpMessageHandler: new DurableHttpMessageHandlerFactory(httpMessageHandler)))
+            {
+                await host.StartAsync();
+
+                // Uri uri = new Uri("https://dummy-test-url.com");
+                // var request = new DurableHttpRequest(HttpMethod.Get, uri);
+                // StringValues stringValues = new StringValues("application/json");
+                // request.Headers.Add("Accept", stringValues);
+
+                Dictionary<string, string> headers = new Dictionary<string, string>();
+                headers.Add("Accept", "application/json");
+
+                TestDurableHttpRequest testRequest = new TestDurableHttpRequest(
+                    httpMethod: HttpMethod.Get,
+                    headers: headers);
+
+                var client = await host.StartOrchestratorAsync(nameof(TestOrchestrations.CallHttpAsyncOrchestrator), testRequest, this.output);
+                var status = await client.WaitForCompletionAsync(this.output, timeout: TimeSpan.FromSeconds(Debugger.IsAttached ? 3000 : 90));
+
+                var output = status?.Output;
+
+                JsonSerializer serializer = new JsonSerializer();
+                serializer.Converters.Add(new DurableHttpResponseJsonConverter());
+                DurableHttpResponse response = output.ToObject<DurableHttpResponse>(serializer);
+
+                var hostHeaders = response.Headers["Host"];
+                bool hasHostValueOne = response.Headers["Host"].Contains("test.host.com");
+
+                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+                Assert.True(hasHostValueOne);
+                Assert.Contains("test content", response.Content);
+
+                await host.StopAsync();
+            }
+        }
+
+        /// <summary>
+        /// End-to-end test which checks if the CallHttpAsync Orchestrator works with a
+        /// Retry-After header.
+        /// </summary>
+        [Theory]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        [MemberData(nameof(TestDataGenerator.GetFullFeaturedStorageProviderOptions), MemberType = typeof(TestDataGenerator))]
+        public async Task DurableHttpAsync_AsynchronousAPI_RetryAfterTest(string storageProvider)
+        {
+            Dictionary<string, string> testHeaders = new Dictionary<string, string>();
+            testHeaders.Add("Retry-After", "20");
+            testHeaders.Add("Location", "https://www.dummy-url.com");
+
+            HttpResponseMessage acceptedHttpResponseMessage = CreateTestHttpResponseMessage(
+                                                                                        statusCode: HttpStatusCode.Accepted,
+                                                                                        headers: testHeaders);
+            HttpMessageHandler httpMessageHandler = MockAsynchronousHttpMessageHandlerWithRetryAfter(acceptedHttpResponseMessage);
+
+            using (JobHost host = TestHelpers.GetJobHost(
+                this.loggerProvider,
+                nameof(this.DurableHttpAsync_AsynchronousAPI_RetryAfterTest),
+                enableExtendedSessions: false,
+                storageProviderType: storageProvider,
+                durableHttpMessageHandler: new DurableHttpMessageHandlerFactory(httpMessageHandler)))
+            {
+                await host.StartAsync();
+
+                Dictionary<string, string> headers = new Dictionary<string, string>();
+                headers.Add("Accept", "application/json");
+                TestDurableHttpRequest testRequest = new TestDurableHttpRequest(
+                    httpMethod: HttpMethod.Get,
+                    headers: headers);
+
+                string functionName = nameof(TestOrchestrations.CallHttpAsyncOrchestrator);
+                var client = await host.StartOrchestratorAsync(functionName, testRequest, this.output);
+                var status = await client.WaitForCompletionAsync(this.output, timeout: TimeSpan.FromSeconds(240));
+
+                var output = status?.Output;
+                JsonSerializer serializer = new JsonSerializer();
+                serializer.Converters.Add(new DurableHttpResponseJsonConverter());
+                DurableHttpResponse response = output.ToObject<DurableHttpResponse>(serializer);
+                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+                await host.StopAsync();
+            }
+        }
+
+        /// <summary>
+        /// End-to-end test which checks if the CallHttpAsync Orchestrator Async functionality
+        /// waits until an OK response is returned.
+        /// </summary>
+        [Theory]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        [MemberData(nameof(TestDataGenerator.GetFullFeaturedStorageProviderOptions), MemberType = typeof(TestDataGenerator))]
+        public async Task DurableHttpAsync_AsynchronousAPI_ReturnsOK200(string storageProvider)
+        {
+            Dictionary<string, string> asyncTestHeaders = new Dictionary<string, string>();
+            asyncTestHeaders.Add("Location", "https://www.dummy-location-url.com");
+
+            HttpResponseMessage acceptedHttpResponseMessage = CreateTestHttpResponseMessage(
+                                                                                               statusCode: HttpStatusCode.Accepted,
+                                                                                               headers: asyncTestHeaders);
+
+            HttpMessageHandler httpMessageHandler = MockAsynchronousHttpMessageHandler(acceptedHttpResponseMessage);
+
+            using (JobHost host = TestHelpers.GetJobHost(
+                this.loggerProvider,
+                nameof(this.DurableHttpAsync_AsynchronousAPI_ReturnsOK200),
+                enableExtendedSessions: false,
+                storageProviderType: storageProvider,
+                durableHttpMessageHandler: new DurableHttpMessageHandlerFactory(httpMessageHandler)))
+            {
+                await host.StartAsync();
+
+                Dictionary<string, string> headers = new Dictionary<string, string>();
+                headers.Add("Accept", "application/json");
+                TestDurableHttpRequest testRequest = new TestDurableHttpRequest(
+                    httpMethod: HttpMethod.Get,
+                    headers: headers);
+
+                string functionName = nameof(TestOrchestrations.CallHttpAsyncOrchestrator);
+                var client = await host.StartOrchestratorAsync(functionName, testRequest, this.output);
+                var status = await client.WaitForCompletionAsync(this.output, timeout: TimeSpan.FromSeconds(Debugger.IsAttached ? 3000 : 90));
+
+                var output = status?.Output;
+                JsonSerializer serializer = new JsonSerializer();
+                serializer.Converters.Add(new DurableHttpResponseJsonConverter());
+                DurableHttpResponse response = output.ToObject<DurableHttpResponse>(serializer);
+                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+                await host.StopAsync();
+            }
+        }
+
+        /// <summary>
+        /// End-to-end test which checks if the CallHttpAsync Orchestrator Async functionality
+        /// works with Content-Type of application/json.
+        /// </summary>
+        [Theory]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        [MemberData(nameof(TestDataGenerator.GetFullFeaturedStorageProviderOptions), MemberType = typeof(TestDataGenerator))]
+        public async Task DurableHttpAsync_SynchronousAPI_RequestContentTest(string storageProvider)
+        {
+            HttpMessageHandler httpMessageHandler = MockHttpMessageHandlerContentType();
+
+            using (JobHost host = TestHelpers.GetJobHost(
+                this.loggerProvider,
+                nameof(this.DurableHttpAsync_AsynchronousAPI_ReturnsOK200),
+                enableExtendedSessions: false,
+                storageProviderType: storageProvider,
+                durableHttpMessageHandler: new DurableHttpMessageHandlerFactory(httpMessageHandler)))
+            {
+                await host.StartAsync();
+
+                string requestBody = "{\"key\": \"value\",\"key\": \"value\",\"values\": {\"key\": \"value\",\"key\": \"value\",\"key\": true,}}";
+
+                Dictionary<string, string> headers = new Dictionary<string, string>();
+                headers.Add("Content-Type", "application/json");
+                TestDurableHttpRequest testRequest = new TestDurableHttpRequest(
+                    httpMethod: HttpMethod.Get,
+                    headers: headers,
+                    content: requestBody);
+
+                string functionName = nameof(TestOrchestrations.CallHttpAsyncOrchestrator);
+                var client = await host.StartOrchestratorAsync(functionName, testRequest, this.output);
+                var status = await client.WaitForCompletionAsync(this.output, timeout: TimeSpan.FromSeconds(Debugger.IsAttached ? 3000 : 90));
+
+                var output = status?.Output;
+                JsonSerializer serializer = new JsonSerializer();
+                serializer.Converters.Add(new DurableHttpResponseJsonConverter());
+                DurableHttpResponse response = output.ToObject<DurableHttpResponse>(serializer);
+                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+                await host.StopAsync();
+            }
+        }
+
+        /// <summary>
+        /// End-to-end test which checks if the CallHttpAsync Orchestrator Async functionality
+        /// returns an OK response when body content is passed to the HTTP request, but the
+        /// Content-Type is not specified.
+        /// </summary>
+        [Theory]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        [MemberData(nameof(TestDataGenerator.GetFullFeaturedStorageProviderOptions), MemberType = typeof(TestDataGenerator))]
+        public async Task DurableHttpAsync_SynchronousAPI_NoContentTypeTest(string storageProvider)
+        {
+            HttpMessageHandler httpMessageHandler = MockHttpMessageHandlerContentType();
+
+            using (JobHost host = TestHelpers.GetJobHost(
+                this.loggerProvider,
+                nameof(this.DurableHttpAsync_SynchronousAPI_NoContentTypeTest),
+                enableExtendedSessions: false,
+                storageProviderType: storageProvider,
+                durableHttpMessageHandler: new DurableHttpMessageHandlerFactory(httpMessageHandler)))
+            {
+                await host.StartAsync();
+
+                string requestBody = "test request body";
+
+                Dictionary<string, string> headers = new Dictionary<string, string>();
+                TestDurableHttpRequest testRequest = new TestDurableHttpRequest(
+                    httpMethod: HttpMethod.Get,
+                    headers: headers,
+                    content: requestBody);
+
+                string functionName = nameof(TestOrchestrations.CallHttpAsyncOrchestrator);
+                var client = await host.StartOrchestratorAsync(functionName, testRequest, this.output);
+                var status = await client.WaitForCompletionAsync(this.output, timeout: TimeSpan.FromSeconds(Debugger.IsAttached ? 3000 : 90));
+
+                var output = status?.Output;
+                JsonSerializer serializer = new JsonSerializer();
+                serializer.Converters.Add(new DurableHttpResponseJsonConverter());
+                DurableHttpResponse response = output.ToObject<DurableHttpResponse>(serializer);
+                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+                await host.StopAsync();
+            }
+        }
+
+        /// <summary>
+        /// End-to-end test which checks if the CallHttpAsync Orchestrator Async functionality
+        /// works when the Content-Type is "application/x-www-form-urlencoded".
+        /// </summary>
+        [Theory]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        [MemberData(nameof(TestDataGenerator.GetFullFeaturedStorageProviderOptions), MemberType = typeof(TestDataGenerator))]
+        public async Task DurableHttpAsync_SynchronousAPI_UrlEncodedTest(string storageProvider)
+        {
+            HttpMessageHandler httpMessageHandler = MockHttpMessageHandlerContentType();
+
+            using (JobHost host = TestHelpers.GetJobHost(
+                this.loggerProvider,
+                nameof(this.DurableHttpAsync_SynchronousAPI_UrlEncodedTest),
+                enableExtendedSessions: false,
+                storageProviderType: storageProvider,
+                durableHttpMessageHandler: new DurableHttpMessageHandlerFactory(httpMessageHandler)))
+            {
+                await host.StartAsync();
+
+                string requestBody = "Test request body";
+                requestBody = string.Format(
+                    "site={0}&content={1}",
+                    Uri.EscapeDataString("https://www.dummy-url.com"),
+                    Uri.EscapeDataString("Test request body"));
+
+                Dictionary<string, string> headers = new Dictionary<string, string>();
+                headers.Add("Content-Type", "application/x-www-form-urlencoded");
+                TestDurableHttpRequest testRequest = new TestDurableHttpRequest(
+                    httpMethod: HttpMethod.Get,
+                    headers: headers,
+                    content: requestBody);
+
+                string functionName = nameof(TestOrchestrations.CallHttpAsyncOrchestrator);
+                var client = await host.StartOrchestratorAsync(functionName, testRequest, this.output);
+                var status = await client.WaitForCompletionAsync(this.output, timeout: TimeSpan.FromSeconds(Debugger.IsAttached ? 3000 : 90));
+
+                var output = status?.Output;
+                JsonSerializer serializer = new JsonSerializer();
+                serializer.Converters.Add(new DurableHttpResponseJsonConverter());
+                DurableHttpResponse response = output.ToObject<DurableHttpResponse>(serializer);
+                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+                await host.StopAsync();
+            }
+        }
+
+        /// <summary>
+        /// End-to-end test which checks if the CallHttpAsync Orchestrator Async functionality
+        /// waits until an OK response is returned with a long running process.
+        /// </summary>
+        [Theory]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        [MemberData(nameof(TestDataGenerator.GetFullFeaturedStorageProviderOptions), MemberType = typeof(TestDataGenerator))]
+        public async Task DurableHttpAsync_AsynchronousAPI_LongRunning(string storageProvider)
+        {
+            Dictionary<string, string> asyncTestHeaders = new Dictionary<string, string>();
+            asyncTestHeaders.Add("Location", "https://www.dummy-location-url.com");
+
+            HttpResponseMessage acceptedHttpResponseMessage = CreateTestHttpResponseMessage(
+                                                                                               statusCode: HttpStatusCode.Accepted,
+                                                                                               headers: asyncTestHeaders);
+            HttpMessageHandler httpMessageHandler = MockAsynchronousHttpMessageHandlerLongRunning(acceptedHttpResponseMessage);
+
+            using (JobHost host = TestHelpers.GetJobHost(
+                this.loggerProvider,
+                nameof(this.DurableHttpAsync_AsynchronousAPI_LongRunning),
+                enableExtendedSessions: false,
+                storageProviderType: storageProvider,
+                httpAsyncSleepTime: 10000,
+                durableHttpMessageHandler: new DurableHttpMessageHandlerFactory(httpMessageHandler)))
+            {
+                await host.StartAsync();
+
+                Dictionary<string, string> headers = new Dictionary<string, string>();
+                headers.Add("Accept", "application/json");
+                TestDurableHttpRequest testRequest = new TestDurableHttpRequest(
+                    httpMethod: HttpMethod.Get,
+                    headers: headers);
+
+                string functionName = nameof(TestOrchestrations.CallHttpAsyncOrchestrator);
+                var client = await host.StartOrchestratorAsync(functionName, testRequest, this.output);
+                var status = await client.WaitForCompletionAsync(this.output, timeout: TimeSpan.FromSeconds(40000));
+
+                var output = status?.Output;
+                DurableHttpResponse response = output.ToObject<DurableHttpResponse>();
+                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+                await host.StopAsync();
+            }
+        }
+
+        /// <summary>
+        /// End-to-end test which checks if multiple CallHttpAsync Orchestrator Async calls
+        /// all return an OK response status code.
+        /// </summary>
+        [Theory]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        [MemberData(nameof(TestDataGenerator.GetFullFeaturedStorageProviderOptions), MemberType = typeof(TestDataGenerator))]
+        public async Task DurableHttpAsync_AsynchronousAPI_MultipleAsyncCalls(string storageProvider)
+        {
+            HttpMessageHandler httpMessageHandler = MockAsynchronousHttpMessageHandlerForMultipleRequestsTwo();
+
+            using (JobHost host = TestHelpers.GetJobHost(
+                this.loggerProvider,
+                nameof(this.DurableHttpAsync_AsynchronousAPI_ReturnsOK200),
+                enableExtendedSessions: false,
+                storageProviderType: storageProvider,
+                durableHttpMessageHandler: new DurableHttpMessageHandlerFactory(httpMessageHandler)))
+            {
+                await host.StartAsync();
+
+                // First request
+                Dictionary<string, string> headersOne = new Dictionary<string, string>();
+                headersOne.Add("Accept", "application/json");
+                TestDurableHttpRequest testRequestOne = new TestDurableHttpRequest(
+                    httpMethod: HttpMethod.Get,
+                    uri: "https://www.dummy-url.com/AsyncRequestOne",
+                    headers: headersOne);
+
+                string functionNameOne = nameof(TestOrchestrations.CallHttpAsyncOrchestrator);
+                var clientOne = await host.StartOrchestratorAsync(functionNameOne, testRequestOne, this.output);
+                var statusOne = await clientOne.WaitForCompletionAsync(this.output, timeout: TimeSpan.FromSeconds(Debugger.IsAttached ? 3000 : 90));
+                var outputOne = statusOne?.Output;
+                DurableHttpResponse responseOne = outputOne.ToObject<DurableHttpResponse>();
+
+                Assert.Equal(HttpStatusCode.OK, responseOne.StatusCode);
+
+                // Second request
+                Dictionary<string, string> headersTwo = new Dictionary<string, string>();
+                headersTwo.Add("Accept", "application/json");
+                TestDurableHttpRequest testRequestTwo = new TestDurableHttpRequest(
+                    httpMethod: HttpMethod.Get,
+                    uri: "https://www.dummy-url.com/AsyncRequestTwo",
+                    headers: headersTwo);
+
+                string functionName = nameof(TestOrchestrations.CallHttpAsyncOrchestrator);
+                var clientTwo = await host.StartOrchestratorAsync(functionName, testRequestTwo, this.output);
+                var statusTwo = await clientTwo.WaitForCompletionAsync(this.output, timeout: TimeSpan.FromSeconds(Debugger.IsAttached ? 3000 : 90));
+                var outputTwo = statusTwo?.Output;
+                DurableHttpResponse responseTwo = outputTwo.ToObject<DurableHttpResponse>();
+
+                Assert.Equal(HttpStatusCode.OK, responseTwo.StatusCode);
+
+                await host.StopAsync();
+            }
+        }
+
+        private static HttpMessageHandler MockAsynchronousHttpMessageHandlerForMultipleRequestsTwo()
+        {
+            Dictionary<string, string> asyncTestHeadersOne = new Dictionary<string, string>();
+            asyncTestHeadersOne.Add("Location", "https://www.dummy-location-url.com/AsyncRequestOne");
+
+            Dictionary<string, string> asyncTestHeadersTwo = new Dictionary<string, string>();
+            asyncTestHeadersTwo.Add("Location", "https://www.dummy-location-url.com/AsyncRequestTwo");
+
+            HttpResponseMessage acceptedHttpResponseMessageOne = CreateTestHttpResponseMessage(
+                                                                                              statusCode: HttpStatusCode.Accepted,
+                                                                                              headers: asyncTestHeadersOne);
+            HttpResponseMessage acceptedHttpResponseMessageTwo = CreateTestHttpResponseMessage(
+                                                                                             statusCode: HttpStatusCode.Accepted,
+                                                                                             headers: asyncTestHeadersTwo);
+            HttpResponseMessage okHttpResponseMessage = CreateTestHttpResponseMessage(HttpStatusCode.OK);
+            HttpResponseMessage forbiddenResponseMessage = CreateTestHttpResponseMessage(HttpStatusCode.Forbidden);
+
+            var handlerMock = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+            handlerMock
+               .Protected()
+               .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.Is<HttpRequestMessage>(req => UriContainsGivenString(req, "AsyncRequestOne")), ItExpr.IsAny<CancellationToken>())
+               .ReturnsAsync(new Queue<HttpResponseMessage>(new[]
+                {
+                    acceptedHttpResponseMessageOne,
+                    acceptedHttpResponseMessageOne,
+                    acceptedHttpResponseMessageOne,
+                    acceptedHttpResponseMessageOne,
+                    okHttpResponseMessage,
+                }).Dequeue);
+
+            handlerMock
+               .Protected()
+               .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.Is<HttpRequestMessage>(req => UriContainsGivenString(req, "AsyncRequestTwo")), ItExpr.IsAny<CancellationToken>())
+               .ReturnsAsync(new Queue<HttpResponseMessage>(new[]
+               {
+                    acceptedHttpResponseMessageTwo,
+                    acceptedHttpResponseMessageTwo,
+                    acceptedHttpResponseMessageTwo,
+                    acceptedHttpResponseMessageTwo,
+                    okHttpResponseMessage,
+               }).Dequeue);
+
+            handlerMock
+                .Protected()
+                .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.Is<HttpRequestMessage>(req => !UriContainsGivenString(req, "AsyncRequestOne") && !UriContainsGivenString(req, "AsyncRequestTwo")), ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(forbiddenResponseMessage);
+
+            return handlerMock.Object;
+        }
+
+        private static bool UriContainsGivenString(HttpRequestMessage req, string uriEnd)
+        {
+            return req.RequestUri.ToString().EndsWith(uriEnd);
+        }
+
+        /// <summary>
+        /// End-to-end test which checks if the CallHttpAsync Orchestrator returns an OK (200) status code
+        /// when a Bearer Token is added to the DurableHttpRequest object.
+        /// </summary>
+        [Theory]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        [MemberData(nameof(TestDataGenerator.GetFullFeaturedStorageProviderOptions), MemberType = typeof(TestDataGenerator))]
+        public async Task DurableHttpAsync_Synchronous_AddsBearerToken(string storageProvider)
+        {
+            HttpMessageHandler httpMessageHandler = MockSynchronousHttpMessageHandlerForTestingTokenSource();
+
+            using (JobHost host = TestHelpers.GetJobHost(
+                this.loggerProvider,
+                nameof(this.DurableHttpAsync_AsynchronousAPI_ReturnsOK200),
+                enableExtendedSessions: false,
+                storageProviderType: storageProvider,
+                durableHttpMessageHandler: new DurableHttpMessageHandlerFactory(httpMessageHandler)))
+            {
+                await host.StartAsync();
+
+                Dictionary<string, string> headers = new Dictionary<string, string>();
+                headers.Add("Accept", "application/json");
+                MockTokenSource mockTokenSource = new MockTokenSource("dummy test token");
+
+                TestDurableHttpRequest testRequest = new TestDurableHttpRequest(
+                    httpMethod: HttpMethod.Get,
+                    headers: headers,
+                    tokenSource: mockTokenSource);
+
+                var client = await host.StartOrchestratorAsync(nameof(TestOrchestrations.CallHttpAsyncOrchestrator), testRequest, this.output);
+                var status = await client.WaitForCompletionAsync(this.output, timeout: TimeSpan.FromSeconds(Debugger.IsAttached ? 3000 : 90));
+                var output = status?.Output;
+                JsonSerializer serializer = new JsonSerializer();
+                serializer.Converters.Add(new DurableHttpResponseJsonConverter());
+                DurableHttpResponse response = output.ToObject<DurableHttpResponse>(serializer);
+
+                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+                await host.StopAsync();
+            }
+        }
+
+        private static HttpMessageHandler MockSynchronousHttpMessageHandlerForTestingTokenSource()
+        {
+            HttpResponseMessage okHttpResponseMessage = CreateTestHttpResponseMessage(HttpStatusCode.OK);
+            HttpResponseMessage forbiddenHttpResponseMessage = CreateTestHttpResponseMessage(HttpStatusCode.Forbidden);
+
+            var handlerMock = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+            handlerMock
+               .Protected()
+               .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.Is<HttpRequestMessage>(req => HasBearerToken(req)), ItExpr.IsAny<CancellationToken>())
+               .ReturnsAsync(okHttpResponseMessage);
+
+            handlerMock
+               .Protected()
+               .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.Is<HttpRequestMessage>(req => !HasBearerToken(req)), ItExpr.IsAny<CancellationToken>())
+               .ReturnsAsync(forbiddenHttpResponseMessage);
+
+            return handlerMock.Object;
+        }
+
+        private static bool HasBearerToken(HttpRequestMessage req)
+        {
+            string headerValue = req.Headers.GetValues("Authorization").FirstOrDefault();
+            return string.Equals(headerValue, "Bearer dummy test token");
+        }
+
+        /// <summary>
+        /// End-to-end test which checks if the CallHttpAsync Orchestrator returns an OK (200) status code
+        /// when a Bearer Token is added to the DurableHttpRequest object and follows the
+        /// asynchronous pattern.
+        /// </summary>
+        [Theory]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        [MemberData(nameof(TestDataGenerator.GetFullFeaturedStorageProviderOptions), MemberType = typeof(TestDataGenerator))]
+        public async Task DurableHttpAsync_Asynchronous_AddsBearerToken(string storageProvider)
+        {
+            HttpMessageHandler httpMessageHandler = MockAsynchronousHttpMessageHandlerForTestingTokenSource();
+
+            using (JobHost host = TestHelpers.GetJobHost(
+                this.loggerProvider,
+                nameof(this.DurableHttpAsync_AsynchronousAPI_ReturnsOK200),
+                enableExtendedSessions: false,
+                storageProviderType: storageProvider,
+                durableHttpMessageHandler: new DurableHttpMessageHandlerFactory(httpMessageHandler)))
+            {
+                await host.StartAsync();
+
+                Dictionary<string, string> headers = new Dictionary<string, string>();
+                headers.Add("Accept", "application/json");
+                MockTokenSource mockTokenSource = new MockTokenSource("dummy test token");
+
+                TestDurableHttpRequest testRequest = new TestDurableHttpRequest(
+                    httpMethod: HttpMethod.Get,
+                    headers: headers,
+                    tokenSource: mockTokenSource);
+
+                var client = await host.StartOrchestratorAsync(nameof(TestOrchestrations.CallHttpAsyncOrchestrator), testRequest, this.output);
+                var status = await client.WaitForCompletionAsync(this.output, timeout: TimeSpan.FromSeconds(Debugger.IsAttached ? 3000 : 90));
+                var output = status?.Output;
+
+                DurableHttpResponse response = output.ToObject<DurableHttpResponse>();
+
+                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+                await host.StopAsync();
+            }
+        }
+
+        private static HttpMessageHandler MockAsynchronousHttpMessageHandlerForTestingTokenSource()
+        {
+            Dictionary<string, string> asyncTestHeaders = new Dictionary<string, string>();
+            asyncTestHeaders.Add("Location", "https://www.dummy-location-url.com");
+
+            HttpResponseMessage okHttpResponseMessage = CreateTestHttpResponseMessage(HttpStatusCode.OK);
+            HttpResponseMessage forbiddenHttpResponseMessage = CreateTestHttpResponseMessage(HttpStatusCode.Forbidden);
+            HttpResponseMessage acceptedHttpResponseMessage = CreateTestHttpResponseMessage(
+                                                                                               statusCode: HttpStatusCode.Accepted,
+                                                                                               headers: asyncTestHeaders);
+
+            var handlerMock = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+            handlerMock
+               .Protected()
+               .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.Is<HttpRequestMessage>(req => HasBearerToken(req)), ItExpr.IsAny<CancellationToken>())
+               .ReturnsAsync(new Queue<HttpResponseMessage>(new[]
+                {
+                    acceptedHttpResponseMessage,
+                    acceptedHttpResponseMessage,
+                    acceptedHttpResponseMessage,
+                    acceptedHttpResponseMessage,
+                    okHttpResponseMessage,
+                }).Dequeue);
+
+            handlerMock
+               .Protected()
+               .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.Is<HttpRequestMessage>(req => !HasBearerToken(req)), ItExpr.IsAny<CancellationToken>())
+               .ReturnsAsync(new Queue<HttpResponseMessage>(new[]
+                {
+                    acceptedHttpResponseMessage,
+                    acceptedHttpResponseMessage,
+                    acceptedHttpResponseMessage,
+                    acceptedHttpResponseMessage,
+                    forbiddenHttpResponseMessage,
+                }).Dequeue);
+
+            return handlerMock.Object;
+        }
+
+        private static HttpMessageHandler CreateAsynchronousHttpMessageHandlerForMultipleRequests()
+        {
+            Dictionary<string, string> asyncTestHeadersOne = new Dictionary<string, string>();
+            asyncTestHeadersOne.Add("Location", "https://www.dummy-location-url.com/AsyncRequestOne");
+
+            Dictionary<string, string> asyncTestHeadersTwo = new Dictionary<string, string>();
+            asyncTestHeadersTwo.Add("Location", "https://www.dummy-location-url.com/AsyncRequestTwo");
+
+            HttpResponseMessage acceptedHttpResponseMessageOne = CreateTestHttpResponseMessage(
+                                                                                               statusCode: HttpStatusCode.Accepted,
+                                                                                               headers: asyncTestHeadersOne);
+
+            HttpResponseMessage acceptedHttpResponseMessageTwo = CreateTestHttpResponseMessage(
+                                                                                              statusCode: HttpStatusCode.Accepted,
+                                                                                              headers: asyncTestHeadersTwo);
+
+            HttpResponseMessage okHttpResponseMessage = CreateTestHttpResponseMessage(HttpStatusCode.OK);
+
+            var handlerMock = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+            handlerMock
+               .Protected()
+               .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.Is<HttpRequestMessage>(req => req.RequestUri.ToString().EndsWith("AsyncRequestOne")), ItExpr.IsAny<CancellationToken>())
+               .ReturnsAsync(new Queue<HttpResponseMessage>(new[]
+                {
+                    acceptedHttpResponseMessageOne,
+                    acceptedHttpResponseMessageOne,
+                    acceptedHttpResponseMessageOne,
+                    acceptedHttpResponseMessageOne,
+                    okHttpResponseMessage,
+                }).Dequeue);
+
+            handlerMock
+                .Protected()
+                .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.Is<HttpRequestMessage>(req => req.RequestUri.ToString().EndsWith("AsyncRequestTwo")), ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(new Queue<HttpResponseMessage>(new[]
+                {
+                    acceptedHttpResponseMessageTwo,
+                    acceptedHttpResponseMessageTwo,
+                    acceptedHttpResponseMessageTwo,
+                    acceptedHttpResponseMessageTwo,
+                    okHttpResponseMessage,
+                }).Dequeue);
+
+            return handlerMock.Object;
+        }
+
+        private static HttpMessageHandler MockSynchronousHttpMessageHandler(HttpResponseMessage httpResponseMessage)
+        {
+            var handlerMock = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+            handlerMock
+               .Protected()
+               .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+               .ReturnsAsync(httpResponseMessage);
+
+            return handlerMock.Object;
+        }
+
+        private static HttpMessageHandler MockHttpMessageHandlerCheckUserAgent()
+        {
+            HttpResponseMessage okHttpResponseMessage = CreateTestHttpResponseMessage(HttpStatusCode.OK);
+            HttpResponseMessage forbiddenHttpResponseMessage = CreateTestHttpResponseMessage(HttpStatusCode.Forbidden);
+
+            var handlerMock = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+            handlerMock
+               .Protected()
+               .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.Is<HttpRequestMessage>(req => req.Headers.UserAgent != null), ItExpr.IsAny<CancellationToken>())
+               .ReturnsAsync(okHttpResponseMessage);
+
+            handlerMock
+               .Protected()
+               .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.Is<HttpRequestMessage>(req => req.Headers.UserAgent == null), ItExpr.IsAny<CancellationToken>())
+               .ReturnsAsync(forbiddenHttpResponseMessage);
+
+            return handlerMock.Object;
+        }
+
+        private static HttpMessageHandler MockHttpMessageHandlerCheckAcceptHeader()
+        {
+            HttpResponseMessage okHttpResponseMessage = CreateTestHttpResponseMessage(HttpStatusCode.OK);
+            HttpResponseMessage forbiddenHttpResponseMessage = CreateTestHttpResponseMessage(HttpStatusCode.Forbidden);
+
+            var handlerMock = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+            handlerMock
+               .Protected()
+               .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.Is<HttpRequestMessage>(req => req.Headers.Accept != null), ItExpr.IsAny<CancellationToken>())
+               .ReturnsAsync(okHttpResponseMessage);
+
+            handlerMock
+               .Protected()
+               .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.Is<HttpRequestMessage>(req => req.Headers.Accept == null), ItExpr.IsAny<CancellationToken>())
+               .ReturnsAsync(forbiddenHttpResponseMessage);
+
+            return handlerMock.Object;
+        }
+
+        private static HttpMessageHandler MockHttpMessageHandlerContentType()
+        {
+            HttpResponseMessage okHttpResponseMessage = CreateTestHttpResponseMessage(HttpStatusCode.OK);
+            HttpResponseMessage forbiddenHttpResponseMessage = CreateTestHttpResponseMessage(HttpStatusCode.Forbidden);
+
+            var handlerMock = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+            handlerMock
+               .Protected()
+               .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.Is<HttpRequestMessage>(req => !HasContentTypeHeader(req)), ItExpr.IsAny<CancellationToken>())
+               .ReturnsAsync(okHttpResponseMessage);
+
+            handlerMock
+               .Protected()
+               .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.Is<HttpRequestMessage>(req => HasContentTypeHeader(req)), ItExpr.IsAny<CancellationToken>())
+               .ReturnsAsync(forbiddenHttpResponseMessage);
+
+            return handlerMock.Object;
+        }
+
+        public static bool HasContentTypeHeader(HttpRequestMessage req)
+        {
+            IEnumerable<string> values = new List<string>();
+            bool containsContentType = req.Headers.TryGetValues("Content-Type", out values);
+            return containsContentType;
+        }
+
+        private static HttpMessageHandler MockAsynchronousHttpMessageHandler(HttpResponseMessage acceptedHttpResponseMessage)
+        {
+            HttpResponseMessage okHttpResponseMessage = CreateTestHttpResponseMessage(HttpStatusCode.OK);
+
+            var handlerMock = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+            handlerMock
+               .Protected()
+               .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+               .ReturnsAsync(new Queue<HttpResponseMessage>(new[]
+                {
+                    acceptedHttpResponseMessage,
+                    acceptedHttpResponseMessage,
+                    acceptedHttpResponseMessage,
+                    acceptedHttpResponseMessage,
+                    okHttpResponseMessage,
+                }).Dequeue);
+
+            return handlerMock.Object;
+        }
+
+        private static HttpMessageHandler MockAsynchronousHttpMessageHandlerLongRunning(HttpResponseMessage acceptedHttpResponseMessage)
+        {
+            HttpResponseMessage okHttpResponseMessage = CreateTestHttpResponseMessage(HttpStatusCode.OK);
+
+            var handlerMock = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+            handlerMock
+               .Protected()
+               .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+               .ReturnsAsync(new Queue<HttpResponseMessage>(new[]
+                {
+                    acceptedHttpResponseMessage,
+                    acceptedHttpResponseMessage,
+                    acceptedHttpResponseMessage,
+                    acceptedHttpResponseMessage,
+                    okHttpResponseMessage,
+                }).Dequeue);
+
+            return handlerMock.Object;
+        }
+
+        private static HttpMessageHandler MockAsynchronousHttpMessageHandlerWithRetryAfter(HttpResponseMessage acceptedHttpResponseMessage)
+        {
+            HttpResponseMessage okHttpResponseMessage = CreateTestHttpResponseMessage(HttpStatusCode.OK);
+
+            var handlerMock = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+            handlerMock
+               .Protected()
+               .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+               .ReturnsAsync(new Queue<HttpResponseMessage>(new[]
+                {
+                    acceptedHttpResponseMessage,
+                    acceptedHttpResponseMessage,
+                    acceptedHttpResponseMessage,
+                    acceptedHttpResponseMessage,
+                    okHttpResponseMessage,
+                }).Dequeue);
+
+            return handlerMock.Object;
+        }
+
+        private static HttpResponseMessage CreateTestHttpResponseMessage(
+                                                                    HttpStatusCode statusCode,
+                                                                    Dictionary<string, string> headers = null,
+                                                                    string content = "")
+        {
+            HttpResponseMessage newHttpResponseMessage = new HttpResponseMessage(statusCode);
+            if (headers != null)
+            {
+                foreach (KeyValuePair<string, string> header in headers)
+                {
+                    newHttpResponseMessage.Headers.Add(header.Key, header.Value);
+                }
+            }
+
+            string json = JsonConvert.SerializeObject(content);
+            var httpContent = new StringContent(json, Encoding.UTF8, "application/json");
+            newHttpResponseMessage.Content = httpContent;
+            return newHttpResponseMessage;
+        }
+
+        private static HttpResponseMessage CreateTestHttpResponseMessageMultHeaders(
+                                                                    HttpStatusCode statusCode,
+                                                                    Dictionary<string, StringValues> headers = null,
+                                                                    string content = "")
+        {
+            HttpResponseMessage newHttpResponseMessage = new HttpResponseMessage(statusCode);
+            if (headers != null)
+            {
+                foreach (KeyValuePair<string, StringValues> header in headers)
+                {
+                    newHttpResponseMessage.Headers.Add(header.Key, (IEnumerable<string>)header.Value);
+                }
+            }
+
+            string json = JsonConvert.SerializeObject(content);
+            var httpContent = new StringContent(json, Encoding.UTF8, "application/json");
+            newHttpResponseMessage.Content = httpContent;
+            return newHttpResponseMessage;
+        }
+
+        [DataContract]
+        private class MockTokenSource : ITokenSource
+        {
+            [DataMember]
+            private readonly string token;
+
+            public MockTokenSource(string token)
+            {
+                this.token = token;
+            }
+
+            public Task<string> GetTokenAsync()
+            {
+                return Task.FromResult(this.token);
+            }
+        }
+    }
+}

--- a/test/FunctionsV2/PlatformSpecificHelpers.FunctionsV2.cs
+++ b/test/FunctionsV2/PlatformSpecificHelpers.FunctionsV2.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System.Net.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -20,7 +21,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         public static JobHost CreateJobHost(
             IOptions<DurableTaskOptions> options,
             ILoggerProvider loggerProvider,
-            INameResolver nameResolver)
+            INameResolver nameResolver,
+            IDurableHttpMessageHandlerFactory durableHttpMessageHandler)
         {
             IHost host = new HostBuilder()
                 .ConfigureLogging(
@@ -40,6 +42,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                         ITypeLocator typeLocator = TestHelpers.GetTypeLocator();
                         serviceCollection.AddSingleton(typeLocator);
                         serviceCollection.AddSingleton(nameResolver);
+                        serviceCollection.AddSingleton(durableHttpMessageHandler);
                     })
                 .Build();
 


### PR DESCRIPTION
Includes CallHttpAsync API to DurableOrchestrationContext. Also, adds
support for Bearer tokens to the CallHttpAsync API. This API supports an
asynchronous 202 HTTP pattern.

Resolves https://github.com/Azure/azure-functions-durable-extension/issues/469