### PR TITLE
Alternate proposal for fixing failing unit tests caused by deserialization

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/Bindings/BindingHelper.cs
+++ b/src/WebJobs.Extensions.DurableTask/Bindings/BindingHelper.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 BaseUrl = this.config.HttpApiHandler.GetBaseUrl(),
                 RequiredQueryStringParameters = this.config.HttpApiHandler.GetUniversalQueryStrings(),
             };
-            return this.config.DataConverter.Serialize(payload);
+            return JsonConvert.SerializeObject(payload);
         }
 
         public StartOrchestrationArgs JObjectToStartOrchestrationArgs(JObject input, DurableClientAttribute attr)
@@ -47,7 +47,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
         public StartOrchestrationArgs StringToStartOrchestrationArgs(string input, DurableClientAttribute attr)
         {
-            return !string.IsNullOrEmpty(input) ? this.config.DataConverter.Deserialize<StartOrchestrationArgs>(input) : null;
+            return !string.IsNullOrEmpty(input) ? JsonConvert.DeserializeObject<StartOrchestrationArgs>(input) : null;
         }
 
         private class OrchestrationClientAsyncCollector : IAsyncCollector<StartOrchestrationArgs>

--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableClient.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableClient.cs
@@ -267,7 +267,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             var guid = Guid.NewGuid(); // unique id for this request
             var instanceId = EntityId.GetSchedulerIdFromEntityId(entityId);
             var instance = new OrchestrationInstance() { InstanceId = instanceId };
-            var request = new RequestMessage(this.dataConverter)
+            var request = new RequestMessage()
             {
                 ParentInstanceId = null,
                 Id = guid,
@@ -277,9 +277,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             };
             if (operationInput != null)
             {
-                request.SetInput(operationInput);
+                request.SetInput(operationInput, this.dataConverter);
             }
-          
+
             var jrequest = JToken.FromObject(request, this.dataConverter.MessageSerializer);
             var eventName = scheduledTimeUtc.HasValue ? EntityMessageEventNames.ScheduledRequestMessageEventName(scheduledTimeUtc.Value) : EntityMessageEventNames.RequestMessageEventName;
             await client.RaiseEventAsync(instance, eventName, jrequest);

--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableOrchestrationContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableOrchestrationContext.cs
@@ -556,7 +556,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     var target = new OrchestrationInstance() { InstanceId = instanceId };
                     operationId = guid.ToString();
                     operationName = operation;
-                    var request = new RequestMessage(this.dataConverter)
+                    var request = new RequestMessage()
                     {
                         ParentInstanceId = this.InstanceId,
                         Id = guid,
@@ -566,7 +566,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     };
                     if (input != null)
                     {
-                        request.SetInput(input);
+                        request.SetInput(input, this.dataConverter);
                     }
 
                     this.SendEntityMessage(target, request);
@@ -709,7 +709,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             }
 
             // can rethrow an exception if that was the result of the operation
-            return response.GetResult<TResult>();
+            return response.GetResult<TResult>(this.dataConverter);
         }
 
         internal Task<T> WaitForExternalEvent<T>(string name, string reason)
@@ -971,7 +971,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
             // send lock request to first entity in the lock set
             var target = new OrchestrationInstance() { InstanceId = EntityId.GetSchedulerIdFromEntityId(entities[0]) };
