### PR TITLE
Support for scheduled signals

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableClient.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableClient.cs
@@ -278,7 +278,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             }
 
             var jrequest = JToken.FromObject(request, MessagePayloadDataConverter.DefaultSerializer);
-            await client.RaiseEventAsync(instance, scheduledTimeUtc.HasValue ? $"op@{scheduledTimeUtc.Value:o}" : "op", jrequest);
+            var eventName = scheduledTimeUtc.HasValue ? EntityMessageEventNames.ScheduledRequestMessageEventName(scheduledTimeUtc.Value) : EntityMessageEventNames.RequestMessageEventName;
+            await client.RaiseEventAsync(instance, eventName, jrequest);
 
             this.traceHelper.FunctionScheduled(
                 hubName,

--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableClient.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableClient.cs
@@ -207,7 +207,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         {
             if (string.IsNullOrEmpty(taskHubName))
             {
-                return this.SignalEntityAsync(this.client, this.TaskHubName, entityId, operationName, operationInput);
+                return this.SignalEntityAsyncInternal(this.client, this.TaskHubName, entityId, null, operationName, operationInput);
             }
             else
             {
@@ -223,11 +223,36 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 };
 
                 TaskHubClient taskHubClient = ((DurableClient)this.config.GetClient(attribute)).client;
-                return this.SignalEntityAsync(taskHubClient, taskHubName, entityId, operationName, operationInput);
+                return this.SignalEntityAsyncInternal(taskHubClient, taskHubName, entityId, null, operationName, operationInput);
             }
         }
 
-        private async Task SignalEntityAsync(TaskHubClient client, string hubName, EntityId entityId, string operationName, object operationInput)
+        /// <inheritdoc />
+        Task IDurableEntityClient.SignalEntityAsync(EntityId entityId, DateTime scheduledTimeUtc, string operationName, object operationInput, string taskHubName, string connectionName)
+        {
+            if (string.IsNullOrEmpty(taskHubName))
+            {
+                return this.SignalEntityAsyncInternal(this.client, this.TaskHubName, entityId, scheduledTimeUtc, operationName, operationInput);
+            }
+            else
+            {
+                if (string.IsNullOrEmpty(connectionName))
+                {
+                    connectionName = this.attribute.ConnectionName;
+                }
+
+                var attribute = new DurableClientAttribute
+                {
+                    TaskHub = taskHubName,
+                    ConnectionName = connectionName,
+                };
+
+                TaskHubClient taskHubClient = ((DurableClient)this.config.GetClient(attribute)).client;
+                return this.SignalEntityAsyncInternal(taskHubClient, taskHubName, entityId, scheduledTimeUtc, operationName, operationInput);
+            }
+        }
+
+        private async Task SignalEntityAsyncInternal(TaskHubClient client, string hubName, EntityId entityId, DateTime? scheduledTimeUtc, string operationName, object operationInput)
         {
             if (operationName == null)
             {
@@ -245,6 +270,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 Id = guid,
                 IsSignal = true,
                 Operation = operationName,
+                ScheduledTime = scheduledTimeUtc,
             };
             if (operationInput != null)
             {
@@ -252,7 +278,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             }
 
             var jrequest = JToken.FromObject(request, MessagePayloadDataConverter.DefaultSerializer);
-            await client.RaiseEventAsync(instance, "op", jrequest);
+            await client.RaiseEventAsync(instance, scheduledTimeUtc.HasValue ? $"op@{scheduledTimeUtc.Value:o}" : "op", jrequest);
 
             this.traceHelper.FunctionScheduled(
                 hubName,

--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableEntityContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableEntityContext.cs
@@ -399,13 +399,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
                 if (requestMessage.ScheduledTime.HasValue)
                 {
-                    eventName = $"op@{requestMessage.ScheduledTime.Value:o}";
+                    eventName = EntityMessageEventNames.ScheduledRequestMessageEventName(requestMessage.ScheduledTime.Value);
                 }
                 else
                 {
                     this.State.MessageSorter.LabelOutgoingMessage(requestMessage, target.InstanceId, DateTime.UtcNow, this.EntityMessageReorderWindow);
-
-                    eventName = "op";
+                    eventName = EntityMessageEventNames.RequestMessageEventName;
                 }
 
                 this.outbox.Add(new OperationMessage()
@@ -429,7 +428,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 this.outbox.Add(new ResultMessage()
                 {
                     Target = target,
-                    EventName = requestId.ToString(),
+                    EventName = EntityMessageEventNames.ResponseMessageEventName(requestId),
                     EventContent = message,
                     IsError = isException,
                 });
@@ -443,7 +442,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 this.outbox.Add(new LockMessage()
                 {
                     Target = target,
-                    EventName = "op",
+                    EventName = EntityMessageEventNames.RequestMessageEventName,
                     EventContent = message,
                 });
             }
@@ -456,7 +455,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 this.outbox.Add(new LockMessage()
                 {
                     Target = target,
-                    EventName = requestId.ToString(),
+                    EventName = EntityMessageEventNames.ResponseMessageEventName(requestId),
                     EventContent = new ResponseMessage()
                     {
                         Result = "Lock Acquisition Completed", // ignored by receiver but shows up in traces

--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableOrchestrationContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableOrchestrationContext.cs
@@ -206,7 +206,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// <inheritdoc />
         Task<TResult> IDurableOrchestrationContext.CallSubOrchestratorAsync<TResult>(string functionName, string instanceId, object input)
         {
-            return this.CallDurableTaskFunctionAsync<TResult>(functionName, FunctionType.Orchestrator, false, instanceId, null, null, input);
+            return this.CallDurableTaskFunctionAsync<TResult>(functionName, FunctionType.Orchestrator, false, instanceId, null, null, input, null);
         }
 
         /// <inheritdoc />
@@ -217,7 +217,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 throw new ArgumentNullException(nameof(retryOptions));
             }
 
-            return this.CallDurableTaskFunctionAsync<TResult>(functionName, FunctionType.Orchestrator, false, instanceId, null, retryOptions, input);
+            return this.CallDurableTaskFunctionAsync<TResult>(functionName, FunctionType.Orchestrator, false, instanceId, null, retryOptions, input, null);
         }
 
         Task<DurableHttpResponse> IDurableOrchestrationContext.CallHttpAsync(HttpMethod method, Uri uri, string content)
@@ -268,7 +268,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 instanceId: null,
                 operation: null,
                 retryOptions: null,
-                input: req);
+                input: req,
+                scheduledTimeUtc: null);
 
             return durableHttpResponse;
         }
@@ -344,7 +345,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// <inheritdoc />
         Task<TResult> IDurableOrchestrationContext.CallActivityAsync<TResult>(string functionName, object input)
         {
-            return this.CallDurableTaskFunctionAsync<TResult>(functionName, FunctionType.Activity, false, null, null, null, input);
+            return this.CallDurableTaskFunctionAsync<TResult>(functionName, FunctionType.Activity, false, null, null, null, input, null);
         }
 
         /// <inheritdoc />
