### PR TITLE
[Refactor] Generically-typed StartNewAsync() overloads

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableClient.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableClient.cs
@@ -101,7 +101,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         }
 
         /// <inheritdoc />
-        async Task<string> IDurableOrchestrationClient.StartNewAsync(string orchestratorFunctionName, string instanceId, object input)
+        async Task<string> IDurableOrchestrationClient.StartNewAsync<T>(string orchestratorFunctionName, string instanceId, T input)
         {
             this.config.ThrowIfFunctionDoesNotExist(orchestratorFunctionName, FunctionType.Orchestrator);
 

--- a/src/WebJobs.Extensions.DurableTask/ContextInterfaces/DurableContextExtensions.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextInterfaces/DurableContextExtensions.cs
@@ -397,6 +397,26 @@ namespace Microsoft.Azure.WebJobs
         /// </summary>
         /// <param name="client">The client object.</param>
         /// <param name="orchestratorFunctionName">The name of the orchestrator function to start.</param>
+        /// <param name="instanceId">The ID to use for the new orchestration instance.</param>
+        /// <typeparam name="T">The type of the input value for the orchestrator function.</typeparam>
+        /// <returns>A task that completes when the orchestration is started. The task contains the instance id of the started
+        /// orchestratation instance.</returns>
+        /// <exception cref="ArgumentException">
+        /// The specified function does not exist, is disabled, or is not an orchestrator function.
+        /// </exception>
+        public static Task<string> StartNewAsync(
+            this IDurableOrchestrationClient client,
+            string orchestratorFunctionName,
+            string instanceId)
+        {
+            return client.StartNewAsync<object>(orchestratorFunctionName, instanceId, null);
+        }
+
+        /// <summary>
+        /// Starts a new execution of the specified orchestrator function.
+        /// </summary>
+        /// <param name="client">The client object.</param>
+        /// <param name="orchestratorFunctionName">The name of the orchestrator function to start.</param>
         /// <param name="input">JSON-serializeable input value for the orchestrator function.</param>
         /// <typeparam name="T">The type of the input value for the orchestrator function.</typeparam>
         /// <returns>A task that completes when the orchestration is started. The task contains the instance id of the started

--- a/src/WebJobs.Extensions.DurableTask/ContextInterfaces/DurableContextExtensions.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextInterfaces/DurableContextExtensions.cs
@@ -398,6 +398,26 @@ namespace Microsoft.Azure.WebJobs
         /// <param name="client">The client object.</param>
         /// <param name="orchestratorFunctionName">The name of the orchestrator function to start.</param>
         /// <param name="input">JSON-serializeable input value for the orchestrator function.</param>
+        /// <typeparam name="T">The type of the input value for the orchestrator function.</typeparam>
+        /// <returns>A task that completes when the orchestration is started. The task contains the instance id of the started
+        /// orchestratation instance.</returns>
+        /// <exception cref="ArgumentException">
+        /// The specified function does not exist, is disabled, or is not an orchestrator function.
+        /// </exception>
+        public static Task<string> StartNewAsync<T>(
+            this IDurableOrchestrationClient client,
+            string orchestratorFunctionName,
+            T input)
+            where T : class
+        {
+            return client.StartNewAsync(orchestratorFunctionName, string.Empty, input);
+        }
+
+        /// <summary>
+        /// Starts a new execution of the specified orchestrator function.
+        /// </summary>
+        /// <param name="client">The client object.</param>
+        /// <param name="orchestratorFunctionName">The name of the orchestrator function to start.</param>
         /// <returns>A task that completes when the orchestration is started. The task contains the instance id of the started
         /// orchestratation instance.</returns>
         /// <exception cref="ArgumentException">
@@ -405,10 +425,9 @@ namespace Microsoft.Azure.WebJobs
         /// </exception>
         public static Task<string> StartNewAsync(
             this IDurableOrchestrationClient client,
-            string orchestratorFunctionName,
-            object input)
+            string orchestratorFunctionName)
         {
-            return client.StartNewAsync(orchestratorFunctionName, string.Empty, input);
+            return client.StartNewAsync<object>(orchestratorFunctionName, null);
         }
 
         /// <summary>
