### PR TITLE
Add support for delete operation in DispatchAsync and in Http API

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/EntityScheduler/TypedInvocationExtensions.cs
+++ b/src/WebJobs.Extensions.DurableTask/EntityScheduler/TypedInvocationExtensions.cs
@@ -37,7 +37,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
             if (method == null)
             {
-                throw new InvalidOperationException($"No operation named '{context.OperationName}' was found.");
+                if (string.Equals("delete", context.OperationName, StringComparison.InvariantCultureIgnoreCase))
+                {
+                    Entity.Current.DeleteState();
+                    return;
+                }
+                else
+                {
+                    throw new InvalidOperationException($"No operation named '{context.OperationName}' was found.");
+                }
             }
 
             // check that the number of arguments is zero or one

--- a/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
+++ b/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
@@ -216,7 +216,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                         {
                             return await this.HandleGetEntityRequestAsync(request, entityId);
                         }
-                        else if (request.Method == HttpMethod.Post)
+                        else if (request.Method == HttpMethod.Post || request.Method == HttpMethod.Delete)
                         {
                             return await this.HandlePostEntityOperationRequestAsync(request, entityId);
                         }
@@ -708,7 +708,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         {
             IDurableEntityClient client = this.GetClient(request);
 
-            string operationName = request.GetQueryNameValuePairs()["op"] ?? string.Empty;
+            string operationName;
+
+            if (request.Method == HttpMethod.Delete)
+            {
+                operationName = "delete";
+            }
+            else
+            {
+                operationName = request.GetQueryNameValuePairs()["op"] ?? string.Empty;
+            }
 
             if (request.Content == null || request.Content.Headers.ContentLength == 0)
             {

--- a/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
+++ b/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
@@ -71,8 +71,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.DurableTask.Core" Version="2.1.3" />
-    <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage" Version="1.6.5" />
+    <PackageReference Include="Microsoft.Azure.DurableTask.Core" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage" Version="1.7.0" />
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.0.3" />
   </ItemGroup>
 

--- a/test/FunctionsV1/WebJobs.Extensions.DurableTask.Tests.V1.csproj
+++ b/test/FunctionsV1/WebJobs.Extensions.DurableTask.Tests.V1.csproj
@@ -16,7 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="4.19.4" />
-    <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage" Version="1.6.5" />
+    <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage" Version="1.7.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="2.2.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" Version="2.2.0" />
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.33" />

--- a/test/FunctionsV2/WebJobs.Extensions.DurableTask.Tests.V2.csproj
+++ b/test/FunctionsV2/WebJobs.Extensions.DurableTask.Tests.V2.csproj
@@ -16,7 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="4.19.4" />
-    <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage" Version="1.6.5" />
+    <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage" Version="1.7.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.14" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="3.0.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" Version="3.0.0" />
@@ -27,8 +27,8 @@
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.*" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.Azure.DurableTask.Emulator" Version="2.1.3" />
-    <PackageReference Include="Microsoft.Azure.DurableTask.Redis" Version="0.1.1-alpha" />
+    <PackageReference Include="Microsoft.Azure.DurableTask.Emulator" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Azure.DurableTask.Redis" Version="0.1.2-alpha" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
As discussed in #931, this PR adds a bit of convenience for implementing deletion of entities. 

- One can now issue a DELETE request to the HTTP API, with the effect of signaling an operation called 'delete' on the entity.

- For the class-based syntax, one can call `delete` on an entity with class `T` even if `T` does not have a delete method. In that case `DispatchAsync<T>` simply calls `Entity.Current.Delete()`. 