### PR TITLE
Fix flaky tests sharing a task hub name

### DIFF
--- a/test/Common/DurableTaskEndToEndTests.cs
+++ b/test/Common/DurableTaskEndToEndTests.cs
@@ -216,9 +216,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         [Trait("Category", PlatformSpecificHelpers.TestCategory)]
         [InlineData(true)]
         [InlineData(false)]
-        public async Task HelloWorldOrchestration_Activity_Validate_Logs_For_Replay_Events(bool logReplayEvents)
+        public async Task HelloWorldOrchestration_ValidateReplayEventLogs(bool logReplayEvents)
         {
-            await this.HelloWorldOrchestration_Activity_Main_Logic(nameof(this.HelloWorldOrchestration_Activity_Validate_Logs_For_Replay_Events), false, logReplayEvents: logReplayEvents);
+            await this.HelloWorldOrchestration_Activity_Main_Logic(nameof(this.HelloWorldOrchestration_ValidateReplayEventLogs), false, logReplayEvents: logReplayEvents);
         }
 
         /// <summary>
@@ -240,9 +240,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         [Trait("Category", PlatformSpecificHelpers.TestCategory)]
         [InlineData(true)]
         [InlineData(false)]
-        public async Task HelloWorldOrchestration_Activity_HistoryInputOutput(bool extendedSessions)
+        public async Task HelloWorldOrchestration_ShowHistoryInputOutput(bool extendedSessions)
         {
-            await this.HelloWorldOrchestration_Activity_Main_Logic(nameof(this.HelloWorldOrchestration_Activity_HistoryInputOutput), extendedSessions, true, true);
+            await this.HelloWorldOrchestration_Activity_Main_Logic(nameof(this.HelloWorldOrchestration_ShowHistoryInputOutput), extendedSessions, true, true);
         }
 
         /// <summary>


### PR DESCRIPTION
Many of the `HelloWorldOrchestration_*` tests were sharing a common helper method that used an identical TaskHub name, making the tests interfere with each other in the CI pipeline. I made the task hub name a parameter to the helper method so they won't interfere.

Some of the names were too long to be task hub names, so I renamed the method names to be shorter as well.