### PR TITLE
Change FunctionAborted trace from error to warning

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/EndToEndTraceHelper.cs
+++ b/src/WebJobs.Extensions.DurableTask/EndToEndTraceHelper.cs
@@ -310,6 +310,30 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             }
         }
 
+        public void FunctionAborted(
+            string hubName,
+            string functionName,
+            string instanceId,
+            string reason,
+            FunctionType functionType)
+        {
+            EtwEventSource.Instance.FunctionAborted(
+                hubName,
+                LocalAppName,
+                LocalSlotName,
+                functionName,
+                instanceId,
+                reason,
+                functionType.ToString(),
+                ExtensionVersion,
+                IsReplay: false);
+
+            this.logger.LogWarning(
+                "{instanceId}: Function '{functionName} ({functionType})' was aborted. Reason: {reason}. IsReplay: {isReplay}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}. SequenceNumber: {sequenceNumber}.",
+                instanceId, functionName, functionType, reason, false /*isReplay*/, hubName,
+                LocalAppName, LocalSlotName, ExtensionVersion, this.sequenceNumber++);
+        }
+
         public void OperationCompleted(
            string hubName,
            string functionName,

--- a/src/WebJobs.Extensions.DurableTask/EtwEventSource.cs
+++ b/src/WebJobs.Extensions.DurableTask/EtwEventSource.cs
@@ -382,6 +382,20 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             this.WriteEvent(223, TaskHub, AppName, SlotName, Details, ExtensionVersion);
         }
 
+        [Event(224, Level = EventLevel.Warning)]
+        public void FunctionAborted(
+            string TaskHub,
+            string AppName,
+            string SlotName,
+            string FunctionName,
+            string InstanceId,
+            string Reason,
+            string FunctionType,
+            string ExtensionVersion,
+            bool IsReplay)
+        {
+            this.WriteEvent(224, TaskHub, AppName, SlotName, FunctionName, InstanceId, Reason, FunctionType, ExtensionVersion, IsReplay);
+        }
 #pragma warning restore SA1313 // Parameter names should begin with lower-case letter
     }
 }

--- a/src/WebJobs.Extensions.DurableTask/Listener/TaskActivityShim.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/TaskActivityShim.cs
@@ -61,13 +61,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             }
             catch (Exception e)
             {
-                this.config.TraceHelper.FunctionFailed(
+                this.config.TraceHelper.FunctionAborted(
                     this.config.Options.HubName,
                     this.activityName,
                     instanceId,
                     $"An internal error occurred while attempting to execute this function. The execution will be aborted and retried. Details: {e}",
-                    functionType: FunctionType.Activity,
-                    isReplay: false);
+                    functionType: FunctionType.Activity);
 
                 // This will abort the execution and cause the message to go back onto the queue for re-processing
                 throw new SessionAbortedException(


### PR DESCRIPTION
There are two problems with the current trace experience for the newly added function aborted logic:

1. It's an error, but it should actually be a warning since it's a transient issue.
2. We trace `FunctionFailed` but it didn't actually "fail".

I'm adding a new `FunctionAborted` trace instead of reusing `FunctionFailed`. This is both to improve clarity but also to avoid counting problems. For example, it would be odd to have a function that both failed and completed, and could cause existing Kusto or AI queries to double-count function executions in some cases.