### PR TITLE
Fix message sorter

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableClient.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableClient.cs
@@ -269,7 +269,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             var instance = new OrchestrationInstance() { InstanceId = instanceId };
             var request = new RequestMessage()
             {
-                ParentInstanceId = null,
+                ParentInstanceId = null, // means this was sent by a client
+                ParentExecutionId = null,
                 Id = guid,
                 IsSignal = true,
                 Operation = operationName,

--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableEntityContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableEntityContext.cs
@@ -325,6 +325,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             var request = new RequestMessage()
             {
                 ParentInstanceId = this.InstanceId,
+                ParentExecutionId = null, // for entities, message sorter persists across executions
                 Id = Guid.NewGuid(),
                 IsSignal = true,
                 Operation = operation,

--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableOrchestrationContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableOrchestrationContext.cs
@@ -559,6 +559,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     var request = new RequestMessage()
                     {
                         ParentInstanceId = this.InstanceId,
+                        ParentExecutionId = this.ExecutionId,
                         Id = guid,
                         IsSignal = oneWay,
                         Operation = operation,
@@ -975,6 +976,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             {
                 Id = lockRequestId,
                 ParentInstanceId = this.InstanceId,
+                ParentExecutionId = this.ExecutionId,
                 LockSet = entities,
                 Position = 0,
             };

--- a/src/WebJobs.Extensions.DurableTask/EndToEndTraceHelper.cs
+++ b/src/WebJobs.Extensions.DurableTask/EndToEndTraceHelper.cs
@@ -554,7 +554,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             string hubName,
             string functionName,
             string instanceId,
-            string requestingInstance,
+            string requestingInstanceId,
+            string requestingExecutionId,
             string requestId,
             bool isReplay)
         {
@@ -566,7 +567,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 LocalSlotName,
                 functionName,
                 instanceId,
-                requestingInstance,
+                requestingInstanceId,
+                requestingExecutionId,
                 requestId,
                 FunctionType.Entity.ToString(),
                 ExtensionVersion,
@@ -575,8 +577,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             if (this.ShouldLogEvent(isReplay: isReplay))
             {
                 this.logger.LogInformation(
-                    "{instanceId}: Function '{functionName} ({functionType})' granted lock to request {requestId} by instance {requestingInstance}. State: {state}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}. SequenceNumber: {sequenceNumber}.",
-                    instanceId, functionName, functionType, requestId, requestingInstance, FunctionState.LockAcquired, hubName,
+                    "{instanceId}: Function '{functionName} ({functionType})' granted lock to request {requestId} by instance {requestingInstanceId} {requestingExecutionId}. State: {state}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}. SequenceNumber: {sequenceNumber}.",
+                    instanceId, functionName, functionType, requestId, requestingInstanceId, requestingExecutionId, FunctionState.LockAcquired, hubName,
                     LocalAppName, LocalSlotName, ExtensionVersion, this.sequenceNumber++);
             }
         }

--- a/src/WebJobs.Extensions.DurableTask/EndToEndTraceHelper.cs
+++ b/src/WebJobs.Extensions.DurableTask/EndToEndTraceHelper.cs
@@ -577,7 +577,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             if (this.ShouldLogEvent(isReplay: isReplay))
             {
                 this.logger.LogInformation(
-                    "{instanceId}: Function '{functionName} ({functionType})' granted lock to request {requestId} by instance {requestingInstanceId} {requestingExecutionId}. State: {state}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}. SequenceNumber: {sequenceNumber}.",
+                    "{instanceId}: Function '{functionName} ({functionType})' granted lock to request {requestId} by instance {requestingInstanceId}, execution {requestingExecutionId}. State: {state}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}. SequenceNumber: {sequenceNumber}.",
                     instanceId, functionName, functionType, requestId, requestingInstanceId, requestingExecutionId, FunctionState.LockAcquired, hubName,
                     LocalAppName, LocalSlotName, ExtensionVersion, this.sequenceNumber++);
             }

--- a/src/WebJobs.Extensions.DurableTask/EntityScheduler/MessageSorter.cs
+++ b/src/WebJobs.Extensions.DurableTask/EntityScheduler/MessageSorter.cs
@@ -173,14 +173,18 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             else if (receiveBuffer.ExecutionId != message.ParentExecutionId)
             {
                 // this message is from a new execution; release all buffered messages and start over
-                foreach (var kvp in receiveBuffer.Buffered)
+                if (receiveBuffer.Buffered != null)
                 {
-                    yield return kvp.Value;
+                    foreach (var kvp in receiveBuffer.Buffered)
+                    {
+                        yield return kvp.Value;
+                    }
+
+                    receiveBuffer.Buffered.Clear();
                 }
 
                 receiveBuffer.Last = DateTime.MinValue;
                 receiveBuffer.ExecutionId = message.ParentExecutionId;
-                receiveBuffer.Buffered.Clear();
             }
 
             if (message.Timestamp <= receiveBuffer.Last)

--- a/src/WebJobs.Extensions.DurableTask/EntityScheduler/RequestMessage.cs
+++ b/src/WebJobs.Extensions.DurableTask/EntityScheduler/RequestMessage.cs
@@ -44,6 +44,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         public string ParentInstanceId { get; set; }
 
         /// <summary>
+        /// The parent instance that called this operation.
+        /// </summary>
+        [JsonProperty(PropertyName = "parentEx", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string ParentExecutionId { get; set; }
+
+        /// <summary>
         /// Optionally, a scheduled time at which to start the operation.
         /// </summary>
         [JsonProperty(PropertyName = "due", DefaultValueHandling = DefaultValueHandling.Ignore)]
@@ -124,11 +130,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         {
             if (this.IsLockRequest)
             {
-                return $"[Request lock {this.Id} by {this.ParentInstanceId}, position {this.Position}]";
+                return $"[Request lock {this.Id} by {this.ParentInstanceId} {this.ParentExecutionId}, position {this.Position}]";
             }
             else
             {
-                return $"[{(this.IsSignal ? "Signal" : "Call")} '{this.Operation}' operation {this.Id} by {this.ParentInstanceId}]";
+                return $"[{(this.IsSignal ? "Signal" : "Call")} '{this.Operation}' operation {this.Id} by {this.ParentInstanceId} {this.ParentExecutionId}]";
             }
         }
     }

--- a/src/WebJobs.Extensions.DurableTask/EntityScheduler/RequestMessage.cs
+++ b/src/WebJobs.Extensions.DurableTask/EntityScheduler/RequestMessage.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// <summary>
         /// The parent instance that called this operation.
         /// </summary>
-        [JsonProperty(PropertyName = "parentEx", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        [JsonProperty(PropertyName = "parentExecution", DefaultValueHandling = DefaultValueHandling.Ignore)]
         public string ParentExecutionId { get; set; }
 
         /// <summary>

--- a/src/WebJobs.Extensions.DurableTask/EtwEventSource.cs
+++ b/src/WebJobs.Extensions.DurableTask/EtwEventSource.cs
@@ -301,20 +301,21 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             this.WriteEvent(218, TaskHub, AppName, SlotName, FunctionName, InstanceId, OperationId, Result ?? "(null)", FunctionType, ExtensionVersion, IsReplay);
         }
 
-        [Event(219, Level = EventLevel.Informational)]
+        [Event(219, Level = EventLevel.Informational, Version = 2)]
         public void EntityLockAcquired(
             string TaskHub,
             string AppName,
             string SlotName,
             string FunctionName,
             string InstanceId,
-            string RequestingInstance,
+            string RequestingInstanceId,
+            string RequestingExecutionId,
             string RequestId,
             string FunctionType,
             string ExtensionVersion,
             bool IsReplay)
         {
-            this.WriteEvent(219, TaskHub, AppName, SlotName, FunctionName, InstanceId, RequestingInstance, RequestId, FunctionType, ExtensionVersion, IsReplay);
+            this.WriteEvent(219, TaskHub, AppName, SlotName, FunctionName, InstanceId, RequestingInstanceId, RequestingExecutionId, RequestId, FunctionType, ExtensionVersion, IsReplay);
         }
 
         [Event(220, Level = EventLevel.Informational)]

--- a/src/WebJobs.Extensions.DurableTask/EtwEventSource.cs
+++ b/src/WebJobs.Extensions.DurableTask/EtwEventSource.cs
@@ -315,7 +315,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             string ExtensionVersion,
             bool IsReplay)
         {
-            this.WriteEvent(219, TaskHub, AppName, SlotName, FunctionName, InstanceId, RequestingInstanceId, RequestingExecutionId, RequestId, FunctionType, ExtensionVersion, IsReplay);
+            this.WriteEvent(219, TaskHub, AppName, SlotName, FunctionName, InstanceId, RequestingInstanceId, RequestingExecutionId ?? "", RequestId, FunctionType, ExtensionVersion, IsReplay);
         }
 
         [Event(220, Level = EventLevel.Informational)]

--- a/src/WebJobs.Extensions.DurableTask/Listener/TaskEntityShim.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/TaskEntityShim.cs
@@ -235,7 +235,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 this.context.Name,
                 this.context.InstanceId,
                 request.ParentInstanceId,
-                request.ParentExecutionId ?? "",
+                request.ParentExecutionId,
                 request.Id.ToString(),
                 isReplay: false);
 

--- a/src/WebJobs.Extensions.DurableTask/Listener/TaskEntityShim.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/TaskEntityShim.cs
@@ -235,6 +235,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 this.context.Name,
                 this.context.InstanceId,
                 request.ParentInstanceId,
+                request.ParentExecutionId ?? "",
                 request.Id.ToString(),
                 isReplay: false);
 
@@ -252,7 +253,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             else
             {
                 // send lock acquisition completed response back to originating orchestration instance
-                var target = new OrchestrationInstance() { InstanceId = request.ParentInstanceId };
+                var target = new OrchestrationInstance() { InstanceId = request.ParentInstanceId, ExecutionId = request.ParentExecutionId };
                 this.context.SendLockResponseMessage(target, request.Id);
             }
         }
