### PR TITLE
[Refactor] Generically-typed StartNewAsync() overloads

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableClient.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableClient.cs
@@ -99,7 +99,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         }
 
         /// <inheritdoc />
-        async Task<string> IDurableOrchestrationClient.StartNewAsync(string orchestratorFunctionName, string instanceId, object input)
+        async Task<string> IDurableOrchestrationClient.StartNewAsync<T>(string orchestratorFunctionName, string instanceId, T input)
         {
             this.config.ThrowIfFunctionDoesNotExist(orchestratorFunctionName, FunctionType.Orchestrator);
 
@@ -540,7 +540,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                         JObject historyItem = (JObject)historyArray[i];
                         if (Enum.TryParse(historyItem["EventType"].Value<string>(), out EventType eventType))
                         {
-                           // Changing the value of EventType from integer to string for better understanding in the history output
+                            // Changing the value of EventType from integer to string for better understanding in the history output
                             historyItem["EventType"] = eventType.ToString();
                             switch (eventType)
                             {

--- a/src/WebJobs.Extensions.DurableTask/ContextInterfaces/DurableContextExtensions.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextInterfaces/DurableContextExtensions.cs
@@ -397,7 +397,6 @@ namespace Microsoft.Azure.WebJobs
         /// <param name="client">The client object.</param>
         /// <param name="orchestratorFunctionName">The name of the orchestrator function to start.</param>
         /// <param name="instanceId">The ID to use for the new orchestration instance.</param>
-        /// <typeparam name="T">The type of the input value for the orchestrator function.</typeparam>
         /// <returns>A task that completes when the orchestration is started. The task contains the instance id of the started
         /// orchestratation instance.</returns>
         /// <exception cref="ArgumentException">

--- a/src/WebJobs.Extensions.DurableTask/ContextInterfaces/DurableContextExtensions.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextInterfaces/DurableContextExtensions.cs
@@ -396,6 +396,26 @@ namespace Microsoft.Azure.WebJobs
         /// </summary>
         /// <param name="client">The client object.</param>
         /// <param name="orchestratorFunctionName">The name of the orchestrator function to start.</param>
+        /// <param name="instanceId">The ID to use for the new orchestration instance.</param>
+        /// <typeparam name="T">The type of the input value for the orchestrator function.</typeparam>
+        /// <returns>A task that completes when the orchestration is started. The task contains the instance id of the started
+        /// orchestratation instance.</returns>
+        /// <exception cref="ArgumentException">
+        /// The specified function does not exist, is disabled, or is not an orchestrator function.
+        /// </exception>
+        public static Task<string> StartNewAsync(
+            this IDurableOrchestrationClient client,
+            string orchestratorFunctionName,
+            string instanceId)
+        {
+            return client.StartNewAsync<object>(orchestratorFunctionName, instanceId, null);
+        }
+
+        /// <summary>
+        /// Starts a new execution of the specified orchestrator function.
+        /// </summary>
+        /// <param name="client">The client object.</param>
+        /// <param name="orchestratorFunctionName">The name of the orchestrator function to start.</param>
         /// <param name="input">JSON-serializeable input value for the orchestrator function.</param>
         /// <typeparam name="T">The type of the input value for the orchestrator function.</typeparam>
         /// <returns>A task that completes when the orchestration is started. The task contains the instance id of the started

--- a/src/WebJobs.Extensions.DurableTask/ContextInterfaces/DurableContextExtensions.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextInterfaces/DurableContextExtensions.cs
@@ -397,6 +397,26 @@ namespace Microsoft.Azure.WebJobs
         /// <param name="client">The client object.</param>
         /// <param name="orchestratorFunctionName">The name of the orchestrator function to start.</param>
         /// <param name="input">JSON-serializeable input value for the orchestrator function.</param>
+        /// <typeparam name="T">The type of the input value for the orchestrator function.</typeparam>
+        /// <returns>A task that completes when the orchestration is started. The task contains the instance id of the started
+        /// orchestratation instance.</returns>
+        /// <exception cref="ArgumentException">
+        /// The specified function does not exist, is disabled, or is not an orchestrator function.
+        /// </exception>
+        public static Task<string> StartNewAsync<T>(
+            this IDurableOrchestrationClient client,
+            string orchestratorFunctionName,
+            T input)
+            where T : class
+        {
+            return client.StartNewAsync(orchestratorFunctionName, string.Empty, input);
+        }
+
+        /// <summary>
+        /// Starts a new execution of the specified orchestrator function.
+        /// </summary>
+        /// <param name="client">The client object.</param>
+        /// <param name="orchestratorFunctionName">The name of the orchestrator function to start.</param>
         /// <returns>A task that completes when the orchestration is started. The task contains the instance id of the started
         /// orchestratation instance.</returns>
         /// <exception cref="ArgumentException">
@@ -404,10 +424,9 @@ namespace Microsoft.Azure.WebJobs
         /// </exception>
         public static Task<string> StartNewAsync(
             this IDurableOrchestrationClient client,
-            string orchestratorFunctionName,
-            object input)
+            string orchestratorFunctionName)
         {
-            return client.StartNewAsync(orchestratorFunctionName, string.Empty, input);
+            return client.StartNewAsync<object>(orchestratorFunctionName, null);
         }
 
         /// <summary>
@@ -441,7 +460,7 @@ namespace Microsoft.Azure.WebJobs
         /// <param name="client">The client object.</param>
         /// <param name="instanceId">The ID of the orchestration instance to query.</param>
         /// <returns>Returns a task which completes when the status has been fetched.</returns>
-        public static Task<DurableOrchestrationStatus> GetStatusAsync(this IDurableOrchestrationClient client,  string instanceId)
+        public static Task<DurableOrchestrationStatus> GetStatusAsync(this IDurableOrchestrationClient client, string instanceId)
         {
             return client.GetStatusAsync(instanceId, showHistory: false);
         }
@@ -453,7 +472,7 @@ namespace Microsoft.Azure.WebJobs
         /// <param name="instanceId">The ID of the orchestration instance to query.</param>
         /// <param name="showHistory">Boolean marker for including execution history in the response.</param>
         /// <returns>Returns a task which completes when the status has been fetched.</returns>
-        public static Task<DurableOrchestrationStatus> GetStatusAsync(this IDurableOrchestrationClient client,  string instanceId, bool showHistory)
+        public static Task<DurableOrchestrationStatus> GetStatusAsync(this IDurableOrchestrationClient client, string instanceId, bool showHistory)
         {
             return client.GetStatusAsync(instanceId, showHistory, showHistoryOutput: false, showInput: true);
         }

--- a/src/WebJobs.Extensions.DurableTask/ContextInterfaces/IDurableOrchestrationClient.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextInterfaces/IDurableOrchestrationClient.cs
@@ -117,12 +117,13 @@ namespace Microsoft.Azure.WebJobs
         /// <param name="orchestratorFunctionName">The name of the orchestrator function to start.</param>
         /// <param name="instanceId">The ID to use for the new orchestration instance.</param>
         /// <param name="input">JSON-serializeable input value for the orchestrator function.</param>
+        /// <typeparam name="T">The type of the input value for the orchestrator function.</typeparam>
         /// <returns>A task that completes when the orchestration is started. The task contains the instance id of the started
         /// orchestratation instance.</returns>
         /// <exception cref="ArgumentException">
         /// The specified function does not exist, is disabled, or is not an orchestrator function.
         /// </exception>
-        Task<string> StartNewAsync(string orchestratorFunctionName, string instanceId, object input);
+        Task<string> StartNewAsync<T>(string orchestratorFunctionName, string instanceId, T input);
 
         /// <summary>
         /// Sends an event notification message to a waiting orchestration instance.

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net471.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net471.xml
@@ -65,7 +65,7 @@
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClient.Microsoft#Azure#WebJobs#IDurableOrchestrationClient#WaitForCompletionOrCreateCheckStatusResponseAsync(Microsoft.AspNetCore.Http.HttpRequest,System.String,System.TimeSpan,System.TimeSpan)">
             <inheritdoc />
         </member>
-        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClient.Microsoft#Azure#WebJobs#IDurableOrchestrationClient#StartNewAsync(System.String,System.String,System.Object)">
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClient.Microsoft#Azure#WebJobs#IDurableOrchestrationClient#StartNewAsync``1(System.String,System.String,``0)">
             <inheritdoc />
         </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClient.Microsoft#Azure#WebJobs#IDurableOrchestrationClient#RaiseEventAsync(System.String,System.String,System.Object)">
@@ -526,59 +526,6 @@
             </summary>
             <value>
             The HTTP URL for creating a new orchestration instance and waiting on its completion.
-            </value>
-        </member>
-        <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.HttpManagementPayload">
-            <summary>
-            Data structure containing status, terminate and send external event HTTP endpoints.
-            </summary>
-        </member>
-        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.HttpManagementPayload.Id">
-            <summary>
-            Gets the ID of the orchestration instance.
-            </summary>
-            <value>
-            The ID of the orchestration instance.
-            </value>
-        </member>
-        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.HttpManagementPayload.StatusQueryGetUri">
-            <summary>
-            Gets the HTTP GET status query endpoint URL.
-            </summary>
-            <value>
-            The HTTP URL for fetching the instance status.
-            </value>
-        </member>
-        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.HttpManagementPayload.SendEventPostUri">
-            <summary>
-            Gets the HTTP POST external event sending endpoint URL.
-            </summary>
-            <value>
-            The HTTP URL for posting external event notifications.
-            </value>
-        </member>
-        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.HttpManagementPayload.TerminatePostUri">
-            <summary>
-            Gets the HTTP POST instance termination endpoint.
-            </summary>
-            <value>
-            The HTTP URL for posting instance termination commands.
-            </value>
-        </member>
-        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.HttpManagementPayload.RewindPostUri">
-            <summary>
-            Gets the HTTP POST instance rewind endpoint.
-            </summary>
-            <value>
-            The HTTP URL for rewinding orchestration instances.
-            </value>
-        </member>
-        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.HttpManagementPayload.PurgeHistoryDeleteUri">
-            <summary>
-            Gets the HTTP DELETE purge instance history by instance ID endpoint.
-            </summary>
-            <value>
-            The HTTP URL for purging instance history by instance ID.
             </value>
         </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.IConnectionStringResolver">
@@ -1603,13 +1550,39 @@
             <param name="timeout">Total allowed timeout for output from the durable function. The default value is 10 seconds.</param>
             <returns>An HTTP response which may include a 202 and location header or a 200 with the durable function output in the response body.</returns>
         </member>
-        <member name="M:Microsoft.Azure.WebJobs.DurableContextExtensions.StartNewAsync(Microsoft.Azure.WebJobs.IDurableOrchestrationClient,System.String,System.Object)">
+        <member name="M:Microsoft.Azure.WebJobs.DurableContextExtensions.StartNewAsync(Microsoft.Azure.WebJobs.IDurableOrchestrationClient,System.String,System.String)">
+            <summary>
+            Starts a new execution of the specified orchestrator function.
+            </summary>
+            <param name="client">The client object.</param>
+            <param name="orchestratorFunctionName">The name of the orchestrator function to start.</param>
+            <param name="instanceId">The ID to use for the new orchestration instance.</param>
+            <returns>A task that completes when the orchestration is started. The task contains the instance id of the started
+            orchestratation instance.</returns>
+            <exception cref="T:System.ArgumentException">
+            The specified function does not exist, is disabled, or is not an orchestrator function.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.DurableContextExtensions.StartNewAsync``1(Microsoft.Azure.WebJobs.IDurableOrchestrationClient,System.String,``0)">
             <summary>
             Starts a new execution of the specified orchestrator function.
             </summary>
             <param name="client">The client object.</param>
             <param name="orchestratorFunctionName">The name of the orchestrator function to start.</param>
             <param name="input">JSON-serializeable input value for the orchestrator function.</param>
+            <typeparam name="T">The type of the input value for the orchestrator function.</typeparam>
+            <returns>A task that completes when the orchestration is started. The task contains the instance id of the started
+            orchestratation instance.</returns>
+            <exception cref="T:System.ArgumentException">
+            The specified function does not exist, is disabled, or is not an orchestrator function.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.DurableContextExtensions.StartNewAsync(Microsoft.Azure.WebJobs.IDurableOrchestrationClient,System.String)">
+            <summary>
+            Starts a new execution of the specified orchestrator function.
+            </summary>
+            <param name="client">The client object.</param>
+            <param name="orchestratorFunctionName">The name of the orchestrator function to start.</param>
             <returns>A task that completes when the orchestration is started. The task contains the instance id of the started
             orchestratation instance.</returns>
             <exception cref="T:System.ArgumentException">
@@ -1874,10 +1847,10 @@
         </member>
         <member name="M:Microsoft.Azure.WebJobs.IDurableOrchestrationClient.CreateHttpManagementPayload(System.String)">
             <summary>
-            Creates a <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.HttpManagementPayload"/> object that contains status, terminate and send external event HTTP endpoints.
+            Creates a <see cref="T:Microsoft.Azure.WebJobs.HttpManagementPayload"/> object that contains status, terminate and send external event HTTP endpoints.
             </summary>
             <param name="instanceId">The ID of the orchestration instance to check.</param>
-            <returns>Instance of the <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.HttpManagementPayload"/> class.</returns>
+            <returns>Instance of the <see cref="T:Microsoft.Azure.WebJobs.HttpManagementPayload"/> class.</returns>
         </member>
         <member name="M:Microsoft.Azure.WebJobs.IDurableOrchestrationClient.WaitForCompletionOrCreateCheckStatusResponseAsync(System.Net.Http.HttpRequestMessage,System.String,System.TimeSpan,System.TimeSpan)">
             <summary>
@@ -1913,7 +1886,7 @@
             <param name="retryInterval">The timeout between checks for output from the durable function. The default value is 1 second.</param>
             <returns>An HTTP response which may include a 202 and location header or a 200 with the durable function output in the response body.</returns>
         </member>
-        <member name="M:Microsoft.Azure.WebJobs.IDurableOrchestrationClient.StartNewAsync(System.String,System.String,System.Object)">
+        <member name="M:Microsoft.Azure.WebJobs.IDurableOrchestrationClient.StartNewAsync``1(System.String,System.String,``0)">
             <summary>
             Starts a new instance of the specified orchestrator function.
             </summary>
@@ -1924,6 +1897,7 @@
             <param name="orchestratorFunctionName">The name of the orchestrator function to start.</param>
             <param name="instanceId">The ID to use for the new orchestration instance.</param>
             <param name="input">JSON-serializeable input value for the orchestrator function.</param>
+            <typeparam name="T">The type of the input value for the orchestrator function.</typeparam>
             <returns>A task that completes when the orchestration is started. The task contains the instance id of the started
             orchestratation instance.</returns>
             <exception cref="T:System.ArgumentException">
@@ -2910,6 +2884,59 @@
             Gets the string value of the current <see cref="T:Microsoft.Azure.WebJobs.FunctionName"/> instance.
             </summary>
             <returns>The name and optional version of the current <see cref="T:Microsoft.Azure.WebJobs.FunctionName"/> instance.</returns>
+        </member>
+        <member name="T:Microsoft.Azure.WebJobs.HttpManagementPayload">
+            <summary>
+            Data structure containing status, terminate and send external event HTTP endpoints.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.HttpManagementPayload.Id">
+            <summary>
+            Gets the ID of the orchestration instance.
+            </summary>
+            <value>
+            The ID of the orchestration instance.
+            </value>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.HttpManagementPayload.StatusQueryGetUri">
+            <summary>
+            Gets the HTTP GET status query endpoint URL.
+            </summary>
+            <value>
+            The HTTP URL for fetching the instance status.
+            </value>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.HttpManagementPayload.SendEventPostUri">
+            <summary>
+            Gets the HTTP POST external event sending endpoint URL.
+            </summary>
+            <value>
+            The HTTP URL for posting external event notifications.
+            </value>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.HttpManagementPayload.TerminatePostUri">
+            <summary>
+            Gets the HTTP POST instance termination endpoint.
+            </summary>
+            <value>
+            The HTTP URL for posting instance termination commands.
+            </value>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.HttpManagementPayload.RewindPostUri">
+            <summary>
+            Gets the HTTP POST instance rewind endpoint.
+            </summary>
+            <value>
+            The HTTP URL for rewinding orchestration instances.
+            </value>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.HttpManagementPayload.PurgeHistoryDeleteUri">
+            <summary>
+            Gets the HTTP DELETE purge instance history by instance ID endpoint.
+            </summary>
+            <value>
+            The HTTP URL for purging instance history by instance ID.
+            </value>
         </member>
         <member name="T:Microsoft.Azure.WebJobs.OrchestrationRuntimeStatus">
             <summary>

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-netstandard2.0.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-netstandard2.0.xml
@@ -65,7 +65,7 @@
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClient.Microsoft#Azure#WebJobs#IDurableOrchestrationClient#WaitForCompletionOrCreateCheckStatusResponseAsync(Microsoft.AspNetCore.Http.HttpRequest,System.String,System.TimeSpan,System.TimeSpan)">
             <inheritdoc />
         </member>
-        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClient.Microsoft#Azure#WebJobs#IDurableOrchestrationClient#StartNewAsync(System.String,System.String,System.Object)">
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClient.Microsoft#Azure#WebJobs#IDurableOrchestrationClient#StartNewAsync``1(System.String,System.String,``0)">
             <inheritdoc />
         </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClient.Microsoft#Azure#WebJobs#IDurableOrchestrationClient#RaiseEventAsync(System.String,System.String,System.Object)">
@@ -526,59 +526,6 @@
             </summary>
             <value>
             The HTTP URL for creating a new orchestration instance and waiting on its completion.
-            </value>
-        </member>
-        <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.HttpManagementPayload">
-            <summary>
-            Data structure containing status, terminate and send external event HTTP endpoints.
-            </summary>
-        </member>
-        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.HttpManagementPayload.Id">
-            <summary>
-            Gets the ID of the orchestration instance.
-            </summary>
-            <value>
-            The ID of the orchestration instance.
-            </value>
-        </member>
-        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.HttpManagementPayload.StatusQueryGetUri">
-            <summary>
-            Gets the HTTP GET status query endpoint URL.
-            </summary>
-            <value>
-            The HTTP URL for fetching the instance status.
-            </value>
-        </member>
-        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.HttpManagementPayload.SendEventPostUri">
-            <summary>
-            Gets the HTTP POST external event sending endpoint URL.
-            </summary>
-            <value>
-            The HTTP URL for posting external event notifications.
-            </value>
-        </member>
-        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.HttpManagementPayload.TerminatePostUri">
-            <summary>
-            Gets the HTTP POST instance termination endpoint.
-            </summary>
-            <value>
-            The HTTP URL for posting instance termination commands.
-            </value>
-        </member>
-        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.HttpManagementPayload.RewindPostUri">
-            <summary>
-            Gets the HTTP POST instance rewind endpoint.
-            </summary>
-            <value>
-            The HTTP URL for rewinding orchestration instances.
-            </value>
-        </member>
-        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.HttpManagementPayload.PurgeHistoryDeleteUri">
-            <summary>
-            Gets the HTTP DELETE purge instance history by instance ID endpoint.
-            </summary>
-            <value>
-            The HTTP URL for purging instance history by instance ID.
             </value>
         </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.IConnectionStringResolver">
@@ -1642,13 +1589,39 @@
             <param name="timeout">Total allowed timeout for output from the durable function. The default value is 10 seconds.</param>
             <returns>An HTTP response which may include a 202 and location header or a 200 with the durable function output in the response body.</returns>
         </member>
-        <member name="M:Microsoft.Azure.WebJobs.DurableContextExtensions.StartNewAsync(Microsoft.Azure.WebJobs.IDurableOrchestrationClient,System.String,System.Object)">
+        <member name="M:Microsoft.Azure.WebJobs.DurableContextExtensions.StartNewAsync(Microsoft.Azure.WebJobs.IDurableOrchestrationClient,System.String,System.String)">
+            <summary>
+            Starts a new execution of the specified orchestrator function.
+            </summary>
+            <param name="client">The client object.</param>
+            <param name="orchestratorFunctionName">The name of the orchestrator function to start.</param>
+            <param name="instanceId">The ID to use for the new orchestration instance.</param>
+            <returns>A task that completes when the orchestration is started. The task contains the instance id of the started
+            orchestratation instance.</returns>
+            <exception cref="T:System.ArgumentException">
+            The specified function does not exist, is disabled, or is not an orchestrator function.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.DurableContextExtensions.StartNewAsync``1(Microsoft.Azure.WebJobs.IDurableOrchestrationClient,System.String,``0)">
             <summary>
             Starts a new execution of the specified orchestrator function.
             </summary>
             <param name="client">The client object.</param>
             <param name="orchestratorFunctionName">The name of the orchestrator function to start.</param>
             <param name="input">JSON-serializeable input value for the orchestrator function.</param>
+            <typeparam name="T">The type of the input value for the orchestrator function.</typeparam>
+            <returns>A task that completes when the orchestration is started. The task contains the instance id of the started
+            orchestratation instance.</returns>
+            <exception cref="T:System.ArgumentException">
+            The specified function does not exist, is disabled, or is not an orchestrator function.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.DurableContextExtensions.StartNewAsync(Microsoft.Azure.WebJobs.IDurableOrchestrationClient,System.String)">
+            <summary>
+            Starts a new execution of the specified orchestrator function.
+            </summary>
+            <param name="client">The client object.</param>
+            <param name="orchestratorFunctionName">The name of the orchestrator function to start.</param>
             <returns>A task that completes when the orchestration is started. The task contains the instance id of the started
             orchestratation instance.</returns>
             <exception cref="T:System.ArgumentException">
@@ -1918,10 +1891,10 @@
         </member>
         <member name="M:Microsoft.Azure.WebJobs.IDurableOrchestrationClient.CreateHttpManagementPayload(System.String)">
             <summary>
-            Creates a <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.HttpManagementPayload"/> object that contains status, terminate and send external event HTTP endpoints.
+            Creates a <see cref="T:Microsoft.Azure.WebJobs.HttpManagementPayload"/> object that contains status, terminate and send external event HTTP endpoints.
             </summary>
             <param name="instanceId">The ID of the orchestration instance to check.</param>
-            <returns>Instance of the <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.HttpManagementPayload"/> class.</returns>
+            <returns>Instance of the <see cref="T:Microsoft.Azure.WebJobs.HttpManagementPayload"/> class.</returns>
         </member>
         <member name="M:Microsoft.Azure.WebJobs.IDurableOrchestrationClient.WaitForCompletionOrCreateCheckStatusResponseAsync(System.Net.Http.HttpRequestMessage,System.String,System.TimeSpan,System.TimeSpan)">
             <summary>
@@ -1957,7 +1930,7 @@
             <param name="retryInterval">The timeout between checks for output from the durable function. The default value is 1 second.</param>
             <returns>An HTTP response which may include a 202 and location header or a 200 with the durable function output in the response body.</returns>
         </member>
-        <member name="M:Microsoft.Azure.WebJobs.IDurableOrchestrationClient.StartNewAsync(System.String,System.String,System.Object)">
+        <member name="M:Microsoft.Azure.WebJobs.IDurableOrchestrationClient.StartNewAsync``1(System.String,System.String,``0)">
             <summary>
             Starts a new instance of the specified orchestrator function.
             </summary>
@@ -1968,6 +1941,7 @@
             <param name="orchestratorFunctionName">The name of the orchestrator function to start.</param>
             <param name="instanceId">The ID to use for the new orchestration instance.</param>
             <param name="input">JSON-serializeable input value for the orchestrator function.</param>
+            <typeparam name="T">The type of the input value for the orchestrator function.</typeparam>
             <returns>A task that completes when the orchestration is started. The task contains the instance id of the started
             orchestratation instance.</returns>
             <exception cref="T:System.ArgumentException">
@@ -2954,6 +2928,59 @@
             Gets the string value of the current <see cref="T:Microsoft.Azure.WebJobs.FunctionName"/> instance.
             </summary>
             <returns>The name and optional version of the current <see cref="T:Microsoft.Azure.WebJobs.FunctionName"/> instance.</returns>
+        </member>
+        <member name="T:Microsoft.Azure.WebJobs.HttpManagementPayload">
+            <summary>
+            Data structure containing status, terminate and send external event HTTP endpoints.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.HttpManagementPayload.Id">
+            <summary>
+            Gets the ID of the orchestration instance.
+            </summary>
+            <value>
+            The ID of the orchestration instance.
+            </value>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.HttpManagementPayload.StatusQueryGetUri">
+            <summary>
+            Gets the HTTP GET status query endpoint URL.
+            </summary>
+            <value>
+            The HTTP URL for fetching the instance status.
+            </value>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.HttpManagementPayload.SendEventPostUri">
+            <summary>
+            Gets the HTTP POST external event sending endpoint URL.
+            </summary>
+            <value>
+            The HTTP URL for posting external event notifications.
+            </value>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.HttpManagementPayload.TerminatePostUri">
+            <summary>
+            Gets the HTTP POST instance termination endpoint.
+            </summary>
+            <value>
+            The HTTP URL for posting instance termination commands.
+            </value>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.HttpManagementPayload.RewindPostUri">
+            <summary>
+            Gets the HTTP POST instance rewind endpoint.
+            </summary>
+            <value>
+            The HTTP URL for rewinding orchestration instances.
+            </value>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.HttpManagementPayload.PurgeHistoryDeleteUri">
+            <summary>
+            Gets the HTTP DELETE purge instance history by instance ID endpoint.
+            </summary>
+            <value>
+            The HTTP URL for purging instance history by instance ID.
+            </value>
         </member>
         <member name="T:Microsoft.Azure.WebJobs.OrchestrationRuntimeStatus">
             <summary>

--- a/test/Common/DurableClientBaseTests.cs
+++ b/test/Common/DurableClientBaseTests.cs
@@ -37,6 +37,22 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             result.Should().Be(instanceId);
         }
 
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public async Task StartNewAsync_is_calling_overload_method_with_specific_instance_id()
+        {
+            var instanceId = "testInstance";
+            const string functionName = "sampleFunction";
+            var durableOrchestrationClientBaseMock = new Mock<IDurableOrchestrationClient> { CallBase = true };
+            durableOrchestrationClientBaseMock.Setup(x => x.StartNewAsync<object>(functionName, instanceId, null)).ReturnsAsync(instanceId);
+
+            var result = await durableOrchestrationClientBaseMock.Object.StartNewAsync(functionName, instanceId);
+            result.Should().Be(instanceId);
+
+            result = await durableOrchestrationClientBaseMock.Object.StartNewAsync<object>(functionName, instanceId, null);
+            result.Should().Be(instanceId);
+        }
+
         [Theory]
         [Trait("Category", PlatformSpecificHelpers.TestCategory)]
         [InlineData("")]

--- a/test/Common/DurableClientBaseTests.cs
+++ b/test/Common/DurableClientBaseTests.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
 using DurableTask.Core;
@@ -15,10 +14,8 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.WebJobs.Extensions.DurableTask.Options;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Microsoft.Extensions.Primitives;
 using Moq;
 using Xunit;
-using static Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests.HttpApiHandlerTests;
 
 namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 {
@@ -31,9 +28,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             var instanceId = Guid.NewGuid().ToString();
             const string functionName = "sampleFunction";
             var durableOrchestrationClientBaseMock = new Mock<IDurableOrchestrationClient> { CallBase = true };
-            durableOrchestrationClientBaseMock.Setup(x => x.StartNewAsync(functionName, string.Empty, null)).ReturnsAsync(instanceId);
+            durableOrchestrationClientBaseMock.Setup(x => x.StartNewAsync<object>(functionName, string.Empty, null)).ReturnsAsync(instanceId);
 
-            var result = await durableOrchestrationClientBaseMock.Object.StartNewAsync(functionName, null);
+            var result = await durableOrchestrationClientBaseMock.Object.StartNewAsync(functionName);
+            result.Should().Be(instanceId);
+
+            result = await durableOrchestrationClientBaseMock.Object.StartNewAsync<object>(functionName, null);
             result.Should().Be(instanceId);
         }
 


### PR DESCRIPTION
@cgillum Here's my attempt at a PR to alleviate the issue that others and I have ran in to while using the `StartNewAsync` call in Durable Functions.

Problem:
The following code:
```csharp
var instanceId = await client.StartNewAsync(@"MyOrchestrator", "thisInstanceId");
Debug.Assert(instanceId == @"thisInstanceId");
```

Will throw the assertion. This is because if a user wishes to specify the instanceId for a new orchestration they _must_ give some form of input - `null` or otherwise. While intellisense is the way one would realize what they're doing wrong, it's only after they attempt this and end up getting back an instanceId value other than the one they specified that they realize something's gone awry due to the fact that `string : object` so the `StartNewAsync(string, object)` overload gets hit and executed.

By using generics we can not only prevent this runtime confusion, but also enable an even simpler scenario: `StartNewAsync(@"MyOrchestrator")` which is an added benefit.

Hopefully you find this idea/PR valuable. Thanks! You'll notice I have the target for it as the `v2` branch due to its breaking nature.