### PR TITLE
Update HttpApiHandler to work with AllowSynchronousIO = false (#1085)

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
+++ b/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Diagnostics;
-using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -483,15 +482,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 DurableOrchestrationClientBase client = this.GetClient(request);
 
                 object input = null;
-                if (request.Content != null)
+                if (request.Content?.Headers?.ContentLength != 0)
                 {
-                    using (Stream s = await request.Content.ReadAsStreamAsync())
-                    using (StreamReader sr = new StreamReader(s))
-                    using (JsonReader reader = new JsonTextReader(sr))
-                    {
-                        JsonSerializer serializer = JsonSerializer.Create(MessagePayloadDataConverter.MessageSettings);
-                        input = serializer.Deserialize<object>(reader);
-                    }
+                    string json = await request.Content.ReadAsStringAsync();
+                    input = JsonConvert.DeserializeObject(json, MessagePayloadDataConverter.MessageSettings);
                 }
 
                 string id = await client.StartNewAsync(functionName, instanceId, input);

--- a/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
+++ b/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
@@ -482,7 +482,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 DurableOrchestrationClientBase client = this.GetClient(request);
 
                 object input = null;
-                if (request.Content?.Headers?.ContentLength != 0)
+                if (request.Content != null && request.Content.Headers.ContentLength != 0)
                 {
                     string json = await request.Content.ReadAsStringAsync();
                     input = JsonConvert.DeserializeObject(json, MessagePayloadDataConverter.MessageSettings);


### PR DESCRIPTION
Functions V3 now uses .NET Core 3.1. Starting in .NET Core 3.0, AllowSynchronousIO defaults to false. Therefore, we needed to change our JSON deserialization logic in the Start Orchestration API to avoid synchronous stream reads

Fixes #1178