@@ -339,7 +340,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             // send response
             if (!request.IsSignal)
             {
-                var target = new OrchestrationInstance() { InstanceId = request.ParentInstanceId };
+                var target = new OrchestrationInstance() { InstanceId = request.ParentInstanceId, ExecutionId = request.ParentExecutionId };
                 var jresponse = JToken.FromObject(response, this.dataConverter.MessageSerializer);
                 this.context.SendResponseMessage(target, request.Id, jresponse, !response.IsException);
             }
@@ -412,6 +413,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     var target = new OrchestrationInstance()
                     {
                         InstanceId = request.ParentInstanceId,
+                        ExecutionId = request.ParentExecutionId,
                     };
                     var responseMessage = new ResponseMessage()
                     {
@@ -428,6 +430,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 var request = new RequestMessage()
                 {
                     ParentInstanceId = this.context.InstanceId,
+                    ParentExecutionId = null, // for entities, message sorter persists across executions
                     Id = Guid.NewGuid(),
                     IsSignal = true,
                     Operation = signal.Name,

--- a/test/Common/DurableTaskEndToEndTests.cs
+++ b/test/Common/DurableTaskEndToEndTests.cs
@@ -2542,7 +2542,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         /// End-to-end test which validates launching orchestrations from entities.
         /// </summary>
         [Theory]
-        [Trait("Category", PlatformSpecificHelpers.TestCategory + "_UnpublishedDependencies")]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
         [InlineData(true)]
         [InlineData(false)]
         public async Task DurableEntity_EntityFireAndForget(bool extendedSessions)
@@ -2617,7 +2617,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         /// At the end, it validates that all of the appends are reflected in the final state.
         /// </summary>
         [Theory]
-        [Trait("Category", PlatformSpecificHelpers.TestCategory + "_UnpublishedDependencies")]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
         [InlineData(true)]
         [InlineData(false)]
         public async Task DurableEntity_EntityToAndFromBlob(bool extendedSessions)
@@ -2755,6 +2755,43 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 await host.StopAsync();
             }
         }