@@ -442,7 +461,7 @@ namespace Microsoft.Azure.WebJobs
         /// <param name="client">The client object.</param>
         /// <param name="instanceId">The ID of the orchestration instance to query.</param>
         /// <returns>Returns a task which completes when the status has been fetched.</returns>
-        public static Task<DurableOrchestrationStatus> GetStatusAsync(this IDurableOrchestrationClient client,  string instanceId)
+        public static Task<DurableOrchestrationStatus> GetStatusAsync(this IDurableOrchestrationClient client, string instanceId)
         {
             return client.GetStatusAsync(instanceId, showHistory: false);
         }
@@ -454,7 +473,7 @@ namespace Microsoft.Azure.WebJobs
         /// <param name="instanceId">The ID of the orchestration instance to query.</param>
         /// <param name="showHistory">Boolean marker for including execution history in the response.</param>
         /// <returns>Returns a task which completes when the status has been fetched.</returns>
-        public static Task<DurableOrchestrationStatus> GetStatusAsync(this IDurableOrchestrationClient client,  string instanceId, bool showHistory)
+        public static Task<DurableOrchestrationStatus> GetStatusAsync(this IDurableOrchestrationClient client, string instanceId, bool showHistory)
         {
             return client.GetStatusAsync(instanceId, showHistory, showHistoryOutput: false, showInput: true);
         }

--- a/src/WebJobs.Extensions.DurableTask/ContextInterfaces/DurableContextExtensions.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextInterfaces/DurableContextExtensions.cs
@@ -398,7 +398,6 @@ namespace Microsoft.Azure.WebJobs
         /// <param name="client">The client object.</param>
         /// <param name="orchestratorFunctionName">The name of the orchestrator function to start.</param>
         /// <param name="instanceId">The ID to use for the new orchestration instance.</param>
-        /// <typeparam name="T">The type of the input value for the orchestrator function.</typeparam>
         /// <returns>A task that completes when the orchestration is started. The task contains the instance id of the started
         /// orchestratation instance.</returns>
         /// <exception cref="ArgumentException">

--- a/src/WebJobs.Extensions.DurableTask/ContextInterfaces/IDurableOrchestrationClient.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextInterfaces/IDurableOrchestrationClient.cs
@@ -117,12 +117,13 @@ namespace Microsoft.Azure.WebJobs
         /// <param name="orchestratorFunctionName">The name of the orchestrator function to start.</param>
         /// <param name="instanceId">The ID to use for the new orchestration instance.</param>
         /// <param name="input">JSON-serializeable input value for the orchestrator function.</param>
+        /// <typeparam name="T">The type of the input value for the orchestrator function.</typeparam>
         /// <returns>A task that completes when the orchestration is started. The task contains the instance id of the started
         /// orchestratation instance.</returns>
         /// <exception cref="ArgumentException">
         /// The specified function does not exist, is disabled, or is not an orchestrator function.
         /// </exception>
-        Task<string> StartNewAsync(string orchestratorFunctionName, string instanceId, object input);
+        Task<string> StartNewAsync<T>(string orchestratorFunctionName, string instanceId, T input);
 
         /// <summary>
         /// Sends an event notification message to a waiting orchestration instance.

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net471.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net471.xml
@@ -99,7 +99,7 @@
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClient.Microsoft#Azure#WebJobs#IDurableOrchestrationClient#WaitForCompletionOrCreateCheckStatusResponseAsync(Microsoft.AspNetCore.Http.HttpRequest,System.String,System.TimeSpan,System.TimeSpan)">
             <inheritdoc />
         </member>
