### PR TITLE
Fix TaskHub validation

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/AzureStorageDurabilityProviderFactory.cs
+++ b/src/WebJobs.Extensions.DurableTask/AzureStorageDurabilityProviderFactory.cs
@@ -40,9 +40,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         }
 
         // This method should not be called before the app settings are resolved into the options.
-        // Because of this, we wait to validate the options until righ before building a durability provider, rather
+        // Because of this, we wait to validate the options until right before building a durability provider, rather
         // than in the Factory constructor.
-        private void EnsureOptionsAreValid()
+        private void EnsureInitialized()
         {
             if (!this.hasValidatedOptions)
             {
@@ -62,7 +62,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
         public DurabilityProvider GetDurabilityProvider()
         {
-            this.EnsureOptionsAreValid();
+            this.EnsureInitialized();
             if (this.defaultStorageProvider == null)
             {
                 var defaultService = new AzureStorageOrchestrationService(this.defaultSettings);
@@ -74,7 +74,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
         public DurabilityProvider GetDurabilityProvider(DurableClientAttribute attribute)
         {
-            this.EnsureOptionsAreValid();
+            this.EnsureInitialized();
             return this.GetAzureStorageStorageProvider(attribute);
         }
 

--- a/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
@@ -245,6 +245,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
         private void ResolveAppSettingOptions()
         {
+            if (this.Options == null)
+            {
+                throw new InvalidOperationException($"{nameof(this.Options)} must be set before resolving app settings.");
+            }
+
+            if (this.nameResolver == null)
+            {
+                throw new InvalidOperationException($"{nameof(this.nameResolver)} must be set before resolving app settings.");
+            }
+
             if (this.nameResolver.TryResolveWholeString(this.Options.HubName, out string taskHubName))
             {
                 // use the resolved task hub name

--- a/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
@@ -105,6 +105,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             // Options will be null in Functions v1 runtime - populated later.
             this.Options = options?.Value ?? new DurableTaskOptions();
             this.nameResolver = nameResolver ?? throw new ArgumentNullException(nameof(nameResolver));
+            this.ResolveAppSettingOptions();
 
             if (loggerFactory == null)
             {
@@ -195,12 +196,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 this.InitializeForFunctionsV1(context);
             }
 
-            if (this.nameResolver.TryResolveWholeString(this.Options.HubName, out string taskHubName))
-            {
-                // use the resolved task hub name
-                this.Options.HubName = taskHubName;
-            }
-
             // Throw if any of the configured options are invalid
             this.Options.Validate();
 
@@ -248,16 +243,26 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             this.taskHubWorker.AddOrchestrationDispatcherMiddleware(this.OrchestrationMiddleware);
         }
 
+        private void ResolveAppSettingOptions()
+        {
+            if (this.nameResolver.TryResolveWholeString(this.Options.HubName, out string taskHubName))
+            {
+                // use the resolved task hub name
+                this.Options.HubName = taskHubName;
+            }
+        }
+
         private void InitializeForFunctionsV1(ExtensionConfigContext context)
         {
 #if FUNCTIONS_V1
             context.ApplyConfig(this.Options, "DurableTask");
+            this.nameResolver = context.Config.NameResolver;
+            this.ResolveAppSettingOptions();
             ILogger logger = context.Config.LoggerFactory.CreateLogger(LoggerCategoryName);
             this.TraceHelper = new EndToEndTraceHelper(logger, this.Options.Tracing.TraceReplayEvents);
             this.connectionStringResolver = new WebJobsConnectionStringProvider();
             this.durabilityProviderFactory = new AzureStorageDurabilityProviderFactory(new OptionsWrapper<DurableTaskOptions>(this.Options), this.connectionStringResolver);
             this.defaultDurabilityProvider = this.durabilityProviderFactory.GetDurabilityProvider();
-            this.nameResolver = context.Config.NameResolver;
             this.LifeCycleNotificationHelper = this.CreateLifeCycleNotificationHelper();
             this.HttpApiHandler = new HttpApiHandler(this, logger);
 #endif

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net471.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net471.xml
@@ -2964,10 +2964,15 @@
             <summary>
             Gets or set the number of control queue messages that can be buffered in memory
             at a time, at which point the dispatcher will wait before dequeuing any additional
-            messages. The default is 64.
+            messages. The default is 256. The maximum value is 1000.
             </summary>
-            <remarks>This has historically always been fixed to 64, but increasing it may increase
-            throughput.</remarks>
+            <remarks>
+            Increasing this value can improve orchestration throughput by pre-fetching more
+            orchestration messages from control queues. The downside is that it increases the
+            possibility of duplicate function executions if partition leases move between app
+            instances. This most often occurs when the number of app instances changes.
+            </remarks>
+            <value>A non-negative integer between 0 and 1000. The default value is <c>256</c>.</value>
         </member>
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureStorageOptions.ControlQueueVisibilityTimeout">
             <summary>

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
@@ -3031,10 +3031,15 @@
             <summary>
             Gets or set the number of control queue messages that can be buffered in memory
             at a time, at which point the dispatcher will wait before dequeuing any additional
-            messages. The default is 64.
+            messages. The default is 256. The maximum value is 1000.
             </summary>
-            <remarks>This has historically always been fixed to 64, but increasing it may increase
-            throughput.</remarks>
+            <remarks>
+            Increasing this value can improve orchestration throughput by pre-fetching more
+            orchestration messages from control queues. The downside is that it increases the
+            possibility of duplicate function executions if partition leases move between app
+            instances. This most often occurs when the number of app instances changes.
+            </remarks>
+            <value>A non-negative integer between 0 and 1000. The default value is <c>256</c>.</value>
         </member>
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureStorageOptions.ControlQueueVisibilityTimeout">
             <summary>

--- a/src/WebJobs.Extensions.DurableTask/Options/AzureStorageOptions.cs
+++ b/src/WebJobs.Extensions.DurableTask/Options/AzureStorageOptions.cs
@@ -144,7 +144,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
         private static string GetTaskHubErrorString(string hubName)
         {
-            return $"Task hub name '{hubName}' should contain only alphanumeric characters excluding '-' and have length up to {MaxTaskHubNameSize}.";
+            return $"Task hub name '{hubName}' should contain only alphanumeric characters and have length between {MinTaskHubNameSize} and {MaxTaskHubNameSize}.";
         }
 
         internal bool IsSanitizedHubName(string hubName, out string sanitizedHubName)

--- a/test/Common/DurableTaskEndToEndTests.cs
+++ b/test/Common/DurableTaskEndToEndTests.cs
@@ -4036,14 +4036,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             DurableTaskOptions durableTaskOptions = new DurableTaskOptions();
             durableTaskOptions.HubName = $"%{taskHubSettingName}%";
 
-            var mockNameResolver = new Mock<INameResolver>();
-            mockNameResolver.Setup(res => res.Resolve(taskHubSettingName))
-                .Returns(taskHubName);
+            var nameResolver = new SimpleNameResolver(new Dictionary<string, string>()
+            {
+                { taskHubSettingName, taskHubName },
+            });
 
             using (var host = TestHelpers.GetJobHostWithOptions(
                 this.loggerProvider,
                 durableTaskOptions,
-                nameResolver: mockNameResolver.Object))
+                nameResolver: nameResolver))
             {
                 await host.StartAsync();
                 await host.StopAsync();
@@ -4061,9 +4062,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             DurableTaskOptions durableTaskOptions = new DurableTaskOptions();
             durableTaskOptions.HubName = $"%{taskHubSettingName}%";
 
-            var mockNameResolver = new Mock<INameResolver>();
-            mockNameResolver.Setup(res => res.Resolve(taskHubSettingName))
-                .Returns(taskHubName);
+            var nameResolver = new SimpleNameResolver(new Dictionary<string, string>()
+            {
+                { taskHubSettingName, taskHubName },
+            });
 
             ArgumentException exception =
                 await Assert.ThrowsAsync<ArgumentException>(async () =>
@@ -4071,7 +4073,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                     using (var host = TestHelpers.GetJobHostWithOptions(
                             this.loggerProvider,
                             durableTaskOptions,
-                            nameResolver: mockNameResolver.Object))
+                            nameResolver: nameResolver))
                     {
                         await host.StartAsync();
                         await host.StopAsync();

--- a/test/Common/DurableTaskEndToEndTests.cs
+++ b/test/Common/DurableTaskEndToEndTests.cs
@@ -16,6 +16,7 @@ using Microsoft.Azure.WebJobs.Host.TestCommon;
 using Microsoft.Diagnostics.Tracing;
 using Microsoft.WindowsAzure.Storage;
 using Microsoft.WindowsAzure.Storage.Blob;
+using Moq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using Newtonsoft.Json.Linq;
@@ -3943,8 +3944,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             Assert.NotNull(argumentException);
             Assert.Equal(
                 argumentException.Message.Contains($"{taskHubName}V1")
-                    ? $"Task hub name '{taskHubName}V1' should contain only alphanumeric characters excluding '-' and have length up to 45."
-                    : $"Task hub name '{taskHubName}V2' should contain only alphanumeric characters excluding '-' and have length up to 45.",
+                    ? $"Task hub name '{taskHubName}V1' should contain only alphanumeric characters and have length between 3 and 45."
+                    : $"Task hub name '{taskHubName}V2' should contain only alphanumeric characters and have length between 3 and 45.",
                 argumentException.Message);
         }
 
@@ -4024,6 +4025,63 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 Environment.SetEnvironmentVariable("WEBSITE_SITE_NAME", currSiteName);
                 Environment.SetEnvironmentVariable("WEBSITE_SLOT_NAME", currSlotName);
             }
+        }
+
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public async Task TaskHubName_AppSettingReference_ValidTaskHub_UsesResolvedTaskHub()
+        {
+            string taskHubSettingName = "TaskHubName";
+            string taskHubName = "ValidTaskHub";
+            DurableTaskOptions durableTaskOptions = new DurableTaskOptions();
+            durableTaskOptions.HubName = $"%{taskHubSettingName}%";
+
+            var mockNameResolver = new Mock<INameResolver>();
+            mockNameResolver.Setup(res => res.Resolve(taskHubSettingName))
+                .Returns(taskHubName);
+
+            using (var host = TestHelpers.GetJobHostWithOptions(
+                this.loggerProvider,
+                durableTaskOptions,
+                nameResolver: mockNameResolver.Object))
+            {
+                await host.StartAsync();
+                await host.StopAsync();
+            }
+
+            Assert.Equal(taskHubName, durableTaskOptions.HubName);
+        }
+
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public async Task TaskHubName_AppSettingReference_InvalidTaskHub_ThrowsException()
+        {
+            string taskHubSettingName = "TaskHubName";
+            string taskHubName = "Invalid-Task-Hub";
+            DurableTaskOptions durableTaskOptions = new DurableTaskOptions();
+            durableTaskOptions.HubName = $"%{taskHubSettingName}%";
+
+            var mockNameResolver = new Mock<INameResolver>();
+            mockNameResolver.Setup(res => res.Resolve(taskHubSettingName))
+                .Returns(taskHubName);
+
+            ArgumentException exception =
+                await Assert.ThrowsAsync<ArgumentException>(async () =>
+                {
+                    using (var host = TestHelpers.GetJobHostWithOptions(
+                            this.loggerProvider,
+                            durableTaskOptions,
+                            nameResolver: mockNameResolver.Object))
+                    {
+                        await host.StartAsync();
+                        await host.StopAsync();
+                    }
+                });
+
+            Assert.NotNull(exception);
+            Assert.Equal(
+                $"Task hub name '{taskHubName}' should contain only alphanumeric characters and have length between 3 and 45.",
+                exception.Message);
         }
 
         [Fact]


### PR DESCRIPTION
TaskHub validation needs to occur after the TaskHub has been resolved.
To achieve this, we resolve app settings earlier in the pipeline, as
well as waiting to validate the TaskHub until after finishing
constructing AzureStorageDurabilityProviderFactory.

Resolves #1122