### PR TITLE
fix bug in sorting of lock messages

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableEntityContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableEntityContext.cs
@@ -391,12 +391,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         {
             lock (this.outbox)
             {
-                if (message is RequestMessage requestMessage)
-                {
-                    this.State.MessageSorter.LabelOutgoingMessage(requestMessage, target.InstanceId, DateTime.UtcNow, this.EntityMessageReorderWindow);
-                }
-
-                this.outbox.Add(new OperationMessage()
+                this.outbox.Add(new LockMessage()
                 {
                     Target = target,
                     EventName = eventName,

--- a/src/WebJobs.Extensions.DurableTask/EntityScheduler/MessageSorter.cs
+++ b/src/WebJobs.Extensions.DurableTask/EntityScheduler/MessageSorter.cs
@@ -93,8 +93,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// </summary>
         public IEnumerable<RequestMessage> ReceiveInOrder(RequestMessage message, TimeSpan reorderWindow)
         {
-            // messages sent from clients are  not participating in the sorting.
-            if (message.ParentInstanceId == null)
+            // messages sent from clients and forwarded lock messages are not participating in the sorting.
+            if (message.ParentInstanceId == null || message.Position > 0)
             {
                 // Just pass the message through.
                 yield return message;


### PR DESCRIPTION
Fix a bug that was exposed by the recent changes in #946: forwarded lock messages must not participate in message sorting. I discovered this bug because it caused a deadlock in the RideSharing sample.