### PR TITLE
Durable Client Factory (DurableOrchestrationClient outside Azure Functions )

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableClientFactory.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableClientFactory.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Microsoft.Azure.WebJobs.Extensions.DurableTask.Options;
+using Microsoft.Extensions.Options;
 
 namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.ContextImplementations
 {
@@ -11,14 +12,17 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.ContextImplementations
     public class DurableClientFactory : IDurableClientFactory
     {
         private readonly DurableTaskExtension durableTaskConfig;
+        private readonly DurableClientOptions defaultDurableClientOptions;
 
         /// <summary>
         ///     Initializes a new instance of the <see cref="DurableClientFactory"/> class.
         /// </summary>
         /// <param name="durableTaskConfig">Configuration for the Durable Functions extension.</param>
-        public DurableClientFactory(DurableTaskExtension durableTaskConfig)
+        /// <param name="defaultDurableClientOptions">Default Options to Build Durable Clients.</param>
+        public DurableClientFactory(DurableTaskExtension durableTaskConfig, IOptions<DurableClientOptions> defaultDurableClientOptions)
         {
             this.durableTaskConfig = durableTaskConfig;
+            this.defaultDurableClientOptions = defaultDurableClientOptions.Value;
         }
 
         /// <summary>
@@ -34,6 +38,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.ContextImplementations
             }
 
             return this.durableTaskConfig.GetClient(new DurableClientAttribute(durableClientOptions));
+        }
+
+        /// <summary>
+        /// Gets a <see cref="IDurableClient"/> using configuration from a <see cref="DurableClientOptions"/> instance.
+        /// </summary>
+        /// <returns>Returns a <see cref="IDurableClient"/> instance. The returned instance may be a cached instance.</returns>
+        public IDurableClient CreateClient()
+        {
+            return this.CreateClient(this.defaultDurableClientOptions);
         }
     }
 }

--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableClientFactory.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableClientFactory.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Microsoft.Azure.WebJobs.Extensions.DurableTask.Options;
+
+namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.ContextImplementations
+{
+    /// <summary>
+    ///     Factory class to create Durable Client to start works outside an azure function context.
+    /// </summary>
+    public class DurableClientFactory : IDurableClientFactory
+    {
+        private readonly DurableTaskExtension durableTaskConfig;
+
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="DurableClientFactory"/> class.
+        /// </summary>
+        /// <param name="durableTaskConfig">Configuration for the Durable Functions extension.</param>
+        public DurableClientFactory(DurableTaskExtension durableTaskConfig)
+        {
+            this.durableTaskConfig = durableTaskConfig;
+        }
+
+        /// <summary>
+        /// Gets a <see cref="IDurableClient"/> using configuration from a <see cref="DurableClientOptions"/> instance.
+        /// </summary>
+        /// <param name="durableClientOptions">options containing the client configuration parameters.</param>
+        /// <returns>Returns a <see cref="IDurableClient"/> instance. The returned instance may be a cached instance.</returns>
+        public IDurableClient CreateClient(DurableClientOptions durableClientOptions)
+        {
+            if (string.IsNullOrWhiteSpace(durableClientOptions.TaskHub))
+            {
+                durableClientOptions.TaskHub = DurableTaskOptions.DefaultHubName;
+            }
+
+            return this.durableTaskConfig.GetClient(new DurableClientAttribute(durableClientOptions));
+        }
+    }
+}

--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/IDurableClientFactory.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/IDurableClientFactory.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Microsoft.Azure.WebJobs.Extensions.DurableTask.Options;
+
+namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.ContextImplementations
+{
+    /// <summary>
+    ///     Factory class to create Durable Client to start works outside an azure function context.
+    /// </summary>
+    public interface IDurableClientFactory
+    {
+        /// <summary>
+        /// Gets a <see cref="IDurableClient"/> using configuration from a <see cref="DurableClientOptions"/> instance.
+        /// </summary>
+        /// <param name="durableClientOptions">options containing the client configuration parameters.</param>
+        /// <returns>Returns a <see cref="IDurableClient"/> instance. The returned instance may be a cached instance.</returns>
+        IDurableClient CreateClient(DurableClientOptions durableClientOptions);
+    }
+}

--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/IDurableClientFactory.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/IDurableClientFactory.cs
@@ -16,5 +16,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.ContextImplementations
         /// <param name="durableClientOptions">options containing the client configuration parameters.</param>
         /// <returns>Returns a <see cref="IDurableClient"/> instance. The returned instance may be a cached instance.</returns>
         IDurableClient CreateClient(DurableClientOptions durableClientOptions);
+
+        /// <summary>
+        /// Gets a <see cref="IDurableClient"/> using configuration from a <see cref="DurableClientOptions"/> instance.
+        /// </summary>
+        /// <returns>Returns a <see cref="IDurableClient"/> instance. The returned instance may be a cached instance.</returns>
+        IDurableClient CreateClient();
     }
 }

--- a/src/WebJobs.Extensions.DurableTask/DurableClientAttribute.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableClientAttribute.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Diagnostics;
 using Microsoft.Azure.WebJobs.Description;
