### PR TITLE
Add Azure Storage time delay exceptions

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/AzureStorageDurabilityProvider.cs
+++ b/src/WebJobs.Extensions.DurableTask/AzureStorageDurabilityProvider.cs
@@ -118,14 +118,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             return this.ConvertFrom(statusContext);
         }
 
-        public override (bool, string) CheckTimeInterval(TimeSpan timespan)
+        public override bool ValidateDelayTime(TimeSpan timespan, out string errorMessage)
         {
             if (timespan > MaxTimerDuration)
             {
-                return (false, $"The Azure Storage provider supports a maximum of {MaxTimerDuration.TotalDays} days for time-based delays");
+                errorMessage = $"The Azure Storage provider supports a maximum of {MaxTimerDuration.TotalDays} days for time-based delays";
+                return false;
             }
 
-            return base.CheckTimeInterval(timespan);
+            return base.ValidateDelayTime(timespan, out errorMessage);
         }
 
         private OrchestrationStatusQueryResult ConvertFrom(DurableStatusQueryResult statusContext)

--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableOrchestrationContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableOrchestrationContext.cs
@@ -285,11 +285,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         {
             this.ThrowIfInvalidAccess();
 
-            (bool isValidTimespan, string errorMessage) = this.durabilityProvider.CheckTimeInterval(fireAt.Subtract(this.InnerContext.CurrentUtcDateTime));
-
-            if (!isValidTimespan)
+            if (!this.durabilityProvider.ValidateDelayTime(fireAt.Subtract(this.InnerContext.CurrentUtcDateTime), out string errorMessage))
             {
-                throw new ArgumentException($"Invalid timer duration: {errorMessage}");
+                throw new ArgumentException(errorMessage, nameof(fireAt));
             }
 
             Task<T> timerTask = this.InnerContext.CreateTimer(fireAt, state, cancelToken);
@@ -402,17 +400,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         {
             this.ThrowIfInvalidAccess();
 
-            (bool isValidTimespan, string errorMessage) = this.durabilityProvider.CheckTimeInterval(retryOptions.MaxRetryInterval);
-
-            if (!isValidTimespan)
+            if (!this.durabilityProvider.ValidateDelayTime(retryOptions.MaxRetryInterval, out string errorMessage))
             {
-                throw new ArgumentException($"Invalid max retry interval duration: {errorMessage}");
+                throw new ArgumentException(errorMessage, nameof(retryOptions.MaxRetryInterval));
             }
 
-            (isValidTimespan, errorMessage) = this.durabilityProvider.CheckTimeInterval(retryOptions.FirstRetryInterval);
-            if (!isValidTimespan)
+            if (!this.durabilityProvider.ValidateDelayTime(retryOptions.FirstRetryInterval, out errorMessage))
             {
-                throw new ArgumentException($"Invalid first retry interval duration: {errorMessage}");
+                throw new ArgumentException(errorMessage, nameof(retryOptions.FirstRetryInterval));
             }
 
             // TODO: Support for versioning
@@ -829,11 +824,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
         private Task<T> WaitForExternalEvent<T>(string name, TimeSpan timeout, Action<TaskCompletionSource<T>> timeoutAction)
         {
-            (bool isValidTimespan, string errorMessage) = this.durabilityProvider.CheckTimeInterval(timeout);
-
-            if (!isValidTimespan)
+            if (!this.durabilityProvider.ValidateDelayTime(timeout, out string errorMessage))
             {
-                throw new ArgumentException($"Invalid wait for event timeout duration: {errorMessage}");
+                throw new ArgumentException(errorMessage, nameof(timeout));
             }
 
             var tcs = new TaskCompletionSource<T>();

--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableOrchestrationContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableOrchestrationContext.cs
@@ -407,14 +407,17 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         {
             this.ThrowIfInvalidAccess();
 
-            if (!this.durabilityProvider.ValidateDelayTime(retryOptions.MaxRetryInterval, out string errorMessage))
+            if (retryOptions != null)
             {
-                throw new ArgumentException(errorMessage, nameof(retryOptions.MaxRetryInterval));
-            }
+                if (!this.durabilityProvider.ValidateDelayTime(retryOptions.MaxRetryInterval, out string errorMessage))
+                {
+                    throw new ArgumentException(errorMessage, nameof(retryOptions.MaxRetryInterval));
+                }
 
-            if (!this.durabilityProvider.ValidateDelayTime(retryOptions.FirstRetryInterval, out errorMessage))
-            {
-                throw new ArgumentException(errorMessage, nameof(retryOptions.FirstRetryInterval));
+                if (!this.durabilityProvider.ValidateDelayTime(retryOptions.FirstRetryInterval, out errorMessage))
+                {
+                    throw new ArgumentException(errorMessage, nameof(retryOptions.FirstRetryInterval));
+                }
             }
 
             // TODO: Support for versioning

--- a/src/WebJobs.Extensions.DurableTask/DurabilityProvider.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurabilityProvider.cs
@@ -376,15 +376,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         }
 
         /// <summary>
-        /// Uses durability provider specific logic to verify whether a timespan for a timer
-        /// or a retry interval is allowed by the provider.
+        /// Uses durability provider specific logic to verify whether a timespan for a timer, timeout
+        /// or retry interval is allowed by the provider.
         /// </summary>
-        /// <param name="timespan">The timespan for a timer or retry interval.</param>
-        /// <returns>A boolean indicating whether the time interval is valid and an error message if it is invalid.</returns>
-        public virtual (bool, string) CheckTimeInterval(TimeSpan timespan)
+        /// <param name="timespan">The timespan that the code will have to wait for.</param>
+        /// <param name="errorMessage">The error message if the timespan is invalid.</param>
+        /// <returns>A boolean indicating whether the time interval is valid.</returns>
+        public virtual bool ValidateDelayTime(TimeSpan timespan, out string errorMessage)
         {
-            // No operation by default
-            return (true, string.Empty);
+            errorMessage = null;
+            return true;
         }
     }
 }

--- a/src/WebJobs.Extensions.DurableTask/DurabilityProvider.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurabilityProvider.cs
@@ -374,5 +374,17 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         {
             return this.GetOrchestrationServiceClient().PurgeOrchestrationHistoryAsync(thresholdDateTimeUtc, timeRangeFilterType);
         }
+
+        /// <summary>
+        /// Uses durability provider specific logic to verify whether a timespan for a timer
+        /// or a retry interval is allowed by the provider.
+        /// </summary>
+        /// <param name="timespan">The timespan for a timer or retry interval.</param>
+        /// <returns>A boolean indicating whether the time interval is valid and an error message if it is invalid.</returns>
+        public virtual (bool, string) CheckTimeInterval(TimeSpan timespan)
+        {
+            // No operation by default
+            return (true, string.Empty);
+        }
     }
 }

