### PR TITLE
Task hub fix with lazy

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net471.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net471.xml
@@ -2964,10 +2964,15 @@
             <summary>
             Gets or set the number of control queue messages that can be buffered in memory
             at a time, at which point the dispatcher will wait before dequeuing any additional
-            messages. The default is 64.
+            messages. The default is 256. The maximum value is 1000.
             </summary>
-            <remarks>This has historically always been fixed to 64, but increasing it may increase
-            throughput.</remarks>
+            <remarks>
+            Increasing this value can improve orchestration throughput by pre-fetching more
+            orchestration messages from control queues. The downside is that it increases the
+            possibility of duplicate function executions if partition leases move between app
+            instances. This most often occurs when the number of app instances changes.
+            </remarks>
+            <value>A non-negative integer between 0 and 1000. The default value is <c>256</c>.</value>
         </member>
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureStorageOptions.ControlQueueVisibilityTimeout">
             <summary>
@@ -3024,11 +3029,6 @@
             </summary>
             <value>Maximum interval for polling control and work-item queues.</value>
         </member>
-        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureStorageOptions.ValidateHubName(System.String)">
-            <summary>
-            Throws an exception if the provided hub name violates any naming conventions for the storage provider.
-            </summary>
-        </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureStorageOptions.Validate">
             <summary>
             Throws an exception if any of the settings of the storage provider are invalid.
@@ -3037,6 +3037,11 @@
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskOptions">
             <summary>
             Configuration options for the Durable Task extension.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskOptions.#ctor">
+            <summary>
+            Default constructor.
             </summary>
         </member>
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskOptions.HttpSettings">

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
@@ -3031,10 +3031,15 @@
             <summary>
             Gets or set the number of control queue messages that can be buffered in memory
             at a time, at which point the dispatcher will wait before dequeuing any additional
-            messages. The default is 64.
+            messages. The default is 256. The maximum value is 1000.
             </summary>
-            <remarks>This has historically always been fixed to 64, but increasing it may increase
-            throughput.</remarks>
+            <remarks>
+            Increasing this value can improve orchestration throughput by pre-fetching more
+            orchestration messages from control queues. The downside is that it increases the
+            possibility of duplicate function executions if partition leases move between app
+            instances. This most often occurs when the number of app instances changes.
+            </remarks>
+            <value>A non-negative integer between 0 and 1000. The default value is <c>256</c>.</value>
         </member>
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureStorageOptions.ControlQueueVisibilityTimeout">
             <summary>
@@ -3091,11 +3096,6 @@
             </summary>
             <value>Maximum interval for polling control and work-item queues.</value>
         </member>
-        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureStorageOptions.ValidateHubName(System.String)">
-            <summary>
-            Throws an exception if the provided hub name violates any naming conventions for the storage provider.
-            </summary>
-        </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureStorageOptions.Validate">
             <summary>
             Throws an exception if any of the settings of the storage provider are invalid.
@@ -3104,6 +3104,11 @@
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskOptions">
             <summary>
             Configuration options for the Durable Task extension.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskOptions.#ctor">
+            <summary>
+            Default constructor.
             </summary>
         </member>
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskOptions.HttpSettings">

--- a/src/WebJobs.Extensions.DurableTask/Options/AzureStorageOptions.cs
+++ b/src/WebJobs.Extensions.DurableTask/Options/AzureStorageOptions.cs
@@ -2,9 +2,6 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
-using System.Linq;
-using System.Runtime.Serialization;
-using Microsoft.WindowsAzure.Storage;
 
 namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 {
@@ -13,11 +10,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
     /// </summary>
     public class AzureStorageOptions
     {
-        // 45 alphanumeric characters gives us a buffer in our table/queue/blob container names.
-        private const int MaxTaskHubNameSize = 45;
-        private const int MinTaskHubNameSize = 3;
-        private const string TaskHubPadding = "Hub";
-
         /// <summary>
         /// Gets or sets the name of the Azure Storage connection string used to manage the underlying Azure Storage resources.
         /// </summary>
@@ -118,53 +110,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// </summary>
         /// <value>Maximum interval for polling control and work-item queues.</value>
         public TimeSpan MaxQueuePollingInterval { get; set; } = TimeSpan.FromSeconds(30);
-
-        /// <summary>
-        /// Throws an exception if the provided hub name violates any naming conventions for the storage provider.
-        /// </summary>
-        public void ValidateHubName(string hubName)
-        {
-            try
-            {
-                NameValidator.ValidateBlobName(hubName);
-                NameValidator.ValidateContainerName(hubName.ToLowerInvariant());
-                NameValidator.ValidateTableName(hubName);
-                NameValidator.ValidateQueueName(hubName.ToLowerInvariant());
-            }
-            catch (ArgumentException e)
-            {
-                throw new ArgumentException(GetTaskHubErrorString(hubName), e);
-            }
-
-            if (hubName.Length > 50)
-            {
-                throw new ArgumentException(GetTaskHubErrorString(hubName));
-            }
-        }
-
-        private static string GetTaskHubErrorString(string hubName)
-        {
-            return $"Task hub name '{hubName}' should contain only alphanumeric characters excluding '-' and have length up to {MaxTaskHubNameSize}.";
-        }
-
-        internal bool IsSanitizedHubName(string hubName, out string sanitizedHubName)
-        {
-            sanitizedHubName = new string(hubName.ToCharArray()
-                                .Where(char.IsLetterOrDigit)
-                                .Take(MaxTaskHubNameSize)
-                                .ToArray());
-            if (sanitizedHubName.Length < MinTaskHubNameSize)
-            {
-                sanitizedHubName = sanitizedHubName + TaskHubPadding;
-            }
-
-            if (string.Equals(hubName, sanitizedHubName))
-            {
-                return true;
-            }
-
-            return false;
-        }
 
         /// <summary>
         /// Throws an exception if any of the settings of the storage provider are invalid.

--- a/src/WebJobs.Extensions.DurableTask/Options/DurableTaskOptions.cs
+++ b/src/WebJobs.Extensions.DurableTask/Options/DurableTaskOptions.cs
@@ -179,6 +179,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             sb.Append(nameof(this.MaxConcurrentActivityFunctions)).Append(": ").Append(this.MaxConcurrentActivityFunctions).Append(", ");
             sb.Append(nameof(this.MaxConcurrentOrchestratorFunctions)).Append(": ").Append(this.MaxConcurrentOrchestratorFunctions).Append(", ");
             sb.Append(nameof(this.ExtendedSessionsEnabled)).Append(": ").Append(this.ExtendedSessionsEnabled).Append(", ");
+            sb.Append(nameof(this.UseGracefulShutdown)).Append(": ").Append(this.UseGracefulShutdown).Append(", ");
             if (this.ExtendedSessionsEnabled)
             {
                 sb.Append(nameof(this.ExtendedSessionIdleTimeoutInSeconds)).Append(": ").Append(this.ExtendedSessionIdleTimeoutInSeconds).Append(", ");


### PR DESCRIPTION
TaskHub validation needs to occur after the TaskHub has been resolved and after the costruction of the AzureStorageDurabilityProviderFactory.
To achieve this, we use lazy objects to get the configuration only when we need it, always after the initializations.
Improved slot recognition and "development environment" recognition
Improved default task hub name assignation.