### PR TITLE
Analyzer: Fixed V2 namespace references

### DIFF
--- a/src/WebJobs.Extensions.DurableTask.Analyzers/Analyzers/ActivityFunction/FunctionAnalyzer.cs
+++ b/src/WebJobs.Extensions.DurableTask.Analyzers/Analyzers/ActivityFunction/FunctionAnalyzer.cs
@@ -141,7 +141,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
                         if (SyntaxNodeUtils.TryGetParameterNodeNextToAttribute(attributeExpression, context, out SyntaxNode inputTypeNode))
                         {
                             ITypeSymbol inputType = context.SemanticModel.GetTypeInfo(inputTypeNode).Type;
-                            if (inputType.ToString().Equals("Microsoft.Azure.WebJobs.IDurableActivityContext") || inputType.ToString().Equals("Microsoft.Azure.WebJobs.DurableActivityContext"))
+                            if (inputType.ToString().Equals("Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableActivityContext") || inputType.ToString().Equals("Microsoft.Azure.WebJobsDurableActivityContext"))
                             {
                                 if (!TryGetInputTypeFromDurableContextCall(out inputType, context, attributeExpression))
                                 {

--- a/src/WebJobs.Extensions.DurableTask.Analyzers/Analyzers/ActivityFunction/FunctionAnalyzer.cs
+++ b/src/WebJobs.Extensions.DurableTask.Analyzers/Analyzers/ActivityFunction/FunctionAnalyzer.cs
@@ -141,7 +141,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
                         if (SyntaxNodeUtils.TryGetParameterNodeNextToAttribute(attributeExpression, context, out SyntaxNode inputTypeNode))
                         {
                             ITypeSymbol inputType = context.SemanticModel.GetTypeInfo(inputTypeNode).Type;
-                            if (inputType.ToString().Equals("Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableActivityContext") || inputType.ToString().Equals("Microsoft.Azure.WebJobsDurableActivityContext"))
+                            if (inputType.ToString().Equals("Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableActivityContext") || inputType.ToString().Equals("Microsoft.Azure.WebJobs.DurableActivityContext"))
                             {
                                 if (!TryGetInputTypeFromDurableContextCall(out inputType, context, attributeExpression))
                                 {

--- a/src/WebJobs.Extensions.DurableTask.Analyzers/SyntaxNodeUtils.cs
+++ b/src/WebJobs.Extensions.DurableTask.Analyzers/SyntaxNodeUtils.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
                 return (DurableVersion)version;
             }
 
-            var versionTwoInterface = semanticModel.Compilation.GetTypeByMetadataName("Microsoft.Azure.WebJobs.IDurableOrchestrationContext");
+            var versionTwoInterface = semanticModel.Compilation.GetTypeByMetadataName("Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableOrchestrationContext");
             version = versionTwoInterface != null ? DurableVersion.V2 : DurableVersion.V1;
             return (DurableVersion)version;
         }


### PR DESCRIPTION
Recently we changed the namespace of all of our durable classes. #1004 
This PR fixes the namespace references in the Durable Functions Analyzer to match those changes.

resolves #1018 
resolves #1019 