### PR TITLE
Limit the number of actions per orchestration

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableOrchestrationContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableOrchestrationContext.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
         private readonly int maxActionCount;
 
-        private static int actionCount;
+        private int actionCount;
 
         private string serializedOutput;
         private string serializedCustomStatus;
@@ -56,7 +56,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         internal DurableOrchestrationContext(DurableTaskExtension config, string functionName)
             : base(config, functionName)
         {
-            actionCount = 0;
+            this.actionCount = 0;
             this.maxActionCount = config.Options.MaxOrchestrationActions;
         }
 
@@ -821,7 +821,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     // Need to round-trip serialization since SendEvent always tries to serialize.
                     string rawInput = events.Dequeue();
                     JToken jsonData = JToken.Parse(rawInput);
-                    this.IncrementActionsOrThrowException();
                     this.InnerContext.SendEvent(instance, eventName, jsonData);
                 }
             }
@@ -1022,13 +1021,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
         private void IncrementActionsOrThrowException()
         {
-            if (actionCount >= this.maxActionCount)
+            if (this.actionCount >= this.maxActionCount)
             {
-                throw new InvalidOperationException("Maximum amount of orchestration actions (" + this.maxActionCount + ") has been reached. This value can be configured in local.settings.json file as MaxOrchestrationActions.");
+                throw new InvalidOperationException("Maximum amount of orchestration actions (" + this.maxActionCount + ") has been reached. This value can be configured in host.json file as MaxOrchestrationActions.");
             }
             else
             {
-                actionCount++;
+                this.actionCount++;
             }
         }
 

--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableOrchestrationContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableOrchestrationContext.cs
@@ -38,6 +38,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         private readonly Dictionary<string, Queue<string>> bufferedExternalEvents =
             new Dictionary<string, Queue<string>>(StringComparer.OrdinalIgnoreCase);
 
+        private readonly int maxActionCount;
+
+        private static int actionCount;
+
         private string serializedOutput;
         private string serializedCustomStatus;
 
@@ -52,6 +56,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         internal DurableOrchestrationContext(DurableTaskExtension config, string functionName)
             : base(config, functionName)
         {
+            actionCount = 0;
+            this.maxActionCount = config.Options.MaxOrchestrationActions;
         }
 
         internal string ParentInstanceId { get; set; }
@@ -243,6 +249,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     fireAt = this.InnerContext.CurrentUtcDateTime.AddMilliseconds(this.Config.Options.HttpSettings.DefaultAsyncRequestSleepTimeMilliseconds);
                 }
 
+                this.IncrementActionsOrThrowException();
                 await this.InnerContext.CreateTimer(fireAt, CancellationToken.None);
 
                 DurableHttpRequest durableAsyncHttpRequest = this.CreateHttpRequestMessageCopy(req, durableHttpResponse.Headers["Location"]);
@@ -291,6 +298,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 throw new ArgumentException($"Timer durations must not exceed {MaxTimerDurationInDays} days.", nameof(fireAt));
             }
 
