### PR TITLE
Allow Azure Storage timers longer than 7 days for Functions V2

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/AzureStorageDurabilityProvider.cs
+++ b/src/WebJobs.Extensions.DurableTask/AzureStorageDurabilityProvider.cs
@@ -120,11 +120,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
         public override bool ValidateDelayTime(TimeSpan timespan, out string errorMessage)
         {
+#if FUNCTIONS_V1
             if (timespan > MaxTimerDuration)
             {
                 errorMessage = $"The Azure Storage provider supports a maximum of {MaxTimerDuration.TotalDays} days for time-based delays";
                 return false;
             }
+#endif
 
             return base.ValidateDelayTime(timespan, out errorMessage);
         }

--- a/test/Common/DurableTaskEndToEndTests.cs
+++ b/test/Common/DurableTaskEndToEndTests.cs
@@ -1083,6 +1083,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             }
         }
 
+#if FUNCTIONS_V1
         /// <summary>
         /// End-to-end test which validates correct exceptions for invalid timeout values.
         /// </summary>
@@ -1110,6 +1111,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 await host.StopAsync();
             }
         }
+#endif
 
         /// <summary>
         /// End-to-end test which validates that orchestrations run concurrently of each other (up to 100 by default).
@@ -1955,6 +1957,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             }
         }
 
+#if FUNCTIONS_V1
         [Theory]
         [Trait("Category", PlatformSpecificHelpers.TestCategory)]
         [MemberData(nameof(TestDataGenerator.GetExtendedSessionAndFullFeaturedStorageProviderOptions), MemberType = typeof(TestDataGenerator))]
@@ -1981,6 +1984,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 await host.StopAsync();
             }
         }
+#endif
 
         /// <summary>
         /// End-to-end test which runs a orchestrator function that calls a non-existent activity function.
@@ -2922,6 +2926,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             }
         }
 
+#if FUNCTIONS_V1
         [Fact]
         [Trait("Category", PlatformSpecificHelpers.TestCategory)]
         public async Task AzureStorage_TimerLimitExceeded_ThrowsException()
@@ -3026,6 +3031,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 Assert.Contains("timeout", output);
             }
         }
+#endif
 
         /// <summary>
         /// End-to-end test which validates basic use of the object dispatch feature.


### PR DESCRIPTION
In Functions V2, we now use version 9.x of the Azure Storage SDK, which
removed the maximum visibility delay on queues. We can now support
indefinite timers.

Resolves #14