--- a/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
@@ -294,7 +294,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             }
             else
             {
-                return new TaskOrchestrationShim(this, name);
+                return new TaskOrchestrationShim(this, this.defaultDurabilityProvider, name);
             }
         }
 

--- a/src/WebJobs.Extensions.DurableTask/Listener/TaskOrchestrationShim.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/TaskOrchestrationShim.cs
@@ -20,10 +20,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         private readonly DurableOrchestrationContext context;
         private readonly OutOfProcOrchestrationShim outOfProcShim;
 
-        public TaskOrchestrationShim(DurableTaskExtension config, string name)
+        public TaskOrchestrationShim(DurableTaskExtension config, DurabilityProvider durabilityProvider, string name)
             : base(config)
         {
-            this.context = new DurableOrchestrationContext(config, name);
+            this.context = new DurableOrchestrationContext(config, durabilityProvider, name);
             this.outOfProcShim = new OutOfProcOrchestrationShim(this.context);
         }
 

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net471.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net471.xml
@@ -445,6 +445,14 @@
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurabilityProvider.PurgeOrchestrationHistoryAsync(System.DateTime,DurableTask.Core.OrchestrationStateTimeRangeFilterType)">
             <inheritdoc />
         </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurabilityProvider.CheckTimeInterval(System.TimeSpan)">