+            this.IncrementActionsOrThrowException();
             Task<T> timerTask = this.InnerContext.CreateTimer(fireAt, state, cancelToken);
 
             this.Config.TraceHelper.FunctionListening(
@@ -418,10 +426,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     System.Diagnostics.Debug.Assert(!oneWay, "The oneWay parameter should not be used for activity functions.");
                     if (retryOptions == null)
                     {
+                        this.IncrementActionsOrThrowException();
                         callTask = this.InnerContext.ScheduleTask<TResult>(functionName, version, input);
                     }
                     else
                     {
+                        this.IncrementActionsOrThrowException();
                         callTask = this.InnerContext.ScheduleWithRetry<TResult>(
                             functionName,
                             version,
@@ -449,6 +459,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
                     if (oneWay)
                     {
+                        this.IncrementActionsOrThrowException();
                         var dummyTask = this.InnerContext.CreateSubOrchestrationInstance<TResult>(
                                 functionName,
                                 version,
@@ -467,6 +478,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
                         if (retryOptions == null)
                         {
+                            this.IncrementActionsOrThrowException();
                             callTask = this.InnerContext.CreateSubOrchestrationInstance<TResult>(
                                 functionName,
                                 version,
@@ -475,6 +487,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                         }
                         else
                         {
+                            this.IncrementActionsOrThrowException();
                             callTask = this.InnerContext.CreateSubOrchestrationInstanceWithRetry<TResult>(
                                 functionName,
                                 version,
@@ -808,6 +821,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     // Need to round-trip serialization since SendEvent always tries to serialize.
                     string rawInput = events.Dequeue();
                     JToken jsonData = JToken.Parse(rawInput);
+                    this.IncrementActionsOrThrowException();
                     this.InnerContext.SendEvent(instance, eventName, jsonData);
                 }
             }
@@ -1002,7 +1016,20 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     eventContent);
             }
 
+            this.IncrementActionsOrThrowException();
             this.InnerContext.SendEvent(target, eventName, eventContent);
+        }
+
+        private void IncrementActionsOrThrowException()
+        {
+            if (actionCount >= this.maxActionCount)
+            {
+                throw new InvalidOperationException("Maximum amount of orchestration actions (" + this.maxActionCount + ") has been reached. This value can be configured in local.settings.json file as MaxOrchestrationActions.");
+            }
+            else
+            {
+                actionCount++;
+            }
         }
 
         private Guid NewGuid()

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net471.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net471.xml
@@ -528,59 +528,6 @@
             The HTTP URL for creating a new orchestration instance and waiting on its completion.
             </value>
         </member>
-        <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.HttpManagementPayload">
-            <summary>
-            Data structure containing status, terminate and send external event HTTP endpoints.
-            </summary>
-        </member>
-        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.HttpManagementPayload.Id">
-            <summary>
-            Gets the ID of the orchestration instance.
-            </summary>
-            <value>
-            The ID of the orchestration instance.
-            </value>
-        </member>
-        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.HttpManagementPayload.StatusQueryGetUri">
-            <summary>
-            Gets the HTTP GET status query endpoint URL.
-            </summary>
-            <value>
-            The HTTP URL for fetching the instance status.
-            </value>
-        </member>
-        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.HttpManagementPayload.SendEventPostUri">
-            <summary>
-            Gets the HTTP POST external event sending endpoint URL.
-            </summary>
-            <value>
-            The HTTP URL for posting external event notifications.
-            </value>
-        </member>
-        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.HttpManagementPayload.TerminatePostUri">
-            <summary>
-            Gets the HTTP POST instance termination endpoint.
-            </summary>
-            <value>
-            The HTTP URL for posting instance termination commands.
-            </value>
-        </member>
-        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.HttpManagementPayload.RewindPostUri">
-            <summary>
-            Gets the HTTP POST instance rewind endpoint.
-            </summary>
-            <value>
-            The HTTP URL for rewinding orchestration instances.
-            </value>
-        </member>
-        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.HttpManagementPayload.PurgeHistoryDeleteUri">
-            <summary>
-            Gets the HTTP DELETE purge instance history by instance ID endpoint.
-            </summary>
-            <value>
-            The HTTP URL for purging instance history by instance ID.
-            </value>
-        </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.IConnectionStringResolver">
             <summary>
             Interface defining methods to resolve connection strings.
@@ -1174,6 +1121,11 @@
             <value>
             The number of seconds before an idle session times out.
             </value>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskOptions.MaxOrchestrationActions">
+            <summary>
+            Gets or sets the maximum number of orchestration actions. The default value is 100,000.
+            </summary>
         </member>
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskOptions.EntityMessageReorderWindowInMinutes">
             <summary>
@@ -1874,10 +1826,10 @@
         </member>
         <member name="M:Microsoft.Azure.WebJobs.IDurableOrchestrationClient.CreateHttpManagementPayload(System.String)">
             <summary>
-            Creates a <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.HttpManagementPayload"/> object that contains status, terminate and send external event HTTP endpoints.
+            Creates a <see cref="T:Microsoft.Azure.WebJobs.HttpManagementPayload"/> object that contains status, terminate and send external event HTTP endpoints.
             </summary>
             <param name="instanceId">The ID of the orchestration instance to check.</param>
-            <returns>Instance of the <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.HttpManagementPayload"/> class.</returns>
+            <returns>Instance of the <see cref="T:Microsoft.Azure.WebJobs.HttpManagementPayload"/> class.</returns>
         </member>
         <member name="M:Microsoft.Azure.WebJobs.IDurableOrchestrationClient.WaitForCompletionOrCreateCheckStatusResponseAsync(System.Net.Http.HttpRequestMessage,System.String,System.TimeSpan,System.TimeSpan)">
             <summary>
@@ -2910,6 +2862,59 @@
             Gets the string value of the current <see cref="T:Microsoft.Azure.WebJobs.FunctionName"/> instance.
             </summary>
             <returns>The name and optional version of the current <see cref="T:Microsoft.Azure.WebJobs.FunctionName"/> instance.</returns>
+        </member>
+        <member name="T:Microsoft.Azure.WebJobs.HttpManagementPayload">
+            <summary>
+            Data structure containing status, terminate and send external event HTTP endpoints.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.HttpManagementPayload.Id">
+            <summary>
+            Gets the ID of the orchestration instance.
+            </summary>
+            <value>
+            The ID of the orchestration instance.
+            </value>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.HttpManagementPayload.StatusQueryGetUri">
+            <summary>
+            Gets the HTTP GET status query endpoint URL.
+            </summary>
+            <value>
+            The HTTP URL for fetching the instance status.
+            </value>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.HttpManagementPayload.SendEventPostUri">
+            <summary>
+            Gets the HTTP POST external event sending endpoint URL.
+            </summary>
+            <value>
+            The HTTP URL for posting external event notifications.
+            </value>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.HttpManagementPayload.TerminatePostUri">
+            <summary>
+            Gets the HTTP POST instance termination endpoint.
+            </summary>
+            <value>
+            The HTTP URL for posting instance termination commands.
+            </value>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.HttpManagementPayload.RewindPostUri">
+            <summary>
+            Gets the HTTP POST instance rewind endpoint.
+            </summary>
+            <value>
+            The HTTP URL for rewinding orchestration instances.
+            </value>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.HttpManagementPayload.PurgeHistoryDeleteUri">
+            <summary>
+            Gets the HTTP DELETE purge instance history by instance ID endpoint.
+            </summary>
+            <value>
+            The HTTP URL for purging instance history by instance ID.
+            </value>
         </member>
         <member name="T:Microsoft.Azure.WebJobs.OrchestrationRuntimeStatus">
             <summary>

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-netstandard2.0.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-netstandard2.0.xml
@@ -528,59 +528,6 @@
             The HTTP URL for creating a new orchestration instance and waiting on its completion.
             </value>
         </member>
-        <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.HttpManagementPayload">
-            <summary>
-            Data structure containing status, terminate and send external event HTTP endpoints.
-            </summary>
-        </member>
-        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.HttpManagementPayload.Id">
-            <summary>
-            Gets the ID of the orchestration instance.
-            </summary>
-            <value>
-            The ID of the orchestration instance.
-            </value>
-        </member>
-        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.HttpManagementPayload.StatusQueryGetUri">
-            <summary>
-            Gets the HTTP GET status query endpoint URL.
-            </summary>
-            <value>
-            The HTTP URL for fetching the instance status.
-            </value>
-        </member>
-        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.HttpManagementPayload.SendEventPostUri">
-            <summary>
-            Gets the HTTP POST external event sending endpoint URL.
-            </summary>
-            <value>
-            The HTTP URL for posting external event notifications.
-            </value>
-        </member>
-        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.HttpManagementPayload.TerminatePostUri">
-            <summary>
-            Gets the HTTP POST instance termination endpoint.
-            </summary>
-            <value>
-            The HTTP URL for posting instance termination commands.
-            </value>
-        </member>
-        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.HttpManagementPayload.RewindPostUri">
-            <summary>
-            Gets the HTTP POST instance rewind endpoint.
-            </summary>
-            <value>
-            The HTTP URL for rewinding orchestration instances.
-            </value>
-        </member>
-        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.HttpManagementPayload.PurgeHistoryDeleteUri">
-            <summary>
-            Gets the HTTP DELETE purge instance history by instance ID endpoint.
-            </summary>
-            <value>
-            The HTTP URL for purging instance history by instance ID.
-            </value>
-        </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.IConnectionStringResolver">
             <summary>
             Interface defining methods to resolve connection strings.
@@ -1174,6 +1121,11 @@
             <value>
             The number of seconds before an idle session times out.
             </value>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskOptions.MaxOrchestrationActions">
+            <summary>
+            Gets or sets the maximum number of orchestration actions. The default value is 100,000.
+            </summary>
         </member>
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskOptions.EntityMessageReorderWindowInMinutes">
             <summary>
@@ -1918,10 +1870,10 @@
         </member>
         <member name="M:Microsoft.Azure.WebJobs.IDurableOrchestrationClient.CreateHttpManagementPayload(System.String)">
             <summary>
-            Creates a <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.HttpManagementPayload"/> object that contains status, terminate and send external event HTTP endpoints.
+            Creates a <see cref="T:Microsoft.Azure.WebJobs.HttpManagementPayload"/> object that contains status, terminate and send external event HTTP endpoints.
             </summary>
             <param name="instanceId">The ID of the orchestration instance to check.</param>
-            <returns>Instance of the <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.HttpManagementPayload"/> class.</returns>
+            <returns>Instance of the <see cref="T:Microsoft.Azure.WebJobs.HttpManagementPayload"/> class.</returns>
         </member>
         <member name="M:Microsoft.Azure.WebJobs.IDurableOrchestrationClient.WaitForCompletionOrCreateCheckStatusResponseAsync(System.Net.Http.HttpRequestMessage,System.String,System.TimeSpan,System.TimeSpan)">
             <summary>
@@ -2954,6 +2906,59 @@
             Gets the string value of the current <see cref="T:Microsoft.Azure.WebJobs.FunctionName"/> instance.
             </summary>
             <returns>The name and optional version of the current <see cref="T:Microsoft.Azure.WebJobs.FunctionName"/> instance.</returns>
+        </member>
+        <member name="T:Microsoft.Azure.WebJobs.HttpManagementPayload">
+            <summary>
+            Data structure containing status, terminate and send external event HTTP endpoints.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.HttpManagementPayload.Id">
+            <summary>
+            Gets the ID of the orchestration instance.
+            </summary>
+            <value>
+            The ID of the orchestration instance.
+            </value>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.HttpManagementPayload.StatusQueryGetUri">
+            <summary>
+            Gets the HTTP GET status query endpoint URL.
+            </summary>
+            <value>
+            The HTTP URL for fetching the instance status.
+            </value>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.HttpManagementPayload.SendEventPostUri">
+            <summary>
+            Gets the HTTP POST external event sending endpoint URL.
+            </summary>
+            <value>
+            The HTTP URL for posting external event notifications.
+            </value>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.HttpManagementPayload.TerminatePostUri">
+            <summary>
+            Gets the HTTP POST instance termination endpoint.
+            </summary>
+            <value>
+            The HTTP URL for posting instance termination commands.
+            </value>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.HttpManagementPayload.RewindPostUri">
+            <summary>
+            Gets the HTTP POST instance rewind endpoint.
+            </summary>
+            <value>
+            The HTTP URL for rewinding orchestration instances.
+            </value>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.HttpManagementPayload.PurgeHistoryDeleteUri">
+            <summary>
+            Gets the HTTP DELETE purge instance history by instance ID endpoint.
+            </summary>
+            <value>
+            The HTTP URL for purging instance history by instance ID.
+            </value>
         </member>
         <member name="T:Microsoft.Azure.WebJobs.OrchestrationRuntimeStatus">
             <summary>

--- a/src/WebJobs.Extensions.DurableTask/Options/DurableTaskOptions.cs
+++ b/src/WebJobs.Extensions.DurableTask/Options/DurableTaskOptions.cs
@@ -129,6 +129,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         public int ExtendedSessionIdleTimeoutInSeconds { get; set; } = 30;
 
         /// <summary>
+        /// Gets or sets the maximum number of orchestration actions. The default value is 100,000.
+        /// </summary>
+        public int MaxOrchestrationActions { get; set; } = 100000;
+
+        /// <summary>
         /// Gets or sets the time window within which entity messages get deduplicated and reordered.
         /// </summary>
         public int EntityMessageReorderWindowInMinutes { get; set; } = 30;

--- a/test/Common/DurableTaskEndToEndTests.cs
+++ b/test/Common/DurableTaskEndToEndTests.cs
@@ -3354,8 +3354,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         [Trait("Category", PlatformSpecificHelpers.TestCategory)]
         public async Task MaxOrchestrationAction_MaxReached_OrchestrationFails()
         {
+            string[] orchestratorFunctionNames =
+            {
+                nameof(TestOrchestrations.AllOrchestratorActivityActions),
+            };
+
             DurableTaskOptions options = new DurableTaskOptions();
-            var maxActions = 1;
+            var maxActions = 7;
             options.MaxOrchestrationActions = maxActions;
 
             using (var host = TestHelpers.GetJobHost(
@@ -3364,7 +3369,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             {
                 await host.StartAsync();
 
-                var client = await host.StartOrchestratorAsync(nameof(TestOrchestrations.TwoOrchestratorActivityActions), "", this.output);
+                var counterEntityId = new EntityId("Counter", Guid.NewGuid().ToString());
+
+                var client = await host.StartOrchestratorAsync(orchestratorFunctionNames[0], counterEntityId, this.output);
                 DurableOrchestrationStatus status = await client.WaitForCompletionAsync(this.output);
 
                 Assert.NotNull(status);

--- a/test/Common/DurableTaskEndToEndTests.cs
+++ b/test/Common/DurableTaskEndToEndTests.cs
@@ -3371,7 +3371,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 Assert.Equal(OrchestrationRuntimeStatus.Failed, status.RuntimeStatus);
                 Assert.Equal(
                     $"Orchestrator function 'TwoOrchestratorActivityActions' failed: Maximum amount of orchestration actions ({maxActions}) has been reached. " +
-                    $"This value can be configured in local.settings.json file as MaxOrchestrationActions.",
+                    $"This value can be configured in host.json file as MaxOrchestrationActions.",
                     status.Output.ToString());
             }
         }

--- a/test/Common/DurableTaskEndToEndTests.cs
+++ b/test/Common/DurableTaskEndToEndTests.cs
@@ -3375,7 +3375,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 DurableOrchestrationStatus status = await client.WaitForCompletionAsync(this.output);
 
                 Assert.NotNull(status);
-                Assert.Equal(OrchestrationRuntimeStatus.Failed, status.RuntimeStatus);
+                Assert.Equal("AllAPICallsUsed", status.CustomStatus);
                 Assert.Equal(
                     $"Orchestrator function 'AllOrchestratorActivityActions' failed: Maximum amount of orchestration actions ({maxActions}) has been reached. " +
                     $"This value can be configured in host.json file as MaxOrchestrationActions.",

--- a/test/Common/DurableTaskEndToEndTests.cs
+++ b/test/Common/DurableTaskEndToEndTests.cs
@@ -3350,7 +3350,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             }
         }
 
-
         [Fact]
         [Trait("Category", PlatformSpecificHelpers.TestCategory)]
         public async Task MaxOrchestrationAction_MaxReached_OrchestrationFails()
@@ -3372,7 +3371,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 Assert.Equal(OrchestrationRuntimeStatus.Failed, status.RuntimeStatus);
                 Assert.Equal(
                     $"Orchestrator function 'TwoOrchestratorActivityActions' failed: Maximum amount of orchestration actions ({maxActions}) has been reached. " +
-                    $"This value can be configured in local.settings.json file as MaxOrchestrationActions.", 
+                    $"This value can be configured in local.settings.json file as MaxOrchestrationActions.",
                     status.Output.ToString());
             }
         }

--- a/test/Common/DurableTaskEndToEndTests.cs
+++ b/test/Common/DurableTaskEndToEndTests.cs
@@ -3377,7 +3377,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 Assert.NotNull(status);
                 Assert.Equal(OrchestrationRuntimeStatus.Failed, status.RuntimeStatus);
                 Assert.Equal(
-                    $"Orchestrator function 'TwoOrchestratorActivityActions' failed: Maximum amount of orchestration actions ({maxActions}) has been reached. " +
+                    $"Orchestrator function 'AllOrchestratorActivityActions' failed: Maximum amount of orchestration actions ({maxActions}) has been reached. " +
                     $"This value can be configured in host.json file as MaxOrchestrationActions.",
                     status.Output.ToString());
             }

--- a/test/Common/TestOrchestrations.cs
+++ b/test/Common/TestOrchestrations.cs
@@ -40,12 +40,21 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             return firstGuid != secondGuid && firstGuid != thirdGuid && secondGuid != thirdGuid;
         }
 
