### PR TITLE
Overhaul exception handling for entities

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableClient.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableClient.cs
@@ -215,6 +215,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 throw new ArgumentNullException(nameof(operationName));
             }
 
+            this.config.ThrowIfFunctionDoesNotExist(entityId.EntityName, FunctionType.Entity);
+
             var guid = Guid.NewGuid(); // unique id for this request
             var instanceId = EntityId.GetSchedulerIdFromEntityId(entityId);
             var instance = new OrchestrationInstance() { InstanceId = instanceId };
@@ -382,6 +384,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
         private async Task<EntityStateResponse<T>> ReadEntityStateAsync<T>(TaskHubClient client, string hubName, EntityId entityId)
         {
+            this.config.ThrowIfFunctionDoesNotExist(entityId.EntityName, FunctionType.Entity);
+
             var instanceId = EntityId.GetSchedulerIdFromEntityId(entityId);
             IList<OrchestrationState> stateList = await client.ServiceClient.GetOrchestrationStateAsync(instanceId, false);
 

--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableEntityContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableEntityContext.cs
@@ -4,6 +4,8 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.ExceptionServices;
 using System.Threading.Tasks;
 using DurableTask.Core;
 using Microsoft.Azure.WebJobs.Host.Bindings;
@@ -53,6 +55,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
         internal List<RequestMessage> OperationBatch => this.shim.OperationBatch;
 
+        internal ExceptionDispatchInfo InternalError { get; set; }
+
+        internal List<ExceptionDispatchInfo> ApplicationErrors { get; set; }
+
         internal EntityId Self => this.self;
 
         string IDurableEntityContext.OperationName
@@ -76,6 +82,68 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 #if NETSTANDARD2_0
         public FunctionBindingContext FunctionBindingContext { get; set; }
 #endif
+
+        public void CaptureInternalError(Exception e)
+        {
+            this.InternalError = ExceptionDispatchInfo.Capture(e);
+        }
+
+        public void CaptureApplicationError(Exception e)
+        {
+            if (this.ApplicationErrors == null)
+            {
+                this.ApplicationErrors = new List<ExceptionDispatchInfo>();
+            }
+
+            this.ApplicationErrors.Add(ExceptionDispatchInfo.Capture(e));
+        }
+
+        public void ThrowInternalExceptionIfAny()
+        {
+            if (this.InternalError != null)
+            {
+                this.InternalError.Throw();
+            }
+        }
+
+        public void ThrowApplicationExceptionsIfAny()
+        {
+            if (this.ApplicationErrors != null)
+            {
+                if (this.ApplicationErrors.Count == 1)
+                {
+                    // throw single exceptions directly
+                    this.ApplicationErrors[0].Throw();
+                }
+                else
+                {
+                    // aggregate multiple exceptions
+                    throw new AggregateException(
+                        "One or more operations failed.",
+                        this.ApplicationErrors.Select(i => i.SourceException));
+                }
+            }
+        }
+
+        public bool ErrorsPresent(out string description)
+        {
+            if (this.InternalError != null)
+            {
+                description = $"Internal error: {this.InternalError.SourceException}";
+                return true;
+            }
+            else if (this.ApplicationErrors != null)
+            {
+                var messages = this.ApplicationErrors.Select(i => $"({i.SourceException.Message})");
+                description = $"One or more operations failed: {string.Concat(messages)}";
+                return true;
+            }
+            else
+            {
+                description = string.Empty;
+                return false;
+            }
+        }
 
         void IDurableEntityContext.DestructOnExit()
         {
@@ -101,7 +169,19 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
             if (!this.StateWasAccessed)
             {
-                TState defaultValue = initializer != null ? initializer() : default(TState);
+                TState defaultValue = default(TState);
+
+                if (initializer != null)
+                {
+                    try
+                    {
+                        defaultValue = initializer();
+                    }
+                    catch (Exception e)
+                    {
+                        throw new EntitySchedulerException($"failed to construct entity state: {e.Message}", e);
+                    }
+                }
 
                 if (this.State.EntityState != null)
                 {
@@ -120,16 +200,23 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
         private TState GetPopulatedState<TState>(TState initialValue, bool usedTypeInitializer)
         {
-            if (usedTypeInitializer)
+            try
             {
-                // Only populate serialized state, as some fields may be populated by the initializer
-                // using dependency injection.
-                JsonConvert.PopulateObject(this.State.EntityState, initialValue);
-                return initialValue;
+                if (usedTypeInitializer)
+                {
+                    // Only populate serialized state, as some fields may be populated by the initializer
+                    // using dependency injection.
+                    JsonConvert.PopulateObject(this.State.EntityState, initialValue);
+                    return initialValue;
+                }
+                else
+                {
+                    return JsonConvert.DeserializeObject<TState>(this.State.EntityState);
+                }
             }
-            else
+            catch (Exception e)
             {
-                return JsonConvert.DeserializeObject<TState>(this.State.EntityState);
+                throw new EntitySchedulerException($"failed to deserialize entity state: {e.Message}", e);
             }
         }
 
@@ -141,11 +228,34 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             this.StateWasAccessed = true;
         }
 
-        internal void Writeback()
+        internal void Writeback(out ResponseMessage stateSerializationFailedNotification)
         {
+            stateSerializationFailedNotification = null;
+
             if (this.StateWasAccessed)
             {
-                this.State.EntityState = MessagePayloadDataConverter.Default.Serialize(this.CurrentState);
+                try
+                {
+                    this.State.EntityState = MessagePayloadDataConverter.Default.Serialize(this.CurrentState);
+                }
+                catch (Exception e)
+                {
+                    // we cannot serialize the entity state - this is an application error.
+                    var serializationException = new EntitySchedulerException(
+                        $"failed to serialize state of '{this.FunctionName}' entity: {e.Message}", e);
+
+                    this.CaptureApplicationError(serializationException);
+
+                    // Since for all of the operations in the batch, their effect on the entity state
+                    // is lost, we don't want the calling orchestrations to think everything is o.k.
+                    // They should be notified, so we replace all non-error operation results
+                    // with an exception result.
+                    stateSerializationFailedNotification = new ResponseMessage()
+                    {
+                        ExceptionType = serializationException.GetType().AssemblyQualifiedName,
+                        Result = MessagePayloadDataConverter.ErrorConverter.Serialize(serializationException),
+                    };
+                }
 
                 this.CurrentState = null;
                 this.StateWasAccessed = false;
@@ -179,7 +289,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 request.SetInput(input);
             }
 
-            this.SendEntityMessage(target, "op", request);
+            this.SendOperationMessage(target, "op", request);
 
             this.Config.TraceHelper.FunctionScheduled(
                 this.Config.Options.HubName,
@@ -238,7 +348,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             }
         }
 
-        internal void SendEntityMessage(OrchestrationInstance target, string eventName, object message)
+        internal void SendOperationMessage(OrchestrationInstance target, string eventName, object message)
         {
             lock (this.outbox)
             {
@@ -247,7 +357,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     this.State.MessageSorter.LabelOutgoingMessage(requestMessage, target.InstanceId, DateTime.UtcNow, this.EntityMessageReorderWindow);
                 }
 
-                this.outbox.Add(new EventMessage()
+                this.outbox.Add(new OperationMessage()
                 {
                     Target = target,
                     EventName = eventName,
@@ -256,22 +366,92 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             }
         }
 
-        internal void SendOutbox(OrchestrationContext innerContext)
+        internal void SendResponseMessage(OrchestrationInstance target, string eventName, object message, bool isException)
+        {
+            lock (this.outbox)
+            {
+                if (message is RequestMessage requestMessage)
+                {
+                    this.State.MessageSorter.LabelOutgoingMessage(requestMessage, target.InstanceId, DateTime.UtcNow, this.EntityMessageReorderWindow);
+                }
+
+                this.outbox.Add(new ResultMessage()
+                {
+                    Target = target,
+                    EventName = eventName,
+                    EventContent = message,
+                    IsError = isException,
+                });
+            }
+        }
+
+        internal void SendLockMessage(OrchestrationInstance target, string eventName, object message, bool notifyOnFailedWriteback = false)
+        {
+            lock (this.outbox)
+            {
+                if (message is RequestMessage requestMessage)
+                {
+                    this.State.MessageSorter.LabelOutgoingMessage(requestMessage, target.InstanceId, DateTime.UtcNow, this.EntityMessageReorderWindow);
+                }
+
+                this.outbox.Add(new OperationMessage()
+                {
+                    Target = target,
+                    EventName = eventName,
+                    EventContent = message,
+                });
+            }
+        }
+
+        internal void SendOutbox(OrchestrationContext innerContext, ResponseMessage writebackFailedResponse)
         {
             lock (this.outbox)
             {
                 foreach (var message in this.outbox)
                 {
-                    if (message is EventMessage eventMessage)
+                    if (message is LockMessage lockMessage)
                     {
                         this.Config.TraceHelper.SendingEntityMessage(
-                        this.InstanceId,
-                        this.ExecutionId,
-                        eventMessage.Target.InstanceId,
-                        eventMessage.EventName,
-                        eventMessage.EventContent);
+                            this.InstanceId,
+                            this.ExecutionId,
+                            lockMessage.Target.InstanceId,
+                            lockMessage.EventName,
+                            lockMessage.EventContent);
 
-                        innerContext.SendEvent(eventMessage.Target, eventMessage.EventName, eventMessage.EventContent);
+                        innerContext.SendEvent(lockMessage.Target, lockMessage.EventName, lockMessage.EventContent);
+                    }
+                    else if (message is ResultMessage resultMessage)
+                    {
+                        // non-error result messages are replaced with the writeback failed response
+                        if (writebackFailedResponse != null && !resultMessage.IsError)
+                        {
+                            resultMessage.EventContent = writebackFailedResponse;
+                        }
+
+                        this.Config.TraceHelper.SendingEntityMessage(
+                            this.InstanceId,
+                            this.ExecutionId,
+                            resultMessage.Target.InstanceId,
+                            resultMessage.EventName,
+                            resultMessage.EventContent);
+
+                        innerContext.SendEvent(resultMessage.Target, resultMessage.EventName, resultMessage.EventContent);
+                    }
+                    else if (writebackFailedResponse != null)
+                    {
+                        // all other messages (signals and fire-and-forget) are suppressed if the writeback failed
+                        // this helps to keep the observer pattern correct, for example.
+                    }
+                    else if (message is OperationMessage operationMessage)
+                    {
+                        this.Config.TraceHelper.SendingEntityMessage(
+                            this.InstanceId,
+                            this.ExecutionId,
+                            operationMessage.Target.InstanceId,
+                            operationMessage.EventName,
+                            operationMessage.EventContent);
+
+                        innerContext.SendEvent(operationMessage.Target, operationMessage.EventName, operationMessage.EventContent);
                     }
                     else if (message is FireAndForgetMessage fireAndForgetMessage)
                     {
@@ -303,7 +483,27 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             public object Input { get; set; }
         }
 
-        private class EventMessage : OutgoingMessage
+        private class OperationMessage : OutgoingMessage
+        {
+            public OrchestrationInstance Target { get; set; }
+
+            public string EventName { get; set; }
+
+            public object EventContent { get; set; }
+        }
+
+        private class ResultMessage : OutgoingMessage
+        {
+            public OrchestrationInstance Target { get; set; }
+
+            public string EventName { get; set; }
+
+            public object EventContent { get; set; }
+
+            public bool IsError { get; set; }
+        }
+
+        private class LockMessage : OutgoingMessage
         {
             public OrchestrationInstance Target { get; set; }
 

--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableOrchestrationContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableOrchestrationContext.cs
@@ -604,7 +604,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                             operationId,
                             operationName,
                             input: "(replayed)",
-                            output: "(replayed)",
+                            exception: "(replayed)",
                             duration: 0,
                             isReplay: true);
                     }

--- a/src/WebJobs.Extensions.DurableTask/EndToEndTraceHelper.cs
+++ b/src/WebJobs.Extensions.DurableTask/EndToEndTraceHelper.cs
@@ -352,7 +352,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
            string operationId,
            string operationName,
            string input,
-           string output,
+           string exception,
            double duration,
            bool isReplay)
         {
@@ -365,7 +365,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 operationId,
                 operationName,
                 input,
-                output,
+                exception,
                 duration,
                 FunctionType.Entity.ToString(),
                 ExtensionVersion,
@@ -375,7 +375,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             {
                 this.logger.LogError(
                     "{instanceId}: Function '{functionName} ({functionType})' failed '{operationName}' operation {operationId} after {duration}ms with exception {exception}. Input: {input}. IsReplay: {isReplay}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}. SequenceNumber: {sequenceNumber}.",
-                    instanceId, functionName, FunctionType.Entity, operationName, operationId, duration, output, input, isReplay, hubName,
+                    instanceId, functionName, FunctionType.Entity, operationName, operationId, duration, exception, input, isReplay, hubName,
                     LocalAppName, LocalSlotName, ExtensionVersion, this.sequenceNumber++);
             }
         }

--- a/src/WebJobs.Extensions.DurableTask/EntityScheduler/EntitySchedulerException.cs
+++ b/src/WebJobs.Extensions.DurableTask/EntityScheduler/EntitySchedulerException.cs
@@ -1,0 +1,44 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+using System.Text;
+
+namespace Microsoft.Azure.WebJobs
+{
+    /// <summary>
+    /// Exception used to describe various issues encountered by the entity scheduler.
+    /// </summary>
+    [Serializable]
+    public class EntitySchedulerException : Exception
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EntitySchedulerException"/> class.
+        /// </summary>
+        public EntitySchedulerException()
+        {
+        }
+
+        /// <summary>
+        /// Initializes an new instance of the <see cref="EntitySchedulerException"/> class.
+        /// </summary>
+        /// <param name="errorMessage">The message that describes the error.</param>
+        /// <param name="innerException">The exception that was caught.</param>
+        public EntitySchedulerException(string errorMessage, Exception innerException)
+            : base(errorMessage, innerException)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EntitySchedulerException"/> class with serialized data.
+        /// </summary>
+        /// <param name="info">The System.Runtime.Serialization.SerializationInfo that holds the serialized object data about the exception being thrown.</param>
+        /// <param name="context">The System.Runtime.Serialization.StreamingContext that contains contextual information about the source or destination.</param>
+        protected EntitySchedulerException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+        }
+    }
+}

--- a/src/WebJobs.Extensions.DurableTask/EntityScheduler/OperationErrorException.cs
+++ b/src/WebJobs.Extensions.DurableTask/EntityScheduler/OperationErrorException.cs
@@ -1,0 +1,44 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+using System.Text;
+
+namespace Microsoft.Azure.WebJobs
+{
+    /// <summary>
+    /// Exception result representing an operation that failed, in case
+    /// the original exception is not serializable, or out-of-proc.
+    /// </summary>
+    [Serializable]
+    public class OperationErrorException : Exception
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OperationErrorException"/> class.
+        /// </summary>
+        public OperationErrorException()
+        {
+        }
+
+        /// <summary>
+        /// Initializes an new instance of the <see cref="OperationErrorException"/> class.
+        /// </summary>
+        /// <param name="errorMessage">The message that describes the error.</param>
+        public OperationErrorException(string errorMessage)
+            : base(errorMessage)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OperationErrorException"/> class with serialized data.
+        /// </summary>
+        /// <param name="info">The System.Runtime.Serialization.SerializationInfo that holds the serialized object data about the exception being thrown.</param>
+        /// <param name="context">The System.Runtime.Serialization.StreamingContext that contains contextual information about the source or destination.</param>
+        protected OperationErrorException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+        }
+    }
+}

--- a/src/WebJobs.Extensions.DurableTask/EntityScheduler/RequestMessage.cs
+++ b/src/WebJobs.Extensions.DurableTask/EntityScheduler/RequestMessage.cs
@@ -78,24 +78,45 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
         public void SetInput(object obj)
         {
-            if (obj is JToken jtoken)
+            try
             {
-                this.Input = jtoken.ToString(Formatting.None);
+                if (obj is JToken jtoken)
+                {
+                    this.Input = jtoken.ToString(Formatting.None);
+                }
+                else
+                {
+                    this.Input = MessagePayloadDataConverter.Default.Serialize(obj);
+                }
             }
-            else
+            catch (Exception e)
             {
-                this.Input = MessagePayloadDataConverter.Default.Serialize(obj);
+                throw new EntitySchedulerException($"failed to serialize input for operation '{this.Operation}': {e.Message}", e);
             }
         }
 
         public T GetInput<T>()
         {
-            return JsonConvert.DeserializeObject<T>(this.Input);
+            try
+            {
+                return JsonConvert.DeserializeObject<T>(this.Input);
+            }
+            catch (Exception e)
+            {
+                throw new EntitySchedulerException($"failed to deserialize input for operation '{this.Operation}': {e.Message}", e);
+            }
         }
 
         public object GetInput(Type inputType)
         {
-            return JsonConvert.DeserializeObject(this.Input, inputType);
+            try
+            {
+                return JsonConvert.DeserializeObject(this.Input, inputType);
+            }
+            catch (Exception e)
+            {
+                throw new EntitySchedulerException($"failed to deserialize input for operation '{this.Operation}': {e.Message}", e);
+            }
         }
 
         public override string ToString()

--- a/src/WebJobs.Extensions.DurableTask/EntityScheduler/RequestMessage.cs
+++ b/src/WebJobs.Extensions.DurableTask/EntityScheduler/RequestMessage.cs
@@ -91,7 +91,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             }
             catch (Exception e)
             {
-                throw new EntitySchedulerException($"failed to serialize input for operation '{this.Operation}': {e.Message}", e);
+                throw new EntitySchedulerException($"Failed to serialize input for operation '{this.Operation}': {e.Message}", e);
             }
         }
 
