### PR TITLE
Sanitize the default task hub names for Azure Storage

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/AzureStorageDurabilityProviderFactory.cs
+++ b/src/WebJobs.Extensions.DurableTask/AzureStorageDurabilityProviderFactory.cs
@@ -27,8 +27,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             JsonConvert.PopulateObject(JsonConvert.SerializeObject(this.options.StorageProvider), this.azureStorageOptions);
 
             this.azureStorageOptions.Validate();
-            if (this.options.HubName != null // Need to access HubName once to populate IsDefaultHubName
-                && !this.options.IsDefaultHubName)
+            if (!this.options.IsDefaultHubName())
             {
                 this.azureStorageOptions.ValidateHubName(this.options.HubName);
             }

--- a/src/WebJobs.Extensions.DurableTask/AzureStorageDurabilityProviderFactory.cs
+++ b/src/WebJobs.Extensions.DurableTask/AzureStorageDurabilityProviderFactory.cs
@@ -27,7 +27,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             JsonConvert.PopulateObject(JsonConvert.SerializeObject(this.options.StorageProvider), this.azureStorageOptions);
 
             this.azureStorageOptions.Validate();
-            this.azureStorageOptions.ValidateHubName(this.options.HubName);
+            if (this.options.HubName != null // Need to access HubName once to populate IsDefaultHubName
+                && !this.options.IsDefaultHubName)
+            {
+                this.azureStorageOptions.ValidateHubName(this.options.HubName);
+            }
+            else if (!this.azureStorageOptions.IsSanitizedHubName(this.options.HubName, out string sanitizedHubName))
+            {
+                this.options.HubName = sanitizedHubName;
+            }
 
             this.connectionStringResolver = connectionStringResolver;
             this.defaultConnectionName = this.azureStorageOptions.ConnectionStringName ?? ConnectionStringNames.Storage;

--- a/src/WebJobs.Extensions.DurableTask/Options/AzureStorageOptions.cs
+++ b/src/WebJobs.Extensions.DurableTask/Options/AzureStorageOptions.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Options
         // 45 alphanumeric characters gives us a buffer in our table/queue/blob container names.
         private const int MaxTaskHubNameSize = 45;
         private const int MinTaskHubNameSize = 3;
-        private const char TaskHubPadding = 'a';
+        private const string TaskHubPadding = "Hub";
 
         /// <summary>
         /// Gets or sets the name of the Azure Storage connection string used to manage the underlying Azure Storage resources.
@@ -141,7 +141,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Options
                                 .ToArray());
             if (sanitizedHubName.Length < MinTaskHubNameSize)
             {
-                sanitizedHubName = sanitizedHubName + new string(TaskHubPadding, MinTaskHubNameSize - sanitizedHubName.Length);
+                sanitizedHubName = sanitizedHubName + TaskHubPadding;
             }
 
             if (string.Equals(hubName, sanitizedHubName))