+using Microsoft.Azure.WebJobs.Extensions.DurableTask.Options;
 
 namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 {
@@ -15,6 +16,22 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
     [Binding]
     public class DurableClientAttribute : Attribute, IEquatable<DurableClientAttribute>
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DurableClientAttribute"/> class.
+        /// </summary>
+        public DurableClientAttribute() { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DurableClientAttribute"/> class.
+        /// </summary>
+        /// <param name="durableClientOptions">durable client options</param>
+        public DurableClientAttribute(DurableClientOptions durableClientOptions)
+        {
+            this.TaskHub = durableClientOptions.TaskHub;
+            this.ConnectionName = durableClientOptions.ConnectionName;
+            this.ExternalClient = durableClientOptions.IsExternalClient;
+        }
+
         /// <summary>
         /// Optional. Gets or sets the name of the task hub in which the orchestration data lives.
         /// </summary>
@@ -38,6 +55,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// If no value exists there, then the default behavior is to use the standard `AzureWebJobsStorage` connection string for all storage usage.
         /// </remarks>
         public string ConnectionName { get; set; }
+
+        /// <summary>
+        ///     Indicate if the client is External from the azure function where orchestrator functions are hosted.
+        /// </summary>
+        public bool ExternalClient { get; set; }
 
         /// <summary>
         /// Returns a hash code for this attribute.

--- a/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         INameVersionObjectManager<TaskOrchestration>,
         INameVersionObjectManager<TaskActivity>
     {
-        private static readonly string LoggerCategoryName = LogCategories.CreateTriggerCategory("DurableTask");
+        internal static readonly string LoggerCategoryName = LogCategories.CreateTriggerCategory("DurableTask");
 
         // Creating client objects is expensive, so we cache them when the attributes match.
         // Note that DurableClientAttribute defines a custom equality comparer.
@@ -132,7 +132,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             DurableHttpClientFactory durableHttpClientFactory = new DurableHttpClientFactory();
             this.durableHttpClient = durableHttpClientFactory.GetClient(durableHttpMessageHandlerFactory);
 
-            this.MessageDataConverter = this.CreateMessageDataConverter(messageSerializerSettingsFactory);
+            this.MessageDataConverter = CreateMessageDataConverter(messageSerializerSettingsFactory);
             this.ErrorDataConverter = this.CreateErrorDataConverter(errorSerializerSettingsFactory);
 
             this.HttpApiHandler = new HttpApiHandler(this, logger);
@@ -188,7 +188,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
         internal MessagePayloadDataConverter ErrorDataConverter { get; private set; }
 
-        private MessagePayloadDataConverter CreateMessageDataConverter(IMessageSerializerSettingsFactory messageSerializerSettingsFactory)
+        internal static MessagePayloadDataConverter CreateMessageDataConverter(IMessageSerializerSettingsFactory messageSerializerSettingsFactory)
         {
             bool isDefault;
             if (messageSerializerSettingsFactory == null)

--- a/src/WebJobs.Extensions.DurableTask/DurableTaskJobHostConfigurationExtensions.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskJobHostConfigurationExtensions.cs
@@ -6,6 +6,7 @@ using System.Net.Http;
 using System.Threading;
 #if !FUNCTIONS_V1
 using Microsoft.Azure.WebJobs.Extensions.DurableTask.ContextImplementations;
+using Microsoft.Azure.WebJobs.Extensions.DurableTask.Options;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
@@ -70,6 +71,19 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             serviceCollection.TryAddSingleton<IErrorSerializerSettingsFactory, ErrorSerializerSettingsFactory>();
             serviceCollection.TryAddSingleton<IDurableClientFactory, DurableClientFactory>();
 
+            return serviceCollection;
+        }
+
+        /// <summary>
+        /// Adds the Durable Task extension to the provided <see cref="IServiceCollection"/>.
+        /// </summary>
+        /// <param name="serviceCollection">The <see cref="IServiceCollection"/> to configure.</param>
+        /// <param name="optionsBuilder">Populate default configurations of <see cref="DurableClientOptions"/> to create Durable Clients.</param>
+        /// <returns>Returns the provided <see cref="IServiceCollection"/>.</returns>
+        public static IServiceCollection AddDurableTask(this IServiceCollection serviceCollection, Action<DurableClientOptions> optionsBuilder)
+        {
+            AddDurableTask(serviceCollection);
+            serviceCollection.Configure<DurableClientOptions>(optionsBuilder.Invoke);
             return serviceCollection;
         }
 

--- a/src/WebJobs.Extensions.DurableTask/DurableTaskJobHostConfigurationExtensions.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskJobHostConfigurationExtensions.cs
@@ -5,6 +5,7 @@ using System;
 using System.Net.Http;
 using System.Threading;
 #if !FUNCTIONS_V1
+using Microsoft.Azure.WebJobs.Extensions.DurableTask.ContextImplementations;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
@@ -43,8 +44,33 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             serviceCollection.TryAddSingleton<IMessageSerializerSettingsFactory, MessageSerializerSettingsFactory>();
             serviceCollection.TryAddSingleton<IErrorSerializerSettingsFactory, ErrorSerializerSettingsFactory>();
             serviceCollection.TryAddSingleton<IApplicationLifetimeWrapper, HostLifecycleService>();
+            serviceCollection.TryAddSingleton<IDurableClientFactory, DurableClientFactory>();
 
             return builder;
+        }
+
+        /// <summary>
+        /// Adds the Durable Task extension to the provided <see cref="IServiceCollection"/>.
+        /// </summary>
+        /// <param name="serviceCollection">The <see cref="IServiceCollection"/> to configure.</param>
+        /// <returns>Returns the provided <see cref="IServiceCollection"/>.</returns>
+        public static IServiceCollection AddDurableTask(this IServiceCollection serviceCollection)
+        {
+            if (serviceCollection == null)
+            {
+                throw new ArgumentNullException(nameof(serviceCollection));
+            }
+
+            serviceCollection.TryAddSingleton<DurableTaskExtension>();
+            serviceCollection.TryAddSingleton<INameResolver, DefaultNameResolver>();
+            serviceCollection.TryAddSingleton<IConnectionStringResolver, StandardConnectionStringProvider>();
+            serviceCollection.TryAddSingleton<IDurableHttpMessageHandlerFactory, DurableHttpMessageHandlerFactory>();
+            serviceCollection.TryAddSingleton<IDurabilityProviderFactory, AzureStorageDurabilityProviderFactory>();
+            serviceCollection.TryAddSingleton<IMessageSerializerSettingsFactory, MessageSerializerSettingsFactory>();
+            serviceCollection.TryAddSingleton<IErrorSerializerSettingsFactory, ErrorSerializerSettingsFactory>();
+            serviceCollection.TryAddSingleton<IDurableClientFactory, DurableClientFactory>();
+
+            return serviceCollection;
         }
 
         /// <summary>

--- a/src/WebJobs.Extensions.DurableTask/DurableTaskJobHostConfigurationExtensions.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskJobHostConfigurationExtensions.cs
@@ -62,14 +62,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 throw new ArgumentNullException(nameof(serviceCollection));
             }
 
-            serviceCollection.TryAddSingleton<DurableTaskExtension>();
             serviceCollection.TryAddSingleton<INameResolver, DefaultNameResolver>();
             serviceCollection.TryAddSingleton<IConnectionStringResolver, StandardConnectionStringProvider>();
-            serviceCollection.TryAddSingleton<IDurableHttpMessageHandlerFactory, DurableHttpMessageHandlerFactory>();
             serviceCollection.TryAddSingleton<IDurabilityProviderFactory, AzureStorageDurabilityProviderFactory>();
-            serviceCollection.TryAddSingleton<IMessageSerializerSettingsFactory, MessageSerializerSettingsFactory>();
-            serviceCollection.TryAddSingleton<IErrorSerializerSettingsFactory, ErrorSerializerSettingsFactory>();
             serviceCollection.TryAddSingleton<IDurableClientFactory, DurableClientFactory>();
+            serviceCollection.TryAddSingleton<IMessageSerializerSettingsFactory, MessageSerializerSettingsFactory>();
 
             return serviceCollection;
         }

