### PR TITLE
Implementing a fix for #928

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/EntityScheduler/TypedInvocationExtensions.cs
+++ b/src/WebJobs.Extensions.DurableTask/EntityScheduler/TypedInvocationExtensions.cs
@@ -1,10 +1,8 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using Microsoft.AspNetCore.JsonPatch.Operations;
 using System;
 using System.Reflection;
-using System.Runtime.InteropServices.ComTypes;
 using System.Threading.Tasks;
 
 namespace Microsoft.Azure.WebJobs

--- a/src/WebJobs.Extensions.DurableTask/EntityScheduler/TypedInvocationExtensions.cs
+++ b/src/WebJobs.Extensions.DurableTask/EntityScheduler/TypedInvocationExtensions.cs
@@ -32,14 +32,7 @@ namespace Microsoft.Azure.WebJobs
         /// constructor via dependency injection.</param>
         public static async Task DispatchAsync<T>(this IDurableEntityContext context, params object[] constructorParameters)
         {
-            // find the method corresponding to the operation
-            // (may throw an AmbiguousMatchException)
-            MethodInfo method = typeof(T).GetMethod(
-                context.OperationName,
-                System.Reflection.BindingFlags.IgnoreCase
-                | System.Reflection.BindingFlags.Public
-                | System.Reflection.BindingFlags.NonPublic
-                | System.Reflection.BindingFlags.Instance);
+            MethodInfo method = FindMethodForContext<T>(context);
 
             if (method == null)
             {
@@ -90,6 +83,18 @@ namespace Microsoft.Azure.WebJobs
                     context.Return(result);
                 }
             }
+        }
+
+        internal static MethodInfo FindMethodForContext<T>(IDurableEntityContext context)
+        {
+            // find the method corresponding to the operation
+            // (may throw an AmbiguousMatchException)
+            return typeof(T).GetMethod(
+                context.OperationName,
+                System.Reflection.BindingFlags.IgnoreCase
+                | System.Reflection.BindingFlags.Public
+                | System.Reflection.BindingFlags.NonPublic
+                | System.Reflection.BindingFlags.Instance);
         }
     }
 }

--- a/test/FunctionsV2/EntityMethodDiscoveryTests.cs
+++ b/test/FunctionsV2/EntityMethodDiscoveryTests.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests;
 using Moq;
 using Xunit;
 
@@ -12,6 +13,7 @@ namespace WebJobs.Extensions.DurableTask.Tests.V2
         }
 
         [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
         public void CanFindMemberOnClassWithoutInterface()
         {
             var context = new Mock<IDurableEntityContext>();
@@ -23,6 +25,7 @@ namespace WebJobs.Extensions.DurableTask.Tests.V2
         }
 
         [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
         public void WillReceiveNullForMissingMember()
         {
             var context = new Mock<IDurableEntityContext>();
@@ -34,6 +37,7 @@ namespace WebJobs.Extensions.DurableTask.Tests.V2
         }
 
         [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
         public void WillFindMemberOnClassWithImplicitInterface()
         {
             var context = new Mock<IDurableEntityContext>();
@@ -45,6 +49,7 @@ namespace WebJobs.Extensions.DurableTask.Tests.V2
         }
 
         [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
         public void WillFindMemberOnClassWithExplicitInterface()
         {
             var context = new Mock<IDurableEntityContext>();

--- a/test/FunctionsV2/EntityMethodDiscoveryTests.cs
+++ b/test/FunctionsV2/EntityMethodDiscoveryTests.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.Azure.WebJobs;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Microsoft.Azure.WebJobs;
 using Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests;
 using Moq;
 using Xunit;

--- a/test/FunctionsV2/EntityMethodDiscoveryTests.cs
+++ b/test/FunctionsV2/EntityMethodDiscoveryTests.cs
@@ -1,0 +1,79 @@
+﻿using Microsoft.Azure.WebJobs;
+using Moq;
+using Xunit;
+
+namespace WebJobs.Extensions.DurableTask.Tests.V2
+{
+    public class EntityMethodDiscoveryTests
+    {
+        private interface ICounter
+        {
+            void Add(int count);
+        }
+
+        [Fact]
+        public void CanFindMemberOnClassWithoutInterface()
+        {
+            var context = new Mock<IDurableEntityContext>();
+            context.Setup(ctx => ctx.OperationName).Returns("Method");
+
+            var method = TypedInvocationExtensions.FindMethodForContext<ClassWithoutInterface>(context.Object);
+
+            Assert.NotNull(method);
+        }
+
+        [Fact]
+        public void WillReceiveNullForMissingMember()
+        {
+            var context = new Mock<IDurableEntityContext>();
+            context.Setup(ctx => ctx.OperationName).Returns("NonExistingMethod");
+
+            var method = TypedInvocationExtensions.FindMethodForContext<ClassWithoutInterface>(context.Object);
+
+            Assert.Null(method);
+        }
+
+        [Fact]
+        public void WillFindMemberOnClassWithImplicitInterface()
+        {
+            var context = new Mock<IDurableEntityContext>();
+            context.Setup(ctx => ctx.OperationName).Returns("Add");
+
+            var method = TypedInvocationExtensions.FindMethodForContext<CounterImplicit>(context.Object);
+
+            Assert.NotNull(method);
+        }
+
+        [Fact]
+        public void WillFindMemberOnClassWithExplicitInterface()
+        {
+            var context = new Mock<IDurableEntityContext>();
+            context.Setup(ctx => ctx.OperationName).Returns("Add");
+
+            var method = TypedInvocationExtensions.FindMethodForContext<CounterExplicit>(context.Object);
+
+            Assert.NotNull(method);
+        }
+
+        private class ClassWithoutInterface
+        {
+            public void Method()
+            {
+            }
+        }
+
+        private class CounterImplicit : ICounter
+        {
+            public void Add(int count)
+            {
+            }
+        }
+
+        private class CounterExplicit : ICounter
+        {
+            void ICounter.Add(int count)
+            {
+            }
+        }
+    }
+}


### PR DESCRIPTION
I extracted the logic for the looking for the method that does the lookup of the member on an entity so that it was easier to test in isolation.

Created some tests for the main scenarios of method discovery (that I could think of).

#928 