@@ -355,7 +356,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 throw new ArgumentNullException(nameof(retryOptions));
             }
 
-            return this.CallDurableTaskFunctionAsync<TResult>(functionName, FunctionType.Activity, false, null, null, retryOptions, input);
+            return this.CallDurableTaskFunctionAsync<TResult>(functionName, FunctionType.Activity, false, null, null, retryOptions, input, null);
         }
 
         /// <inheritdoc/>
@@ -380,8 +381,22 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 throw new ArgumentNullException(nameof(operationName));
             }
 
-            var alreadyCompletedTask = this.CallDurableTaskFunctionAsync<object>(entity.EntityName, FunctionType.Entity, true, EntityId.GetSchedulerIdFromEntityId(entity), operationName, null, operationInput);
+            var alreadyCompletedTask = this.CallDurableTaskFunctionAsync<object>(entity.EntityName, FunctionType.Entity, true, EntityId.GetSchedulerIdFromEntityId(entity), operationName, null, operationInput, null);
             System.Diagnostics.Debug.Assert(alreadyCompletedTask.IsCompleted, "signaling entities is synchronous");
+            alreadyCompletedTask.Wait(); // just so we see exceptions during testing
+        }
+
+        /// <inheritdoc/>
+        void IDurableOrchestrationContext.SignalEntity(EntityId entity, DateTime startTime, string operationName, object operationInput)
+        {
+            this.ThrowIfInvalidAccess();
+            if (operationName == null)
+            {
+                throw new ArgumentNullException(nameof(operationName));
+            }
+
+            var alreadyCompletedTask = this.CallDurableTaskFunctionAsync<object>(entity.EntityName, FunctionType.Entity, true, EntityId.GetSchedulerIdFromEntityId(entity), operationName, null, operationInput, startTime);
+            System.Diagnostics.Debug.Assert(alreadyCompletedTask.IsCompleted, "scheduling operations on entities is synchronous");
             alreadyCompletedTask.Wait(); // just so we see exceptions during testing
         }
 
@@ -390,7 +405,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         {
             this.ThrowIfInvalidAccess();
             var actualInstanceId = string.IsNullOrEmpty(instanceId) ? this.NewGuid().ToString() : instanceId;
-            var alreadyCompletedTask = this.CallDurableTaskFunctionAsync<string>(functionName, FunctionType.Orchestrator, true, actualInstanceId, null, null, input);
+            var alreadyCompletedTask = this.CallDurableTaskFunctionAsync<string>(functionName, FunctionType.Orchestrator, true, actualInstanceId, null, null, input, null);
             System.Diagnostics.Debug.Assert(alreadyCompletedTask.IsCompleted, "starting orchestrations is synchronous");
             return actualInstanceId;
         }
@@ -402,7 +417,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             string instanceId,
             string operation,
             RetryOptions retryOptions,
-            object input)
+            object input,
+            DateTime? scheduledTimeUtc)
         {
             this.ThrowIfInvalidAccess();
 
@@ -543,13 +559,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                         Id = guid,
                         IsSignal = oneWay,
                         Operation = operation,
+                        ScheduledTime = scheduledTimeUtc,
                     };
                     if (input != null)
                     {
                         request.SetInput(input);
                     }
 
-                    this.SendEntityMessage(target, "op", request);
+                    this.SendEntityMessage(target, request);
 
                     if (!oneWay)
                     {
@@ -904,14 +921,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         Task<TResult> IDurableOrchestrationContext.CallEntityAsync<TResult>(EntityId entityId, string operationName, object operationInput)
         {
             this.ThrowIfInvalidAccess();
-            return this.CallDurableTaskFunctionAsync<TResult>(entityId.EntityName, FunctionType.Entity, false, EntityId.GetSchedulerIdFromEntityId(entityId), operationName, null, operationInput);
+            return this.CallDurableTaskFunctionAsync<TResult>(entityId.EntityName, FunctionType.Entity, false, EntityId.GetSchedulerIdFromEntityId(entityId), operationName, null, operationInput, null);
         }
 
         /// <inheritdoc/>
         Task IDurableOrchestrationContext.CallEntityAsync(EntityId entityId, string operationName, object operationInput)
         {
             this.ThrowIfInvalidAccess();
-            return this.CallDurableTaskFunctionAsync<object>(entityId.EntityName, FunctionType.Entity, false, EntityId.GetSchedulerIdFromEntityId(entityId), operationName, null, operationInput);
+            return this.CallDurableTaskFunctionAsync<object>(entityId.EntityName, FunctionType.Entity, false, EntityId.GetSchedulerIdFromEntityId(entityId), operationName, null, operationInput, null);
         }
 
         /// <inheritdoc/>
@@ -961,7 +978,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
             this.LockRequestId = lockRequestId.ToString();
 
-            this.SendEntityMessage(target, "op", request);
+            this.SendEntityMessage(target, request);
 
             // wait for the response from the last entity in the lock set
             await this.WaitForExternalEvent<ResponseMessage>(this.LockRequestId, "LockAcquisitionCompleted");
@@ -986,7 +1003,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                         ParentInstanceId = this.InstanceId,
                         LockRequestId = this.LockRequestId,
                     };
-                    this.SendEntityMessage(instance, "release", message);
+                    this.SendEntityMessage(instance, message);
                 }
 
                 this.ContextLocks = null;
@@ -1009,25 +1026,40 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             }
         }
 
-        internal void SendEntityMessage(OrchestrationInstance target, string eventName, object eventContent)
+        internal void SendEntityMessage(OrchestrationInstance target, object eventContent)
         {
+            string eventName;
+
             if (eventContent is RequestMessage requestMessage)
             {
-                this.MessageSorter.LabelOutgoingMessage(
-                    requestMessage,
-                    target.InstanceId,
-                    this.InnerContext.CurrentUtcDateTime,
-                    TimeSpan.FromMinutes(this.Config.Options.EntityMessageReorderWindowInMinutes));
+                if (requestMessage.ScheduledTime.HasValue)
+                {
+                    eventName = $"op@{requestMessage.ScheduledTime.Value:o}";
+                }
+                else
+                {
+                    this.MessageSorter.LabelOutgoingMessage(
+                        requestMessage,
+                        target.InstanceId,
+                        this.InnerContext.CurrentUtcDateTime,
+                        TimeSpan.FromMinutes(this.Config.Options.EntityMessageReorderWindowInMinutes));
+
+                    eventName = "op";
+                }
+            }
+            else
+            {
+                eventName = "release";
             }
 
             if (!this.IsReplaying)
             {
                 this.Config.TraceHelper.SendingEntityMessage(
-                    this.InstanceId,
-                    this.ExecutionId,
-                    target.InstanceId,
-                    eventName,
-                    eventContent);
+                this.InstanceId,
+                this.ExecutionId,
+                target.InstanceId,
+                eventName,
+                eventContent);
             }
 
             this.IncrementActionsOrThrowException();

