### PR TITLE
Gracefully handle ObjectDisposedException on host shutdown

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
@@ -902,10 +902,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             using (await this.taskHubLock.AcquireAsync())
             {
                 // Wait to shut down the task hub worker until all function listeners have been shut down.
-                // We set IsDeregistered to true when Stop() is called on the listener
-                // We set Executor to a non-null value only if there is a listener associated with this function.
-                // If there is no listener for a function (e.g. it's a [NoAutomaticTrigger] function) then we don't
-                // need to wait for it to be deregistered before shutting down the task hub worker.
                 if (this.isTaskHubWorkerStarted &&
                     !this.knownOrchestrators.Values.Any(info => info.HasActiveListener) &&
                     !this.knownActivities.Values.Any(info => info.HasActiveListener) &&

--- a/src/WebJobs.Extensions.DurableTask/Listener/TaskActivityShim.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/TaskActivityShim.cs
@@ -65,15 +65,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     this.config.Options.HubName,
                     this.activityName,
                     instanceId,
-                    $"An internal error occurred while attempting to execute this function: " + e,
+                    $"An internal error occurred while attempting to execute this function. The execution will be aborted and retried. Details: {e}",
                     functionType: FunctionType.Activity,
                     isReplay: false);
 
-                // TODO: Throw a different exception that can be used to abort the orchestration rather than failing it.
-                //       https://github.com/Azure/azure-functions-durable-extension/issues/472
-                throw new TaskFailureException(
-                    $"An internal error occurred while attempting to execute '{this.activityName}'.",
-                    Utils.SerializeCause(e, this.config.DataConverter.ErrorConverter));
+                // This will abort the execution and cause the message to go back onto the queue for re-processing
+                throw new SessionAbortedException(
+                    $"An internal error occurred while attempting to execute '{this.activityName}'.", e);
             }
 
             if (!result.Succeeded)

--- a/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
+++ b/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
@@ -71,8 +71,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.DurableTask.Core" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage" Version="1.7.0" />
+    <PackageReference Include="Microsoft.Azure.DurableTask.Core" Version="2.2.1" />
+    <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage" Version="1.7.1" />
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.0.3" />
   </ItemGroup>
 

--- a/test/FunctionsV1/WebJobs.Extensions.DurableTask.Tests.V1.csproj
+++ b/test/FunctionsV1/WebJobs.Extensions.DurableTask.Tests.V1.csproj
@@ -16,7 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="4.19.4" />
-    <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage" Version="1.7.0" />
+    <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage" Version="1.7.1" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="2.2.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" Version="2.2.0" />
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.33" />

--- a/test/FunctionsV2/WebJobs.Extensions.DurableTask.Tests.V2.csproj
+++ b/test/FunctionsV2/WebJobs.Extensions.DurableTask.Tests.V2.csproj
@@ -16,7 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="4.19.4" />
-    <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage" Version="1.7.0" />
+    <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage" Version="1.7.1" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.14" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="3.0.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" Version="3.0.0" />


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-functions-durable-extension/issues/472.

This PR currently has a lot of commits because it is waiting for multiple other PRs to be merged.

### Summary
This PR improves upon https://github.com/Azure/azure-functions-durable-extension/pull/1132 by throwing a `SessionAbortedException` inside `TaskActivityShim` if the WebJobs APIs throw any exception (such as `ObjectDisposedException`).

As part of https://github.com/Azure/durabletask/pull/359, the `SessionAbortedException` now is capable of aborting activity execution. Instead of the activity going into a "failed" state, the execution is abandoned and restarted. The restart will happen on an alternate, healthy instance of the functions runtime and will complete successfully.

### Validation
I used the following orchestration code to reproduce the `ObjectDisposedException` and validate that this code change works as intended:

```csharp
[FunctionName("ODE_Orchestration")]
public static async Task Run(
    [OrchestrationTrigger] IDurableOrchestrationContext context)
{
    await context.CallActivityAsync("ODE_Activity", null);
}

[FunctionName("ODE_Activity")]
public static void SayHello([ActivityTrigger] IDurableActivityContext context)
{
    Thread.Sleep(TimeSpan.FromSeconds(60));
}
```

**Repro steps**
This can be done using the Functions core tools on a local machine:

1. Start the orchestration above
2. Wait 5 seconds and then make a change to `host.json` to trigger a function host restart
3. Wait for the activity function to complete
4. Observe the task failure log with `ObjectDisposedException` in the message
5. Wait until the activity function restarts and then completes
6. Verify that the orchestration completed successfully

