### PR TITLE
Fix a bug related to using default state initialization + primitives

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableEntityContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableEntityContext.cs
@@ -171,7 +171,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
             if (!this.StateWasAccessed)
             {
-                TState defaultValue = default(TState);
+                TState defaultValue = default;
 
                 if (initializer != null)
                 {
@@ -187,7 +187,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
                 if (this.State.EntityState != null)
                 {
-                    this.CurrentState = this.GetPopulatedState<TState>(defaultValue, initializer != null);
+                    this.CurrentState = this.GetPopulatedState(defaultValue, initializer != null);
                 }
                 else
                 {
@@ -205,10 +205,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         {
             try
             {
-                if (usedTypeInitializer)
+                if (usedTypeInitializer && typeof(TState).IsClass)
                 {
                     // Only populate serialized state, as some fields may be populated by the initializer
-                    // using dependency injection.
+                    // using dependency injection. Note that we can do this for classes but not for structs.
                     JsonConvert.PopulateObject(this.State.EntityState, initialValue);
                     return initialValue;
                 }

--- a/src/WebJobs.Extensions.DurableTask/EntityScheduler/TypedInvocationExtensions.cs
+++ b/src/WebJobs.Extensions.DurableTask/EntityScheduler/TypedInvocationExtensions.cs
@@ -31,6 +31,7 @@ namespace Microsoft.Azure.WebJobs
         /// output bindings. Parameters must match the order in the constructor after ignoring parameters populated on
         /// constructor via dependency injection.</param>
         public static async Task DispatchAsync<T>(this IDurableEntityContext context, params object[] constructorParameters)
+            where T : class
         {
             MethodInfo method = FindMethodForContext<T>(context);
 
@@ -60,10 +61,12 @@ namespace Microsoft.Azure.WebJobs
             }
 
 #if NETSTANDARD2_0
-            T state = context.GetState(() => (T)context.FunctionBindingContext.CreateObjectInstance(typeof(T), constructorParameters));
+            T Constructor() => (T)context.FunctionBindingContext.CreateObjectInstance(typeof(T), constructorParameters);
 #else
-            T state = context.GetState(() => (T)Activator.CreateInstance(typeof(T)));
+            T Constructor() => (T)Activator.CreateInstance(typeof(T), constructorParameters);
 #endif
+
+            var state = ((Extensions.DurableTask.DurableEntityContext)context).GetStateWithInjectedDependencies(Constructor);
 
             object result = method.Invoke(state, args);
 


### PR DESCRIPTION
Fixes #954 

The `GetState<TState>(Func<TState> initializer` breaks when `TState` is not a complex type. For example, consider the following "functional" entity definition:

```csharp
[FunctionName("MyClass")]
public static void RunOperation([EntityTrigger] IDurableEntityContext ctx)
{
    int state = ctx.GetState(() => 0);
    state++;
    ctx.SetState(state);
}
```

The entity gets and saves its state correctly the first time, but subsequent calls to `GetState` fail with a JSON deserialization exception:

```
Microsoft.Azure.WebJobs.EntitySchedulerException
  HResult=0x80131500
  Message=Failed to deserialize entity state: Unexpected initial token 'Integer' when populating object. Expected JSON object or array. Path '', line 1, position 1.
  Source=Microsoft.Azure.WebJobs.Extensions.DurableTask
  StackTrace:
   at Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableEntityContext.GetPopulatedState[TState](TState initialValue, Boolean usedTypeInitializer) in C:\GitHub\azure-functions-durable-extension\src\WebJobs.Extensions.DurableTask\ContextImplementations\DurableEntityContext.cs:line 222
   at Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableEntityContext.Microsoft.Azure.WebJobs.IDurableEntityContext.GetState[TState](Func`1 initializer) in C:\GitHub\azure-functions-durable-extension\src\WebJobs.Extensions.DurableTask\ContextImplementations\DurableEntityContext.cs:line 190
   at VSSample.MyClass.RunOperation(IDurableEntityContext ctx) in C:\GitHub\azure-functions-durable-extension\samples\v2\precompiled\Repro.cs:line 14
   at Microsoft.Azure.WebJobs.Host.Executors.VoidMethodInvoker`2.InvokeAsync(TReflected instance, Object[] arguments) in C:\projects\azure-webjobs-sdk-rqm4t\src\Microsoft.Azure.WebJobs.Host\Executors\VoidMethodInvoker.cs:line 20
   at Microsoft.Azure.WebJobs.Host.Executors.FunctionInvoker`2.<InvokeAsync>d__10.MoveNext() in C:\projects\azure-webjobs-sdk-rqm4t\src\Microsoft.Azure.WebJobs.Host\Executors\FunctionInvoker.cs:line 52
```

This PR is a simple fix which avoids using the `JsonConvert.PopulateObject` API unless we know that `TState` is a class.

One downside of this fix is that we can't use the `PopulateObject` API for structs. I'm not aware of a way to know whether `TState` represents a JSON object or a JSON primitive value. If we had a way to know for sure whether `TState` represented a JSON object, then we could use `PopulateObject` for that as well. Without this, the behavior for structs is that we will ignore any pre-populated state. It's a bit of a corner case (structs + default initializers), so it might be worth the tradeoff.