### PR TITLE
fixing 'sampling' host setting to match latest schema

### DIFF
--- a/samples/precompiled/host.json
+++ b/samples/precompiled/host.json
@@ -2,7 +2,7 @@
   "version": "2.0",
   "logging": {
     "applicationInsights": {
-      "sampling": {
+      "samplingSettings": {
         "isEnabled": false
       }
     }


### PR DESCRIPTION
`logging/applicationinsights/sampling` has changed to `logging/applicationinsights/samplingsettings` per the host.json schema. 