--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableOrchestrationContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableOrchestrationContext.cs
@@ -1034,7 +1034,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             {
                 if (requestMessage.ScheduledTime.HasValue)
                 {
-                    eventName = $"op@{requestMessage.ScheduledTime.Value:o}";
+                    eventName = EntityMessageEventNames.ScheduledRequestMessageEventName(requestMessage.ScheduledTime.Value);
                 }
                 else
                 {
@@ -1044,22 +1044,22 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                         this.InnerContext.CurrentUtcDateTime,
                         TimeSpan.FromMinutes(this.Config.Options.EntityMessageReorderWindowInMinutes));
 
-                    eventName = "op";
+                    eventName = EntityMessageEventNames.RequestMessageEventName;
                 }
             }
             else
             {
-                eventName = "release";
+                eventName = EntityMessageEventNames.ReleaseMessageEventName;
             }
 
             if (!this.IsReplaying)
             {
                 this.Config.TraceHelper.SendingEntityMessage(
-                this.InstanceId,
-                this.ExecutionId,
-                target.InstanceId,
-                eventName,
-                eventContent);
+                    this.InstanceId,
+                    this.ExecutionId,
+                    target.InstanceId,
+                    eventName,
+                    eventContent);
             }
 
             this.IncrementActionsOrThrowException();

--- a/src/WebJobs.Extensions.DurableTask/ContextInterfaces/IDurableEntityClient.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextInterfaces/IDurableEntityClient.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System;
 using System.Threading.Tasks;
 
 namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
@@ -28,6 +29,18 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// <param name="connectionName">The name of the connection string associated with <paramref name="taskHubName"/>.</param>
         /// <returns>A task that completes when the message has been reliably enqueued.</returns>
         Task SignalEntityAsync(EntityId entityId, string operationName, object operationInput = null, string taskHubName = null, string connectionName = null);
+
+        /// <summary>
+        /// Signals an entity to perform an operation, at a specified time.
+        /// </summary>
+        /// <param name="entityId">The target entity.</param>
+        /// <param name="scheduledTimeUtc">The time at which to start the operation.</param>
+        /// <param name="operationName">The name of the operation.</param>
+        /// <param name="operationInput">The input for the operation.</param>
+        /// <param name="taskHubName">The TaskHubName of the target entity.</param>
+        /// <param name="connectionName">The name of the connection string associated with <paramref name="taskHubName"/>.</param>
+        /// <returns>A task that completes when the message has been reliably enqueued.</returns>
+        Task SignalEntityAsync(EntityId entityId, DateTime scheduledTimeUtc, string operationName, object operationInput = null, string taskHubName = null, string connectionName = null);
 
         /// <summary>
         /// Tries to read the current state of an entity. Returns default(<typeparamref name="T"/>) if the entity does not

--- a/src/WebJobs.Extensions.DurableTask/ContextInterfaces/IDurableEntityContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextInterfaces/IDurableEntityContext.cs
@@ -105,6 +105,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         void SignalEntity(EntityId entity, string operationName, object operationInput = null);
 
         /// <summary>
+        /// Signals an entity to perform an operation, at a specified time. Any result or exception is ignored (fire and forget).
+        /// </summary>
+        /// <param name="entity">The target entity.</param>
+        /// <param name="scheduledTimeUtc">The time at which to start the operation.</param>
+        /// <param name="operationName">The name of the operation.</param>
+        /// <param name="operationInput">The input for the operation.</param>
+        void SignalEntity(EntityId entity, DateTime scheduledTimeUtc, string operationName, object operationInput = null);
+
+        /// <summary>
         /// Schedules a orchestration function named <paramref name="functionName"/> for execution./>.
         /// Any result or exception is ignored (fire and forget).
         /// </summary>

--- a/src/WebJobs.Extensions.DurableTask/ContextInterfaces/IDurableOrchestrationContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextInterfaces/IDurableOrchestrationContext.cs
@@ -327,6 +327,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         void SignalEntity(EntityId entity, string operationName, object operationInput = null);
 
         /// <summary>
+        /// Signals an operation to be performed by an entity at a specified time. Any result or exception is ignored (fire and forget).
+        /// </summary>
+        /// <param name="entity">The target entity.</param>
+        /// <param name="scheduledTimeUtc">The time at which to start the operation.</param>
+        /// <param name="operationName">The name of the operation.</param>
+        /// <param name="operationInput">The input for the operation.</param>
+        void SignalEntity(EntityId entity, DateTime scheduledTimeUtc, string operationName, object operationInput = null);
+
+        /// <summary>
         /// Schedules a orchestration function named <paramref name="functionName"/> for execution./>.
         /// Any result or exception is ignored (fire and forget).
         /// </summary>

--- a/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
@@ -467,7 +467,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
                             entityShim.NumberEventsToReceive++;
 
-                            if (eventRaisedEvent.Name.StartsWith("op"))
+                            if (EntityMessageEventNames.IsRequestMessage(eventRaisedEvent.Name))
                             {
                                 // we are receiving an operation request or a lock request
                                 var requestMessage = JsonConvert.DeserializeObject<RequestMessage>(eventRaisedEvent.Input);

--- a/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
 using System.Reflection;
@@ -466,13 +467,23 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
                             entityShim.NumberEventsToReceive++;
 
-                            if (eventRaisedEvent.Name == "op")
+                            if (eventRaisedEvent.Name.StartsWith("op"))
                             {
                                 // we are receiving an operation request or a lock request
                                 var requestMessage = JsonConvert.DeserializeObject<RequestMessage>(eventRaisedEvent.Input);
 
-                                // run this through the message sorter to help with reordering and duplicate filtering
-                                var deliverNow = entityContext.State.MessageSorter.ReceiveInOrder(requestMessage, entityContext.EntityMessageReorderWindow);
+                                IEnumerable<RequestMessage> deliverNow;
+
+                                if (requestMessage.ScheduledTime.HasValue)
+                                {
+                                    // messages with a scheduled time are always delivered immediately
+                                    deliverNow = new RequestMessage[] { requestMessage };
+                                }
+                                else
+                                {
+                                    // run this through the message sorter to help with reordering and duplicate filtering
+                                    deliverNow = entityContext.State.MessageSorter.ReceiveInOrder(requestMessage, entityContext.EntityMessageReorderWindow);
+                                }
 
                                 foreach (var message in deliverNow)
                                 {

--- a/src/WebJobs.Extensions.DurableTask/EntityScheduler/EntityMessageEventNames.cs
+++ b/src/WebJobs.Extensions.DurableTask/EntityScheduler/EntityMessageEventNames.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+
+namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
+{
+    /// <summary>
+    /// Determines event names to use for messages sent to and from entities.
+    /// </summary>
+    internal static class EntityMessageEventNames
+    {
+        public static string RequestMessageEventName => "op";
+
+        public static string ReleaseMessageEventName => "release";
+
+        public static string ScheduledRequestMessageEventName(DateTime scheduledUtc) => $"op@{scheduledUtc:o}";
+
+        public static string ResponseMessageEventName(Guid requestId) => requestId.ToString();
+
+        public static bool IsRequestMessage(string eventName) => eventName.StartsWith("op");
+    }
+}

--- a/src/WebJobs.Extensions.DurableTask/EntityScheduler/Proxy/EntityClientProxy.cs
+++ b/src/WebJobs.Extensions.DurableTask/EntityScheduler/Proxy/EntityClientProxy.cs
@@ -9,10 +9,17 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
     internal class EntityClientProxy : IEntityProxyContext
     {
         private readonly IDurableEntityClient client;
+        private readonly DateTime? scheduledTimeForSignal;
 
         internal EntityClientProxy(IDurableEntityClient client)
         {
             this.client = client;
+        }
+
+        internal EntityClientProxy(IDurableEntityClient client, DateTime scheduledTimeForSignal)
+        {
+            this.client = client;
+            this.scheduledTimeForSignal = scheduledTimeForSignal;
         }
 
         internal Task SignalTask { get; private set; }
@@ -41,7 +48,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 throw new InvalidOperationException("The operation action must not perform more than one operation");
             }
 
-            this.SignalTask = this.client.SignalEntityAsync(entityId, operationName, operationInput);
+            if (this.scheduledTimeForSignal.HasValue)
+            {
+                this.SignalTask = this.client.SignalEntityAsync(entityId, this.scheduledTimeForSignal.Value, operationName, operationInput);
+            }
+            else
+            {
+                this.SignalTask = this.client.SignalEntityAsync(entityId, operationName, operationInput);
+            }
         }
     }
 }

