### PR TITLE
Allow OrchestrationClientAttribute on DurableOrchestrationClientBase

### DIFF
--- a/src/WebJobs.Extensions.DurableTask.Analyzers/Analyzers/Binding/ClientAnalyzer.cs
+++ b/src/WebJobs.Extensions.DurableTask.Analyzers/Analyzers/Binding/ClientAnalyzer.cs
@@ -101,7 +101,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
 
             if (version.Equals(DurableVersion.V1))
             {
-                if (string.Equals(paramTypeName, "DurableOrchestrationClient"))
+                if (string.Equals(paramTypeName, "DurableOrchestrationClient") || string.Equals(paramTypeName, "DurableOrchestrationClientBase"))
                 {
                     return true;
                 }


### PR DESCRIPTION
Currently, the binding analyzer only allows for parameters of type
`DurableOrchestrationClient` for the `OrchestrationClientAttribute`.

This change also allows for `DurableOrchestrationClientBase` as the
abstract base class can be used to facilitate unit testing of the orchestration starter.

This change only affects the analyzer for V1 function apps.

resolves #1053