+            <summary>
+            Uses durability provider specific logic to verify whether a timespan for a timer
+            or a retry interval is allowed by the provider.
+            </summary>
+            <param name="timespan">The timespan for a timer or retry interval.</param>
+            <returns>A boolean indicating whether the time interval is valid and an error message if it is invalid.</returns>
+        </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableHttpRequest">
             <summary>
             Request used to make an HTTP call through Durable Functions.

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net471.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net471.xml
@@ -445,13 +445,14 @@
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurabilityProvider.PurgeOrchestrationHistoryAsync(System.DateTime,DurableTask.Core.OrchestrationStateTimeRangeFilterType)">
             <inheritdoc />
         </member>
-        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurabilityProvider.CheckTimeInterval(System.TimeSpan)">
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurabilityProvider.ValidateDelayTime(System.TimeSpan,System.String@)">
             <summary>
-            Uses durability provider specific logic to verify whether a timespan for a timer
-            or a retry interval is allowed by the provider.
+            Uses durability provider specific logic to verify whether a timespan for a timer, timeout
+            or retry interval is allowed by the provider.
             </summary>
-            <param name="timespan">The timespan for a timer or retry interval.</param>
-            <returns>A boolean indicating whether the time interval is valid and an error message if it is invalid.</returns>
+            <param name="timespan">The timespan that the code will have to wait for.</param>
+            <param name="errorMessage">The error message if the timespan is invalid.</param>
+            <returns>A boolean indicating whether the time interval is valid.</returns>
         </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableHttpRequest">
             <summary>

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-netstandard2.0.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-netstandard2.0.xml
@@ -445,6 +445,14 @@
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurabilityProvider.PurgeOrchestrationHistoryAsync(System.DateTime,DurableTask.Core.OrchestrationStateTimeRangeFilterType)">
             <inheritdoc />
         </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurabilityProvider.CheckTimeInterval(System.TimeSpan)">
+            <summary>
+            Uses durability provider specific logic to verify whether a timespan for a timer
+            or a retry interval is allowed by the provider.
+            </summary>
+            <param name="timespan">The timespan for a timer or retry interval.</param>
+            <returns>A boolean indicating whether the time interval is valid and an error message if it is invalid.</returns>
+        </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableHttpRequest">
             <summary>
             Request used to make an HTTP call through Durable Functions.

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-netstandard2.0.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-netstandard2.0.xml
@@ -445,13 +445,14 @@
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurabilityProvider.PurgeOrchestrationHistoryAsync(System.DateTime,DurableTask.Core.OrchestrationStateTimeRangeFilterType)">
             <inheritdoc />
         </member>
-        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurabilityProvider.CheckTimeInterval(System.TimeSpan)">
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurabilityProvider.ValidateDelayTime(System.TimeSpan,System.String@)">
             <summary>
-            Uses durability provider specific logic to verify whether a timespan for a timer
-            or a retry interval is allowed by the provider.
+            Uses durability provider specific logic to verify whether a timespan for a timer, timeout
+            or retry interval is allowed by the provider.
             </summary>
-            <param name="timespan">The timespan for a timer or retry interval.</param>
-            <returns>A boolean indicating whether the time interval is valid and an error message if it is invalid.</returns>
+            <param name="timespan">The timespan that the code will have to wait for.</param>
+            <param name="errorMessage">The error message if the timespan is invalid.</param>
+            <returns>A boolean indicating whether the time interval is valid.</returns>
         </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableHttpRequest">
             <summary>

