### PR TITLE
Fixed TaskHubName to work regardless of get/set order

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/AzureStorageDurabilityProviderFactory.cs
+++ b/src/WebJobs.Extensions.DurableTask/AzureStorageDurabilityProviderFactory.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             }
             else if (!this.azureStorageOptions.IsSanitizedHubName(this.options.HubName, out string sanitizedHubName))
             {
-                this.options.HubName = sanitizedHubName;
+                this.options.SetDefaultHubName(sanitizedHubName);
             }
 
             this.connectionStringResolver = connectionStringResolver;

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net471.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net471.xml
@@ -2942,6 +2942,12 @@
             Gets or sets the time window within which entity messages get deduplicated and reordered.
             </summary>
         </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskOptions.SetDefaultHubName(System.String)">
+            <summary>
+            Sets HubName to a value that is considered a default value.
+            </summary>
+            <param name="hubName">TaskHub name that is considered the default.</param>
+        </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.EventGridNotificationOptions">
             <summary>
             Configuration of the Event Grid notification options

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
@@ -3009,6 +3009,12 @@
             Gets or sets the time window within which entity messages get deduplicated and reordered.
             </summary>
         </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskOptions.SetDefaultHubName(System.String)">
+            <summary>
+            Sets HubName to a value that is considered a default value.
+            </summary>
+            <param name="hubName">TaskHub name that is considered the default.</param>
+        </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.EventGridNotificationOptions">
             <summary>
             Configuration of the Event Grid notification options

--- a/src/WebJobs.Extensions.DurableTask/Options/DurableTaskOptions.cs
+++ b/src/WebJobs.Extensions.DurableTask/Options/DurableTaskOptions.cs
@@ -52,12 +52,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             }
         }
 
-        internal void SetDefaultHubName(string hubName)
-        {
-            this.HubName = hubName;
-            this.defaultHubName = hubName;
-        }
-
         /// <summary>
         /// The section of configuration related to storage providers. If using Azure Storage provider, the schema should match
         /// <see cref="AzureStorageOptions"/>.
@@ -153,6 +147,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         // Used for mocking the lifecycle notification helper.
         internal HttpMessageHandler NotificationHandler { get; set; }
 
+        /// <summary>
+        /// Sets HubName to a value that is considered a default value.
+        /// </summary>
+        /// <param name="hubName">TaskHub name that is considered the default.</param>
+        public void SetDefaultHubName(string hubName)
+        {
+            this.HubName = hubName;
+            this.defaultHubName = hubName;
+        }
+
         internal string GetDebugString()
         {
             var sb = new StringBuilder(4096);
@@ -207,8 +211,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
             if (IsInNonProductionSlot() && this.IsDefaultHubName())
             {
-                throw new InvalidOperationException("Task Hub name must be specified in host.json when using slots. See documentation on Task Hubs for " +
-                    "information on how to set this: https://docs.microsoft.com/azure/azure-functions/durable/durable-functions-task-hubs");
+                throw new InvalidOperationException($"Task Hub name must be specified in host.json when using slots. Specified name must not equal the defaultHubName ({this.defaultHubName})." +
+                    "See documentation on Task Hubs for information on how to set this: https://docs.microsoft.com/azure/azure-functions/durable/durable-functions-task-hubs");
             }
 
             this.Notifications.Validate();

--- a/src/WebJobs.Extensions.DurableTask/Options/DurableTaskOptions.cs
+++ b/src/WebJobs.Extensions.DurableTask/Options/DurableTaskOptions.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
     {
         private string hubName;
 
-        private bool? isDefaultHubName = null;
+        private string defaultHubName;
 
         /// <summary>
         /// Settings used for Durable HTTP functionality.
@@ -37,11 +37,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             {
                 if (this.hubName == null)
                 {
-                    this.isDefaultHubName = true;
-
                     // "WEBSITE_SITE_NAME" is an environment variable used in Azure functions infrastructure. When running locally, this can be
                     // specified in local.settings.json file to avoid being defaulted to "TestHubName"
                     this.hubName = Environment.GetEnvironmentVariable("WEBSITE_SITE_NAME") ?? "TestHubName";
+                    this.defaultHubName = this.hubName;
                 }
 
                 return this.hubName;
@@ -50,11 +49,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             set
             {
                 this.hubName = value;
-                if (!this.isDefaultHubName.HasValue)
-                {
-                    this.isDefaultHubName = false;
-                }
             }
+        }
+
+        internal void SetDefaultHubName(string hubName)
+        {
+            this.HubName = hubName;
+            this.defaultHubName = hubName;
         }
 
         /// <summary>
@@ -225,12 +226,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
         internal bool IsDefaultHubName()
         {
-            return this.isDefaultHubName ?? this.hubName == null;
-        }
-
-        internal void SetDefaultHubName(string defaultHubName)
-        {
-            this.hubName = defaultHubName;
+            return string.Equals(this.defaultHubName, this.hubName);
         }
 
         private static bool IsInNonProductionSlot()

--- a/src/WebJobs.Extensions.DurableTask/Options/DurableTaskOptions.cs
+++ b/src/WebJobs.Extensions.DurableTask/Options/DurableTaskOptions.cs
@@ -211,7 +211,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
             if (IsInNonProductionSlot() && this.IsDefaultHubName())
             {
-                throw new InvalidOperationException($"Task Hub name must be specified in host.json when using slots. Specified name must not equal the defaultHubName ({this.defaultHubName})." +
+                throw new InvalidOperationException($"Task Hub name must be specified in host.json when using slots. Specified name must not equal the default HubName ({this.defaultHubName})." +
                     "See documentation on Task Hubs for information on how to set this: https://docs.microsoft.com/azure/azure-functions/durable/durable-functions-task-hubs");
             }
 
@@ -230,7 +230,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
         internal bool IsDefaultHubName()
         {
-            return string.Equals(this.defaultHubName, this.hubName);
+            return string.Equals(this.defaultHubName, this.hubName, StringComparison.OrdinalIgnoreCase);
         }
 
         private static bool IsInNonProductionSlot()


### PR DESCRIPTION
Changed TaskHubName in DurableTaskOptions to compare to default value instead of using get and set logic to set a bool field.

This fixes many issues with TaskHub names using slots.

resolves #1068 
resolves #1057 