### PR TITLE
Analyzer: Fixed MethodAttributeAnalyzer to allow local functions inside an orchestrator

### DIFF
--- a/src/WebJobs.Extensions.DurableTask.Analyzers/Analyzers/Orchestrator/MethodAttributeAnalyzer.cs
+++ b/src/WebJobs.Extensions.DurableTask.Analyzers/Analyzers/Orchestrator/MethodAttributeAnalyzer.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
         public const string DiagnosticId = "DF0107";
 
         private static readonly LocalizableString Title = new LocalizableResourceString(nameof(Resources.MethodAttributeAnalyzerTitle), Resources.ResourceManager, typeof(Resources));
-        private static readonly LocalizableString MessageFormat = new LocalizableResourceString(nameof(Resources.DeterministicAnalyzerMessageFormat), Resources.ResourceManager, typeof(Resources));
+        private static readonly LocalizableString MessageFormat = new LocalizableResourceString(nameof(Resources.MethodAnalyzerMessageFormat), Resources.ResourceManager, typeof(Resources));
         private static readonly LocalizableString Description = new LocalizableResourceString(nameof(Resources.DeterministicAnalyzerDescription), Resources.ResourceManager, typeof(Resources));
         private const string Category = SupportedCategories.Orchestrator;
         public const DiagnosticSeverity severity = DiagnosticSeverity.Warning;
@@ -53,7 +53,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
 
             var declaration = syntaxReference.GetSyntax(context.CancellationToken);
 
-            if (SyntaxNodeUtils.IsMarkedDeterministic(declaration))
+            if (SyntaxNodeUtils.IsMarkedDeterministic(declaration) || SyntaxNodeUtils.IsInsideOrchestrator(declaration))
             {
                 return;
             }

--- a/src/WebJobs.Extensions.DurableTask.Analyzers/Resources.Designer.cs
+++ b/src/WebJobs.Extensions.DurableTask.Analyzers/Resources.Designer.cs
@@ -531,6 +531,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Method call &apos;{0}&apos; violates the orchestrator deterministic code constraint. Method does not have the Deterministic attribute on the method declaration..
+        /// </summary>
+        public static string MethodAnalyzerMessageFormat {
+            get {
+                return ResourceManager.GetString("MethodAnalyzerMessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Method calls in an orchestrator must be marked [Deterministic] on the method declaration..
         /// </summary>
         public static string MethodAttributeAnalyzerTitle {

--- a/src/WebJobs.Extensions.DurableTask.Analyzers/Resources.resx
+++ b/src/WebJobs.Extensions.DurableTask.Analyzers/Resources.resx
@@ -275,6 +275,9 @@ https://docs.microsoft.com/azure/azure-functions/durable/durable-functions-check
   <data name="IOTypesAnalyzerTitle" xml:space="preserve">
     <value>I/O operations are not allowed inside an orchestrator function.</value>
   </data>
+  <data name="MethodAnalyzerMessageFormat" xml:space="preserve">
+    <value>Method call '{0}' violates the orchestrator deterministic code constraint. Method does not have the Deterministic attribute on the method declaration.</value>
+  </data>
   <data name="MethodAttributeAnalyzerTitle" xml:space="preserve">
     <value>Method calls in an orchestrator must be marked [Deterministic] on the method declaration.</value>
   </data>

--- a/src/WebJobs.Extensions.DurableTask.Analyzers/WebJobs.Extensions.DurableTask.Analyzers.csproj
+++ b/src/WebJobs.Extensions.DurableTask.Analyzers/WebJobs.Extensions.DurableTask.Analyzers.csproj
@@ -8,7 +8,7 @@
 
   <PropertyGroup>
     <PackageId>Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers</PackageId>
-    <PackageVersion>0.1.2</PackageVersion>
+    <PackageVersion>0.1.3</PackageVersion>
     <Authors>Microsoft</Authors>
     <PackageLicenseUrl>https://go.microsoft.com/fwlink/?linkid=2028464</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/Azure/azure-functions-durable-extension</PackageProjectUrl>


### PR DESCRIPTION
Fixed bug that caused functions defined in an orchestrator to be flagged unless the orchestrator had the Deterministic attribute. Also updated the message appearing on the diagnostic to be more clear.

resolves #1045 