+
+        /// <summary>
+        /// End-to-end test which validates calling an entity from successive incarnations of an orchestration.
+        /// </summary>
+        [Theory]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task DurableEntity_ContinueAsNewBetweenCalls(bool extendedSessions)
+        {
+            using (var host = TestHelpers.GetJobHost(
+                this.loggerProvider,
+                nameof(this.DurableEntity_ContinueAsNewBetweenCalls),
+                extendedSessions))
+            {
+                await host.StartAsync();
+
+                var entityId = new EntityId(nameof(TestEntities.SchedulerEntity), Guid.NewGuid().ToString("N"));
+
+                var orchestratorClient = await host.StartOrchestratorAsync(
+                    nameof(TestOrchestrations.ThreeSuccessiveCalls),
+                    (entityId, 0),
+                    this.output);
+
+                TestEntityClient client = await host.GetEntityClientAsync(entityId, this.output);
+                var timeout = Debugger.IsAttached ? TimeSpan.FromMinutes(5) : TimeSpan.FromSeconds(10);
+                var state = await client.WaitForEntityState<List<string>>(this.output, timeout, curstate => curstate.Count == 3 ? null : "expect 3 calls");
+
+                var status = await orchestratorClient.WaitForCompletionAsync(this.output);
+                Assert.Equal(OrchestrationRuntimeStatus.Completed, status?.RuntimeStatus);
+
+                Assert.Equal("ok", (string)status?.Output);
+
+                await host.StopAsync();
+            }
+        }
+
 
         /// <summary>
         /// Send a scheduled signal, then an immediate signal, and test delivery order.

--- a/test/Common/TestOrchestrations.cs
+++ b/test/Common/TestOrchestrations.cs
@@ -972,6 +972,26 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             return string.Join(",", result.Select(kvp => kvp.Value));
         }
 
+        public static async Task<string> ThreeSuccessiveCalls([OrchestrationTrigger] IDurableOrchestrationContext ctx)
+        {
+            var (entityId, count) = ctx.GetInput<(EntityId, int)>();
+
+            await ctx.CallEntityAsync(entityId, count.ToString());
+
+            count++;
+
+            if (count < 3)
+            {
+                ctx.ContinueAsNew((entityId, count));
+
+                return "continue as new";
+            }
+            else
+            {
+                return "ok";
+            }
+        }
+
         public static async Task<string> ContinueAsNew_Repro285([OrchestrationTrigger] IDurableOrchestrationContext ctx)
         {
             var input = ctx.GetInput<int>();


### PR DESCRIPTION
Previously, for messages sent to entities, the execution id of the originating orchestration was not being tracked, only the instance id. This can lead to problems with the message sorter logic, as discussed in #1152. I added

- tracking and tracing of execution id for messages sent from orchestrations to entities
- include this execution id in events representing responses
- add a testcase where an orchestration sends multiple messages separated by continueAsNew
- modify the message sorter so it starts over when receiving a message from a different execution id