@@ -103,7 +103,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             }
             catch (Exception e)
             {
-                throw new EntitySchedulerException($"failed to deserialize input for operation '{this.Operation}': {e.Message}", e);
+                throw new EntitySchedulerException($"Failed to deserialize input for operation '{this.Operation}': {e.Message}", e);
             }
         }
 
@@ -115,7 +115,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             }
             catch (Exception e)
             {
-                throw new EntitySchedulerException($"failed to deserialize input for operation '{this.Operation}': {e.Message}", e);
+                throw new EntitySchedulerException($"Failed to deserialize input for operation '{this.Operation}': {e.Message}", e);
             }
         }
 

--- a/src/WebJobs.Extensions.DurableTask/EntityScheduler/ResponseMessage.cs
+++ b/src/WebJobs.Extensions.DurableTask/EntityScheduler/ResponseMessage.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             {
                 this.Result = MessagePayloadDataConverter.ErrorConverter.Serialize(exception);
             }
-            catch (Exception e)
+            catch (Exception)
             {
                 // sometimes, exceptions cannot be serialized. In that case we create a serializable wrapper
                 // exception which lets the caller know something went wrong.

--- a/src/WebJobs.Extensions.DurableTask/Listener/TaskEntityShim.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/TaskEntityShim.cs
@@ -131,7 +131,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 }
                 catch (Exception e)
                 {
-                    throw new EntitySchedulerException("failed to deserialize entity scheduler state - may be corrupted or wrong version.", e);
+                    throw new EntitySchedulerException("Failed to deserialize entity scheduler state - may be corrupted or wrong version.", e);
                 }
             }
 
