### PR TITLE
Analyzer: FunctionReturnTypeAnalyzer wont flag code when expected return type is Task

### DIFF
--- a/src/WebJobs.Extensions.DurableTask.Analyzers/Analyzers/ActivityFunction/FunctionReturnTypeAnalyzer.cs
+++ b/src/WebJobs.Extensions.DurableTask.Analyzers/Analyzers/ActivityFunction/FunctionReturnTypeAnalyzer.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
                 var functionDefinition = availableFunctions.Where(x => x.FunctionName == node.Name).SingleOrDefault();
                 if (functionDefinition != null)
                 {
-
+                    // Functions can always return Task, regardless of function definition return type
                     if (functionDefinition.ReturnType != node.ExpectedReturnType &&
                         (node.ExpectedReturnType != "System.Threading.Tasks.Task"))
                     {

--- a/src/WebJobs.Extensions.DurableTask.Analyzers/Analyzers/ActivityFunction/FunctionReturnTypeAnalyzer.cs
+++ b/src/WebJobs.Extensions.DurableTask.Analyzers/Analyzers/ActivityFunction/FunctionReturnTypeAnalyzer.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
                 {
 
                     if (functionDefinition.ReturnType != node.ExpectedReturnType &&
-                        !(functionDefinition.ReturnType == "System.Void" && node.ExpectedReturnType == "System.Threading.Tasks.Task"))
+                        (node.ExpectedReturnType != "System.Threading.Tasks.Task"))
                     {
                         if ($"System.Threading.Tasks.Task<{functionDefinition.ReturnType}>" != node.ExpectedReturnType)
                             cac.ReportDiagnostic(Diagnostic.Create(Rule, node.ExpectedReturnTypeNode.GetLocation(), node.Name, functionDefinition.ReturnType, node.ExpectedReturnType));


### PR DESCRIPTION
Fixed activity FunctionReturnTypeAnalyzer to accept the expected return type to be Task regardless of activity function definition return type.

resolves #998 