### PR TITLE
Fix 2 flakey tests

### DIFF
--- a/test/Common/DurableTaskEndToEndTests.cs
+++ b/test/Common/DurableTaskEndToEndTests.cs
@@ -2925,11 +2925,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         /// TODO: This test is flakey in Functions V1.
         /// </summary>
         [Theory]
-#if NETCOREAPP2_0
         [Trait("Category", PlatformSpecificHelpers.TestCategory)]
-#else
-        [Trait("Category", PlatformSpecificHelpers.FlakeyTestCategory)]
-#endif
         [InlineData(true)]
         [InlineData(false)]
         public async Task DurableEntity_BasicObjects(bool extendedSessions)

--- a/test/Common/MessageSorterTests.cs
+++ b/test/Common/MessageSorterTests.cs
@@ -113,11 +113,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             var receiverId = "B";
 
             var senderSorter = new MessageSorter();
+            var now = DateTime.UtcNow;
 
             // last message is sent after an interval exceeding the reorder window
-            var message1 = Send(senderId, receiverId, "1", senderSorter, DateTime.UtcNow);
-            var message2 = Send(senderId, receiverId, "2", senderSorter, DateTime.UtcNow);
-            var message3 = Send(senderId, receiverId, "3", senderSorter, DateTime.UtcNow + ReorderWindow);
+            var message1 = Send(senderId, receiverId, "1", senderSorter, now);
+            var message2 = Send(senderId, receiverId, "2", senderSorter, now + TimeSpan.FromTicks(1));
+            var message3 = Send(senderId, receiverId, "3", senderSorter, now + TimeSpan.FromTicks(2) + ReorderWindow);
 
             List<RequestMessage> batch;
             MessageSorter receiverSorter = new MessageSorter();

--- a/test/Common/TestEntityClasses.cs
+++ b/test/Common/TestEntityClasses.cs
@@ -84,8 +84,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             // an operation that adds a message to the chat
             public DateTime Post(string content)
             {
-                var timestamp = DateTime.UtcNow;
+                // create a monotonically increasing timestamp
+                var lastPost = this.ChatEntries.LastOrDefault().Key;
+                var timestamp = new DateTime(Math.Max(DateTime.UtcNow.Ticks, lastPost.Ticks + 1));
+
                 this.ChatEntries.Add(timestamp, content);
+
                 return timestamp;
             }
 


### PR DESCRIPTION
Fixing two tests that were written incorrectly - the tests assumed `DateTime.UtcNow` always increases and therefore failed in situations where two successive invocations returned the same `DateTime`.