### PR TITLE
Make Durable HTTP sample more robust

### DIFF
--- a/samples/v2/precompiled/HttpStart.cs
+++ b/samples/v2/precompiled/HttpStart.cs
@@ -1,9 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System;
 using System.Net.Http;
-using System.Net.Http.Headers;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs;
 using Microsoft.Azure.WebJobs.Extensions.Http;
@@ -16,7 +14,7 @@ namespace VSSample
         [FunctionName("HttpStart")]
         public static async Task<HttpResponseMessage> Run(
             [HttpTrigger(AuthorizationLevel.Function, methods: "post", Route = "orchestrators/{functionName}")] HttpRequestMessage req,
-            [OrchestrationClient] IDurableOrchestrationClient starter,
+            [DurableClient] IDurableOrchestrationClient starter,
             string functionName,
             ILogger log)
         {

--- a/samples/v2/precompiled/HttpSyncStart.cs
+++ b/samples/v2/precompiled/HttpSyncStart.cs
@@ -19,7 +19,7 @@ namespace VSSample
         public static async Task<HttpResponseMessage> Run(
             [HttpTrigger(AuthorizationLevel.Function, methods: "post", Route = "orchestrators/{functionName}/wait")]
             HttpRequestMessage req,
-            [OrchestrationClient] IDurableOrchestrationClient starter,
+            [DurableClient] IDurableOrchestrationClient starter,
             string functionName,
             ILogger log)
         {

--- a/samples/v2/precompiled/RestartVMs.cs
+++ b/samples/v2/precompiled/RestartVMs.cs
@@ -60,9 +60,9 @@ namespace VSSample
                     new Uri($"https://management.azure.com/subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}/providers/Microsoft.Compute/virtualMachines/{vmName}/restart?api-version={apiVersion}"),
                     tokenSource: managedIdentityTokenSource);
                 DurableHttpResponse restartResponse = await context.CallHttpAsync(restartRequest);
-                if (listAllResponse.StatusCode != HttpStatusCode.OK)
+                if (restartResponse.StatusCode != HttpStatusCode.OK)
                 {
-                    throw new ArgumentException($"Failed to restart VM: {listAllResponse.StatusCode}: {listAllResponse.Content}");
+                    throw new ArgumentException($"Failed to restart VM: {restartResponse.StatusCode}: {restartResponse.Content}");
                 }
             }
         }

--- a/samples/v2/precompiled/RestartVMs.cs
+++ b/samples/v2/precompiled/RestartVMs.cs
@@ -1,12 +1,14 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
 using System;
-using System.Collections;
 using System.Collections.Generic;
+using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs;
 using Microsoft.Azure.WebJobs.Extensions.DurableTask;
 using Microsoft.Azure.WebJobs.Extensions.Http;