-        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClient.Microsoft#Azure#WebJobs#IDurableOrchestrationClient#StartNewAsync(System.String,System.String,System.Object)">
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClient.Microsoft#Azure#WebJobs#IDurableOrchestrationClient#StartNewAsync``1(System.String,System.String,``0)">
             <inheritdoc />
         </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClient.Microsoft#Azure#WebJobs#IDurableOrchestrationClient#RaiseEventAsync(System.String,System.String,System.Object)">
@@ -1767,13 +1767,39 @@
             <param name="timeout">Total allowed timeout for output from the durable function. The default value is 10 seconds.</param>
             <returns>An HTTP response which may include a 202 and location header or a 200 with the durable function output in the response body.</returns>
         </member>
-        <member name="M:Microsoft.Azure.WebJobs.DurableContextExtensions.StartNewAsync(Microsoft.Azure.WebJobs.IDurableOrchestrationClient,System.String,System.Object)">
+        <member name="M:Microsoft.Azure.WebJobs.DurableContextExtensions.StartNewAsync(Microsoft.Azure.WebJobs.IDurableOrchestrationClient,System.String,System.String)">
+            <summary>
+            Starts a new execution of the specified orchestrator function.
+            </summary>
+            <param name="client">The client object.</param>
+            <param name="orchestratorFunctionName">The name of the orchestrator function to start.</param>
+            <param name="instanceId">The ID to use for the new orchestration instance.</param>
+            <returns>A task that completes when the orchestration is started. The task contains the instance id of the started
+            orchestratation instance.</returns>
+            <exception cref="T:System.ArgumentException">
+            The specified function does not exist, is disabled, or is not an orchestrator function.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.DurableContextExtensions.StartNewAsync``1(Microsoft.Azure.WebJobs.IDurableOrchestrationClient,System.String,``0)">
             <summary>
             Starts a new execution of the specified orchestrator function.
             </summary>
             <param name="client">The client object.</param>
             <param name="orchestratorFunctionName">The name of the orchestrator function to start.</param>
             <param name="input">JSON-serializeable input value for the orchestrator function.</param>
+            <typeparam name="T">The type of the input value for the orchestrator function.</typeparam>
+            <returns>A task that completes when the orchestration is started. The task contains the instance id of the started
+            orchestratation instance.</returns>
+            <exception cref="T:System.ArgumentException">
+            The specified function does not exist, is disabled, or is not an orchestrator function.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.DurableContextExtensions.StartNewAsync(Microsoft.Azure.WebJobs.IDurableOrchestrationClient,System.String)">
+            <summary>
+            Starts a new execution of the specified orchestrator function.
+            </summary>
+            <param name="client">The client object.</param>
+            <param name="orchestratorFunctionName">The name of the orchestrator function to start.</param>
             <returns>A task that completes when the orchestration is started. The task contains the instance id of the started
             orchestratation instance.</returns>
             <exception cref="T:System.ArgumentException">
@@ -2086,7 +2112,7 @@
             <param name="retryInterval">The timeout between checks for output from the durable function. The default value is 1 second.</param>
             <returns>An HTTP response which may include a 202 and location header or a 200 with the durable function output in the response body.</returns>
         </member>
-        <member name="M:Microsoft.Azure.WebJobs.IDurableOrchestrationClient.StartNewAsync(System.String,System.String,System.Object)">
+        <member name="M:Microsoft.Azure.WebJobs.IDurableOrchestrationClient.StartNewAsync``1(System.String,System.String,``0)">
             <summary>
             Starts a new instance of the specified orchestrator function.
             </summary>
@@ -2097,6 +2123,7 @@
             <param name="orchestratorFunctionName">The name of the orchestrator function to start.</param>
             <param name="instanceId">The ID to use for the new orchestration instance.</param>
             <param name="input">JSON-serializeable input value for the orchestrator function.</param>
+            <typeparam name="T">The type of the input value for the orchestrator function.</typeparam>
             <returns>A task that completes when the orchestration is started. The task contains the instance id of the started
             orchestratation instance.</returns>
             <exception cref="T:System.ArgumentException">

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-netstandard2.0.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-netstandard2.0.xml
@@ -99,7 +99,7 @@
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClient.Microsoft#Azure#WebJobs#IDurableOrchestrationClient#WaitForCompletionOrCreateCheckStatusResponseAsync(Microsoft.AspNetCore.Http.HttpRequest,System.String,System.TimeSpan,System.TimeSpan)">
             <inheritdoc />
         </member>