--- a/src/WebJobs.Extensions.DurableTask/Options/DurableTaskOptions.cs
+++ b/src/WebJobs.Extensions.DurableTask/Options/DurableTaskOptions.cs
@@ -17,8 +17,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
     {
         private string hubName;
 
-        [JsonIgnore]
-        internal bool IsDefaultHubName { get; set; } = false;
+        private bool? isDefaultHubName = null;
 
         /// <summary>
         /// Settings used for Durable HTTP functionality.
@@ -40,7 +39,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             {
                 if (this.hubName == null)
                 {
-                    this.IsDefaultHubName = true;
+                    this.isDefaultHubName = true;
 
                     // "WEBSITE_SITE_NAME" is an environment variable used in Azure functions infrastructure. When running locally, this can be
                     // specified in local.settings.json file to avoid being defaulted to "TestHubName"
@@ -53,6 +52,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             set
             {
                 this.hubName = value;
+                if (!this.isDefaultHubName.HasValue)
+                {
+                    this.isDefaultHubName = false;
+                }
             }
         }
 
@@ -203,7 +206,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 throw new InvalidOperationException($"A non-empty {nameof(this.HubName)} configuration is required.");
             }
 
-            if (IsInNonProductionSlot() && this.IsDefaultHubName)
+            if (IsInNonProductionSlot() && this.IsDefaultHubName())
             {
                 throw new InvalidOperationException("Task Hub name must be specified in host.json when using slots. See documentation on Task Hubs for " +
                     "information on how to set this: https://docs.microsoft.com/azure/azure-functions/durable/durable-functions-task-hubs");
@@ -220,6 +223,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             {
                 throw new InvalidOperationException($"{nameof(this.MaxConcurrentOrchestratorFunctions)} must be a non-negative integer value.");
             }
+        }
+
+        internal bool IsDefaultHubName()
+        {
+            return this.isDefaultHubName ?? this.hubName == null;
+        }
+
+        internal void SetDefaultHubName(string defaultHubName)
+        {
+            this.hubName = defaultHubName;
         }
 
         private static bool IsInNonProductionSlot()

--- a/src/WebJobs.Extensions.DurableTask/Options/DurableTaskOptions.cs
+++ b/src/WebJobs.Extensions.DurableTask/Options/DurableTaskOptions.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 using System.Net.Http;
 using System.Text;
 using Microsoft.Azure.WebJobs.Extensions.DurableTask.Options;
-using Newtonsoft.Json.Linq;
+using Newtonsoft.Json;
 
 namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 {
@@ -16,7 +16,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
     public class DurableTaskOptions
     {
         private string hubName;
-        private bool isDefaultHubName = false;
+
+        [JsonIgnore]
+        internal bool IsDefaultHubName { get; set; } = false;
 
         /// <summary>
         /// Settings used for Durable HTTP functionality.
@@ -38,7 +40,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             {
                 if (this.hubName == null)
                 {
-                    this.isDefaultHubName = true;
+                    this.IsDefaultHubName = true;
 
                     // "WEBSITE_SITE_NAME" is an environment variable used in Azure functions infrastructure. When running locally, this can be
                     // specified in local.settings.json file to avoid being defaulted to "TestHubName"
@@ -201,7 +203,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 throw new InvalidOperationException($"A non-empty {nameof(this.HubName)} configuration is required.");
             }
 
-            if (IsInNonProductionSlot() && this.isDefaultHubName)
+            if (IsInNonProductionSlot() && this.IsDefaultHubName)
             {
                 throw new InvalidOperationException("Task Hub name must be specified in host.json when using slots. See documentation on Task Hubs for " +
                     "information on how to set this: https://docs.microsoft.com/azure/azure-functions/durable/durable-functions-task-hubs");

--- a/test/Common/DurableTaskEndToEndTests.cs
+++ b/test/Common/DurableTaskEndToEndTests.cs
@@ -3603,6 +3603,81 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         }
 
         [Fact]
+        public void TaskHubName_DefaultNameSiteWithDashes_UsesSanitizedHubName()
+        {
+            string currSiteName = Environment.GetEnvironmentVariable("WEBSITE_SITE_NAME");
+            string currSlotName = Environment.GetEnvironmentVariable("WEBSITE_SLOT_NAME");
+
+            try
+            {
+                Environment.SetEnvironmentVariable("WEBSITE_SITE_NAME", "Test-Site-Name");
+                Environment.SetEnvironmentVariable("WEBSITE_SLOT_NAME", null);
+
+                var options = new DurableTaskOptions();
+
+                var expectedHubName = "TestSiteName";
+
+                var host = TestHelpers.GetJobHost(this.loggerProvider, options);
+                Assert.Equal(expectedHubName, options.HubName);
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("WEBSITE_SITE_NAME", currSiteName);
+                Environment.SetEnvironmentVariable("WEBSITE_SLOT_NAME", currSlotName);
+            }
+        }
+
+        [Fact]
+        public void TaskHubName_DefaultNameSiteTooLong_UsesSanitizedHubName()
+        {
+            string currSiteName = Environment.GetEnvironmentVariable("WEBSITE_SITE_NAME");
+            string currSlotName = Environment.GetEnvironmentVariable("WEBSITE_SLOT_NAME");
+
+            try
+            {
+                Environment.SetEnvironmentVariable("WEBSITE_SITE_NAME", new string('a', 100));
+                Environment.SetEnvironmentVariable("WEBSITE_SLOT_NAME", null);
+
+                var options = new DurableTaskOptions();
+
+                var expectedHubName = new string('a', 45);
+
+                var host = TestHelpers.GetJobHost(this.loggerProvider, options);
+                Assert.Equal(expectedHubName, options.HubName);
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("WEBSITE_SITE_NAME", currSiteName);
+                Environment.SetEnvironmentVariable("WEBSITE_SLOT_NAME", currSlotName);
+            }
+        }
+
+        [Fact]
+        public void TaskHubName_DefaultNameSiteTooShort_UsesSanitizedHubName()
+        {
+            string currSiteName = Environment.GetEnvironmentVariable("WEBSITE_SITE_NAME");
+            string currSlotName = Environment.GetEnvironmentVariable("WEBSITE_SLOT_NAME");
+
+            try
+            {
+                Environment.SetEnvironmentVariable("WEBSITE_SITE_NAME", new string('b', 2));
+                Environment.SetEnvironmentVariable("WEBSITE_SLOT_NAME", null);
+
+                var options = new DurableTaskOptions();
+
+                var expectedHubName = "bba";
+
+                var host = TestHelpers.GetJobHost(this.loggerProvider, options);
+                Assert.Equal(expectedHubName, options.HubName);
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("WEBSITE_SITE_NAME", currSiteName);
+                Environment.SetEnvironmentVariable("WEBSITE_SLOT_NAME", currSlotName);
+            }
+        }
+
+        [Fact]
         [Trait("Category", PlatformSpecificHelpers.TestCategory)]
         public async Task ReplaySafeLogger_LogsOnlyOnce()
         {

--- a/test/Common/DurableTaskEndToEndTests.cs
+++ b/test/Common/DurableTaskEndToEndTests.cs
@@ -3603,6 +3603,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         }
 
         [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
         public void TaskHubName_DefaultNameSiteWithDashes_UsesSanitizedHubName()
         {
             string currSiteName = Environment.GetEnvironmentVariable("WEBSITE_SITE_NAME");
@@ -3628,6 +3629,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         }
 
         [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
         public void TaskHubName_DefaultNameSiteTooLong_UsesSanitizedHubName()
         {
             string currSiteName = Environment.GetEnvironmentVariable("WEBSITE_SITE_NAME");
@@ -3653,6 +3655,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         }
 
         [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
         public void TaskHubName_DefaultNameSiteTooShort_UsesSanitizedHubName()
         {
             string currSiteName = Environment.GetEnvironmentVariable("WEBSITE_SITE_NAME");

--- a/test/Common/DurableTaskEndToEndTests.cs
+++ b/test/Common/DurableTaskEndToEndTests.cs
@@ -3519,8 +3519,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             Assert.NotNull(argumentException);
             Assert.Equal(
                 argumentException.Message.Contains($"{taskHubName}V1")
-                    ? $"Task hub name '{taskHubName}V1' should contain only alphanumeric characters excluding '-' and have length up to 50."
-                    : $"Task hub name '{taskHubName}V2' should contain only alphanumeric characters excluding '-' and have length up to 50.",
+                    ? $"Task hub name '{taskHubName}V1' should contain only alphanumeric characters excluding '-' and have length up to 45."
+                    : $"Task hub name '{taskHubName}V2' should contain only alphanumeric characters excluding '-' and have length up to 45.",
                 argumentException.Message);
         }
 
@@ -3665,7 +3665,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
                 var options = new DurableTaskOptions();
 
-                var expectedHubName = "bba";
+                var expectedHubName = "bbHub";
 
                 var host = TestHelpers.GetJobHost(this.loggerProvider, options);
                 Assert.Equal(expectedHubName, options.HubName);


### PR DESCRIPTION
In a previous release, we started using the site name as the default
task hub value. However, it is possible for the site name not to be a
valid task hub name for Azure Storage, due to having '-' characters and
not meeting the length requirements. We now ensure that no matter the
sitename, the customer will have a valid task hub.

Addresses issue #976