--- a/src/WebJobs.Extensions.DurableTask/EntityScheduler/Proxy/OrchestrationContextProxy.cs
+++ b/src/WebJobs.Extensions.DurableTask/EntityScheduler/Proxy/OrchestrationContextProxy.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System;
 using System.Threading.Tasks;
 
 namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
@@ -8,10 +9,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
     internal class OrchestrationContextProxy : IEntityProxyContext
     {
         private readonly IDurableOrchestrationContext context;
+        private readonly DateTime? scheduledTimeForSignal;
 
         internal OrchestrationContextProxy(IDurableOrchestrationContext context)
         {
             this.context = context;
+        }
+
+        internal OrchestrationContextProxy(IDurableOrchestrationContext context, DateTime scheduledTimeForSignal)
+        {
+            this.scheduledTimeForSignal = scheduledTimeForSignal;
         }
 
         public Task CallAsync(EntityId entityId, string operationName, object operationInput)
@@ -26,7 +33,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
         public void Signal(EntityId entityId, string operationName, object operationInput)
         {
-            this.context.SignalEntity(entityId, operationName, operationInput);
+            if (this.scheduledTimeForSignal.HasValue)
+            {
+                this.context.SignalEntity(entityId, this.scheduledTimeForSignal.Value, operationName, operationInput);
+            }
+            else
+            {
+                this.context.SignalEntity(entityId, operationName, operationInput);
+            }
         }
     }
 }

--- a/src/WebJobs.Extensions.DurableTask/EntityScheduler/RequestMessage.cs
+++ b/src/WebJobs.Extensions.DurableTask/EntityScheduler/RequestMessage.cs
@@ -44,6 +44,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         public string ParentInstanceId { get; set; }
 
         /// <summary>