--- a/src/WebJobs.Extensions.DurableTask/RetryOptions.cs
+++ b/src/WebJobs.Extensions.DurableTask/RetryOptions.cs
@@ -13,6 +13,10 @@ namespace Microsoft.Azure.WebJobs
     {
         private readonly DurableTaskCore.RetryOptions retryOptions;
 
+        // Would like to make this durability provider specific, but since this is a customer
+        // facing type, that is difficult.
+        private static readonly TimeSpan defaultMaxRetryinterval = TimeSpan.FromDays(6);
+
         /// <summary>
         /// Creates a new instance RetryOptions with the supplied first retry and max attempts.
         /// </summary>
@@ -24,6 +28,7 @@ namespace Microsoft.Azure.WebJobs
         public RetryOptions(TimeSpan firstRetryInterval, int maxNumberOfAttempts)
         {
             this.retryOptions = new DurableTaskCore.RetryOptions(firstRetryInterval, maxNumberOfAttempts);
+            this.MaxRetryInterval = defaultMaxRetryinterval;
         }
 
         /// <summary>

--- a/src/WebJobs.Extensions.DurableTask/RetryOptions.cs
+++ b/src/WebJobs.Extensions.DurableTask/RetryOptions.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Azure.WebJobs
 
         // Would like to make this durability provider specific, but since this is a customer
         // facing type, that is difficult.
-        private static readonly TimeSpan defaultMaxRetryinterval = TimeSpan.FromDays(6);
+        private static readonly TimeSpan DefaultMaxRetryinterval = TimeSpan.FromDays(6);
 
         /// <summary>
         /// Creates a new instance RetryOptions with the supplied first retry and max attempts.
@@ -28,7 +28,7 @@ namespace Microsoft.Azure.WebJobs
         public RetryOptions(TimeSpan firstRetryInterval, int maxNumberOfAttempts)
         {
             this.retryOptions = new DurableTaskCore.RetryOptions(firstRetryInterval, maxNumberOfAttempts);
-            this.MaxRetryInterval = defaultMaxRetryinterval;
+            this.MaxRetryInterval = DefaultMaxRetryinterval;
         }
 
         /// <summary>

--- a/test/Common/DurableTaskEndToEndTests.cs
+++ b/test/Common/DurableTaskEndToEndTests.cs
@@ -2923,6 +2923,110 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             }
         }
 
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public async Task AzureStorage_TimerLimitExceeded_ThrowsException()
+        {
+            string orchestrationFunctionName = nameof(TestOrchestrations.SimpleTimerSucceeds);
+
+            using (var host = TestHelpers.GetJobHost(
+                this.loggerProvider,
+                nameof(this.AzureStorage_TimerLimitExceeded_ThrowsException),
+                false))
+            {
+                await host.StartAsync();
+
+                var invalidFireAtTime = DateTime.UtcNow.AddDays(7);
+
+                var client = await host.StartOrchestratorAsync(orchestrationFunctionName, invalidFireAtTime, this.output);
+
+                var status = await client.WaitForCompletionAsync(this.output);
+
+                Assert.Equal(OrchestrationRuntimeStatus.Completed, status.RuntimeStatus);
+
+                Assert.False((bool)status.Output);
+            }
+        }
+
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public async Task AzureStorage_FirstRetryIntervalLimitHit_ThrowsException()
+        {
+            string orchestrationFunctionName = nameof(TestOrchestrations.SimpleActivityRetrySuccceds);
+
+            using (var host = TestHelpers.GetJobHost(
+                this.loggerProvider,
+                // Need custom name so don't exceed 50 chars
+                "AzureStorageFirstRetryIntervalException",
+                false))
+            {
+                await host.StartAsync();
+
+                var firstRetryInterval = TimeSpan.FromDays(7);
+                var maxRetryInterval = TimeSpan.FromDays(1);
+
+                var client = await host.StartOrchestratorAsync(orchestrationFunctionName, (firstRetryInterval, maxRetryInterval), this.output);
+
+                var status = await client.WaitForCompletionAsync(this.output);
+
+                Assert.Equal(OrchestrationRuntimeStatus.Completed, status.RuntimeStatus);
+
+                Assert.False((bool)status.Output);
+            }
+        }
+
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public async Task AzureStorage_MaxRetryIntervalLimitHit_ThrowsException()
+        {
+            string orchestrationFunctionName = nameof(TestOrchestrations.SimpleActivityRetrySuccceds);
+
+            using (var host = TestHelpers.GetJobHost(
+                this.loggerProvider,
+                // Need custom name so don't exceed 50 chars
+                "AzureStorageMaxRetryIntervalException",
+                false))
+            {
+                await host.StartAsync();
+
+                var firstRetryInterval = TimeSpan.FromDays(1); 
+                var maxRetryInterval = TimeSpan.FromDays(7);
+
+                var client = await host.StartOrchestratorAsync(orchestrationFunctionName, (firstRetryInterval, maxRetryInterval), this.output);
+
+                var status = await client.WaitForCompletionAsync(this.output);
+
+                Assert.Equal(OrchestrationRuntimeStatus.Completed, status.RuntimeStatus);
+
+                Assert.False((bool)status.Output);
+            }
+        }
+
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public async Task AzureStorage_EventTimeoutLimitHit_ThrowsException()
+        {
+            string orchestrationFunctionName = nameof(TestOrchestrations.SimpleEventWithTimeoutSucceeds);
+
+            using (var host = TestHelpers.GetJobHost(
+                this.loggerProvider,
+                nameof(this.AzureStorage_EventTimeoutLimitHit_ThrowsException),
+                false))
+            {
+                await host.StartAsync();
+
+                var timeout = TimeSpan.FromDays(7);
+
+                var client = await host.StartOrchestratorAsync(orchestrationFunctionName, timeout, this.output);
+
+                var status = await client.WaitForCompletionAsync(this.output);
+
+                Assert.Equal(OrchestrationRuntimeStatus.Completed, status.RuntimeStatus);
+
+                Assert.False((bool)status.Output);
+            }
+        }
+
         /// <summary>
         /// End-to-end test which validates basic use of the object dispatch feature.
         /// TODO: This test is flakey in Functions V1.

