### PR TITLE
Added Option to Configure Behavior When Starting a New Orchestrator With an Existing Instance Id

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableClient.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableClient.cs
@@ -121,7 +121,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 throw new ArgumentException($"Instance ID lengths must not exceed {MaxInstanceIdLength} characters.");
             }
 
-            this.GetStatusesNotToOverride(out OrchestrationStatus[] dedupeStatuses);
+            var dedupeStatuses = this.GetStatusesNotToOverride();
             Task<OrchestrationInstance> createTask = this.client.CreateOrchestrationInstanceAsync(
                 orchestratorFunctionName, DefaultVersion, instanceId, input, null, dedupeStatuses);
 
@@ -137,12 +137,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             return instance.InstanceId;
         }
 
-        private void GetStatusesNotToOverride(out OrchestrationStatus[] dedupeStatuses)
+        private OrchestrationStatus[] GetStatusesNotToOverride()
         {
             var overridableStates = this.config.Options.OverridableExistingInstanceStates;
             if (overridableStates == OverridableStates.NonRunningStates)
             {
-                dedupeStatuses = new OrchestrationStatus[]
+                return new OrchestrationStatus[]
                 {
                     OrchestrationStatus.Running,
                     OrchestrationStatus.ContinuedAsNew,
@@ -150,7 +150,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 };
             }
 
-            dedupeStatuses = null;
+            return new OrchestrationStatus[0];
         }
 
         private static bool IsInvalidCharacter(char c)

--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableClient.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableClient.cs
@@ -121,7 +121,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 throw new ArgumentException($"Instance ID lengths must not exceed {MaxInstanceIdLength} characters.");
             }
 
-            this.TryGetStatusesNotToOverride(out OrchestrationStatus[] dedupeStatuses);
+            this.GetStatusesNotToOverride(out OrchestrationStatus[] dedupeStatuses);
             Task<OrchestrationInstance> createTask = this.client.CreateOrchestrationInstanceAsync(
                 orchestratorFunctionName, DefaultVersion, instanceId, input, null, dedupeStatuses);
 
@@ -137,17 +137,20 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             return instance.InstanceId;
         }
 
-        private bool TryGetStatusesNotToOverride(out OrchestrationStatus[] dedupeStatuses)
+        private void GetStatusesNotToOverride(out OrchestrationStatus[] dedupeStatuses)
         {
             var overridableStates = this.config.Options.OverridableExistingInstanceStates;
-            if (overridableStates == OverridableStates.IfTerminatedFailedOrCompleted)
+            if (overridableStates == OverridableStates.NonRunningStates)
             {
-                dedupeStatuses = new OrchestrationStatus[] { OrchestrationStatus.Running, OrchestrationStatus.ContinuedAsNew, OrchestrationStatus.Canceled, OrchestrationStatus.Pending };
-                return true;
+                dedupeStatuses = new OrchestrationStatus[]
+                {
+                    OrchestrationStatus.Running,
+                    OrchestrationStatus.ContinuedAsNew,
+                    OrchestrationStatus.Pending,
+                };
             }
 
             dedupeStatuses = null;
-            return false;
         }
 
         private static bool IsInvalidCharacter(char c)

--- a/src/WebJobs.Extensions.DurableTask/Options/DurableTaskOptions.cs
+++ b/src/WebJobs.Extensions.DurableTask/Options/DurableTaskOptions.cs
@@ -131,7 +131,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// <summary>
         ///  States that will override an existing orchestrator when attempting to start a new orchestrator with the same instance Id.
         /// </summary>
-        public OverridableStates OverridableExistingInstanceStates { get; set; } = OverridableStates.AnyState;
+        public OverridableStates OverridableExistingInstanceStates { get; set; } = OverridableStates.NonRunningStates;
 
         /// <summary>
         /// Gets or sets the time window within which entity messages get deduplicated and reordered.

--- a/src/WebJobs.Extensions.DurableTask/Options/DurableTaskOptions.cs
+++ b/src/WebJobs.Extensions.DurableTask/Options/DurableTaskOptions.cs
@@ -129,6 +129,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         public int ExtendedSessionIdleTimeoutInSeconds { get; set; } = 30;
 
         /// <summary>
+        ///  States that will override an existing orchestrator when attempting to start a new orchestrator with the same instance Id.
+        /// </summary>
+        public OverridableStates OverridableExistingInstanceStates { get; set; } = OverridableStates.AnyState;
+
+        /// <summary>
         /// Gets or sets the time window within which entity messages get deduplicated and reordered.
         /// </summary>
         public int EntityMessageReorderWindowInMinutes { get; set; } = 30;

--- a/src/WebJobs.Extensions.DurableTask/OverridableStates.cs
+++ b/src/WebJobs.Extensions.DurableTask/OverridableStates.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Microsoft.Azure.WebJobs
+{
+    /// <summary>
+    /// Represents options for different states that an existing orchestrator can be in to be able to be overwritten by
+    /// an attempt to start a new instance with the same instance Id.
+    /// </summary>
+    public enum OverridableStates
+    {
+        /// <summary>
+        /// Option to start a new orchestrator instance with an existing instnace Id when the existing
+        /// instance is in any state.
+        /// </summary>
+        AnyState,
+
+        /// <summary>
+        /// Option to only start a new orchestrator instance with an existing instance Id when the existing
+        /// instance is in a termincated, failed, or completed state.
+        /// </summary>
+        IfTerminatedFailedOrCompleted,
+    }
+}

--- a/src/WebJobs.Extensions.DurableTask/OverridableStates.cs
+++ b/src/WebJobs.Extensions.DurableTask/OverridableStates.cs
@@ -17,8 +17,8 @@ namespace Microsoft.Azure.WebJobs
 
         /// <summary>
         /// Option to only start a new orchestrator instance with an existing instance Id when the existing
-        /// instance is in a termincated, failed, or completed state.
+        /// instance is in a terminated, failed, or completed state.
         /// </summary>
-        IfTerminatedFailedOrCompleted,
+        NonRunningStates,
     }
 }


### PR DESCRIPTION
Added the ability to configure which states you would like to override an existing orchestrator with the same instanceId.

fixes #367 