### PR TITLE
Fix [Obsolete] warning messages

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/ContextInterfaces/LegacyCompatibility.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextInterfaces/LegacyCompatibility.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
     /// Now obsolete: use <see cref="IDurableActivityContext"/> instead.
     /// </summary>
     [SuppressMessage("StyleCop.CSharp.NamingRules", "SA1302", Justification = "Engineered for v1 legacy compatibility.")]
-    [Obsolete("Use IDurableOrchestrationContext instead.")]
+    [Obsolete("Use IDurableActivityContext instead.")]
     public interface DurableActivityContextBase : IDurableActivityContext
     {
     }
@@ -32,7 +32,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
     /// Now obsolete: use <see cref="IDurableOrchestrationClient"/> instead.
     /// </summary>
     [SuppressMessage("StyleCop.CSharp.NamingRules", "SA1302", Justification = "Engineered for v1 legacy compatibility.")]
-    [Obsolete("Use IDurableOrchestrationContext instead.")]
+    [Obsolete("Use IDurableOrchestrationClient instead.")]
     public interface DurableOrchestrationClientBase : IDurableOrchestrationClient
     {
     }


### PR DESCRIPTION
I found this while looking at the auto-generated API documentation. It appears to be a simple copy/paste error.