--- a/test/Common/DurableTaskEndToEndTests.cs
+++ b/test/Common/DurableTaskEndToEndTests.cs
@@ -2941,10 +2941,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 var client = await host.StartOrchestratorAsync(orchestrationFunctionName, invalidFireAtTime, this.output);
 
                 var status = await client.WaitForCompletionAsync(this.output);
+                Assert.Equal(OrchestrationRuntimeStatus.Failed, status.RuntimeStatus);
 
-                Assert.Equal(OrchestrationRuntimeStatus.Completed, status.RuntimeStatus);
-
-                Assert.False((bool)status.Output);
+                string output = status.Output.ToString();
+                Assert.Contains("fireAt", output);
             }
         }
 
@@ -2956,8 +2956,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
             using (var host = TestHelpers.GetJobHost(
                 this.loggerProvider,
-                // Need custom name so don't exceed 50 chars
-                "AzureStorageFirstRetryIntervalException",
+                "AzureStorageFirstRetryIntervalException", // Need custom name so don't exceed 50 chars
                 false))
             {
                 await host.StartAsync();
@@ -2969,9 +2968,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
                 var status = await client.WaitForCompletionAsync(this.output);
 
-                Assert.Equal(OrchestrationRuntimeStatus.Completed, status.RuntimeStatus);
+                Assert.Equal(OrchestrationRuntimeStatus.Failed, status.RuntimeStatus);
 
-                Assert.False((bool)status.Output);
+                string output = status.Output.ToString();
+                Assert.Contains("FirstRetryInterval", output);
             }
         }
 
@@ -2983,22 +2983,22 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
             using (var host = TestHelpers.GetJobHost(
                 this.loggerProvider,
-                // Need custom name so don't exceed 50 chars
-                "AzureStorageMaxRetryIntervalException",
+                "AzureStorageMaxRetryIntervalException", // Need custom name so don't exceed 50 chars
                 false))
             {
                 await host.StartAsync();
 
-                var firstRetryInterval = TimeSpan.FromDays(1); 
+                var firstRetryInterval = TimeSpan.FromDays(1);
                 var maxRetryInterval = TimeSpan.FromDays(7);
 
                 var client = await host.StartOrchestratorAsync(orchestrationFunctionName, (firstRetryInterval, maxRetryInterval), this.output);
 
                 var status = await client.WaitForCompletionAsync(this.output);
 
-                Assert.Equal(OrchestrationRuntimeStatus.Completed, status.RuntimeStatus);
+                Assert.Equal(OrchestrationRuntimeStatus.Failed, status.RuntimeStatus);
 
-                Assert.False((bool)status.Output);
+                string output = status.Output.ToString();
+                Assert.Contains("MaxRetryInterval", output);
             }
         }
 
