### PR TITLE
Enforce a maximum of 6 day intervals for RetryOptions

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/DurableOrchestrationContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableOrchestrationContext.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Azure.WebJobs
     public sealed class DurableOrchestrationContext : DurableOrchestrationContextBase
     {
         private const string DefaultVersion = "";
-        private const int MaxTimerDurationInDays = 6;
+        internal const int MaxTimerDurationInDays = 6;
 
         private readonly Dictionary<string, Stack> pendingExternalEvents =
             new Dictionary<string, Stack>(StringComparer.OrdinalIgnoreCase);
@@ -421,6 +421,18 @@ namespace Microsoft.Azure.WebJobs
             object input)
         {
             this.ThrowIfInvalidAccess();
+
+            // These check can be removed once the storage provider supports extended timers.
+            // https://github.com/Azure/azure-functions-durable-extension/issues/14
+            if (retryOptions.FirstRetryInterval > TimeSpan.FromDays(MaxTimerDurationInDays))
+            {
+                throw new ArgumentException($"Retry intervals must not exceed {MaxTimerDurationInDays} days.", nameof(retryOptions.FirstRetryInterval));
+            }
+
+            if (retryOptions.MaxRetryInterval > TimeSpan.FromDays(MaxTimerDurationInDays))
+            {
+                throw new ArgumentException($"Retry intervals must not exceed {MaxTimerDurationInDays} days.", nameof(retryOptions.MaxRetryInterval));
+            }
 
             // TODO: Support for versioning
             string version = DefaultVersion;

--- a/src/WebJobs.Extensions.DurableTask/DurableOrchestrationContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableOrchestrationContext.cs
@@ -422,18 +422,6 @@ namespace Microsoft.Azure.WebJobs
         {
             this.ThrowIfInvalidAccess();
 
-            // These check can be removed once the storage provider supports extended timers.
-            // https://github.com/Azure/azure-functions-durable-extension/issues/14
-            if (retryOptions.FirstRetryInterval > TimeSpan.FromDays(MaxTimerDurationInDays))
-            {
-                throw new ArgumentException($"Retry intervals must not exceed {MaxTimerDurationInDays} days.", nameof(retryOptions.FirstRetryInterval));
-            }
-
-            if (retryOptions.MaxRetryInterval > TimeSpan.FromDays(MaxTimerDurationInDays))
-            {
-                throw new ArgumentException($"Retry intervals must not exceed {MaxTimerDurationInDays} days.", nameof(retryOptions.MaxRetryInterval));
-            }
-
             // TODO: Support for versioning
             string version = DefaultVersion;
             this.config.ThrowIfFunctionDoesNotExist(functionName, functionType);

--- a/src/WebJobs.Extensions.DurableTask/RetryOptions.cs
+++ b/src/WebJobs.Extensions.DurableTask/RetryOptions.cs
@@ -24,6 +24,7 @@ namespace Microsoft.Azure.WebJobs
         public RetryOptions(TimeSpan firstRetryInterval, int maxNumberOfAttempts)
         {
             this.retryOptions = new DurableTaskCore.RetryOptions(firstRetryInterval, maxNumberOfAttempts);
+            this.MaxRetryInterval = TimeSpan.FromDays(DurableOrchestrationContext.MaxTimerDurationInDays);
         }
 
         /// <summary>

--- a/src/WebJobs.Extensions.DurableTask/RetryOptions.cs
+++ b/src/WebJobs.Extensions.DurableTask/RetryOptions.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Azure.WebJobs
     public class RetryOptions
     {
         private readonly DurableTaskCore.RetryOptions retryOptions;
-        private readonly TimeSpan maxStorageTimeSpan = TimeSpan.FromDays(DurableOrchestrationContext.MaxTimerDurationInDays);
+        private static readonly TimeSpan MaxStorageTimeSpan = TimeSpan.FromDays(DurableOrchestrationContext.MaxTimerDurationInDays);
 
         /// <summary>
         /// Creates a new instance RetryOptions with the supplied first retry and max attempts.
@@ -25,7 +25,7 @@ namespace Microsoft.Azure.WebJobs
         public RetryOptions(TimeSpan firstRetryInterval, int maxNumberOfAttempts)
         {
             this.retryOptions = new DurableTaskCore.RetryOptions(firstRetryInterval, maxNumberOfAttempts);
-            this.MaxRetryInterval = TimeSpan.FromDays(DurableOrchestrationContext.MaxTimerDurationInDays);
+            this.MaxRetryInterval = MaxStorageTimeSpan;
         }
 
         /// <summary>
@@ -43,13 +43,13 @@ namespace Microsoft.Azure.WebJobs
 
             set
             {
-                if (value < this.maxStorageTimeSpan)
+                if (value < MaxStorageTimeSpan)
                 {
                     this.retryOptions.FirstRetryInterval = value;
                 }
                 else
                 {
-                    this.retryOptions.FirstRetryInterval = this.maxStorageTimeSpan;
+                    this.retryOptions.FirstRetryInterval = MaxStorageTimeSpan;
                 }
             }
         }
@@ -69,13 +69,13 @@ namespace Microsoft.Azure.WebJobs
 
             set
             {
-                if (value < this.maxStorageTimeSpan)
+                if (value < MaxStorageTimeSpan)
                 {
                     this.retryOptions.MaxRetryInterval = value;
                 }
                 else
                 {
-                    this.retryOptions.MaxRetryInterval = this.maxStorageTimeSpan;
+                    this.retryOptions.MaxRetryInterval = MaxStorageTimeSpan;
                 }
             }
         }

--- a/src/WebJobs.Extensions.DurableTask/RetryOptions.cs
+++ b/src/WebJobs.Extensions.DurableTask/RetryOptions.cs
@@ -12,6 +12,7 @@ namespace Microsoft.Azure.WebJobs
     public class RetryOptions
     {
         private readonly DurableTaskCore.RetryOptions retryOptions;
+        private readonly TimeSpan maxStorageTimeSpan = TimeSpan.FromDays(DurableOrchestrationContext.MaxTimerDurationInDays);
 
         /// <summary>
         /// Creates a new instance RetryOptions with the supplied first retry and max attempts.
@@ -35,8 +36,22 @@ namespace Microsoft.Azure.WebJobs
         /// </value>
         public TimeSpan FirstRetryInterval
         {
-            get { return this.retryOptions.FirstRetryInterval; }
-            set { this.retryOptions.FirstRetryInterval = value; }
+            get
+            {
+                return this.retryOptions.FirstRetryInterval;
+            }
+
+            set
+            {
+                if (value < this.maxStorageTimeSpan)
+                {
+                    this.retryOptions.FirstRetryInterval = value;
+                }
+                else
+                {
+                    this.retryOptions.FirstRetryInterval = this.maxStorageTimeSpan;
+                }
+            }
         }
 
         /// <summary>
@@ -47,8 +62,22 @@ namespace Microsoft.Azure.WebJobs
         /// </value>
         public TimeSpan MaxRetryInterval
         {
-            get { return this.retryOptions.MaxRetryInterval; }
-            set { this.retryOptions.MaxRetryInterval = value; }
+            get
+            {
+                return this.retryOptions.MaxRetryInterval;
+            }
+
+            set
+            {
+                if (value < this.maxStorageTimeSpan)
+                {
+                    this.retryOptions.MaxRetryInterval = value;
+                }
+                else
+                {
+                    this.retryOptions.MaxRetryInterval = this.maxStorageTimeSpan;
+                }
+            }
         }
 
         /// <summary>

--- a/test/FunctionsV1/WebJobs.Extensions.DurableTask.Tests.V1.csproj
+++ b/test/FunctionsV1/WebJobs.Extensions.DurableTask.Tests.V1.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="4.19.4" />
     <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage" Version="1.6.3" />
-    <PackageReference Include="Microsoft.Azure.WebJobs" Version="2.3.0" />
+    <PackageReference Include="Microsoft.Azure.WebJobs" Version="2.2.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" Version="2.2.0" />
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.33" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />


### PR DESCRIPTION
Our current version of the storage SDK limits our timer functionality to a maximum of 7 days. We already had these checks for timers, but the same limitations apply to our retry intervals. Without enforcing these limits, customers could get permenantly stuck, and it was difficult to debug why. This silently sets the interval to our maximum when the customer attempts to use intervals larger than our maximum.

Addresses issue #944.