+        /// Optionally, a scheduled time at which to start the operation.
+        /// </summary>
+        [JsonProperty(PropertyName = "due", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public DateTime? ScheduledTime { get; set; }
+
+        /// <summary>
         /// A timestamp for this request.
         /// Used for duplicate filtering and in-order delivery.
         /// </summary>

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net471.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net471.xml
@@ -111,6 +111,9 @@
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClient.Microsoft#Azure#WebJobs#Extensions#DurableTask#IDurableEntityClient#SignalEntityAsync(Microsoft.Azure.WebJobs.Extensions.DurableTask.EntityId,System.String,System.Object,System.String,System.String)">
             <inheritdoc />
         </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClient.Microsoft#Azure#WebJobs#Extensions#DurableTask#IDurableEntityClient#SignalEntityAsync(Microsoft.Azure.WebJobs.Extensions.DurableTask.EntityId,System.DateTime,System.String,System.Object,System.String,System.String)">
+            <inheritdoc />
+        </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClient.Microsoft#Azure#WebJobs#Extensions#DurableTask#IDurableOrchestrationClient#TerminateAsync(System.String,System.String)">
             <inheritdoc />
         </member>
@@ -228,6 +231,9 @@
             <inheritdoc/>
         </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableOrchestrationContext.Microsoft#Azure#WebJobs#Extensions#DurableTask#IDurableOrchestrationContext#SignalEntity(Microsoft.Azure.WebJobs.Extensions.DurableTask.EntityId,System.String,System.Object)">
+            <inheritdoc/>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableOrchestrationContext.Microsoft#Azure#WebJobs#Extensions#DurableTask#IDurableOrchestrationContext#SignalEntity(Microsoft.Azure.WebJobs.Extensions.DurableTask.EntityId,System.DateTime,System.String,System.Object)">
             <inheritdoc/>
         </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableOrchestrationContext.Microsoft#Azure#WebJobs#Extensions#DurableTask#IDurableOrchestrationContext#StartNewOrchestration(System.String,System.Object,System.String)">
@@ -652,6 +658,18 @@
             <param name="connectionName">The name of the connection string associated with <paramref name="taskHubName"/>.</param>
             <returns>A task that completes when the message has been reliably enqueued.</returns>
         </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableEntityClient.SignalEntityAsync(Microsoft.Azure.WebJobs.Extensions.DurableTask.EntityId,System.DateTime,System.String,System.Object,System.String,System.String)">
+            <summary>
+            Signals an entity to perform an operation, at a specified time.
+            </summary>
+            <param name="entityId">The target entity.</param>
+            <param name="scheduledTimeUtc">The time at which to start the operation.</param>
+            <param name="operationName">The name of the operation.</param>
+            <param name="operationInput">The input for the operation.</param>
+            <param name="taskHubName">The TaskHubName of the target entity.</param>
+            <param name="connectionName">The name of the connection string associated with <paramref name="taskHubName"/>.</param>
+            <returns>A task that completes when the message has been reliably enqueued.</returns>
+        </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableEntityClient.ReadEntityStateAsync``1(Microsoft.Azure.WebJobs.Extensions.DurableTask.EntityId,System.String,System.String)">
             <summary>
             Tries to read the current state of an entity. Returns default(<typeparamref name="T"/>) if the entity does not
@@ -753,6 +771,15 @@
             <param name="entity">The target entity.</param>
             <param name="operationName">The name of the operation.</param>
             <param name="operationInput">The operation input.</param>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableEntityContext.SignalEntity(Microsoft.Azure.WebJobs.Extensions.DurableTask.EntityId,System.DateTime,System.String,System.Object)">
+            <summary>
+            Signals an entity to perform an operation, at a specified time. Any result or exception is ignored (fire and forget).
+            </summary>
+            <param name="entity">The target entity.</param>
+            <param name="scheduledTimeUtc">The time at which to start the operation.</param>
+            <param name="operationName">The name of the operation.</param>
+            <param name="operationInput">The input for the operation.</param>
         </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableEntityContext.StartNewOrchestration(System.String,System.Object,System.String)">
             <summary>
@@ -1300,6 +1327,15 @@
             Signals an entity to perform an operation, without waiting for a response. Any result or exception is ignored (fire and forget).
             </summary>
             <param name="entity">The target entity.</param>
+            <param name="operationName">The name of the operation.</param>
+            <param name="operationInput">The input for the operation.</param>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableOrchestrationContext.SignalEntity(Microsoft.Azure.WebJobs.Extensions.DurableTask.EntityId,System.DateTime,System.String,System.Object)">
+            <summary>
+            Signals an operation to be performed by an entity at a specified time. Any result or exception is ignored (fire and forget).
+            </summary>
+            <param name="entity">The target entity.</param>
+            <param name="scheduledTimeUtc">The time at which to start the operation.</param>
             <param name="operationName">The name of the operation.</param>
             <param name="operationInput">The input for the operation.</param>
         </member>
@@ -1946,6 +1982,11 @@
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.EntityId.CompareTo(System.Object)">
             <inheritdoc/>
         </member>
+        <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.EntityMessageEventNames">
+            <summary>
+            Determines event names to use for messages sent to and from entities.
+            </summary>
+        </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.EntitySchedulerException">
             <summary>
             Exception used to describe various issues encountered by the entity scheduler.
@@ -2077,6 +2118,17 @@
             <param name="operation">A delegate that performs the desired operation on the entity.</param>
             <returns>A task that completes when the message has been reliably enqueued.</returns>
         </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableEntityProxyExtensions.SignalEntityAsync``1(Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableEntityClient,System.String,System.DateTime,System.Action{``0})">
+            <summary>
+            Signals an entity to perform an operation, at a specified time.
+            </summary>
+            <typeparam name="TEntityInterface">Entity interface.</typeparam>
+            <param name="client">orchestration client.</param>
+            <param name="entityKey">The target entity key.</param>
+            <param name="scheduledTimeUtc">The time at which to start the operation.</param>
+            <param name="operation">A delegate that performs the desired operation on the entity.</param>
+            <returns>A task that completes when the message has been reliably enqueued.</returns>
+        </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableEntityProxyExtensions.SignalEntityAsync``1(Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableEntityClient,Microsoft.Azure.WebJobs.Extensions.DurableTask.EntityId,System.Action{``0})">
             <summary>
             Signals an entity to perform an operation.
@@ -2084,6 +2136,17 @@
             <typeparam name="TEntityInterface">Entity interface.</typeparam>
             <param name="client">orchestration client.</param>
             <param name="entityId">The target entity.</param>
+            <param name="operation">A delegate that performs the desired operation on the entity.</param>
+            <returns>A task that completes when the message has been reliably enqueued.</returns>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableEntityProxyExtensions.SignalEntityAsync``1(Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableEntityClient,Microsoft.Azure.WebJobs.Extensions.DurableTask.EntityId,System.DateTime,System.Action{``0})">
+            <summary>
+            Signals an entity to perform an operation, at a specified time.
+            </summary>
+            <typeparam name="TEntityInterface">Entity interface.</typeparam>
+            <param name="client">orchestration client.</param>
+            <param name="entityId">The target entity.</param>
+            <param name="scheduledTimeUtc">The time at which to start the operation.</param>
             <param name="operation">A delegate that performs the desired operation on the entity.</param>
             <returns>A task that completes when the message has been reliably enqueued.</returns>
         </member>
@@ -2114,12 +2177,32 @@
             <param name="operation">A delegate that performs the desired operation on the entity.</param>
             <typeparam name="TEntityInterface">Entity interface.</typeparam>
         </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableEntityProxyExtensions.SignalEntity``1(Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableEntityContext,System.String,System.DateTime,System.Action{``0})">
+            <summary>
+            Signals an entity to perform an operation, at a specified time.
+            </summary>
+            <param name="context">entity context.</param>
+            <param name="entityKey">The target entity key.</param>
+            <param name="scheduledTimeUtc">The time at which to start the operation.</param>
+            <param name="operation">A delegate that performs the desired operation on the entity.</param>
+            <typeparam name="TEntityInterface">Entity interface.</typeparam>
+        </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableEntityProxyExtensions.SignalEntity``1(Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableEntityContext,Microsoft.Azure.WebJobs.Extensions.DurableTask.EntityId,System.Action{``0})">
             <summary>
             Signals an entity to perform an operation.
             </summary>
             <param name="context">entity context.</param>
             <param name="entityId">The target entity.</param>
+            <param name="operation">A delegate that performs the desired operation on the entity.</param>
+            <typeparam name="TEntityInterface">Entity interface.</typeparam>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableEntityProxyExtensions.SignalEntity``1(Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableEntityContext,Microsoft.Azure.WebJobs.Extensions.DurableTask.EntityId,System.DateTime,System.Action{``0})">
+            <summary>
+            Signals an entity to perform an operation, at a specified time.
+            </summary>
+            <param name="context">entity context.</param>
+            <param name="entityId">The target entity.</param>
+            <param name="scheduledTimeUtc">The time at which to start the operation.</param>
             <param name="operation">A delegate that performs the desired operation on the entity.</param>
             <typeparam name="TEntityInterface">Entity interface.</typeparam>
         </member>
@@ -2220,6 +2303,11 @@
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.RequestMessage.ParentInstanceId">
             <summary>
             The parent instance that called this operation.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.RequestMessage.ScheduledTime">
+            <summary>
+            Optionally, a scheduled time at which to start the operation.
             </summary>
         </member>
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.RequestMessage.Timestamp">

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
@@ -111,6 +111,9 @@
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClient.Microsoft#Azure#WebJobs#Extensions#DurableTask#IDurableEntityClient#SignalEntityAsync(Microsoft.Azure.WebJobs.Extensions.DurableTask.EntityId,System.String,System.Object,System.String,System.String)">
             <inheritdoc />
         </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClient.Microsoft#Azure#WebJobs#Extensions#DurableTask#IDurableEntityClient#SignalEntityAsync(Microsoft.Azure.WebJobs.Extensions.DurableTask.EntityId,System.DateTime,System.String,System.Object,System.String,System.String)">
+            <inheritdoc />
+        </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClient.Microsoft#Azure#WebJobs#Extensions#DurableTask#IDurableOrchestrationClient#TerminateAsync(System.String,System.String)">
             <inheritdoc />
         </member>
@@ -228,6 +231,9 @@
             <inheritdoc/>
         </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableOrchestrationContext.Microsoft#Azure#WebJobs#Extensions#DurableTask#IDurableOrchestrationContext#SignalEntity(Microsoft.Azure.WebJobs.Extensions.DurableTask.EntityId,System.String,System.Object)">
+            <inheritdoc/>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableOrchestrationContext.Microsoft#Azure#WebJobs#Extensions#DurableTask#IDurableOrchestrationContext#SignalEntity(Microsoft.Azure.WebJobs.Extensions.DurableTask.EntityId,System.DateTime,System.String,System.Object)">
             <inheritdoc/>
         </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableOrchestrationContext.Microsoft#Azure#WebJobs#Extensions#DurableTask#IDurableOrchestrationContext#StartNewOrchestration(System.String,System.Object,System.String)">
@@ -685,6 +691,18 @@
             <param name="connectionName">The name of the connection string associated with <paramref name="taskHubName"/>.</param>
             <returns>A task that completes when the message has been reliably enqueued.</returns>
         </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableEntityClient.SignalEntityAsync(Microsoft.Azure.WebJobs.Extensions.DurableTask.EntityId,System.DateTime,System.String,System.Object,System.String,System.String)">
+            <summary>
+            Signals an entity to perform an operation, at a specified time.
+            </summary>
+            <param name="entityId">The target entity.</param>
+            <param name="scheduledTimeUtc">The time at which to start the operation.</param>
+            <param name="operationName">The name of the operation.</param>
+            <param name="operationInput">The input for the operation.</param>
+            <param name="taskHubName">The TaskHubName of the target entity.</param>
+            <param name="connectionName">The name of the connection string associated with <paramref name="taskHubName"/>.</param>
+            <returns>A task that completes when the message has been reliably enqueued.</returns>
+        </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableEntityClient.ReadEntityStateAsync``1(Microsoft.Azure.WebJobs.Extensions.DurableTask.EntityId,System.String,System.String)">
             <summary>
             Tries to read the current state of an entity. Returns default(<typeparamref name="T"/>) if the entity does not
@@ -791,6 +809,15 @@
             <param name="entity">The target entity.</param>
             <param name="operationName">The name of the operation.</param>
             <param name="operationInput">The operation input.</param>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableEntityContext.SignalEntity(Microsoft.Azure.WebJobs.Extensions.DurableTask.EntityId,System.DateTime,System.String,System.Object)">
+            <summary>
+            Signals an entity to perform an operation, at a specified time. Any result or exception is ignored (fire and forget).
+            </summary>
+            <param name="entity">The target entity.</param>
+            <param name="scheduledTimeUtc">The time at which to start the operation.</param>
+            <param name="operationName">The name of the operation.</param>
+            <param name="operationInput">The input for the operation.</param>
         </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableEntityContext.StartNewOrchestration(System.String,System.Object,System.String)">
             <summary>
@@ -1338,6 +1365,15 @@
             Signals an entity to perform an operation, without waiting for a response. Any result or exception is ignored (fire and forget).
             </summary>
             <param name="entity">The target entity.</param>
+            <param name="operationName">The name of the operation.</param>
+            <param name="operationInput">The input for the operation.</param>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableOrchestrationContext.SignalEntity(Microsoft.Azure.WebJobs.Extensions.DurableTask.EntityId,System.DateTime,System.String,System.Object)">
+            <summary>
+            Signals an operation to be performed by an entity at a specified time. Any result or exception is ignored (fire and forget).
+            </summary>
+            <param name="entity">The target entity.</param>
+            <param name="scheduledTimeUtc">The time at which to start the operation.</param>
             <param name="operationName">The name of the operation.</param>
             <param name="operationInput">The input for the operation.</param>
         </member>
@@ -1984,6 +2020,11 @@
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.EntityId.CompareTo(System.Object)">
             <inheritdoc/>
         </member>
+        <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.EntityMessageEventNames">
+            <summary>
+            Determines event names to use for messages sent to and from entities.
+            </summary>
+        </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.EntitySchedulerException">
             <summary>
             Exception used to describe various issues encountered by the entity scheduler.
@@ -2115,6 +2156,17 @@
             <param name="operation">A delegate that performs the desired operation on the entity.</param>
             <returns>A task that completes when the message has been reliably enqueued.</returns>
         </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableEntityProxyExtensions.SignalEntityAsync``1(Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableEntityClient,System.String,System.DateTime,System.Action{``0})">
+            <summary>
+            Signals an entity to perform an operation, at a specified time.
+            </summary>
+            <typeparam name="TEntityInterface">Entity interface.</typeparam>
+            <param name="client">orchestration client.</param>
+            <param name="entityKey">The target entity key.</param>
+            <param name="scheduledTimeUtc">The time at which to start the operation.</param>
+            <param name="operation">A delegate that performs the desired operation on the entity.</param>
+            <returns>A task that completes when the message has been reliably enqueued.</returns>
+        </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableEntityProxyExtensions.SignalEntityAsync``1(Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableEntityClient,Microsoft.Azure.WebJobs.Extensions.DurableTask.EntityId,System.Action{``0})">
             <summary>
             Signals an entity to perform an operation.
@@ -2122,6 +2174,17 @@
             <typeparam name="TEntityInterface">Entity interface.</typeparam>
             <param name="client">orchestration client.</param>
             <param name="entityId">The target entity.</param>
+            <param name="operation">A delegate that performs the desired operation on the entity.</param>
+            <returns>A task that completes when the message has been reliably enqueued.</returns>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableEntityProxyExtensions.SignalEntityAsync``1(Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableEntityClient,Microsoft.Azure.WebJobs.Extensions.DurableTask.EntityId,System.DateTime,System.Action{``0})">
+            <summary>
+            Signals an entity to perform an operation, at a specified time.
+            </summary>
+            <typeparam name="TEntityInterface">Entity interface.</typeparam>
+            <param name="client">orchestration client.</param>
+            <param name="entityId">The target entity.</param>
+            <param name="scheduledTimeUtc">The time at which to start the operation.</param>
             <param name="operation">A delegate that performs the desired operation on the entity.</param>
             <returns>A task that completes when the message has been reliably enqueued.</returns>
         </member>
@@ -2152,12 +2215,32 @@
             <param name="operation">A delegate that performs the desired operation on the entity.</param>
             <typeparam name="TEntityInterface">Entity interface.</typeparam>
         </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableEntityProxyExtensions.SignalEntity``1(Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableEntityContext,System.String,System.DateTime,System.Action{``0})">
+            <summary>
+            Signals an entity to perform an operation, at a specified time.
+            </summary>
+            <param name="context">entity context.</param>
+            <param name="entityKey">The target entity key.</param>
+            <param name="scheduledTimeUtc">The time at which to start the operation.</param>
+            <param name="operation">A delegate that performs the desired operation on the entity.</param>
+            <typeparam name="TEntityInterface">Entity interface.</typeparam>
+        </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableEntityProxyExtensions.SignalEntity``1(Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableEntityContext,Microsoft.Azure.WebJobs.Extensions.DurableTask.EntityId,System.Action{``0})">
             <summary>
             Signals an entity to perform an operation.
             </summary>
             <param name="context">entity context.</param>
             <param name="entityId">The target entity.</param>
+            <param name="operation">A delegate that performs the desired operation on the entity.</param>
+            <typeparam name="TEntityInterface">Entity interface.</typeparam>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableEntityProxyExtensions.SignalEntity``1(Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableEntityContext,Microsoft.Azure.WebJobs.Extensions.DurableTask.EntityId,System.DateTime,System.Action{``0})">
+            <summary>
+            Signals an entity to perform an operation, at a specified time.
+            </summary>
+            <param name="context">entity context.</param>
+            <param name="entityId">The target entity.</param>
+            <param name="scheduledTimeUtc">The time at which to start the operation.</param>
             <param name="operation">A delegate that performs the desired operation on the entity.</param>
             <typeparam name="TEntityInterface">Entity interface.</typeparam>
         </member>
@@ -2258,6 +2341,11 @@
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.RequestMessage.ParentInstanceId">
             <summary>
             The parent instance that called this operation.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.RequestMessage.ScheduledTime">
+            <summary>
+            Optionally, a scheduled time at which to start the operation.
             </summary>
         </member>
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.RequestMessage.Timestamp">

--- a/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
+++ b/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
@@ -71,8 +71,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.DurableTask.Core" Version="2.1.3" />
-    <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage" Version="1.6.5" />
+    <PackageReference Include="Microsoft.Azure.DurableTask.Core" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage" Version="1.7.0" />
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.0.3" />
   </ItemGroup>
 

--- a/test/Common/DurableTaskEndToEndTests.cs
+++ b/test/Common/DurableTaskEndToEndTests.cs
@@ -2667,6 +2667,127 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         }
 
         /// <summary>
+        /// Send a bunch of signals from a client to a single entity, then test that they are all being delivered.
+        /// </summary>
+        [Theory]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        [InlineData(true, false, 1)]
+        [InlineData(true, false, 2)]
+        [InlineData(true, false, 20)]
+        [InlineData(true, false, 200)]
+        [InlineData(false, false, 1)]
+        [InlineData(false, false, 2)]
+        [InlineData(false, false, 20)]
+        [InlineData(false, false, 200)]
+        [InlineData(true, true, 1)]
+        [InlineData(true, true, 2)]
+        [InlineData(true, true, 20)]
+        [InlineData(true, true, 200)]
+        [InlineData(false, true, 1)]
+        [InlineData(false, true, 2)]
+        [InlineData(false, true, 20)]
+        [InlineData(false, true, 200)]
+        public async Task DurableEntity_ManyScheduledSignals(bool extendedSessions, bool delay, int numSignals)
+        {
+            using (var host = TestHelpers.GetJobHost(
+                this.loggerProvider,
+                nameof(this.DurableEntity_ManyScheduledSignals),
+                enableExtendedSessions: extendedSessions))
+            {
+                await host.StartAsync();
+
+                var entityId = new EntityId(nameof(TestEntities.SchedulerEntity), Guid.NewGuid().ToString("N"));
+                TestEntityClient client = await host.GetEntityClientAsync(entityId, this.output);
+
+                var now = DateTime.UtcNow;
+
+                for (int i = 0; i < numSignals; i++)
+                {
+                    if (delay)
+                    {
+                        await client.SignalEntity(this.output, now + TimeSpan.FromSeconds(i * (10.0 / numSignals)), i.ToString(), null);
+                    }
+                    else
+                    {
+                        await client.SignalEntity(this.output, i.ToString(), null);
+                    }
+                }
+
+                string DescribeWhatsMissing(List<string> curstate)
+                {
+                    var expected = new HashSet<string>();
+                    for (int i = 0; i < numSignals; i++)
+                    {
+                        expected.Add(i.ToString());
+                    }
+
+                    foreach (var s in curstate)
+                    {
+                        expected.Remove(s);
+                    }
+
+                    if (expected.Count == 0)
+                    {
+                        return null;
+                    }
+                    else
+                    {
+                        return string.Join(",", expected);
+                    }
+                }
+
+                var timeout = Debugger.IsAttached ? TimeSpan.FromMinutes(5) : TimeSpan.FromSeconds(30);
+                var state = await client.WaitForEntityState<List<string>>(this.output, timeout, DescribeWhatsMissing);
+
+                this.output.WriteLine(string.Join(", ", state));
+
+                // The scheduled signals are not guaranteed to be delivered in order, so we sort before comparing
+                var intlist = state.Select(s => int.Parse(s)).ToList();
+                intlist.Sort();
+
+                for (int i = 0; i < numSignals; i++)
+                {
+                    Assert.Equal(i, intlist[i]);
+                }
+
+                await host.StopAsync();
+            }
+        }
+
+        /// <summary>
+        /// Send a scheduled signal, then an immediate signal, and test delivery order.
+        /// </summary>
+        [Theory]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task DurableEntity_ScheduledSignal(bool extendedSessions)
+        {
+            using (var host = TestHelpers.GetJobHost(
+                this.loggerProvider,
+                nameof(this.DurableEntity_ScheduledSignal),
+                enableExtendedSessions: extendedSessions))
+            {
+                await host.StartAsync();
+
+                var entityId = new EntityId(nameof(TestEntities.SchedulerEntity), Guid.NewGuid().ToString("N"));
+                TestEntityClient client = await host.GetEntityClientAsync(entityId, this.output);
+
+                var now = DateTime.UtcNow;
+
+                await client.SignalEntity(this.output, now + TimeSpan.FromSeconds(5), "delayed", null);
+                await client.SignalEntity(this.output, "immediate", null);
+
+                var timeout = Debugger.IsAttached ? TimeSpan.FromMinutes(5) : TimeSpan.FromSeconds(10);
+                var state = await client.WaitForEntityState<List<string>>(this.output, timeout, curstate => curstate.Count == 2 ? null : "expect both messages");
+
+                Assert.Equal("immediate, delayed", string.Join(", ", state));
+
+                await host.StopAsync();
+            }
+        }
+
+        /// <summary>
         /// End-to-end test which validates an entity scenario where three "LockedIncrement" orchestrations
         /// concurrently increment a counter saved in blob storage, using a read-modify-write pattern, while holding
         /// a lock on the same entity. This tests that the lock prevents the interleaving of these orchestrations.
@@ -3163,6 +3284,67 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
                 Assert.Equal(OrchestrationRuntimeStatus.Completed, status?.RuntimeStatus);
                 Assert.Equal(true, status?.Output);
+
+                await host.StopAsync();
+            }
+        }
+
+        /// <summary>
+        /// Test which validates that orchestrations can call a timer after doing a continue as new.
+        /// This is meant to catch regressions of azure/durabletask/#285.
+        /// </summary>
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public async Task ContinueAsNew_Repro285()
+        {
+            using (var host = TestHelpers.GetJobHost(
+                this.loggerProvider,
+                nameof(this.ContinueAsNew_Repro285),
+                enableExtendedSessions: true))
+            {
+                await host.StartAsync();
+
+                var client = await host.StartOrchestratorAsync(nameof(TestOrchestrations.ContinueAsNew_Repro285), 0, this.output);
+
+                var status = await client.WaitForCompletionAsync(this.output);
+
+                Assert.Equal(OrchestrationRuntimeStatus.Completed, status?.RuntimeStatus);
+                Assert.Equal("ok", status?.Output);
+
+                await host.StopAsync();
+            }
+        }
+
+        /// <summary>
+        /// Test which validates that orchestrations can call a timer and then cancel it if receiving an event instead.
+        /// This is meant to catch regressions of azure/durabletask/#285.
+        /// </summary>
+        [Theory]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        [InlineData(true, 20)]
+        [InlineData(false, 20)]
+        public async Task ContinueAsNewMultipleTimersAndEvents(bool extendedSessions, int numSignals)
+        {
+            using (var host = TestHelpers.GetJobHost(
+                this.loggerProvider,
+                nameof(this.ContinueAsNewMultipleTimersAndEvents),
+                enableExtendedSessions: extendedSessions))
+            {
+                await host.StartAsync();
+
+                var client = await host.StartOrchestratorAsync(nameof(TestOrchestrations.ContinueAsNewMultipleTimersAndEvents), numSignals, this.output);
+
+                await Task.Delay(TimeSpan.FromSeconds(10));
+
+                for (int i = numSignals; i > 0; i--)
+                {
+                    await client.RaiseEventAsync($"signal{i}", this.output);
+                }
+
+                var status = await client.WaitForCompletionAsync(this.output, false, false, TimeSpan.FromSeconds(80));
+
+                Assert.Equal(OrchestrationRuntimeStatus.Completed, status?.RuntimeStatus);
+                Assert.Equal("ok", status?.Output);
 
                 await host.StopAsync();
             }

--- a/test/Common/TestEntities.cs
+++ b/test/Common/TestEntities.cs
@@ -243,6 +243,22 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             }
         }
 
