### PR TITLE
support StartNewOrchestration from within orchestrations and entities

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/ContextInterfaces/IDurableEntityContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextInterfaces/IDurableEntityContext.cs
@@ -102,5 +102,18 @@ namespace Microsoft.Azure.WebJobs
         /// <param name="operationName">The name of the operation.</param>
         /// <param name="operationInput">The operation input.</param>
         void SignalEntity(EntityId entity, string operationName, object operationInput = null);
+
+        /// <summary>
+        /// Schedules a orchestration function named <paramref name="functionName"/> for execution./>.
+        /// Any result or exception is ignored (fire and forget).
+        /// </summary>
+        /// <param name="functionName">The name of the orchestrator function to call.</param>
+        /// <param name="input">the input to pass to the orchestrator function.</param>
+        /// <param name="instanceId">optionally, an instance id for the orchestration. By default, a random GUID is used.</param>
+        /// <exception cref="ArgumentException">
+        /// The specified function does not exist, is disabled, or is not an orchestrator function.
+        /// </exception>
+        /// <returns>The instance id of the new orchestration.</returns>
+        string StartNewOrchestration(string functionName, object input, string instanceId = null);
     }
 }

--- a/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
+++ b/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
@@ -58,7 +58,7 @@
   <ItemGroup> 
     <PackageReference Include="Microsoft.Azure.DurableTask.Redis" Version="0.1.0-alpha" />
     <PackageReference Include="Microsoft.Azure.DurableTask.Emulator" Version="2.1.1" />
-    <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage" Version="1.6.3" />
+    <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage" Version="1.6.4-preview" />
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.0.3" />
   </ItemGroup>
 

--- a/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
+++ b/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
@@ -8,7 +8,7 @@
     <MajorVersion>2</MajorVersion>
     <MinorVersion>0</MinorVersion>
     <PatchVersion>0</PatchVersion>
-    <Version>$(MajorVersion).$(MinorVersion).$(PatchVersion)-beta2</Version>
+    <Version>$(MajorVersion).$(MinorVersion).$(PatchVersion)-beta3</Version>
     <FileVersion>$(MajorVersion).$(MinorVersion).$(PatchVersion)</FileVersion>
     <AssemblyVersion>$(MajorVersion).0.0.0</AssemblyVersion>
     <Company>Microsoft Corporation</Company>
@@ -58,7 +58,7 @@
   <ItemGroup> 
     <PackageReference Include="Microsoft.Azure.DurableTask.Redis" Version="0.1.0-alpha" />
     <PackageReference Include="Microsoft.Azure.DurableTask.Emulator" Version="2.1.1" />
-    <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage" Version="1.6.4-preview" />
+    <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage" Version="1.6.4" />
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.0.3" />
   </ItemGroup>
 

--- a/test/FunctionsV1/WebJobs.Extensions.DurableTask.Tests.V1.csproj
+++ b/test/FunctionsV1/WebJobs.Extensions.DurableTask.Tests.V1.csproj
@@ -16,7 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="4.19.4" />
-    <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage" Version="1.6.3" />
+    <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage" Version="1.6.4-preview" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="2.2.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" Version="2.2.0" />
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.33" />

--- a/test/FunctionsV1/WebJobs.Extensions.DurableTask.Tests.V1.csproj
+++ b/test/FunctionsV1/WebJobs.Extensions.DurableTask.Tests.V1.csproj
@@ -16,7 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="4.19.4" />
-    <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage" Version="1.6.4-preview" />
+    <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage" Version="1.6.4" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="2.2.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" Version="2.2.0" />
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.33" />

--- a/test/FunctionsV2/WebJobs.Extensions.DurableTask.Tests.V2.csproj
+++ b/test/FunctionsV2/WebJobs.Extensions.DurableTask.Tests.V2.csproj
@@ -16,7 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="4.19.4" />
-    <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage" Version="1.6.4-preview" />
+    <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage" Version="1.6.4" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.12" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="3.0.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" Version="3.0.0" />

--- a/test/FunctionsV2/WebJobs.Extensions.DurableTask.Tests.V2.csproj
+++ b/test/FunctionsV2/WebJobs.Extensions.DurableTask.Tests.V2.csproj
@@ -16,7 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="4.19.4" />
-    <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage" Version="1.6.3" />
+    <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage" Version="1.6.4-preview" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.12" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="3.0.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" Version="3.0.0" />


### PR DESCRIPTION
As discussed in #715, this PR provides the capability to start new orchestrations from within orchestrations and entities, without waiting for them to complete (fire-and-forget). 

It is based on the corresponding feature recently added to DTFx azure/durabletask#312, and thus depends on using a very recent version of DTFx.

(Do not merge until this DTFx dependency is resolved).