-using Microsoft.Azure.WebJobs.Host;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -17,28 +19,34 @@ namespace VSSample
     // Making the subscription an owner of your function app is one solution to this.
     public static class RestartVMs
     {
-
         [FunctionName("RestartVMs")]
         public static async Task RunOrchestrator(
-            [OrchestrationTrigger] IDurableOrchestrationContext context,
-            ILogger log)
+            [OrchestrationTrigger] IDurableOrchestrationContext context)
         {
-            string apiVersion = await context.CallActivityAsync<string>("GetApiVersion", null);
-            string subscriptionId = await context.CallActivityAsync<string>("GetSubscriptionId", null);
-            string resourceGroup = await context.CallActivityAsync<string>("GetResourceGroup", null);
+            ResourceInfo vmInfo = context.GetInput<ResourceInfo>();
+            string apiVersion = vmInfo.ApiVersion ?? "2018-06-01";
+            string subscriptionId = vmInfo.SubscriptionId;
+            string resourceGroup = vmInfo.ResourceGroup;
 
-            ManagedIdentityTokenSource managedIdentityTokenSource = new ManagedIdentityTokenSource("https://management.core.windows.net");
+            var managedIdentityTokenSource = new ManagedIdentityTokenSource("https://management.core.windows.net");
 
-            // List all of the VMs in my subscription and add them to an ArrayList
-            string listAllCallString = $"https://management.azure.com/subscriptions/{subscriptionId}/providers/Microsoft.Compute/virtualMachines?api-version={apiVersion}";
-            Uri listAllUri = new Uri(listAllCallString);
-            DurableHttpRequest listRequest = new DurableHttpRequest(method: HttpMethod.Get, uri: listAllUri, tokenSource: managedIdentityTokenSource);
+            // List all of the VMs in my subscription and add them to a list.
+            // If running locally, the first call might be very slow because it takes a long time for 
+            // the AppAuthentication library to fetch a non-cached token.
+            DurableHttpRequest listRequest = new DurableHttpRequest(
+                HttpMethod.Get,
+                new Uri($"https://management.azure.com/subscriptions/{subscriptionId}/providers/Microsoft.Compute/virtualMachines?api-version={apiVersion}"),
+                tokenSource: managedIdentityTokenSource);
             DurableHttpResponse listAllResponse = await context.CallHttpAsync(listRequest);
+            if (listAllResponse.StatusCode != HttpStatusCode.OK)
+            {
+                throw new ArgumentException($"Failed to list VMs: {listAllResponse.StatusCode}: {listAllResponse.Content}");
+            }
 
             // Deserializes content to just get the names of the VMs in the subscription
             JObject jObject = JsonConvert.DeserializeObject<JObject>(listAllResponse.Content);
-            ArrayList vmNamesList = new ArrayList();
-            foreach (var value in jObject["value"])
+            var vmNamesList = new List<string>();
+            foreach (JToken value in jObject["value"])
             {
                 string vmName = value["name"].ToString();
                 vmNamesList.Add(vmName);
@@ -47,54 +55,54 @@ namespace VSSample
             // Restart all of the VMs in my subscription
             foreach (string vmName in vmNamesList)
             {
-                var restartVMCallString = $"https://management.azure.com/subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}/providers/Microsoft.Compute/virtualMachines/{vmName}/restart?api-version={apiVersion}";
-                DurableHttpRequest restartRequest = new DurableHttpRequest(method: HttpMethod.Post, uri: new Uri(restartVMCallString), tokenSource: managedIdentityTokenSource);
+                var restartRequest = new DurableHttpRequest(
+                    HttpMethod.Post, 
+                    new Uri($"https://management.azure.com/subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}/providers/Microsoft.Compute/virtualMachines/{vmName}/restart?api-version={apiVersion}"),
+                    tokenSource: managedIdentityTokenSource);
                 DurableHttpResponse restartResponse = await context.CallHttpAsync(restartRequest);
-            }
-        }
-
-        [FunctionName("GetApiVersion")]
-        public static string GetApiVersion([ActivityTrigger] string name, ILogger log)
-        {
-            // Get API Version from environment variables
-            return Environment.GetEnvironmentVariable("ApiVersion", EnvironmentVariableTarget.Process);
-        }
-
-        [FunctionName("GetSubscriptionId")]
-        public static string GetSubscriptionId([ActivityTrigger] string name, ILogger log)
-        {
-            // Get subscription Id from environment variables
-            return Environment.GetEnvironmentVariable("SubscriptionId", EnvironmentVariableTarget.Process);
-        }
-
-        [FunctionName("GetResourceGroup")]
-        public static string GetResourceGroup([ActivityTrigger] string name, ILogger log)
-        {
-            // Get resource group from environment variables
-            return Environment.GetEnvironmentVariable("ResourceGroup", EnvironmentVariableTarget.Process);
-        }
-
-        private static void Log(
-        string statement,
-        IDurableOrchestrationContext context,
-        ILogger log)
-        {
-            if (!context.IsReplaying)
-            {
-                log.LogInformation(statement);
+                if (listAllResponse.StatusCode != HttpStatusCode.OK)
+                {
+                    throw new ArgumentException($"Failed to restart VM: {listAllResponse.StatusCode}: {listAllResponse.Content}");
+                }
             }
         }
 
         [FunctionName("RestartVMs_HttpStart")]
         public static async Task<HttpResponseMessage> HttpStart(
-            [HttpTrigger(AuthorizationLevel.Anonymous, "get", "post")]HttpRequestMessage req,
-            [OrchestrationClient]IDurableOrchestrationClient starter,
+            [HttpTrigger(AuthorizationLevel.Anonymous, "get", "post")] HttpRequestMessage req,
+            [DurableClient] IDurableOrchestrationClient starter,
             ILogger log)
         {
+            ResourceInfo vmInfo = await req.Content.ReadAsAsync<ResourceInfo>();
+            if (vmInfo == null || vmInfo.SubscriptionId == null || vmInfo.ResourceGroup == null)
+            {
+                var example = new ResourceInfo
+                {
+                    SubscriptionId = "4c51f150-5b69-4cda-aa7a-88a9ac297393",
+                    ResourceGroup = "my-resource-group"
+                };
+
+                var response = new HttpResponseMessage(HttpStatusCode.BadRequest);
+                response.Content = new StringContent("A request payload is required. Example: " + JsonConvert.SerializeObject(example, Formatting.None));
+                return response;
+            }
+
             // Function input comes from the request content.
-            string instanceId = await starter.StartNewAsync("RestartVMs", null);
+            string instanceId = await starter.StartNewAsync("RestartVMs", vmInfo);
             log.LogInformation($"Started orchestration with ID = '{instanceId}'.");
             return starter.CreateCheckStatusResponse(req, instanceId);
+        }
+
+        class ResourceInfo
+        {
+            [JsonProperty("apiVersion", DefaultValueHandling = DefaultValueHandling.Ignore)]
+            public string ApiVersion { get; set; }
+
+            [JsonProperty("subscriptionId")]
+            public string SubscriptionId { get; set; }
+
+            [JsonProperty("resourceGroup")]
+            public string ResourceGroup { get; set; }
         }
     }
 }


### PR DESCRIPTION
This PR makes the Durable HTTP sample a bit more robust. It also fixes the breaking changes we introduced in the precompiled sample.

I was able to get this running using the following [httpie](https://httpie.org/) commands.

```
http POST http://localhost:7071/RestartVMs_HttpStart subscriptionId=abc resourceGroup=rg
```