+        //-------------- An entity that records all operation names in a list -----------------
+
+        public static void SchedulerEntity(
+            [EntityTrigger(EntityName = "SchedulerEntity")] IDurableEntityContext context,
+            ILogger logger)
+        {
+            var state = context.GetState<List<string>>(() => new List<string>());
+
+            if (state.Contains(context.OperationName))
+            {
+                logger.LogError($"duplicate: {context.OperationName}");
+            }
+
+            state.Add(context.OperationName);
+        }
+
         //-------------- an entity that stores text, and whose state is
         //                  saved/restored to/from storage when the entity is deactivated/activated -----------------
         //

--- a/test/Common/TestEntityClient.cs
+++ b/test/Common/TestEntityClient.cs
@@ -32,9 +32,20 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             await this.InnerClient.SignalEntityAsync(this.entityId, operationName, operationContent);
         }
 
+        public async Task SignalEntity(
+            ITestOutputHelper output,
+            DateTime startTimeUtc,
+            string operationName,
+            object operationContent = null)
+        {
+            output.WriteLine($"Signaling entity {this.entityId} with operation named {operationName}.");
+            await this.InnerClient.SignalEntityAsync(this.entityId, startTimeUtc, operationName, operationContent);
+        }
+
         public async Task<T> WaitForEntityState<T>(
             ITestOutputHelper output,
-            TimeSpan? timeout = null)
+            TimeSpan? timeout = null,
+            Func<T, string> describeWhatWeAreWaitingFor = null)
         {
             if (timeout == null)
             {
@@ -44,23 +55,49 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             Stopwatch sw = Stopwatch.StartNew();
 
             EntityStateResponse<T> response;
+
             do
             {
-                output.WriteLine($"Waiting for {this.entityId} to have state.");
-
                 response = await this.InnerClient.ReadEntityStateAsync<T>(this.entityId);
                 if (response.EntityExists)
                 {
-                    string serializedState = JsonConvert.SerializeObject(response.EntityState);
-                    output.WriteLine($"Found state: {serializedState}");
-                    return response.EntityState;
+                    if (describeWhatWeAreWaitingFor == null)
+                    {
+                        break;
+                    }
+                    else
+                    {
+                        var waitForResult = describeWhatWeAreWaitingFor(response.EntityState);
+
+                        if (string.IsNullOrEmpty(waitForResult))
+                        {
+                            break;
+                        }
+                        else
+                        {
+                            output.WriteLine($"Waiting for {this.entityId} : {waitForResult}");
+                        }
+                    }
+                }
+                else
+                {
+                    output.WriteLine($"Waiting for {this.entityId} to have state.");
                 }
 
                 await Task.Delay(TimeSpan.FromSeconds(1));
             }
             while (sw.Elapsed < timeout);
 
-            throw new TimeoutException($"Durable entity '{this.entityId}' still doesn't have any state!");
+            if (response.EntityExists)
+            {
+                string serializedState = JsonConvert.SerializeObject(response.EntityState);
+                output.WriteLine($"Found state: {serializedState}");
+                return response.EntityState;
+            }
+            else
+            {
+                throw new TimeoutException($"Durable entity '{this.entityId}' still doesn't have any state!");
+            }
         }
     }
 }

