### PR TITLE
Make ControlQueueBufferThreshold configurable for Durable 1.x

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
@@ -465,6 +465,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 TaskHubName = taskHubNameOverride ?? this.Options.HubName,
                 PartitionCount = this.Options.PartitionCount,
                 ControlQueueBatchSize = this.Options.ControlQueueBatchSize,
+                ControlQueueBufferThreshold = this.Options.ControlQueueBufferThreshold,
                 ControlQueueVisibilityTimeout = this.Options.ControlQueueVisibilityTimeout,
                 WorkItemQueueVisibilityTimeout = this.Options.WorkItemQueueVisibilityTimeout,
                 MaxConcurrentTaskOrchestrationWorkItems = this.Options.MaxConcurrentOrchestratorFunctions,

--- a/src/WebJobs.Extensions.DurableTask/DurableTaskOptions.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskOptions.cs
@@ -42,11 +42,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// <summary>
         /// Gets or set the number of control queue messages that can be buffered in memory
         /// at a time, at which point the dispatcher will wait before dequeuing any additional
-        /// messages. The default is 64.
+        /// messages. The default is 256. The maximum value is 1000.
         /// </summary>
-        /// <remarks>This has historically always been fixed to 64, but increasing it may increase
-        /// throughput.</remarks>
-        public int ControlQueueBufferThreshold { get; set; } = 64;
+        /// <remarks>
+        /// Increasing this value can improve orchestration throughput by pre-fetching more
+        /// orchestration messages from control queues. The downside is that it increases the
+        /// possibility of duplicate function executions if partition leases move between app
+        /// instances. This most often occurs when the number of app instances changes.
+        /// </remarks>
+        /// <value>A non-negative integer between 0 and 1000. The default value is <c>256</c>.</value>
+        public int ControlQueueBufferThreshold { get; set; } = 256;
 
         /// <summary>
         /// Gets or sets the partition count for the control queue.

--- a/src/WebJobs.Extensions.DurableTask/DurableTaskOptions.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskOptions.cs
@@ -40,6 +40,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         public int ControlQueueBatchSize { get; set; } = 32;
 
         /// <summary>
+        /// Gets or set the number of control queue messages that can be buffered in memory
+        /// at a time, at which point the dispatcher will wait before dequeuing any additional
+        /// messages. The default is 64.
+        /// </summary>
+        /// <remarks>This has historically always been fixed to 64, but increasing it may increase
+        /// throughput.</remarks>
+        public int ControlQueueBufferThreshold { get; set; } = 64;
+
+        /// <summary>
         /// Gets or sets the partition count for the control queue.
         /// </summary>
         /// <remarks>
@@ -273,6 +282,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             sb.Append(nameof(this.MaxConcurrentOrchestratorFunctions)).Append(": ").Append(this.MaxConcurrentOrchestratorFunctions).Append(", ");
             sb.Append(nameof(this.PartitionCount)).Append(": ").Append(this.PartitionCount).Append(", ");
             sb.Append(nameof(this.ControlQueueBatchSize)).Append(": ").Append(this.ControlQueueBatchSize).Append(", ");
+            sb.Append(nameof(this.ControlQueueBufferThreshold)).Append(": ").Append(this.ControlQueueBufferThreshold).Append(", ");
             sb.Append(nameof(this.ControlQueueVisibilityTimeout)).Append(": ").Append(this.ControlQueueVisibilityTimeout).Append(", ");
             sb.Append(nameof(this.WorkItemQueueVisibilityTimeout)).Append(": ").Append(this.WorkItemQueueVisibilityTimeout).Append(", ");
             sb.Append(nameof(this.FetchLargeMessagesAutomatically)).Append(": ").Append(this.FetchLargeMessagesAutomatically).Append(", ");
@@ -333,6 +343,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             if (this.ControlQueueBatchSize <= 0)
             {
                 throw new InvalidOperationException($"{nameof(this.ControlQueueBatchSize)} must be a non-negative integer.");
+            }
+
+            if (this.ControlQueueBufferThreshold < 1 || this.ControlQueueBufferThreshold > 1000)
+            {
+                throw new InvalidOperationException($"{nameof(this.ControlQueueBufferThreshold)} must be between 1 and 1000.");
             }
 
             if (this.PartitionCount < 1 || this.PartitionCount > 16)

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net461.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net461.xml
@@ -140,6 +140,15 @@
             </remarks>
             <value>A positive integer configured by the host. The default value is <c>32</c>.</value>
         </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskOptions.ControlQueueBufferThreshold">
+            <summary>
+            Gets or set the number of control queue messages that can be buffered in memory
+            at a time, at which point the dispatcher will wait before dequeuing any additional
+            messages. The default is 64.
+            </summary>
+            <remarks>This has historically always been fixed to 64, but increasing it may increase
+            throughput.</remarks>
+        </member>
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskOptions.PartitionCount">
             <summary>
             Gets or sets the partition count for the control queue.

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-netstandard2.0.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-netstandard2.0.xml
@@ -140,6 +140,15 @@
             </remarks>
             <value>A positive integer configured by the host. The default value is <c>32</c>.</value>
         </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskOptions.ControlQueueBufferThreshold">
+            <summary>
+            Gets or set the number of control queue messages that can be buffered in memory
+            at a time, at which point the dispatcher will wait before dequeuing any additional
+            messages. The default is 64.
+            </summary>
+            <remarks>This has historically always been fixed to 64, but increasing it may increase
+            throughput.</remarks>
+        </member>
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskOptions.PartitionCount">
             <summary>
             Gets or sets the partition count for the control queue.


### PR DESCRIPTION
This buffer size appears to impact throughput in a substantial way, so
we are allowing customers to configure this in their host.json to try
and optimize throughput.