--- a/src/WebJobs.Extensions.DurableTask/LocalHttpListener.cs
+++ b/src/WebJobs.Extensions.DurableTask/LocalHttpListener.cs
@@ -22,16 +22,20 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
     {
         private const int DefaultPort = 17071;
 
-        private readonly DurableTaskExtension extension;
         private readonly IWebHost localWebHost;
         private readonly Func<HttpRequestMessage, Task<HttpResponseMessage>> handler;
+        private readonly EndToEndTraceHelper traceHelper;
+        private readonly DurableTaskOptions durableTaskOptions;
 
         public LocalHttpListener(
-            DurableTaskExtension extension,
+            EndToEndTraceHelper traceHelper,
+            DurableTaskOptions durableTaskOptions,
             Func<HttpRequestMessage, Task<HttpResponseMessage>> handler)
         {
-            this.extension = extension ?? throw new ArgumentNullException(nameof(extension));
+            this.traceHelper = traceHelper ?? throw new ArgumentNullException(nameof(traceHelper));
             this.handler = handler ?? throw new ArgumentNullException(nameof(handler));
+            this.durableTaskOptions = durableTaskOptions ?? throw new ArgumentNullException(nameof(durableTaskOptions));
+
 #if !FUNCTIONS_V1
             this.InternalRpcUri = new Uri($"http://127.0.0.1:{this.GetAvailablePort()}/durabletask/");
             var listenUri = new Uri(this.InternalRpcUri.GetLeftPart(UriPartial.Authority));
@@ -114,8 +118,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             }
             catch (Exception e)
             {
-                this.extension.TraceHelper.ExtensionWarningEvent(
-                    this.extension.Options.HubName,
+                this.traceHelper.ExtensionWarningEvent(
+                    this.durableTaskOptions.HubName,
                     functionName: string.Empty,
                     instanceId: string.Empty,
                     message: $"Unhandled exception in HTTP API handler: {e}");

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net461.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net461.xml
@@ -193,6 +193,12 @@
             <param name="durableClientOptions">options containing the client configuration parameters.</param>
             <returns>Returns a <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableClient"/> instance. The returned instance may be a cached instance.</returns>
         </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.ContextImplementations.IDurableClientFactory.CreateClient">
+            <summary>
+            Gets a <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableClient"/> using configuration from a <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.Options.DurableClientOptions"/> instance.
+            </summary>
+            <returns>Returns a <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableClient"/> instance. The returned instance may be a cached instance.</returns>
+        </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableCommonContext">
             <summary>
             Common functionality used by both <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableOrchestrationContext"/>
@@ -3202,6 +3208,9 @@
             <summary>
                 Indicate if the client is External from the azure function where orchestrator functions are hosted.
             </summary>
+            <remarks>
+                Default is true.
+            </remarks>
         </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskOptions">
             <summary>
@@ -3358,6 +3367,16 @@
             after each individual operation. If false, the entity state is serialized
             only after an entire batch of operations completes.
             </remarks>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskOptions.UseAppLease">
+            <summary>
+            If true, takes a lease on the task hub container, allowing for only one app to process messages in a task hub at a time.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskOptions.AppLeaseOptions">
+            <summary>
+            If UseAppLease is true, gets or sets the AppLeaaseOptions used for acquiring the lease to start the application.
+            </summary>
         </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskOptions.SetDefaultHubName(System.String)">
             <summary>

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net461.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net461.xml
@@ -161,17 +161,24 @@
                 Factory class to create Durable Client to start works outside an azure function context.
             </summary>
         </member>
-        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.ContextImplementations.DurableClientFactory.#ctor(Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension)">
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.ContextImplementations.DurableClientFactory.#ctor(Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension,Microsoft.Extensions.Options.IOptions{Microsoft.Azure.WebJobs.Extensions.DurableTask.Options.DurableClientOptions})">
             <summary>
                 Initializes a new instance of the <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.ContextImplementations.DurableClientFactory"/> class.
             </summary>
             <param name="durableTaskConfig">Configuration for the Durable Functions extension.</param>
+            <param name="defaultDurableClientOptions">Default Options to Build Durable Clients.</param>
         </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.ContextImplementations.DurableClientFactory.CreateClient(Microsoft.Azure.WebJobs.Extensions.DurableTask.Options.DurableClientOptions)">
             <summary>
             Gets a <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableClient"/> using configuration from a <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.Options.DurableClientOptions"/> instance.
             </summary>
             <param name="durableClientOptions">options containing the client configuration parameters.</param>
+            <returns>Returns a <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableClient"/> instance. The returned instance may be a cached instance.</returns>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.ContextImplementations.DurableClientFactory.CreateClient">
+            <summary>
+            Gets a <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableClient"/> using configuration from a <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.Options.DurableClientOptions"/> instance.
+            </summary>
             <returns>Returns a <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableClient"/> instance. The returned instance may be a cached instance.</returns>
         </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.ContextImplementations.IDurableClientFactory">

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net461.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net461.xml
@@ -156,6 +156,36 @@
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClient.Microsoft#Azure#WebJobs#Extensions#DurableTask#IDurableEntityClient#SignalEntityAsync``1(Microsoft.Azure.WebJobs.Extensions.DurableTask.EntityId,System.DateTime,System.Action{``0})">
             <inheritdoc/>
         </member>
+        <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.ContextImplementations.DurableClientFactory">
+            <summary>
+                Factory class to create Durable Client to start works outside an azure function context.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.ContextImplementations.DurableClientFactory.#ctor(Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension)">
+            <summary>
+                Initializes a new instance of the <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.ContextImplementations.DurableClientFactory"/> class.
+            </summary>
+            <param name="durableTaskConfig">Configuration for the Durable Functions extension.</param>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.ContextImplementations.DurableClientFactory.CreateClient(Microsoft.Azure.WebJobs.Extensions.DurableTask.Options.DurableClientOptions)">
+            <summary>
+            Gets a <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableClient"/> using configuration from a <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.Options.DurableClientOptions"/> instance.
+            </summary>
+            <param name="durableClientOptions">options containing the client configuration parameters.</param>
+            <returns>Returns a <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableClient"/> instance. The returned instance may be a cached instance.</returns>
+        </member>
+        <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.ContextImplementations.IDurableClientFactory">
+            <summary>
+                Factory class to create Durable Client to start works outside an azure function context.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.ContextImplementations.IDurableClientFactory.CreateClient(Microsoft.Azure.WebJobs.Extensions.DurableTask.Options.DurableClientOptions)">
+            <summary>
+            Gets a <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableClient"/> using configuration from a <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.Options.DurableClientOptions"/> instance.
+            </summary>
+            <param name="durableClientOptions">options containing the client configuration parameters.</param>
+            <returns>Returns a <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableClient"/> instance. The returned instance may be a cached instance.</returns>
+        </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableCommonContext">
             <summary>
             Common functionality used by both <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableOrchestrationContext"/>
@@ -1691,6 +1721,17 @@
             Attribute used to bind a function parameter to a <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableClient"/>, <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableEntityClient"/>, or <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableOrchestrationClient"/> instance.
             </summary>
         </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClientAttribute.#ctor">
+            <summary>
+            Initializes a new instance of the <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClientAttribute"/> class.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClientAttribute.#ctor(Microsoft.Azure.WebJobs.Extensions.DurableTask.Options.DurableClientOptions)">
+            <summary>
+            Initializes a new instance of the <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClientAttribute"/> class.
+            </summary>
+            <param name="durableClientOptions">durable client options</param>
+        </member>
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClientAttribute.TaskHub">
             <summary>
             Optional. Gets or sets the name of the task hub in which the orchestration data lives.
@@ -1711,6 +1752,11 @@
             For Azure Storage the default behavior is to use the value of <see cref="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureStorageOptions.ConnectionStringName"/>.
             If no value exists there, then the default behavior is to use the standard `AzureWebJobsStorage` connection string for all storage usage.
             </remarks>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClientAttribute.ExternalClient">
+            <summary>
+                Indicate if the client is External from the azure function where orchestrator functions are hosted.
+            </summary>
         </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClientAttribute.GetHashCode">
             <summary>
@@ -3119,6 +3165,37 @@
             Throws an exception if any of the settings of the storage provider are invalid.
             </summary>
         </member>
+        <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.Options.DurableClientOptions">
+            <summary>
+            Options used to bind a function parameter to a <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableClient"/>, <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableEntityClient"/>, or <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableOrchestrationClient"/> instance.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.Options.DurableClientOptions.ConnectionName">
+            <summary>
+            Optional. Gets or sets the setting name for the app setting containing connection details used by this binding to connect
+            to instances of the storage provider other than the default one this application communicates with.
+            </summary>
+            <value>The name of an app setting containing connection details.</value>
+            <remarks>
+            For Azure Storage the default behavior is to use the value of <see cref="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureStorageOptions.ConnectionStringName"/>.
+            If no value exists there, then the default behavior is to use the standard `AzureWebJobsStorage` connection string for all storage usage.
+            </remarks>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.Options.DurableClientOptions.TaskHub">
+            <summary>
+            Optional. Gets or sets the name of the task hub in which the orchestration data lives.
+            </summary>
+            <value>The task hub used by this binding.</value>
+            <remarks>
+            The default behavior is to use the task hub name specified in <see cref="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskOptions.HubName"/>.
+            If no value exists there, then a default value will be used.
+            </remarks>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.Options.DurableClientOptions.IsExternalClient">
+            <summary>
+                Indicate if the client is External from the azure function where orchestrator functions are hosted.
+            </summary>
+        </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskOptions">
             <summary>
             Configuration options for the Durable Task extension.
@@ -3608,6 +3685,24 @@
             <value>
             The delegate to handle exception to determie if retries should proceed.
             </value>
+        </member>
+        <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.StandardConnectionStringProvider">
+            <summary>
+            Connection string provider which resolves connection strings from the an standard application (Non WebJob).
+            </summary>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.StandardConnectionStringProvider.#ctor(Microsoft.Extensions.Configuration.IConfiguration)">
+            <summary>
+            Initializes a new instance of the <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.StandardConnectionStringProvider"/> class.
+            </summary>
+            <param name="configuration">A <see cref="T:Microsoft.Extensions.Configuration.IConfiguration"/> object provided by the application host.</param>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.StandardConnectionStringProvider.Resolve(System.String)">
+            <summary>
+            Looks up a connection string value given a name.
+            </summary>
+            <param name="connectionStringName">The name of the connection string.</param>
+            <returns>Returns the resolved connection string value.</returns>
         </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.StartOrchestrationArgs">
             <summary>

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net461.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net461.xml
@@ -161,12 +161,15 @@
                 Factory class to create Durable Client to start works outside an azure function context.
             </summary>
         </member>
-        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.ContextImplementations.DurableClientFactory.#ctor(Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension,Microsoft.Extensions.Options.IOptions{Microsoft.Azure.WebJobs.Extensions.DurableTask.Options.DurableClientOptions})">
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.ContextImplementations.DurableClientFactory.#ctor(Microsoft.Extensions.Options.IOptions{Microsoft.Azure.WebJobs.Extensions.DurableTask.Options.DurableClientOptions},Microsoft.Extensions.Options.IOptions{Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskOptions},Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurabilityProviderFactory,Microsoft.Extensions.Logging.ILoggerFactory,Microsoft.Azure.WebJobs.Extensions.DurableTask.IMessageSerializerSettingsFactory)">
             <summary>
                 Initializes a new instance of the <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.ContextImplementations.DurableClientFactory"/> class.
             </summary>
-            <param name="durableTaskConfig">Configuration for the Durable Functions extension.</param>
             <param name="defaultDurableClientOptions">Default Options to Build Durable Clients.</param>
+            <param name="orchestrationServiceFactory">The factory used to create orchestration service based on the configured storage provider.</param>
+            <param name="loggerFactory">The logger factory used for extension-specific logging and orchestration tracking.</param>
+            <param name="durableTaskOptions">The configuration options for this extension.</param>
+            <param name="messageSerializerSettingsFactory">The factory used to create <see cref="T:Newtonsoft.Json.JsonSerializerSettings"/> for message settings.</param>
         </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.ContextImplementations.DurableClientFactory.CreateClient(Microsoft.Azure.WebJobs.Extensions.DurableTask.Options.DurableClientOptions)">
             <summary>
@@ -180,6 +183,9 @@
             Gets a <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableClient"/> using configuration from a <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.Options.DurableClientOptions"/> instance.
             </summary>
             <returns>Returns a <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableClient"/> instance. The returned instance may be a cached instance.</returns>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.ContextImplementations.DurableClientFactory.Dispose">
+            <inheritdoc />
         </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.ContextImplementations.IDurableClientFactory">
             <summary>
@@ -3196,7 +3202,7 @@
         </member>
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.Options.DurableClientOptions.TaskHub">
             <summary>
-            Optional. Gets or sets the name of the task hub in which the orchestration data lives.
+             Gets or sets the name of the task hub in which the orchestration data lives.
             </summary>
             <value>The task hub used by this binding.</value>
             <remarks>

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
@@ -193,6 +193,12 @@
             <param name="durableClientOptions">options containing the client configuration parameters.</param>
             <returns>Returns a <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableClient"/> instance. The returned instance may be a cached instance.</returns>
         </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.ContextImplementations.IDurableClientFactory.CreateClient">
+            <summary>
+            Gets a <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableClient"/> using configuration from a <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.Options.DurableClientOptions"/> instance.
+            </summary>
+            <returns>Returns a <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableClient"/> instance. The returned instance may be a cached instance.</returns>
+        </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableCommonContext">
             <summary>
             Common functionality used by both <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableOrchestrationContext"/>
@@ -3257,6 +3263,9 @@
             <summary>
                 Indicate if the client is External from the azure function where orchestrator functions are hosted.
             </summary>
+            <remarks>
+                Default is true.
+            </remarks>
         </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskOptions">
             <summary>
@@ -3413,6 +3422,16 @@
             after each individual operation. If false, the entity state is serialized
             only after an entire batch of operations completes.
             </remarks>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskOptions.UseAppLease">
+            <summary>
+            If true, takes a lease on the task hub container, allowing for only one app to process messages in a task hub at a time.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskOptions.AppLeaseOptions">
+            <summary>
+            If UseAppLease is true, gets or sets the AppLeaaseOptions used for acquiring the lease to start the application.
+            </summary>
         </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskOptions.SetDefaultHubName(System.String)">
             <summary>

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
@@ -161,12 +161,15 @@
                 Factory class to create Durable Client to start works outside an azure function context.
             </summary>
         </member>
-        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.ContextImplementations.DurableClientFactory.#ctor(Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension,Microsoft.Extensions.Options.IOptions{Microsoft.Azure.WebJobs.Extensions.DurableTask.Options.DurableClientOptions})">
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.ContextImplementations.DurableClientFactory.#ctor(Microsoft.Extensions.Options.IOptions{Microsoft.Azure.WebJobs.Extensions.DurableTask.Options.DurableClientOptions},Microsoft.Extensions.Options.IOptions{Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskOptions},Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurabilityProviderFactory,Microsoft.Extensions.Logging.ILoggerFactory,Microsoft.Azure.WebJobs.Extensions.DurableTask.IMessageSerializerSettingsFactory)">
             <summary>
                 Initializes a new instance of the <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.ContextImplementations.DurableClientFactory"/> class.
             </summary>
-            <param name="durableTaskConfig">Configuration for the Durable Functions extension.</param>
             <param name="defaultDurableClientOptions">Default Options to Build Durable Clients.</param>
+            <param name="orchestrationServiceFactory">The factory used to create orchestration service based on the configured storage provider.</param>
+            <param name="loggerFactory">The logger factory used for extension-specific logging and orchestration tracking.</param>
+            <param name="durableTaskOptions">The configuration options for this extension.</param>
+            <param name="messageSerializerSettingsFactory">The factory used to create <see cref="T:Newtonsoft.Json.JsonSerializerSettings"/> for message settings.</param>
         </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.ContextImplementations.DurableClientFactory.CreateClient(Microsoft.Azure.WebJobs.Extensions.DurableTask.Options.DurableClientOptions)">
             <summary>
@@ -180,6 +183,9 @@
             Gets a <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableClient"/> using configuration from a <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.Options.DurableClientOptions"/> instance.
             </summary>
             <returns>Returns a <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableClient"/> instance. The returned instance may be a cached instance.</returns>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.ContextImplementations.DurableClientFactory.Dispose">
+            <inheritdoc />
         </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.ContextImplementations.IDurableClientFactory">
             <summary>
@@ -3251,7 +3257,7 @@
         </member>
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.Options.DurableClientOptions.TaskHub">
             <summary>
-            Optional. Gets or sets the name of the task hub in which the orchestration data lives.
+             Gets or sets the name of the task hub in which the orchestration data lives.
             </summary>
             <value>The task hub used by this binding.</value>
             <remarks>

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
@@ -156,6 +156,36 @@
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClient.Microsoft#Azure#WebJobs#Extensions#DurableTask#IDurableEntityClient#SignalEntityAsync``1(Microsoft.Azure.WebJobs.Extensions.DurableTask.EntityId,System.DateTime,System.Action{``0})">
             <inheritdoc/>
         </member>
+        <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.ContextImplementations.DurableClientFactory">
+            <summary>
+                Factory class to create Durable Client to start works outside an azure function context.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.ContextImplementations.DurableClientFactory.#ctor(Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension)">
+            <summary>
+                Initializes a new instance of the <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.ContextImplementations.DurableClientFactory"/> class.
+            </summary>
+            <param name="durableTaskConfig">Configuration for the Durable Functions extension.</param>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.ContextImplementations.DurableClientFactory.CreateClient(Microsoft.Azure.WebJobs.Extensions.DurableTask.Options.DurableClientOptions)">
+            <summary>
+            Gets a <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableClient"/> using configuration from a <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.Options.DurableClientOptions"/> instance.
+            </summary>
+            <param name="durableClientOptions">options containing the client configuration parameters.</param>
+            <returns>Returns a <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableClient"/> instance. The returned instance may be a cached instance.</returns>
+        </member>
+        <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.ContextImplementations.IDurableClientFactory">
+            <summary>
+                Factory class to create Durable Client to start works outside an azure function context.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.ContextImplementations.IDurableClientFactory.CreateClient(Microsoft.Azure.WebJobs.Extensions.DurableTask.Options.DurableClientOptions)">
+            <summary>
+            Gets a <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableClient"/> using configuration from a <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.Options.DurableClientOptions"/> instance.
+            </summary>
+            <param name="durableClientOptions">options containing the client configuration parameters.</param>
+            <returns>Returns a <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableClient"/> instance. The returned instance may be a cached instance.</returns>
+        </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableCommonContext">
             <summary>
             Common functionality used by both <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableOrchestrationContext"/>
@@ -1696,6 +1726,17 @@
             Attribute used to bind a function parameter to a <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableClient"/>, <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableEntityClient"/>, or <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableOrchestrationClient"/> instance.
             </summary>
         </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClientAttribute.#ctor">
+            <summary>
+            Initializes a new instance of the <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClientAttribute"/> class.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClientAttribute.#ctor(Microsoft.Azure.WebJobs.Extensions.DurableTask.Options.DurableClientOptions)">
+            <summary>
+            Initializes a new instance of the <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClientAttribute"/> class.
+            </summary>
+            <param name="durableClientOptions">durable client options</param>
+        </member>
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClientAttribute.TaskHub">
             <summary>
             Optional. Gets or sets the name of the task hub in which the orchestration data lives.
@@ -1716,6 +1757,11 @@
             For Azure Storage the default behavior is to use the value of <see cref="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureStorageOptions.ConnectionStringName"/>.
             If no value exists there, then the default behavior is to use the standard `AzureWebJobsStorage` connection string for all storage usage.
             </remarks>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClientAttribute.ExternalClient">
+            <summary>
+                Indicate if the client is External from the azure function where orchestrator functions are hosted.
+            </summary>
         </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClientAttribute.GetHashCode">
             <summary>
@@ -2058,6 +2104,13 @@
             </summary>
             <param name="builder">The <see cref="T:Microsoft.Azure.WebJobs.IWebJobsBuilder"/> to configure.</param>
             <returns>Returns the provided <see cref="T:Microsoft.Azure.WebJobs.IWebJobsBuilder"/>.</returns>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskJobHostConfigurationExtensions.AddDurableTask(Microsoft.Extensions.DependencyInjection.IServiceCollection)">
+            <summary>
+            Adds the Durable Task extension to the provided <see cref="T:Microsoft.Extensions.DependencyInjection.IServiceCollection"/>.
+            </summary>
+            <param name="serviceCollection">The <see cref="T:Microsoft.Extensions.DependencyInjection.IServiceCollection"/> to configure.</param>
+            <returns>Returns the provided <see cref="T:Microsoft.Extensions.DependencyInjection.IServiceCollection"/>.</returns>
         </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskJobHostConfigurationExtensions.AddDurableTask(Microsoft.Azure.WebJobs.IWebJobsBuilder,Microsoft.Extensions.Options.IOptions{Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskOptions})">
             <summary>
@@ -3159,6 +3212,37 @@
             Throws an exception if any of the settings of the storage provider are invalid.
             </summary>
         </member>
+        <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.Options.DurableClientOptions">
+            <summary>
+            Options used to bind a function parameter to a <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableClient"/>, <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableEntityClient"/>, or <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableOrchestrationClient"/> instance.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.Options.DurableClientOptions.ConnectionName">
+            <summary>
+            Optional. Gets or sets the setting name for the app setting containing connection details used by this binding to connect
+            to instances of the storage provider other than the default one this application communicates with.
+            </summary>
+            <value>The name of an app setting containing connection details.</value>
+            <remarks>
+            For Azure Storage the default behavior is to use the value of <see cref="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureStorageOptions.ConnectionStringName"/>.
+            If no value exists there, then the default behavior is to use the standard `AzureWebJobsStorage` connection string for all storage usage.
+            </remarks>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.Options.DurableClientOptions.TaskHub">
+            <summary>
+            Optional. Gets or sets the name of the task hub in which the orchestration data lives.
+            </summary>
+            <value>The task hub used by this binding.</value>
+            <remarks>
+            The default behavior is to use the task hub name specified in <see cref="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskOptions.HubName"/>.
+            If no value exists there, then a default value will be used.
+            </remarks>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.Options.DurableClientOptions.IsExternalClient">
+            <summary>
+                Indicate if the client is External from the azure function where orchestrator functions are hosted.
+            </summary>
+        </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskOptions">
             <summary>
             Configuration options for the Durable Task extension.
@@ -3648,6 +3732,24 @@
             <value>
             The delegate to handle exception to determie if retries should proceed.
             </value>
+        </member>
+        <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.StandardConnectionStringProvider">
+            <summary>
+            Connection string provider which resolves connection strings from the an standard application (Non WebJob).
+            </summary>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.StandardConnectionStringProvider.#ctor(Microsoft.Extensions.Configuration.IConfiguration)">
+            <summary>
+            Initializes a new instance of the <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.StandardConnectionStringProvider"/> class.
+            </summary>
+            <param name="configuration">A <see cref="T:Microsoft.Extensions.Configuration.IConfiguration"/> object provided by the application host.</param>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.StandardConnectionStringProvider.Resolve(System.String)">
+            <summary>
+            Looks up a connection string value given a name.
+            </summary>
+            <param name="connectionStringName">The name of the connection string.</param>
+            <returns>Returns the resolved connection string value.</returns>
         </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.StartOrchestrationArgs">
             <summary>

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
@@ -161,17 +161,24 @@
                 Factory class to create Durable Client to start works outside an azure function context.
             </summary>
         </member>
-        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.ContextImplementations.DurableClientFactory.#ctor(Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension)">
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.ContextImplementations.DurableClientFactory.#ctor(Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension,Microsoft.Extensions.Options.IOptions{Microsoft.Azure.WebJobs.Extensions.DurableTask.Options.DurableClientOptions})">
             <summary>
                 Initializes a new instance of the <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.ContextImplementations.DurableClientFactory"/> class.
             </summary>
             <param name="durableTaskConfig">Configuration for the Durable Functions extension.</param>
+            <param name="defaultDurableClientOptions">Default Options to Build Durable Clients.</param>
         </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.ContextImplementations.DurableClientFactory.CreateClient(Microsoft.Azure.WebJobs.Extensions.DurableTask.Options.DurableClientOptions)">
             <summary>
             Gets a <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableClient"/> using configuration from a <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.Options.DurableClientOptions"/> instance.
             </summary>
             <param name="durableClientOptions">options containing the client configuration parameters.</param>
+            <returns>Returns a <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableClient"/> instance. The returned instance may be a cached instance.</returns>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.ContextImplementations.DurableClientFactory.CreateClient">
+            <summary>
+            Gets a <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableClient"/> using configuration from a <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.Options.DurableClientOptions"/> instance.
+            </summary>
             <returns>Returns a <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableClient"/> instance. The returned instance may be a cached instance.</returns>
         </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.ContextImplementations.IDurableClientFactory">
@@ -2110,6 +2117,14 @@
             Adds the Durable Task extension to the provided <see cref="T:Microsoft.Extensions.DependencyInjection.IServiceCollection"/>.
             </summary>
             <param name="serviceCollection">The <see cref="T:Microsoft.Extensions.DependencyInjection.IServiceCollection"/> to configure.</param>
+            <returns>Returns the provided <see cref="T:Microsoft.Extensions.DependencyInjection.IServiceCollection"/>.</returns>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskJobHostConfigurationExtensions.AddDurableTask(Microsoft.Extensions.DependencyInjection.IServiceCollection,System.Action{Microsoft.Azure.WebJobs.Extensions.DurableTask.Options.DurableClientOptions})">
+            <summary>
+            Adds the Durable Task extension to the provided <see cref="T:Microsoft.Extensions.DependencyInjection.IServiceCollection"/>.
+            </summary>
+            <param name="serviceCollection">The <see cref="T:Microsoft.Extensions.DependencyInjection.IServiceCollection"/> to configure.</param>
+            <param name="optionsBuilder">Populate default configurations of <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.Options.DurableClientOptions"/> to create Durable Clients.</param>
             <returns>Returns the provided <see cref="T:Microsoft.Extensions.DependencyInjection.IServiceCollection"/>.</returns>
         </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskJobHostConfigurationExtensions.AddDurableTask(Microsoft.Azure.WebJobs.IWebJobsBuilder,Microsoft.Extensions.Options.IOptions{Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskOptions})">

--- a/src/WebJobs.Extensions.DurableTask/Options/DurableClientOptions.cs
+++ b/src/WebJobs.Extensions.DurableTask/Options/DurableClientOptions.cs
@@ -32,6 +32,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Options
         /// <summary>
         ///     Indicate if the client is External from the azure function where orchestrator functions are hosted.
         /// </summary>
-        public bool IsExternalClient { get; set; }
+        /// <remarks>
+        ///     Default is true.
+        /// </remarks>
+        public bool IsExternalClient { get; set; } = true;
     }
 }

--- a/src/WebJobs.Extensions.DurableTask/Options/DurableClientOptions.cs
+++ b/src/WebJobs.Extensions.DurableTask/Options/DurableClientOptions.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Options
+{
+    /// <summary>
+    /// Options used to bind a function parameter to a <see cref="IDurableClient"/>, <see cref="IDurableEntityClient"/>, or <see cref="IDurableOrchestrationClient"/> instance.
+    /// </summary>
+    public class DurableClientOptions
+    {
+        /// <summary>
+        /// Optional. Gets or sets the setting name for the app setting containing connection details used by this binding to connect
+        /// to instances of the storage provider other than the default one this application communicates with.
+        /// </summary>
+        /// <value>The name of an app setting containing connection details.</value>
+        /// <remarks>
+        /// For Azure Storage the default behavior is to use the value of <see cref="AzureStorageOptions.ConnectionStringName"/>.
+        /// If no value exists there, then the default behavior is to use the standard `AzureWebJobsStorage` connection string for all storage usage.
+        /// </remarks>
+        public string ConnectionName { get; set; }
+
+        /// <summary>
+        /// Optional. Gets or sets the name of the task hub in which the orchestration data lives.
+        /// </summary>
+        /// <value>The task hub used by this binding.</value>
+        /// <remarks>
+        /// The default behavior is to use the task hub name specified in <see cref="DurableTaskOptions.HubName"/>.
+        /// If no value exists there, then a default value will be used.
+        /// </remarks>
+        public string TaskHub { get; set; }
+
+        /// <summary>
+        ///     Indicate if the client is External from the azure function where orchestrator functions are hosted.
+        /// </summary>
+        public bool IsExternalClient { get; set; }
+    }
+}

--- a/src/WebJobs.Extensions.DurableTask/Options/DurableClientOptions.cs
+++ b/src/WebJobs.Extensions.DurableTask/Options/DurableClientOptions.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Options
         public string ConnectionName { get; set; }
 
         /// <summary>
-        /// Optional. Gets or sets the name of the task hub in which the orchestration data lives.
+        ///  Gets or sets the name of the task hub in which the orchestration data lives.
         /// </summary>
         /// <value>The task hub used by this binding.</value>
         /// <remarks>

--- a/src/WebJobs.Extensions.DurableTask/Options/DurableTaskOptions.cs
+++ b/src/WebJobs.Extensions.DurableTask/Options/DurableTaskOptions.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
     /// </summary>
     public class DurableTaskOptions
     {
+        internal const string DefaultHubName = "TestHubName";
         private string originalHubName;
         private string resolvedHubName;
         private string defaultHubName;
@@ -43,7 +44,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 {
                     // "WEBSITE_SITE_NAME" is an environment variable used in Azure functions infrastructure. When running locally, this can be
                     // specified in local.settings.json file to avoid being defaulted to "TestHubName"
-                    this.resolvedHubName = Environment.GetEnvironmentVariable("WEBSITE_SITE_NAME") ?? "TestHubName";
+                    this.resolvedHubName = Environment.GetEnvironmentVariable("WEBSITE_SITE_NAME") ?? DefaultHubName;
                     this.defaultHubName = this.resolvedHubName;
                 }
 

--- a/src/WebJobs.Extensions.DurableTask/StandardConnectionStringProvider.cs
+++ b/src/WebJobs.Extensions.DurableTask/StandardConnectionStringProvider.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Microsoft.Extensions.Configuration;
+
+namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
+{
+    /// <summary>
+    /// Connection string provider which resolves connection strings from the an standard application (Non WebJob).
+    /// </summary>
+    public class StandardConnectionStringProvider : IConnectionStringResolver
+    {
+        private readonly IConfiguration configuration;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StandardConnectionStringProvider"/> class.
+        /// </summary>
+        /// <param name="configuration">A <see cref="IConfiguration"/> object provided by the application host.</param>
+        public StandardConnectionStringProvider(IConfiguration configuration)
+        {
+            this.configuration = configuration;
+        }
+
+        /// <summary>
+        /// Looks up a connection string value given a name.
+        /// </summary>
+        /// <param name="connectionStringName">The name of the connection string.</param>
+        /// <returns>Returns the resolved connection string value.</returns>
+        public string Resolve(string connectionStringName)
+        {
+            return this.configuration[connectionStringName];
+        }
+    }
+}


### PR DESCRIPTION
Ref  : https://github.com/Azure/azure-functions-durable-extension/issues/161

This is intended to init azure durable functions outside of an azure function orchestrators host.
It could have extensive applications to init durable functions from different applications event from other azure functions applications.

Usability is straight forward for a client. Let's take an Asp.Net Core application.

To configure the application just call AddDurableTask, this will use service collection instead of webjob extension builder. 
```C#
        public void ConfigureServices(IServiceCollection services)
        {
            services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_2_2);
            services.AddDurableTask();
        }
```

To create the client just inject `IDurableClientFactory` under the hood this will create a client using the same approach Orchestrator host is doing to avoid breaking changes, we could configure hub name or the connection string for the storage account
```C#
private readonly IDurableClientFactory _clientFactory;

        public SampleController(IDurableClientFactory clientFactory)
        {
            _clientFactory = clientFactory;
        }

        [HttpGet]
        public async Task<IActionResult> Get()
        {
            var client = _clientFactory.CreateClient(new DurableClientOptions
            {
                IsExternalClient = true
            });

            var instanceId = await client.StartNewAsync("Chaining");
            return Ok(instanceId);
        }
```

The implementation on the orchestrator host is exactly the same without any client needed to start the flow.
```C#
  [FunctionName("Chaining")]
        public static async Task<object> Chaining(
            [OrchestrationTrigger] IDurableOrchestrationContext context)
        {
            var x = await context.CallActivityAsync<object>("F1", null);
            var y = await context.CallActivityAsync<object>("F2", x);
            var z = await context.CallActivityAsync<object>("F3", y);
            return await context.CallActivityAsync<object>("F4", z);
        }
```

Let me know your thoughts and will complete a few unit tests required for the external client flag to avoid the validation of know function names. 
https://github.com/Azure/azure-functions-durable-extension/pull/1125/files#diff-b4be2ec3bf4e13899ce8445628aa091aR109 

Any suggestion to control that validation is welcome.