@@ -173,10 +173,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             if (this.context.InternalError == null)
             {
                 // try to serialize the updated entity state
-                this.context.Writeback(out var stateSerializationFailedNotification);
+                bool writeBackSuccessful = this.context.TryWriteback(out var serializationErrorMessage);
 
                 // Send all buffered outgoing messages
-                this.context.SendOutbox(innerContext, stateSerializationFailedNotification);
+                this.context.SendOutbox(innerContext, writeBackSuccessful, serializationErrorMessage);
 
                 var jstate = JToken.FromObject(this.context.State);
 

--- a/src/WebJobs.Extensions.DurableTask/MessagePayloadDataConverter.cs
+++ b/src/WebJobs.Extensions.DurableTask/MessagePayloadDataConverter.cs
@@ -25,6 +25,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         {
             ContractResolver = new ExceptionResolver(),
             TypeNameHandling = TypeNameHandling.Objects,
+            ReferenceLoopHandling = ReferenceLoopHandling.Ignore,
         };
 
         // Default singleton instances


### PR DESCRIPTION
This PR fixes multiple issues to improve the overall experience with how exceptions are caught, transmitted, and surfaced in entities and the calling orchestrations.

- Inside client, when signaling or reading an entity, throw an exception if there is no entity function with that name.
- Fix serialization settings for exceptions, so reference loops are ignored (this is needed so it does not trip over some AzureStorageExceptions).
- If an operation throws an unserializable exception, wrap the info into a serializable exception, so it can still be sent back to the calling orchestration and observed there
- Catch serialization exceptions, and wrap them into a EntitySchedulerException that states the precise situation in which this happened (serialization/deserialization of input/state)
- Inside entity context, track internal errors and all application errors separately. Surface both of them to both the logging back-end and to the functions host, so they are more visible in the portal and Application Insights.
- if a batch observes an internal error, throw it to DTFx so it aborts the batch and backs off.
- provide special logic for serialization errors that prevent the entity state to be written back. In that case, go back to the previous entity state (before the batch), suppress signals and fire-and-forget from operations in the batch, and send an error message describing the problem back to all calling orchestrations.  