-            var request = new RequestMessage(this.dataConverter)
+            var request = new RequestMessage()
             {
                 Id = lockRequestId,
                 ParentInstanceId = this.InstanceId,

--- a/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
@@ -279,7 +279,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             if (this.Options.Notifications.EventGrid != null
                 && (!string.IsNullOrEmpty(this.Options.Notifications.EventGrid.TopicEndpoint) || !string.IsNullOrEmpty(this.Options.Notifications.EventGrid.KeySettingName)))
             {
-                return new EventGridLifeCycleNotificationHelper(this.Options, this.nameResolver, this.TraceHelper, this.DataConverter);
+                return new EventGridLifeCycleNotificationHelper(this.Options, this.nameResolver, this.TraceHelper);
             }
 
             // Fallback: Disable Notification

--- a/src/WebJobs.Extensions.DurableTask/EntityScheduler/RequestMessage.cs
+++ b/src/WebJobs.Extensions.DurableTask/EntityScheduler/RequestMessage.cs
@@ -12,13 +12,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
     /// </summary>
     internal class RequestMessage
     {
-        private readonly MessagePayloadDataConverter dataConverter;
-
-        public RequestMessage(MessagePayloadDataConverter dataConverter)
-        {
-            this.dataConverter = dataConverter;
-        }
-
         /// <summary>
         /// The name of the operation being called (if this is an operation message) or <c>null</c>
         /// (if this is a lock request).
@@ -84,7 +77,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         [JsonIgnore]
         public bool IsLockRequest => this.LockSet != null;
 
-        public void SetInput(object obj)
+        public void SetInput(object obj, MessagePayloadDataConverter dataConverter)
         {
             try
             {
@@ -94,7 +87,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 }
                 else
                 {
-                    this.Input = this.dataConverter.MessageConverter.Serialize(obj);
+                    this.Input = dataConverter.MessageConverter.Serialize(obj);
                 }
             }
             catch (Exception e)
@@ -103,11 +96,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             }
         }
 
-        public T GetInput<T>()
+        public T GetInput<T>(MessagePayloadDataConverter dataConverter)
         {
             try
             {
-                return this.dataConverter.MessageConverter.Deserialize<T>(this.Input);
+                return dataConverter.MessageConverter.Deserialize<T>(this.Input);
             }
             catch (Exception e)
             {
@@ -115,11 +108,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             }
         }
 