-        public static async Task<string> TwoOrchestratorActivityActions([OrchestrationTrigger] IDurableOrchestrationContext ctx)
+        public static async Task<string> AllOrchestratorActivityActions([OrchestrationTrigger] IDurableOrchestrationContext ctx)
         {
-            string input = ctx.GetInput<string>();
-            string output = await ctx.CallActivityAsync<string>(nameof(TestActivities.Hello), input);
-            string outputTwo = await ctx.CallActivityAsync<string>(nameof(TestActivities.Hello), input);
-            return output;
+            EntityId input = ctx.GetInput<EntityId>();
+            var stringInput = input.ToString();
+            RetryOptions options = new RetryOptions(TimeSpan.FromSeconds(5), 3);
+
+            await ctx.CreateTimer(ctx.CurrentUtcDateTime, CancellationToken.None);
+            await ctx.CallActivityAsync<string>(nameof(TestActivities.Hello), stringInput);
+            await ctx.CallActivityWithRetryAsync<string>(nameof(TestActivities.Hello), options, stringInput);
+            await ctx.CallSubOrchestratorAsync<string>(nameof(TestOrchestrations.SayHelloInline), stringInput);
+            await ctx.CallSubOrchestratorWithRetryAsync<string>(nameof(TestOrchestrations.SayHelloWithActivity), options, stringInput);
+            ctx.StartNewOrchestration(nameof(TestOrchestrations.SayHelloWithActivityWithDeterministicGuid), stringInput);
+            ctx.SignalEntity(input, "count");
+            await ctx.CallHttpAsync(null);
+            return "TestCompleted";
         }
 
         public static bool VerifyUniqueGuids([OrchestrationTrigger] IDurableOrchestrationContext ctx)