--- a/test/FunctionsV1/WebJobs.Extensions.DurableTask.Tests.V1.csproj
+++ b/test/FunctionsV1/WebJobs.Extensions.DurableTask.Tests.V1.csproj
@@ -16,7 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="4.19.4" />
-    <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage" Version="1.6.5" />
+    <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage" Version="1.7.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="2.2.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" Version="2.2.0" />
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.33" />

--- a/test/FunctionsV2/WebJobs.Extensions.DurableTask.Tests.V2.csproj
+++ b/test/FunctionsV2/WebJobs.Extensions.DurableTask.Tests.V2.csproj
@@ -16,7 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="4.19.4" />
-    <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage" Version="1.6.5" />
+    <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage" Version="1.7.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.14" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="3.0.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" Version="3.0.0" />
@@ -27,8 +27,8 @@
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.*" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.Azure.DurableTask.Emulator" Version="2.1.3" />
-    <PackageReference Include="Microsoft.Azure.DurableTask.Redis" Version="0.1.1-alpha" />
+    <PackageReference Include="Microsoft.Azure.DurableTask.Emulator" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Azure.DurableTask.Redis" Version="0.1.2-alpha" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Adding support for specifying a delivery time for scheduled signals.

The idea is that anyone who can signal an operation (whether it is a client, an orchestration, or an entity), can specify an intended delivery time. When the signal reaches the entity, and the time has not yet arrived, the operation is durably buffered. 

This feature can also be used for timer/reminder type functionality, as entities can signal an operation to themselves.