-        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClient.Microsoft#Azure#WebJobs#IDurableOrchestrationClient#StartNewAsync(System.String,System.String,System.Object)">
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClient.Microsoft#Azure#WebJobs#IDurableOrchestrationClient#StartNewAsync``1(System.String,System.String,``0)">
             <inheritdoc />
         </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClient.Microsoft#Azure#WebJobs#IDurableOrchestrationClient#RaiseEventAsync(System.String,System.String,System.Object)">
@@ -1806,13 +1806,39 @@
             <param name="timeout">Total allowed timeout for output from the durable function. The default value is 10 seconds.</param>
             <returns>An HTTP response which may include a 202 and location header or a 200 with the durable function output in the response body.</returns>
         </member>
-        <member name="M:Microsoft.Azure.WebJobs.DurableContextExtensions.StartNewAsync(Microsoft.Azure.WebJobs.IDurableOrchestrationClient,System.String,System.Object)">
+        <member name="M:Microsoft.Azure.WebJobs.DurableContextExtensions.StartNewAsync(Microsoft.Azure.WebJobs.IDurableOrchestrationClient,System.String,System.String)">
+            <summary>
+            Starts a new execution of the specified orchestrator function.
+            </summary>
+            <param name="client">The client object.</param>
+            <param name="orchestratorFunctionName">The name of the orchestrator function to start.</param>
+            <param name="instanceId">The ID to use for the new orchestration instance.</param>
+            <returns>A task that completes when the orchestration is started. The task contains the instance id of the started
+            orchestratation instance.</returns>
+            <exception cref="T:System.ArgumentException">
+            The specified function does not exist, is disabled, or is not an orchestrator function.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.DurableContextExtensions.StartNewAsync``1(Microsoft.Azure.WebJobs.IDurableOrchestrationClient,System.String,``0)">
             <summary>
             Starts a new execution of the specified orchestrator function.
             </summary>
             <param name="client">The client object.</param>
             <param name="orchestratorFunctionName">The name of the orchestrator function to start.</param>
             <param name="input">JSON-serializeable input value for the orchestrator function.</param>
+            <typeparam name="T">The type of the input value for the orchestrator function.</typeparam>
+            <returns>A task that completes when the orchestration is started. The task contains the instance id of the started
+            orchestratation instance.</returns>
+            <exception cref="T:System.ArgumentException">
+            The specified function does not exist, is disabled, or is not an orchestrator function.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.DurableContextExtensions.StartNewAsync(Microsoft.Azure.WebJobs.IDurableOrchestrationClient,System.String)">
+            <summary>
+            Starts a new execution of the specified orchestrator function.
+            </summary>
+            <param name="client">The client object.</param>
+            <param name="orchestratorFunctionName">The name of the orchestrator function to start.</param>
             <returns>A task that completes when the orchestration is started. The task contains the instance id of the started
             orchestratation instance.</returns>
             <exception cref="T:System.ArgumentException">
@@ -2130,7 +2156,7 @@
             <param name="retryInterval">The timeout between checks for output from the durable function. The default value is 1 second.</param>
             <returns>An HTTP response which may include a 202 and location header or a 200 with the durable function output in the response body.</returns>
         </member>
-        <member name="M:Microsoft.Azure.WebJobs.IDurableOrchestrationClient.StartNewAsync(System.String,System.String,System.Object)">
+        <member name="M:Microsoft.Azure.WebJobs.IDurableOrchestrationClient.StartNewAsync``1(System.String,System.String,``0)">
             <summary>
             Starts a new instance of the specified orchestrator function.
             </summary>