@@ -3021,9 +3021,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
                 var status = await client.WaitForCompletionAsync(this.output);
 
-                Assert.Equal(OrchestrationRuntimeStatus.Completed, status.RuntimeStatus);
+                Assert.Equal(OrchestrationRuntimeStatus.Failed, status.RuntimeStatus);
 
-                Assert.False((bool)status.Output);
+                string output = status.Output.ToString();
+                Assert.Contains("timeout", output);
             }
         }
 

--- a/test/Common/TestOrchestrations.cs
+++ b/test/Common/TestOrchestrations.cs
@@ -258,16 +258,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         public static async Task<bool> SimpleEventWithTimeoutSucceeds([OrchestrationTrigger] IDurableOrchestrationContext ctx)
         {
             TimeSpan timeout = ctx.GetInput<TimeSpan>();
-
-            try
-            {
-                await ctx.WaitForExternalEvent<string>("approval", timeout);
-            }
-            catch (ArgumentException)
-            {
-                return false;
-            }
-
+            await ctx.WaitForExternalEvent<string>("approval", timeout);
             return true;
         }
 
@@ -279,14 +270,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             {
                 MaxRetryInterval = maxRetry,
             };
-            try
-            {
-                await ctx.CallActivityWithRetryAsync<Guid>(nameof(TestActivities.NewGuid), retry, null);
-            }
-            catch (ArgumentException)
-            {
-                return false;
-            }
+
+            await ctx.CallActivityWithRetryAsync<Guid>(nameof(TestActivities.NewGuid), retry, null);
 
             return true;
         }
@@ -294,15 +279,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         public static async Task<bool> SimpleTimerSucceeds([OrchestrationTrigger] IDurableOrchestrationContext ctx)
         {
             DateTime fireAt = ctx.GetInput<DateTime>();
-            try
-            {
-                await ctx.CreateTimer(fireAt, CancellationToken.None);
-            }
-            catch (ArgumentException)
-            {
-                return false;
-            }
-
+            await ctx.CreateTimer(fireAt, CancellationToken.None);
             return true;
         }
 

--- a/test/Common/TestOrchestrations.cs
+++ b/test/Common/TestOrchestrations.cs
@@ -255,6 +255,57 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             return eventValue;
         }
 
+        public static async Task<bool> SimpleEventWithTimeoutSucceeds([OrchestrationTrigger] IDurableOrchestrationContext ctx)
+        {
+            TimeSpan timeout = ctx.GetInput<TimeSpan>();
+
+            try
+            {
+                await ctx.WaitForExternalEvent<string>("approval", timeout);
+            }
+            catch (ArgumentException)
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        public static async Task<bool> SimpleActivityRetrySuccceds([OrchestrationTrigger] IDurableOrchestrationContext ctx)
+        {
+            (TimeSpan firstRetry, TimeSpan maxRetry) = ctx.GetInput<(TimeSpan, TimeSpan)>();
+
+            RetryOptions retry = new RetryOptions(firstRetry, 5)
+            {
+                MaxRetryInterval = maxRetry,
+            };
+            try
+            {
+                await ctx.CallActivityWithRetryAsync<Guid>(nameof(TestActivities.NewGuid), retry, null);
+            }
+            catch (ArgumentException)
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        public static async Task<bool> SimpleTimerSucceeds([OrchestrationTrigger] IDurableOrchestrationContext ctx)
+        {
+            DateTime fireAt = ctx.GetInput<DateTime>();
+            try
+            {
+                await ctx.CreateTimer(fireAt, CancellationToken.None);
+            }
+            catch (ArgumentException)
+            {
+                return false;
+            }
+
+            return true;
+        }
+
         public static async Task ThrowOrchestrator([OrchestrationTrigger] IDurableOrchestrationContext ctx)
         {
             string message = ctx.GetInput<string>();


### PR DESCRIPTION
Ensure we never schedule a queue message longer than 6 days when using the Azure Storage durability provider.