### PR TITLE
Throws an exception on invalid dedupe status when starting a new orchestration

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/AzureStorageDurabilityProviderFactory.cs
+++ b/src/WebJobs.Extensions.DurableTask/AzureStorageDurabilityProviderFactory.cs
@@ -105,6 +105,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     this.connectionStringResolver,
                     this.azureStorageOptions.TrackingStoreConnectionStringName),
                 FetchLargeMessageDataEnabled = this.azureStorageOptions.FetchLargeMessagesAutomatically,
+                ThrowExceptionOnInvalidDedupeStatus = true,
             };
 
             if (!string.IsNullOrEmpty(this.azureStorageOptions.TrackingStoreNamePrefix))

--- a/test/Common/DurableTaskEndToEndTests.cs
+++ b/test/Common/DurableTaskEndToEndTests.cs
@@ -3496,7 +3496,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         [MemberData(nameof(TestDataGenerator.GetExtendedSessionAndFullFeaturedStorageProviderOptions), MemberType = typeof(TestDataGenerator))]
         public async Task Dedupe_Default_NotRunning_ThrowsException(bool extendedSessions, string storageProvider)
         {
-           var instanceId = "OverridableStatesTest";
+           var instanceId = "OverridableStatesDefaultTest";
 
            using (JobHost host = TestHelpers.GetJobHost(
                 this.loggerProvider,
@@ -3547,7 +3547,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             DurableTaskOptions options = new DurableTaskOptions();
             options.OverridableExistingInstanceStates = OverridableStates.AnyState;
 
-            var instanceId = "OverridableStatesTest";
+            var instanceId = "OverridableStatesAnyStateTest";
 
             using (JobHost host = TestHelpers.GetJobHost(
                 this.loggerProvider,

--- a/test/Common/DurableTaskEndToEndTests.cs
+++ b/test/Common/DurableTaskEndToEndTests.cs
@@ -3498,7 +3498,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         {
            var instanceId = "OverridableStatesTest";
 
-            using (JobHost host = TestHelpers.GetJobHost(
+           using (JobHost host = TestHelpers.GetJobHost(
                 this.loggerProvider,
                 nameof(this.Dedupe_Default_NotRunning_ThrowsException),
                 extendedSessions,

--- a/test/Common/DurableTaskEndToEndTests.cs
+++ b/test/Common/DurableTaskEndToEndTests.cs
@@ -3492,21 +3492,17 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         }
 
         [Theory]
-        [Trait("Category", PlatformSpecificHelpers.TestCategory + "_BVT")]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
         [MemberData(nameof(TestDataGenerator.GetExtendedSessionAndFullFeaturedStorageProviderOptions), MemberType = typeof(TestDataGenerator))]
-        public async Task DedupeStates_NotRunningStates_ThrowsException(bool extendedSessions, string storageProvider)
+        public async Task Dedupe_Default_NotRunning_ThrowsException(bool extendedSessions, string storageProvider)
         {
-            DurableTaskOptions options = new DurableTaskOptions();
-            options.OverridableExistingInstanceStates = OverridableStates.NonRunningStates;
-
-            var instanceId = "OverridableStatesTest";
+           var instanceId = "OverridableStatesTest";
 
             using (JobHost host = TestHelpers.GetJobHost(
                 this.loggerProvider,
-                nameof(this.DedupeStates_NotRunningStates_ThrowsException),
+                nameof(this.Dedupe_Default_NotRunning_ThrowsException),
                 extendedSessions,
-                storageProviderType: storageProvider,
-                options: options))
+                storageProviderType: storageProvider))
             {
                 await host.StartAsync();
 
@@ -3544,7 +3540,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         }
 
         [Theory]
-        [Trait("Category", PlatformSpecificHelpers.TestCategory + "_BVT")]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
         [MemberData(nameof(TestDataGenerator.GetExtendedSessionAndFullFeaturedStorageProviderOptions), MemberType = typeof(TestDataGenerator))]
         public async Task DedupeStates_AnyState(bool extendedSessions, string storageProvider)
         {

--- a/test/Common/DurableTaskLifeCycleNotificationTest.cs
+++ b/test/Common/DurableTaskLifeCycleNotificationTest.cs
@@ -1298,7 +1298,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             int callCount = 0;
             Action<string> handler = eventName => { callCount++; };
 
-            using (JobHost host = TestHelpers.GetJobHost(
+            using (JobHost host = TestHelpers.GetJobHostWithOptions(
                 this.loggerProvider,
                 wrappedOptions.Value,
                 lifeCycleNotificationHelper: new MockLifeCycleNotificationHelper(handler)))

--- a/test/Common/TestHelpers.cs
+++ b/test/Common/TestHelpers.cs
@@ -46,7 +46,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             bool autoFetchLargeMessages = true,
             int httpAsyncSleepTime = 500,
             IDurableHttpMessageHandlerFactory durableHttpMessageHandler = null,
-            ILifeCycleNotificationHelper lifeCycleNotificationHelper = null)
+            ILifeCycleNotificationHelper lifeCycleNotificationHelper = null,
+            DurableTaskOptions options = null)
         {
             switch (storageProviderType)
             {
@@ -60,40 +61,18 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                     throw new InvalidOperationException($"Storage provider {storageProviderType} is not supported for testing infrastructure.");
             }
 
-            var durableTaskOptions = new DurableTaskOptions
+            if (options == null)
             {
-                HubName = GetTaskHubNameFromTestName(testName, enableExtendedSessions),
-                Tracing = new TraceOptions()
-                {
-                    TraceInputsAndOutputs = true,
-                    TraceReplayEvents = traceReplayEvents,
-                },
-                Notifications = new NotificationOptions()
-                {
-                    EventGrid = new EventGridNotificationOptions()
-                    {
-                        KeySettingName = eventGridKeySettingName,
-                        TopicEndpoint = eventGridTopicEndpoint,
-                        PublishEventTypes = eventGridPublishEventTypes,
-                    },
-                },
-                HttpSettings = new HttpOptions()
-                {
-                    DefaultAsyncRequestSleepTimeMilliseconds = httpAsyncSleepTime,
-                },
-                NotificationUrl = notificationUrl,
-                ExtendedSessionsEnabled = enableExtendedSessions,
-                MaxConcurrentOrchestratorFunctions = 200,
-                MaxConcurrentActivityFunctions = 200,
-                NotificationHandler = eventGridNotificationHandler,
-            };
-            durableTaskOptions.HubName = GetTaskHubNameFromTestName(testName, enableExtendedSessions);
-            durableTaskOptions.Tracing = new TraceOptions()
+                options = new DurableTaskOptions();
+            }
+
+            options.HubName = GetTaskHubNameFromTestName(testName, enableExtendedSessions);
+            options.Tracing = new TraceOptions()
             {
                 TraceInputsAndOutputs = true,
                 TraceReplayEvents = traceReplayEvents,
             };
-            durableTaskOptions.Notifications = new NotificationOptions()
+            options.Notifications = new NotificationOptions()
             {
                 EventGrid = new EventGridNotificationOptions()
                 {
@@ -102,56 +81,81 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                     PublishEventTypes = eventGridPublishEventTypes,
                 },
             };
-            durableTaskOptions.HttpSettings = new HttpOptions()
+            options.HttpSettings = new HttpOptions()
             {
                 DefaultAsyncRequestSleepTimeMilliseconds = httpAsyncSleepTime,
             };
-            durableTaskOptions.NotificationUrl = notificationUrl;
-            durableTaskOptions.ExtendedSessionsEnabled = enableExtendedSessions;
-            durableTaskOptions.MaxConcurrentOrchestratorFunctions = 200;
-            durableTaskOptions.MaxConcurrentActivityFunctions = 200;
-            durableTaskOptions.NotificationHandler = eventGridNotificationHandler;
+            options.NotificationUrl = notificationUrl;
+            options.ExtendedSessionsEnabled = enableExtendedSessions;
+            options.MaxConcurrentOrchestratorFunctions = 200;
+            options.MaxConcurrentActivityFunctions = 200;
+            options.NotificationHandler = eventGridNotificationHandler;
+
+            options.HubName = GetTaskHubNameFromTestName(testName, enableExtendedSessions);
+            options.Tracing = new TraceOptions()
+            {
+                TraceInputsAndOutputs = true,
+                TraceReplayEvents = traceReplayEvents,
+            };
+            options.Notifications = new NotificationOptions()
+            {
+                EventGrid = new EventGridNotificationOptions()
+                {
+                    KeySettingName = eventGridKeySettingName,
+                    TopicEndpoint = eventGridTopicEndpoint,
+                    PublishEventTypes = eventGridPublishEventTypes,
+                },
+            };
+            options.HttpSettings = new HttpOptions()
+            {
+                DefaultAsyncRequestSleepTimeMilliseconds = httpAsyncSleepTime,
+            };
+            options.NotificationUrl = notificationUrl;
+            options.ExtendedSessionsEnabled = enableExtendedSessions;
+            options.MaxConcurrentOrchestratorFunctions = 200;
+            options.MaxConcurrentActivityFunctions = 200;
+            options.NotificationHandler = eventGridNotificationHandler;
 
             // Azure Storage specfic tests
             if (string.Equals(storageProviderType, AzureStorageProviderType))
             {
-                durableTaskOptions.StorageProvider["fetchLargeMessagesAutomatically"] = autoFetchLargeMessages;
+                options.StorageProvider["fetchLargeMessagesAutomatically"] = autoFetchLargeMessages;
                 if (maxQueuePollingInterval != null)
                 {
-                    durableTaskOptions.StorageProvider["maxQueuePollingInterval"] = maxQueuePollingInterval.Value;
+                    options.StorageProvider["maxQueuePollingInterval"] = maxQueuePollingInterval.Value;
                 }
             }
 
             if (eventGridRetryCount.HasValue)
             {
-                durableTaskOptions.Notifications.EventGrid.PublishRetryCount = eventGridRetryCount.Value;
+                options.Notifications.EventGrid.PublishRetryCount = eventGridRetryCount.Value;
             }
 
             if (eventGridRetryInterval.HasValue)
             {
-                durableTaskOptions.Notifications.EventGrid.PublishRetryInterval = eventGridRetryInterval.Value;
+                options.Notifications.EventGrid.PublishRetryInterval = eventGridRetryInterval.Value;
             }
 
             if (eventGridRetryHttpStatus != null)
             {
-                durableTaskOptions.Notifications.EventGrid.PublishRetryHttpStatus = eventGridRetryHttpStatus;
+                options.Notifications.EventGrid.PublishRetryHttpStatus = eventGridRetryHttpStatus;
             }
 
             if (maxQueuePollingInterval != null)
             {
-                durableTaskOptions.StorageProvider["maxQueuePollingInterval"] = maxQueuePollingInterval.Value;
+                options.StorageProvider["maxQueuePollingInterval"] = maxQueuePollingInterval.Value;
             }
 
-            return GetJobHost(
+            return GetJobHostWithOptions(
                 loggerProvider,
-                durableTaskOptions,
+                options,
                 storageProviderType,
                 nameResolver,
                 durableHttpMessageHandler,
                 lifeCycleNotificationHelper);
         }
 
-        public static JobHost GetJobHost(
+        public static JobHost GetJobHostWithOptions(
             ILoggerProvider loggerProvider,
             DurableTaskOptions durableTaskOptions,
             string storageProviderType = AzureStorageProviderType,


### PR DESCRIPTION
Starting a new orchestration with an existing instance id now has configurable behavior (#987 ). This PR changes the behavior to throw an exception when attempting to start a new orchestration in an invalid dedupe status.

This PR also adds tests for each of the configurable OverridableStates to test this behavior.

Issue related to this change:
#367 
