### PR TITLE
Fixed default durable http factory registration

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/DurableTaskJobHostConfigurationExtensions.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskJobHostConfigurationExtensions.cs
@@ -3,6 +3,8 @@
 
 using System;
 using System.Net.Http;
+
+using Microsoft.Extensions.DependencyInjection.Extensions;
 #if NETSTANDARD2_0
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
@@ -35,7 +37,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 .BindOptions<DurableTaskOptions>()
                 .Services.AddSingleton<IConnectionStringResolver, WebJobsConnectionStringProvider>()
                          .AddSingleton<IOrchestrationServiceFactory, OrchestrationServiceFactory>()
-                         .AddSingleton<IDurableHttpMessageHandlerFactory, DurableHttpMessageHandlerFactory>();
+                         .TryAddSingleton<IDurableHttpMessageHandlerFactory, DurableHttpMessageHandlerFactory>();
 
             return builder;
         }

--- a/src/WebJobs.Extensions.DurableTask/DurableTaskJobHostConfigurationExtensions.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskJobHostConfigurationExtensions.cs
@@ -4,9 +4,9 @@
 using System;
 using System.Net.Http;
 
-using Microsoft.Extensions.DependencyInjection.Extensions;
 #if NETSTANDARD2_0
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
 #else
 using Microsoft.Azure.WebJobs.Host;


### PR DESCRIPTION
Added default factory only when `IDurableHttpMessageHandlerFactory` is not added.

Azure Functions runtime executes the initialization code in the following order.
1. `FunctionsStartup` code
2. Extensions `Startup` code

Dependency Injection uses the last added service, so customized classes are not used.

Ref #923