### PR TITLE
Update samples to point to latest package versions

### DIFF
--- a/samples/VSSample.Tests/VSSample.Tests.csproj
+++ b/samples/VSSample.Tests/VSSample.Tests.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="2.1.0" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="2.1.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="Moq" Version="4.8.1" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/samples/csx/extensions.csproj
+++ b/samples/csx/extensions.csproj
@@ -5,7 +5,7 @@
 	<DefaultItemExcludes>**</DefaultItemExcludes>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="2.1.0" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="2.1.1" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="3.0.10" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Twilio" Version="3.0.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator" Version="1.1.0" />

--- a/samples/entitites-csharp/Chirper/Chirper.Service/Chirper.Service.csproj
+++ b/samples/entitites-csharp/Chirper/Chirper.Service/Chirper.Service.csproj
@@ -7,7 +7,7 @@
     <None Include="..\README.md" Link="README.md" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="2.1.0" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="2.1.1" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.29" />
   </ItemGroup>
   <ItemGroup>

--- a/samples/entitites-csharp/RideSharing/RideSharing/RideSharing.csproj
+++ b/samples/entitites-csharp/RideSharing/RideSharing/RideSharing.csproj
@@ -7,7 +7,7 @@
     <None Include="..\README.md" Link="README.md" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="2.1.0" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="2.1.1" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.29" />
   </ItemGroup>
   <ItemGroup>

--- a/samples/fsharp/DurableFSharp.fsproj
+++ b/samples/fsharp/DurableFSharp.fsproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="TaskBuilder.fs" Version="1.0.0" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="2.1.0" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="2.1.1" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="3.0.10" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Twilio" Version="3.0.0" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.29" />

--- a/samples/javascript/extensions.csproj
+++ b/samples/javascript/extensions.csproj
@@ -5,7 +5,7 @@
     <DefaultItemExcludes>**</DefaultItemExcludes>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="2.1.0" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="2.1.1" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="3.0.10" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Twilio" Version="3.0.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator" Version="1.0.1" />

--- a/samples/javascript/host.json
+++ b/samples/javascript/host.json
@@ -2,7 +2,7 @@
   "version": "2.0",
   "logging": {
     "applicationInsights": {
-      "sampling": {
+      "samplingSettings": {
         "isEnabled": false
       }
     }

--- a/samples/javascript/local.settings.json
+++ b/samples/javascript/local.settings.json
@@ -2,6 +2,7 @@
   "IsEncrypted": false,
   "Values": {
     "FUNCTIONS_WORKER_RUNTIME": "node",
+    "FUNCTIONS_V2_COMPATIBILITY_MODE": true,
     "AzureWebJobsStorage": "<Put your Azure Storage connection string here>",
     "WeatherUndergroundApiKey": "<Put your Weather Underground API key here - sample 3>",
     "TwilioAccountSid": "<Put your Twilio Account SID here - samples 3 and 4>",

--- a/samples/precompiled/VSSample.csproj
+++ b/samples/precompiled/VSSample.csproj
@@ -6,11 +6,11 @@
 
   <!-- Common packages for all targets -->
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="2.1.0" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="2.1.1" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.29" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Twilio" Version="3.0.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="3.0.10" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers" Version="0.1.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers" Version="0.1.3" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/precompiled/host.json
+++ b/samples/precompiled/host.json
@@ -12,7 +12,7 @@
       "routePrefix": ""
     },
     "durableTask": {
-      "hubName": "SampleHubVS"
+      "hubName": "%MyTaskHubName%"
     }
   }
 }

--- a/samples/precompiled/local.settings.json
+++ b/samples/precompiled/local.settings.json
@@ -5,6 +5,7 @@
     "TwilioAccountSid": "<Put your Twilio Account SID here>",
     "TwilioAuthToken": "<Put your Twilio Auth Token here>",
     "TwilioPhoneNumber": "<Put your Twilio Phone Number here in E.164 format>",
-    "WeatherUndergroundApiKey": "<Put your Weather Underground API key here>"
+    "WeatherUndergroundApiKey": "<Put your Weather Underground API key here>",
+    "MyTaskHubName": "SampleHubVS"
   }
 }


### PR DESCRIPTION
* Updating all sample projects to point to v2.1.1 of the extension
* Updating the main precompiled sample to use the latest analyzer version, v0.1.3
* Also updated the precompiled sample to use an app setting for the task hub name (this capability was broken in previous releases)