-        public object GetInput(Type inputType)
+        public object GetInput(Type inputType, MessagePayloadDataConverter dataConverter)
         {
             try
             {
-                return this.dataConverter.MessageConverter.Deserialize(this.Input, inputType);
+                return dataConverter.MessageConverter.Deserialize(this.Input, inputType);
             }
             catch (Exception e)
             {

--- a/src/WebJobs.Extensions.DurableTask/EventGridLifeCycleNotificationHelper.cs
+++ b/src/WebJobs.Extensions.DurableTask/EventGridLifeCycleNotificationHelper.cs
@@ -19,7 +19,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
     {
         private readonly DurableTaskOptions options;
         private readonly EndToEndTraceHelper traceHelper;
-        private readonly MessagePayloadDataConverter dataConverter;
         private readonly bool useTrace;
         private readonly string eventGridKeyValue;
         private readonly string eventGridTopicEndpoint;
@@ -30,12 +29,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         public EventGridLifeCycleNotificationHelper(
             DurableTaskOptions options,
             INameResolver nameResolver,
-            EndToEndTraceHelper traceHelper,
-            MessagePayloadDataConverter dataConverter)
+            EndToEndTraceHelper traceHelper)
         {
             this.options = options ?? throw new ArgumentNullException(nameof(options));
             this.traceHelper = traceHelper ?? throw new ArgumentNullException(nameof(traceHelper));
-            this.dataConverter = dataConverter;
 
             if (nameResolver == null)
             {
@@ -155,7 +152,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             string reason,
             FunctionState functionState)
         {
-            string json = this.dataConverter.Serialize(eventGridEventArray);
+            string json = JsonConvert.SerializeObject(eventGridEventArray);
             StringContent content = new StringContent(json, Encoding.UTF8, "application/json");
             Stopwatch stopWatch = Stopwatch.StartNew();
 

--- a/src/WebJobs.Extensions.DurableTask/HttpRequestMessageExtensions.cs
+++ b/src/WebJobs.Extensions.DurableTask/HttpRequestMessageExtensions.cs
@@ -21,29 +21,29 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             };
         }
 
-        public static HttpResponseMessage CreateResponse<T>(this HttpRequestMessage request, HttpStatusCode statusCode, T value, MessagePayloadDataConverter dataConverter)
+        public static HttpResponseMessage CreateResponse<T>(this HttpRequestMessage request, HttpStatusCode statusCode, T value)
         {
             return new HttpResponseMessage
             {
-                Content = new StringContent(dataConverter.Serialize(value), Encoding.UTF8, "application/json"),
+                Content = new StringContent(JsonConvert.SerializeObject(value), Encoding.UTF8, "application/json"),
                 RequestMessage = request,
                 StatusCode = statusCode,
             };
         }
 
-        public static HttpResponseMessage CreateErrorResponse(this HttpRequestMessage request, HttpStatusCode statusCode, string message, MessagePayloadDataConverter dataConverter)
+        public static HttpResponseMessage CreateErrorResponse(this HttpRequestMessage request, HttpStatusCode statusCode, string message)
         {
             var error = new { Message = message };
 
             return new HttpResponseMessage
             {
-                Content = new StringContent(dataConverter.Serialize(error), Encoding.UTF8, "application/json"),
+                Content = new StringContent(JsonConvert.SerializeObject(error), Encoding.UTF8, "application/json"),
                 RequestMessage = request,
                 StatusCode = statusCode,
             };
         }
 
-        public static HttpResponseMessage CreateErrorResponse(this HttpRequestMessage request, HttpStatusCode statusCode, string message, Exception e, MessagePayloadDataConverter dataConverter)
+        public static HttpResponseMessage CreateErrorResponse(this HttpRequestMessage request, HttpStatusCode statusCode, string message, Exception e)
         {
             var error = new
             {
@@ -55,7 +55,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
             return new HttpResponseMessage
             {
-                Content = new StringContent(dataConverter.Serialize(error), Encoding.UTF8, "application/json"),
+                Content = new StringContent(JsonConvert.SerializeObject(error), Encoding.UTF8, "application/json"),
                 RequestMessage = request,
                 StatusCode = statusCode,
             };

--- a/src/WebJobs.Extensions.DurableTask/Listener/DurableTaskListener.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/DurableTaskListener.cs
@@ -52,13 +52,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             this.functionType = functionType;
             this.storageConnectionString = storageConnectionString;
 #if !FUNCTIONS_V1
-            this.scaleMonitor = new Lazy<DurableTaskScaleMonitor>(() => new DurableTaskScaleMonitor(
-                                                                                        this.functionId,
-                                                                                        this.functionName,
-                                                                                        this.config.Options.HubName,
-                                                                                        this.storageConnectionString,
-                                                                                        this.config.TraceHelper,
-                                                                                        this.config.DataConverter));
+            this.scaleMonitor = new Lazy<DurableTaskScaleMonitor>(() =>
+                new DurableTaskScaleMonitor(
+                    this.functionId,
+                    this.functionName,
+                    this.config.Options.HubName,
+                    this.storageConnectionString,
+                    this.config.TraceHelper));
 #endif
         }
 

--- a/src/WebJobs.Extensions.DurableTask/Listener/DurableTaskScaleMonitor.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/DurableTaskScaleMonitor.cs
@@ -24,7 +24,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         private readonly string hubName;
         private readonly string storageConnectionString;
         private readonly EndToEndTraceHelper traceHelper;
-        private readonly MessagePayloadDataConverter dataConverter;
         private readonly ScaleMonitorDescriptor scaleMonitorDescriptor;
 
         private DisconnectedPerformanceMonitor performanceMonitor;
@@ -35,7 +34,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             string hubName,
             string storageConnectionString,
             EndToEndTraceHelper traceHelper,
-            MessagePayloadDataConverter dataConverter,
             DisconnectedPerformanceMonitor performanceMonitor = null)
         {
             this.functionId = functionId;
@@ -44,7 +42,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             this.storageConnectionString = storageConnectionString;
             this.performanceMonitor = performanceMonitor;
             this.traceHelper = traceHelper;
-            this.dataConverter = dataConverter;
             this.scaleMonitorDescriptor = new ScaleMonitorDescriptor($"{this.functionId}-DurableTaskTrigger-{this.hubName}".ToLower());
         }
 
@@ -95,8 +92,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             if (heartbeat != null)
             {
                 metrics.PartitionCount = heartbeat.PartitionCount;
-                metrics.ControlQueueLengths = this.dataConverter.Serialize(heartbeat.ControlQueueLengths);
-                metrics.ControlQueueLatencies = this.dataConverter.Serialize(heartbeat.ControlQueueLatencies);
+                metrics.ControlQueueLengths = JsonConvert.SerializeObject(heartbeat.ControlQueueLengths);
+                metrics.ControlQueueLatencies = JsonConvert.SerializeObject(heartbeat.ControlQueueLatencies);
                 metrics.WorkItemQueueLength = heartbeat.WorkItemQueueLength;
                 if (heartbeat.WorkItemQueueLatency != null)
                 {
@@ -144,7 +141,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 }
                 else
                 {
-                    heartbeats[i].ControlQueueLengths = this.dataConverter.Deserialize<IReadOnlyList<int>>(metrics[i].ControlQueueLengths);
+                    heartbeats[i].ControlQueueLengths = JsonConvert.DeserializeObject<IReadOnlyList<int>>(metrics[i].ControlQueueLengths);
                 }
 
                 if (metrics[i].ControlQueueLatencies == null)
@@ -153,7 +150,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 }
                 else
                 {
-                    heartbeats[i].ControlQueueLatencies = this.dataConverter.Deserialize<IReadOnlyList<TimeSpan>>(metrics[i].ControlQueueLatencies);
+                    heartbeats[i].ControlQueueLatencies = JsonConvert.DeserializeObject<IReadOnlyList<TimeSpan>>(metrics[i].ControlQueueLatencies);
                 }
             }
 

--- a/src/WebJobs.Extensions.DurableTask/Listener/OutOfProcOrchestrationShim.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/OutOfProcOrchestrationShim.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using DurableTask.Core.Serializing;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using Newtonsoft.Json.Linq;
@@ -18,17 +17,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
     public class OutOfProcOrchestrationShim
     {
         private readonly IDurableOrchestrationContext context;
-        private readonly JsonDataConverter dataConverter;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="OutOfProcOrchestrationShim"/> class.
         /// </summary>
         /// <param name="context">The orchestration execution context.</param>
-        /// /// <param name="dataConverter">JsonDataConverter for serialization settings.</param>
-        public OutOfProcOrchestrationShim(IDurableOrchestrationContext context, JsonDataConverter dataConverter)
+        public OutOfProcOrchestrationShim(IDurableOrchestrationContext context)
         {
             this.context = context ?? throw new ArgumentNullException(nameof(context));
-            this.dataConverter = dataConverter;
         }
 
         private enum AsyncActionType
@@ -63,7 +59,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// <returns><c>true</c> if there are more executions to process; <c>false</c> otherwise.</returns>
         public async Task<bool> ExecuteAsync(JObject executionJson)
         {
-            var execution = this.dataConverter.Deserialize<OutOfProcOrchestratorState>(executionJson.ToString());
+            var execution = JsonConvert.DeserializeObject<OutOfProcOrchestratorState>(executionJson.ToString());
             if (execution.CustomStatus != null)
             {
                 this.context.SetCustomStatus(execution.CustomStatus);

--- a/src/WebJobs.Extensions.DurableTask/Listener/TaskEntityShim.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/TaskEntityShim.cs
@@ -261,7 +261,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         {
             // set context for operation
             this.context.CurrentOperation = request;
-            this.context.CurrentOperationResponse = new ResponseMessage(this.dataConverter);
+            this.context.CurrentOperationResponse = new ResponseMessage();
 
             // set the async-local static context that is visible to the application code
             Entity.SetContext(this.context);
@@ -294,7 +294,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 this.context.CaptureApplicationError(e);
 
                 // exception must be sent with response back to caller
-                this.context.CurrentOperationResponse.SetExceptionResult(e, this.context.CurrentOperation.Operation, this.EntityId);
+                this.context.CurrentOperationResponse.SetExceptionResult(
+                    e,
+                    this.context.CurrentOperation.Operation,
+                    this.EntityId,
+                    this.dataConverter);
             }
 
             // clear the async-local static context that is visible to the application code
@@ -409,7 +413,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     {
                         InstanceId = request.ParentInstanceId,
                     };
-                    var responseMessage = new ResponseMessage(this.dataConverter)
+                    var responseMessage = new ResponseMessage()
                     {
                         Result = result.Result,
                         ExceptionType = result.IsError ? "Error" : null,
@@ -421,7 +425,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             // send signal messages
             foreach (var signal in outOfProcResult.Signals)
             {
-                var request = new RequestMessage(this.dataConverter)
+                var request = new RequestMessage()
                 {
                     ParentInstanceId = this.context.InstanceId,
                     Id = Guid.NewGuid(),

--- a/src/WebJobs.Extensions.DurableTask/Listener/TaskHttpActivityShim.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/TaskHttpActivityShim.cs
@@ -39,14 +39,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             HttpResponseMessage response = await this.httpClient.SendAsync(requestMessage);
             DurableHttpResponse durableHttpResponse = await DurableHttpResponse.CreateDurableHttpResponseWithHttpResponseMessage(response);
 
-            return this.config.DataConverter.Serialize(durableHttpResponse);
+            return JsonConvert.SerializeObject(durableHttpResponse);
         }
 
         private async Task<HttpRequestMessage> ReconstructHttpRequestMessage(string serializedRequest)
         {
             // DeserializeObject deserializes into a List and then the first element
             // of that list is the DurableHttpRequest
-            IList<DurableHttpRequest> input = this.config.DataConverter.Deserialize<IList<DurableHttpRequest>>(serializedRequest);
+            IList<DurableHttpRequest> input = JsonConvert.DeserializeObject<IList<DurableHttpRequest>>(serializedRequest);
             DurableHttpRequest durableHttpRequest = input.First();
 
             string contentType = "";

--- a/src/WebJobs.Extensions.DurableTask/Listener/TaskOrchestrationShim.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/TaskOrchestrationShim.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         {
             this.dataConverter = config.DataConverter;
             this.context = new DurableOrchestrationContext(config, durabilityProvider, name);
-            this.outOfProcShim = new OutOfProcOrchestrationShim(this.context, this.dataConverter);
+            this.outOfProcShim = new OutOfProcOrchestrationShim(this.context);
         }
 
         public override DurableCommonContext Context => this.context;

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net471.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net471.xml
@@ -2282,11 +2282,6 @@
             A message that represents an operation request or a lock request.
             </summary>
         </member>
-        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.RequestMessage.DataConverter">
-            <summary>
-            
-            </summary>
-        </member>
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.RequestMessage.Operation">
             <summary>
             The name of the operation being called (if this is an operation message) or <c>null</c>
@@ -2339,11 +2334,6 @@
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.RequestMessage.Position">
             <summary>
             For lock requests involving multiple locks, the message number.
-            </summary>
-        </member>
-        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.ResponseMessage.DataConverter">
-            <summary>
-            
             </summary>
         </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.SchedulerState">
@@ -2702,7 +2692,7 @@
             Not intended for public consumption.
             </summary>
         </member>
-        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.OutOfProcOrchestrationShim.#ctor(Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableOrchestrationContext,DurableTask.Core.Serializing.JsonDataConverter)">
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.OutOfProcOrchestrationShim.#ctor(Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableOrchestrationContext)">
             <summary>
             Initializes a new instance of the <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.OutOfProcOrchestrationShim"/> class.
             </summary>

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
@@ -2320,11 +2320,6 @@
             A message that represents an operation request or a lock request.
             </summary>
         </member>
-        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.RequestMessage.DataConverter">
-            <summary>
-            
-            </summary>
-        </member>
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.RequestMessage.Operation">
             <summary>
             The name of the operation being called (if this is an operation message) or <c>null</c>
@@ -2377,11 +2372,6 @@
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.RequestMessage.Position">
             <summary>
             For lock requests involving multiple locks, the message number.
-            </summary>
-        </member>
-        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.ResponseMessage.DataConverter">
-            <summary>
-            
             </summary>
         </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.SchedulerState">
@@ -2769,7 +2759,7 @@
             Not intended for public consumption.
             </summary>
         </member>
-        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.OutOfProcOrchestrationShim.#ctor(Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableOrchestrationContext,DurableTask.Core.Serializing.JsonDataConverter)">
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.OutOfProcOrchestrationShim.#ctor(Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableOrchestrationContext)">
             <summary>
             Initializes a new instance of the <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.OutOfProcOrchestrationShim"/> class.
             </summary>

--- a/test/Common/MessageSorterTests.cs
+++ b/test/Common/MessageSorterTests.cs
@@ -11,7 +11,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
     public class MessageSorterTests
     {
         private static readonly TimeSpan ReorderWindow = TimeSpan.FromMinutes(30);
-        private static readonly MessagePayloadDataConverter DataConverter = new MessagePayloadDataConverter(new MessageSerializerSettingsFactory(), new ErrorSerializerSettingsFactory());
 
         [Fact]
         [Trait("Category", PlatformSpecificHelpers.TestCategory)]
@@ -30,7 +29,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             MessageSorter receiverSorter = new MessageSorter();
 
             // delivering the sequence in order produces 1 message each time
-            receiverSorter = new MessageSorter();
             batch = receiverSorter.ReceiveInOrder(message1, ReorderWindow).ToList();
             Assert.Single(batch).Input.Equals("1");
             batch = receiverSorter.ReceiveInOrder(message2, ReorderWindow).ToList();
@@ -59,7 +57,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             MessageSorter receiverSorter = new MessageSorter();
 
             // delivering the sequence in order produces 1 message each time
-            receiverSorter = new MessageSorter();
             batch = receiverSorter.ReceiveInOrder(message1, ReorderWindow).ToList();
             Assert.Single(batch).Input.Equals("1");
             batch = receiverSorter.ReceiveInOrder(message2, ReorderWindow).ToList();
@@ -291,7 +288,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
         private static RequestMessage Send(string senderId, string receiverId, string input, MessageSorter sorter, DateTime now, TimeSpan? reorderWindow = null)
         {
-            var msg = new RequestMessage(DataConverter)
+            var msg = new RequestMessage()
             {
                 Id = Guid.NewGuid(),
                 ParentInstanceId = senderId,

--- a/test/FunctionsV2/DurableTaskScaleMonitorTests.cs
+++ b/test/FunctionsV2/DurableTaskScaleMonitorTests.cs
@@ -40,16 +40,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             this.traceHelper = new EndToEndTraceHelper(this.loggerFactory.CreateLogger(LogCategories.CreateTriggerCategory("DurableTask")), false);
             this.performanceMonitor = new Mock<DisconnectedPerformanceMonitor>(MockBehavior.Strict, this.storageConnectionString, this.hubName);
 
-            var dataConverter = new MessagePayloadDataConverter(new MessageSerializerSettingsFactory(), new ErrorSerializerSettingsFactory());
-
             this.scaleMonitor = new DurableTaskScaleMonitor(
-                                                this.functionId,
-                                                this.functionName,
-                                                this.hubName,
-                                                this.storageConnectionString,
-                                                this.traceHelper,
-                                                dataConverter,
-                                                this.performanceMonitor.Object);
+                this.functionId,
+                this.functionName,
+                this.hubName,
+                this.storageConnectionString,
+                this.traceHelper,
+                this.performanceMonitor.Object);
         }
 
         [Fact]

--- a/test/FunctionsV2/OutOfProcTests.cs
+++ b/test/FunctionsV2/OutOfProcTests.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 .Callback<DurableHttpRequest>(req => request = req)
                 .Returns(Task.FromResult(new DurableHttpResponse(System.Net.HttpStatusCode.OK)));
 
-            var shim = new OutOfProcOrchestrationShim(contextMock.Object, new MessagePayloadDataConverter(new MessageSerializerSettingsFactory(), new ErrorSerializerSettingsFactory()));
+            var shim = new OutOfProcOrchestrationShim(contextMock.Object);
 
             var executionJson = @"
 {
@@ -89,7 +89,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 .Callback<DurableHttpRequest>(req => request = req)
                 .Returns(Task.FromResult(new DurableHttpResponse(System.Net.HttpStatusCode.OK)));
 
-            var shim = new OutOfProcOrchestrationShim(contextMock.Object, new MessagePayloadDataConverter(new MessageSerializerSettingsFactory(), new ErrorSerializerSettingsFactory()));
+            var shim = new OutOfProcOrchestrationShim(contextMock.Object);
 
             var executionJson = @"
 {


### PR DESCRIPTION
I basically updated all the RequestMessage and ResponseMessage APIs to take a MessagePayloadDataConverter as a parameter. It's a pretty simple solution that removes some of the state management we have to do otherwise.

(Note that this currently conflicts with the latest change you added a few minutes ago)