--- a/test/Common/TestOrchestrations.cs
+++ b/test/Common/TestOrchestrations.cs
@@ -40,6 +40,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             return firstGuid != secondGuid && firstGuid != thirdGuid && secondGuid != thirdGuid;
         }
 
+        public static async Task<string> TwoOrchestratorActivityActions([OrchestrationTrigger] IDurableOrchestrationContext ctx)
+        {
+            string input = ctx.GetInput<string>();
+            string output = await ctx.CallActivityAsync<string>(nameof(TestActivities.Hello), input);
+            string outputTwo = await ctx.CallActivityAsync<string>(nameof(TestActivities.Hello), input);
+            return output;
+        }
+
         public static bool VerifyUniqueGuids([OrchestrationTrigger] IDurableOrchestrationContext ctx)
         {
             HashSet<Guid> guids = new HashSet<Guid>();

--- a/test/Common/TestOrchestrations.cs
+++ b/test/Common/TestOrchestrations.cs
@@ -53,7 +53,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             await ctx.CallSubOrchestratorWithRetryAsync<string>(nameof(TestOrchestrations.SayHelloWithActivity), options, stringInput);
             ctx.StartNewOrchestration(nameof(TestOrchestrations.SayHelloWithActivityWithDeterministicGuid), stringInput);
             ctx.SignalEntity(input, "count");
+
+            ctx.SetCustomStatus("AllAPICallsUsed");
             await ctx.CallHttpAsync(null);
+
             return "TestCompleted";
         }
 


### PR DESCRIPTION
Limits the number of actions per orchestration in order to prevent performance from dropping with instances with a large history.

MaxOrchestrationActions is a configurable value that is defaulted to 100,000.

Fixes #522 