### PR TITLE
Simplify entity state handling

### DIFF
--- a/samples/v2/entitites-csharp/RideSharing/RideSharing/Entities/UserEntity.cs
+++ b/samples/v2/entitites-csharp/RideSharing/RideSharing/Entities/UserEntity.cs
@@ -34,7 +34,7 @@ namespace RideSharing
         {
             // we initialize the entity explicitly here (instead of relying on the implicit default constructor)
             // so we can set the user id to match the entity key
-            if (context.IsNewlyConstructed)
+            if (!context.HasState)
             {
                 context.SetState(new UserEntity()
                 {

--- a/src/WebJobs.Extensions.DurableTask/ContextInterfaces/IDurableEntityContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextInterfaces/IDurableEntityContext.cs
@@ -35,11 +35,6 @@ namespace Microsoft.Azure.WebJobs
         /// </remarks>
         string OperationName { get; }
 
-        /// <summary>
-        /// Whether this entity is freshly constructed, i.e. did not exist prior to this operation being called.
-        /// </summary>
-        bool IsNewlyConstructed { get; }
-
 #if NETSTANDARD2_0
         /// <summary>
         /// Contains function invocation context to assist with dependency injection at Entity construction time.
@@ -48,7 +43,13 @@ namespace Microsoft.Azure.WebJobs
 #endif
 
         /// <summary>
+        /// Whether this entity has a state.
+        /// </summary>
+        bool HasState { get; }
+
+        /// <summary>
         /// Gets the current state of this entity, for reading and/or updating.
+        /// If this entity has no state yet, creates it.
         /// </summary>
         /// <typeparam name="TState">The JSON-serializable type of the entity state.</typeparam>
         /// <param name="initializer">Provides an initial value to use for the state, instead of default(<typeparamref name="TState"/>).</param>
@@ -61,6 +62,11 @@ namespace Microsoft.Azure.WebJobs
         /// </summary>
         /// <param name="state">The JSON-serializable state of the entity.</param>
         void SetState(object state);
+
+        /// <summary>
+        /// Deletes the state of this entity.
+        /// </summary>
+        void DeleteState();
 
         /// <summary>
         /// Gets the input for this operation, as a deserialized value.
@@ -89,11 +95,6 @@ namespace Microsoft.Azure.WebJobs
         /// </summary>
         /// <param name="result">the result to return.</param>
         void Return(object result);
-
-        /// <summary>
-        /// Deletes this entity after this operation completes.
-        /// </summary>
-        void DestructOnExit();
 
         /// <summary>
         /// Signals an entity to perform an operation, without waiting for a response. Any result or exception is ignored (fire and forget).

--- a/src/WebJobs.Extensions.DurableTask/Listener/TaskEntityShim.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/TaskEntityShim.cs
@@ -271,9 +271,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             // set context for operation
             this.context.CurrentOperation = request;
             this.context.CurrentOperationResponse = new ResponseMessage();
-            this.context.IsNewlyConstructed = !this.context.State.EntityExists;
-            this.context.State.EntityExists = true;
-            this.context.DestructOnExit = false;
 
             // set the async-local static context that is visible to the application code
             Entity.SetContext(this.context);
@@ -314,7 +311,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
             // read and clear context
             var response = this.context.CurrentOperationResponse;
-            var destructOnExit = this.context.DestructOnExit;
             this.context.CurrentOperation = null;
             this.context.CurrentOperationResponse = null;
 
@@ -352,15 +348,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 var guid = request.Id.ToString();
                 var jresponse = JToken.FromObject(response, MessagePayloadDataConverter.DefaultSerializer);
                 this.context.SendResponseMessage(target, guid, jresponse, !response.IsException);
-            }
-
-            // destruct the entity if the application code requested it
-            if (destructOnExit)
-            {
-                this.context.State.EntityExists = false;
-                this.context.State.EntityState = null;
-                this.context.CurrentState = null;
-                this.context.StateWasAccessed = false;
             }
         }
 

--- a/test/Common/TestEntities.cs
+++ b/test/Common/TestEntities.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             switch (context.OperationName)
             {
                 case "delete":
-                    context.DestructOnExit();
+                    context.DeleteState();
                     break;
 
                 case "set":
@@ -56,9 +56,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                     break;
 
                 case "get":
-                    if (context.IsNewlyConstructed)
+                    if (!context.HasState)
                     {
-                        context.DestructOnExit();
                         throw new InvalidOperationException("must not call get on a non-existing entity");
                     }
 
@@ -93,7 +92,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                     break;
 
                 case "delete":
-                    context.DestructOnExit();
+                    context.DeleteState();
                     break;
 
                 default:
@@ -114,7 +113,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
         public static void PhoneBookEntity([EntityTrigger(EntityName = "PhoneBook")] IDurableEntityContext context)
         {
-            if (context.IsNewlyConstructed)
+            if (!context.HasState)
             {
                 context.SetState(new JObject());
             }
@@ -152,7 +151,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
                 case "clear":
                     {
-                        context.DestructOnExit();
+                        context.DeleteState();
                         break;
                     }
 
@@ -165,7 +164,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
         public static void LauncherEntity([EntityTrigger(EntityName = "Launcher")] IDurableEntityContext context)
         {
-            var (id, done) = context.IsNewlyConstructed ? (null, false) : context.GetState<(string, bool)>();
+            var (id, done) = context.HasState ? context.GetState<(string, bool)>() : (null, false);
 
             switch (context.OperationName)
             {
@@ -198,7 +197,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
         public static void PhoneBookEntity2([EntityTrigger(EntityName = "PhoneBook2")] IDurableEntityContext context)
         {
-            if (context.IsNewlyConstructed)
+            if (!context.HasState)
             {
                 context.SetState(new Dictionary<string, decimal>());
             }
@@ -236,7 +235,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
                 case "clear":
                     {
-                        context.DestructOnExit();
+                        context.DeleteState();
                         break;
                     }
 
@@ -257,7 +256,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         public static async Task BlobBackedTextStoreEntity(
             [EntityTrigger(EntityName = "BlobBackedTextStore")] IDurableEntityContext context)
         {
-            if (context.IsNewlyConstructed)
+            if (!context.HasState)
             {
                 // try to load state from existing blob
                 var currentFileContent = await TestHelpers.LoadStringFromTextBlobAsync(
@@ -287,7 +286,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                         context.EntityKey, state.ToString());
 
                     // then, destruct this entity (and all of its state)
-                    context.DestructOnExit();
+                    context.DeleteState();
                     break;
 
                 default:
@@ -299,7 +298,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             [EntityTrigger(EntityName = "HttpEntity")] IDurableEntityContext context,
             ILogger log)
         {
-            if (context.IsNewlyConstructed)
+            if (!context.HasState)
             {
                 context.SetState(new Dictionary<string, int>());
             }

--- a/test/Common/TestEntityClasses.cs
+++ b/test/Common/TestEntityClasses.cs
@@ -126,7 +126,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
             public void Delete()
             {
-                Entity.Current.DestructOnExit();
+                Entity.Current.DeleteState();
             }
         }
 
@@ -190,7 +190,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
             public void Delete()
             {
-                Entity.Current.DestructOnExit();
+                Entity.Current.DeleteState();
             }
         }
     }

--- a/test/FunctionsV2/TestEntityWithDependencyInjectionHelpers.cs
+++ b/test/FunctionsV2/TestEntityWithDependencyInjectionHelpers.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
             public void Delete()
             {
-                Entity.Current.DestructOnExit();
+                Entity.Current.DeleteState();
             }
         }
 
@@ -133,7 +133,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
             public void Delete()
             {
-                Entity.Current.DestructOnExit();
+                Entity.Current.DeleteState();
             }
         }
 


### PR DESCRIPTION
In the current implementation, "the existence of state" is somewhat independent of "the existence of an entity". State is created by `ctx.GetState<T>` or `ctx.SetState` (where ctx is the entity context, which can only be accessed while executing an entity operation), and can not be deleted; an entity is created implicitly by any operation, which can be detected after the fact by `ctx.IsFreshlyCreated` and is deleted by calling `ctx.DestructOnExit()` (which also deletes the state). 

*I think this is too confusing* - why not just unify the concepts and the terminology, i.e. consider "entity exists = state exists".

Proposed semantics:

- State is created when an operation calls `ctx.GetState<T>` or `ctx.SetState`
- Existence of State can be tested with `ctx.HasState` 
- State is deleted when an operation calls `ctx.DeleteState` 
  (or via REST API, once we get around to #931) 

This PR does that, and removes `ctx.IsFreshlyCreated` and `ctx.DestructOnExit`.