@@ -2141,6 +2167,7 @@
             <param name="orchestratorFunctionName">The name of the orchestrator function to start.</param>
             <param name="instanceId">The ID to use for the new orchestration instance.</param>
             <param name="input">JSON-serializeable input value for the orchestrator function.</param>
+            <typeparam name="T">The type of the input value for the orchestrator function.</typeparam>
             <returns>A task that completes when the orchestration is started. The task contains the instance id of the started
             orchestratation instance.</returns>
             <exception cref="T:System.ArgumentException">

--- a/test/Common/DurableClientBaseTests.cs
+++ b/test/Common/DurableClientBaseTests.cs
@@ -3,9 +3,7 @@
 
 using System;
 using System.Collections.Generic;
-#if !FUNCTIONS_V1
 using System.Linq;
-#endif
 using System.Net.Http;
 using System.Threading.Tasks;
 using DurableTask.Core;
@@ -14,7 +12,6 @@ using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 #endif
-using Microsoft.Azure.WebJobs.Extensions.DurableTask.Options;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Primitives;
@@ -33,9 +30,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             var instanceId = Guid.NewGuid().ToString();
             const string functionName = "sampleFunction";
             var durableOrchestrationClientBaseMock = new Mock<IDurableOrchestrationClient> { CallBase = true };
-            durableOrchestrationClientBaseMock.Setup(x => x.StartNewAsync(functionName, string.Empty, null)).ReturnsAsync(instanceId);
+            durableOrchestrationClientBaseMock.Setup(x => x.StartNewAsync<object>(functionName, string.Empty, null)).ReturnsAsync(instanceId);
 
-            var result = await durableOrchestrationClientBaseMock.Object.StartNewAsync(functionName, null);
+            var result = await durableOrchestrationClientBaseMock.Object.StartNewAsync(functionName);
+            result.Should().Be(instanceId);
+
+            result = await durableOrchestrationClientBaseMock.Object.StartNewAsync<object>(functionName, null);
             result.Should().Be(instanceId);
         }
 

--- a/test/Common/DurableClientBaseTests.cs
+++ b/test/Common/DurableClientBaseTests.cs
@@ -39,6 +39,22 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             result.Should().Be(instanceId);
         }
 
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public async Task StartNewAsync_is_calling_overload_method_with_specific_instance_id()
+        {
+            var instanceId = "testInstance";
+            const string functionName = "sampleFunction";
+            var durableOrchestrationClientBaseMock = new Mock<IDurableOrchestrationClient> { CallBase = true };
+            durableOrchestrationClientBaseMock.Setup(x => x.StartNewAsync<object>(functionName, instanceId, null)).ReturnsAsync(instanceId);
+
+            var result = await durableOrchestrationClientBaseMock.Object.StartNewAsync(functionName, instanceId);
+            result.Should().Be(instanceId);
+
+            result = await durableOrchestrationClientBaseMock.Object.StartNewAsync<object>(functionName, instanceId, null);
+            result.Should().Be(instanceId);
+        }
+
         [Theory]
         [Trait("Category", PlatformSpecificHelpers.TestCategory)]
         [InlineData("")]


### PR DESCRIPTION
Duplicate of #986 but rebased on to `dev` since v2 got merged in

---

Problem:
The following code:
```csharp
var instanceId = await client.StartNewAsync(@"MyOrchestrator", "thisInstanceId");
Debug.Assert(instanceId == @"thisInstanceId");
```

Will throw the assertion. This is because if a user wishes to specify the instanceId for a new orchestration they _must_ give some form of input - `null` or otherwise. While intellisense is the way one would realize what they're doing wrong, it's only after they attempt this and end up getting back an instanceId value other than the one they specified that they realize something's gone awry due to the fact that `string : object` so the `StartNewAsync(string, object)` overload gets hit and executed.

By using generics we can not only prevent this runtime confusion, but also enable an even simpler scenario: `StartNewAsync(@"MyOrchestrator")` which is an added benefit.

Hopefully you find this idea/PR valuable. Thanks! You'll notice I have the target for it as the `v2` branch due to its breaking nature.