### PR TITLE
Fixed null-ref exception in local HTTP listener (V2)

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/LocalHttpListener.cs
+++ b/src/WebJobs.Extensions.DurableTask/LocalHttpListener.cs
@@ -122,14 +122,17 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 response.Headers[header.Key] = header.Value.ToArray();
             }
 
-            foreach (KeyValuePair<string, IEnumerable<string>> header in responseMessage.Content.Headers)
+            if (responseMessage.Content != null)
             {
-                response.Headers[header.Key] = header.Value.ToArray();
-            }
+                foreach (KeyValuePair<string, IEnumerable<string>> header in responseMessage.Content.Headers)
+                {
+                    response.Headers[header.Key] = header.Value.ToArray();
+                }
 
-            using (Stream responseStream = await responseMessage.Content.ReadAsStreamAsync())
-            {
-                await responseStream.CopyToAsync(response.Body, 81920, context.RequestAborted);
+                using (Stream responseStream = await responseMessage.Content.ReadAsStreamAsync())
+                {
+                    await responseStream.CopyToAsync(response.Body, 81920, context.RequestAborted);
+                }
             }
         }
 


### PR DESCRIPTION
This is a fix for my previous HTTP listener PR. I uncovered this issue when doing end-to-end testing of all APIs from a JavaScript client.

This PR targets the `dev` branch. A separate PR will target the `v1` branch.