### PR TITLE
Added configurable OverridableStates

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/DurableOrchestrationClient.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableOrchestrationClient.cs
@@ -92,7 +92,7 @@ namespace Microsoft.Azure.WebJobs
 
             var dedupeStatuses = this.GetStatusesNotToOverride();
             Task<OrchestrationInstance> createTask = this.client.CreateOrchestrationInstanceAsync(
-            orchestratorFunctionName, DefaultVersion, instanceId, input, null, dedupeStatuses);
+                orchestratorFunctionName, DefaultVersion, instanceId, input, null, dedupeStatuses);
 
             this.traceHelper.FunctionScheduled(
                 this.hubName,

--- a/src/WebJobs.Extensions.DurableTask/DurableOrchestrationClient.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableOrchestrationClient.cs
@@ -90,8 +90,9 @@ namespace Microsoft.Azure.WebJobs
                 throw new ArgumentException($"Instance ID lengths must not exceed {MaxInstanceIdLength} characters.");
             }
 
+            var dedupeStatuses = this.GetStatusesNotToOverride();
             Task<OrchestrationInstance> createTask = this.client.CreateOrchestrationInstanceAsync(
-                orchestratorFunctionName, DefaultVersion, instanceId, input);
+            orchestratorFunctionName, DefaultVersion, instanceId, input, null, dedupeStatuses);
 
             this.traceHelper.FunctionScheduled(
                 this.hubName,
@@ -103,6 +104,22 @@ namespace Microsoft.Azure.WebJobs
 
             OrchestrationInstance instance = await createTask;
             return instance.InstanceId;
+        }
+
+        private OrchestrationStatus[] GetStatusesNotToOverride()
+        {
+            var overridableStates = this.config.Options.OverridableExistingInstanceStates;
+            if (overridableStates == OverridableStates.NonRunningStates)
+            {
+                return new OrchestrationStatus[]
+                {
+                    OrchestrationStatus.Running,
+                    OrchestrationStatus.ContinuedAsNew,
+                    OrchestrationStatus.Pending,
+                };
+            }
+
+            return new OrchestrationStatus[0];
         }
 
         /// <inheritdoc />

--- a/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
@@ -519,6 +519,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 TrackingStoreStorageAccountDetails = this.GetStorageAccountDetailsOrNull(
                     this.Options.TrackingStoreConnectionStringName),
                 FetchLargeMessageDataEnabled = this.Options.FetchLargeMessagesAutomatically,
+                ThrowExceptionOnInvalidDedupeStatus = true,
             };
 
             if (!string.IsNullOrEmpty(this.Options.TrackingStoreNamePrefix))

--- a/src/WebJobs.Extensions.DurableTask/DurableTaskOptions.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskOptions.cs
@@ -302,6 +302,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// </remarks>
         public bool? LocalRpcEndpointEnabled { get; set; }
 
+        /// <summary>
+        ///  States that will override an existing orchestrator when attempting to start a new orchestrator with the same instance Id.
+        /// </summary>
+        public OverridableStates OverridableExistingInstanceStates { get; set; } = OverridableStates.AnyState;
+
         internal string GetDebugString()
         {
             var sb = new StringBuilder(4096);

--- a/src/WebJobs.Extensions.DurableTask/DurableTaskOptions.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskOptions.cs
@@ -311,6 +311,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         {
             var sb = new StringBuilder(4096);
             sb.AppendLine("Initializing extension with the following settings:");
+            sb.Append(nameof(this.HubName)).Append(": ").Append(this.HubName).Append(", ");
             sb.Append(nameof(this.AzureStorageConnectionStringName)).Append(": ").Append(this.AzureStorageConnectionStringName).Append(", ");
             sb.Append(nameof(this.MaxConcurrentActivityFunctions)).Append(": ").Append(this.MaxConcurrentActivityFunctions).Append(", ");
             sb.Append(nameof(this.MaxConcurrentOrchestratorFunctions)).Append(": ").Append(this.MaxConcurrentOrchestratorFunctions).Append(", ");
@@ -334,6 +335,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 sb.Append(nameof(this.EventGridPublishRetryCount)).Append(": ").Append(this.EventGridPublishRetryCount).Append(", ");
                 sb.Append(nameof(this.EventGridPublishRetryInterval)).Append(": ").Append(this.EventGridPublishRetryInterval).Append(", ");
                 sb.Append(nameof(this.EventGridPublishRetryHttpStatus)).Append(": ").Append(string.Join(", ", this.EventGridPublishRetryHttpStatus ?? new int[0])).Append(", ");
+                sb.Append(nameof(this.EventGridPublishEventTypes)).Append(": ").Append(string.Join(", ", this.EventGridPublishEventTypes ?? new string[0])).Append(", ");
             }
 
             if (this.NotificationUrl != null)
@@ -349,8 +351,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 sb.Append(nameof(this.TrackingStoreNamePrefix)).Append(": ").Append(this.TrackingStoreNamePrefix).Append(", ");
             }
 
+            if (this.LocalRpcEndpointEnabled != null)
+            {
+                sb.Append(nameof(this.LocalRpcEndpointEnabled)).Append(": ").Append(this.LocalRpcEndpointEnabled).Append(", ");
+            }
+
             sb.Append(nameof(this.MaxQueuePollingInterval)).Append(": ").Append(this.MaxQueuePollingInterval).Append(", ");
-            sb.Append(nameof(this.LogReplayEvents)).Append(": ").Append(this.LogReplayEvents);
+            sb.Append(nameof(this.LogReplayEvents)).Append(": ").Append(this.LogReplayEvents).Append(", ");
+            sb.Append(nameof(this.OverridableExistingInstanceStates)).Append(": ").Append(this.OverridableExistingInstanceStates).Append(", ");
+            sb.Append(nameof(this.TraceInputsAndOutputs)).Append(": ").Append(this.TraceInputsAndOutputs).Append(", ");
+            sb.Append(nameof(this.CustomLifeCycleNotificationHelperType)).Append(": ").Append(this.CustomLifeCycleNotificationHelperType);
             return sb.ToString();
         }
 

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net461.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net461.xml
@@ -148,10 +148,15 @@
             <summary>
             Gets or set the number of control queue messages that can be buffered in memory
             at a time, at which point the dispatcher will wait before dequeuing any additional
-            messages. The default is 64.
+            messages. The default is 256. The maximum value is 1000.
             </summary>
-            <remarks>This has historically always been fixed to 64, but increasing it may increase
-            throughput.</remarks>
+            <remarks>
+            Increasing this value can improve orchestration throughput by pre-fetching more
+            orchestration messages from control queues. The downside is that it increases the
+            possibility of duplicate function executions if partition leases move between app
+            instances. This most often occurs when the number of app instances changes.
+            </remarks>
+            <value>A non-negative integer between 0 and 1000. The default value is <c>256</c>.</value>
         </member>
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskOptions.PartitionCount">
             <summary>
@@ -398,6 +403,11 @@
               </item>
             </list>
             </remarks>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskOptions.OverridableExistingInstanceStates">
+            <summary>
+             States that will override an existing orchestrator when attempting to start a new orchestrator with the same instance Id.
+            </summary>
         </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.EtwEventSource">
             <summary>
@@ -1927,6 +1937,24 @@
             <value>
             The name of the orchestrator function or <c>null</c> to use the function name.
             </value>
+        </member>
+        <member name="T:Microsoft.Azure.WebJobs.OverridableStates">
+            <summary>
+            Represents options for different states that an existing orchestrator can be in to be able to be overwritten by
+            an attempt to start a new instance with the same instance Id.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Azure.WebJobs.OverridableStates.AnyState">
+            <summary>
+            Option to start a new orchestrator instance with an existing instnace Id when the existing
+            instance is in any state.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Azure.WebJobs.OverridableStates.NonRunningStates">
+            <summary>
+            Option to only start a new orchestrator instance with an existing instance Id when the existing
+            instance is in a terminated, failed, or completed state.
+            </summary>
         </member>
         <member name="T:Microsoft.Azure.WebJobs.PurgeHistoryResult">
             <summary>

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-netstandard2.0.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-netstandard2.0.xml
@@ -148,10 +148,15 @@
             <summary>
             Gets or set the number of control queue messages that can be buffered in memory
             at a time, at which point the dispatcher will wait before dequeuing any additional
-            messages. The default is 64.
+            messages. The default is 256. The maximum value is 1000.
             </summary>
-            <remarks>This has historically always been fixed to 64, but increasing it may increase
-            throughput.</remarks>
+            <remarks>
+            Increasing this value can improve orchestration throughput by pre-fetching more
+            orchestration messages from control queues. The downside is that it increases the
+            possibility of duplicate function executions if partition leases move between app
+            instances. This most often occurs when the number of app instances changes.
+            </remarks>
+            <value>A non-negative integer between 0 and 1000. The default value is <c>256</c>.</value>
         </member>
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskOptions.PartitionCount">
             <summary>
@@ -398,6 +403,11 @@
               </item>
             </list>
             </remarks>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskOptions.OverridableExistingInstanceStates">
+            <summary>
+             States that will override an existing orchestrator when attempting to start a new orchestrator with the same instance Id.
+            </summary>
         </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.EtwEventSource">
             <summary>
@@ -1933,6 +1943,24 @@
             <value>
             The name of the orchestrator function or <c>null</c> to use the function name.
             </value>
+        </member>
+        <member name="T:Microsoft.Azure.WebJobs.OverridableStates">
+            <summary>
+            Represents options for different states that an existing orchestrator can be in to be able to be overwritten by
+            an attempt to start a new instance with the same instance Id.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Azure.WebJobs.OverridableStates.AnyState">
+            <summary>
+            Option to start a new orchestrator instance with an existing instnace Id when the existing
+            instance is in any state.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Azure.WebJobs.OverridableStates.NonRunningStates">
+            <summary>
+            Option to only start a new orchestrator instance with an existing instance Id when the existing
+            instance is in a terminated, failed, or completed state.
+            </summary>
         </member>
         <member name="T:Microsoft.Azure.WebJobs.PurgeHistoryResult">
             <summary>

--- a/src/WebJobs.Extensions.DurableTask/OverridableStates.cs
+++ b/src/WebJobs.Extensions.DurableTask/OverridableStates.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Microsoft.Azure.WebJobs
+{
+    /// <summary>
+    /// Represents options for different states that an existing orchestrator can be in to be able to be overwritten by
+    /// an attempt to start a new instance with the same instance Id.
+    /// </summary>
+    public enum OverridableStates
+    {
+        /// <summary>
+        /// Option to start a new orchestrator instance with an existing instnace Id when the existing
+        /// instance is in any state.
+        /// </summary>
+        AnyState,
+
+        /// <summary>
+        /// Option to only start a new orchestrator instance with an existing instance Id when the existing
+        /// instance is in a terminated, failed, or completed state.
+        /// </summary>
+        NonRunningStates,
+    }
+}

--- a/test/Common/DurableTaskEndToEndTests.cs
+++ b/test/Common/DurableTaskEndToEndTests.cs
@@ -2659,6 +2659,95 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 argumentException.Message);
         }
 
+        [Theory]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task Dedupe_NotRunning_ThrowsException(bool extendedSessions)
+        {
+            var instanceId = "OverridableStatesThrowsExceptionNotRunningTest";
+
+            using (ITestHost host = TestHelpers.GetJobHost(
+                 this.loggerProvider,
+                 nameof(this.Dedupe_NotRunning_ThrowsException),
+                 extendedSessions,
+                 overridableStates: OverridableStates.NonRunningStates))
+            {
+                await host.StartAsync();
+
+                int initialValue = 0;
+
+                var client = await host.StartOrchestratorAsync(nameof(TestOrchestrations.Counter), initialValue, this.output, instanceId: instanceId);
+
+                // Wait for the instance to go into the Running state. This is necessary to ensure log validation consistency.
+                await client.WaitForStartupAsync(this.output);
+
+                TimeSpan waitTimeout = TimeSpan.FromSeconds(Debugger.IsAttached ? 300 : 10);
+
+                // Perform some operations
+                await client.RaiseEventAsync("operation", "incr", this.output);
+                await client.WaitForCustomStatusAsync(waitTimeout, this.output, 1);
+
+                // Make sure it's still running and didn't complete early (or fail).
+                var status = await client.GetStatusAsync();
+                Assert.True(
+                    status?.RuntimeStatus == OrchestrationRuntimeStatus.Running ||
+                    status?.RuntimeStatus == OrchestrationRuntimeStatus.ContinuedAsNew);
+
+                FunctionInvocationException exception =
+                    await Assert.ThrowsAsync<FunctionInvocationException>(async () =>
+                    {
+                        await host.StartOrchestratorAsync(nameof(TestOrchestrations.Counter), initialValue, this.output, instanceId: instanceId);
+                    });
+
+                Assert.Equal(
+                    "An Orchestration instance with the status Running already exists.",
+                    exception.InnerException.Message);
+
+                await host.StopAsync();
+            }
+        }
+
+        [Theory]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task DedupeStates_Default_AnyState(bool extendedSessions)
+        {
+            var instanceId = "OverridableStatesDefaultAnyStateTest";
+
+            using (ITestHost host = TestHelpers.GetJobHost(
+                this.loggerProvider,
+                nameof(this.DedupeStates_Default_AnyState),
+                extendedSessions))
+            {
+                await host.StartAsync();
+
+                int initialValue = 0;
+
+                var client = await host.StartOrchestratorAsync(nameof(TestOrchestrations.Counter), initialValue, this.output, instanceId: instanceId);
+
+                // Wait for the instance to go into the Running state. This is necessary to ensure log validation consistency.
+                await client.WaitForStartupAsync(this.output);
+
+                TimeSpan waitTimeout = TimeSpan.FromSeconds(Debugger.IsAttached ? 300 : 10);
+
+                // Perform some operations
+                await client.RaiseEventAsync("operation", "incr", this.output);
+                await client.WaitForCustomStatusAsync(waitTimeout, this.output, 1);
+
+                // Make sure it's still running and didn't complete early (or fail).
+                var status = await client.GetStatusAsync();
+                Assert.True(
+                    status?.RuntimeStatus == OrchestrationRuntimeStatus.Running ||
+                    status?.RuntimeStatus == OrchestrationRuntimeStatus.ContinuedAsNew);
+
+                await host.StartOrchestratorAsync(nameof(TestOrchestrations.Counter), initialValue, this.output, instanceId: instanceId);
+
+                await host.StopAsync();
+            }
+        }
+
         private static StringBuilder GenerateMediumRandomStringPayload()
         {
             // Generate a medium random string payload

--- a/test/Common/DurableTaskEndToEndTests.cs
+++ b/test/Common/DurableTaskEndToEndTests.cs
@@ -2663,13 +2663,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         [Trait("Category", PlatformSpecificHelpers.TestCategory)]
         [InlineData(true)]
         [InlineData(false)]
-        public async Task Dedupe_NotRunning_ThrowsException(bool extendedSessions)
+        public async Task Dedupe_NotRunningStates_ThrowsException(bool extendedSessions)
         {
             var instanceId = "OverridableStatesThrowsExceptionNotRunningTest";
 
             using (ITestHost host = TestHelpers.GetJobHost(
                  this.loggerProvider,
-                 nameof(this.Dedupe_NotRunning_ThrowsException),
+                 nameof(this.Dedupe_NotRunningStates_ThrowsException),
                  extendedSessions,
                  overridableStates: OverridableStates.NonRunningStates))
             {
@@ -2743,6 +2743,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                     status?.RuntimeStatus == OrchestrationRuntimeStatus.ContinuedAsNew);
 
                 await host.StartOrchestratorAsync(nameof(TestOrchestrations.Counter), initialValue, this.output, instanceId: instanceId);
+
+                // Check that new instance overrode old instacne's counter value
+                await client.WaitForCustomStatusAsync(waitTimeout, this.output, 0);
 
                 await host.StopAsync();
             }

--- a/test/Common/TestHelpers.cs
+++ b/test/Common/TestHelpers.cs
@@ -35,7 +35,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             TimeSpan? maxQueuePollingInterval = null,
             string[] eventGridPublishEventTypes = null,
             bool autoFetchLargeMessages = true,
-            bool? localRpcEndpointEnabled = false)
+            bool? localRpcEndpointEnabled = false,
+            OverridableStates? overridableStates = null)
         {
             var durableTaskOptions = new DurableTaskOptions
             {
@@ -74,8 +75,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 durableTaskOptions.MaxQueuePollingInterval = maxQueuePollingInterval.Value;
             }
 
+            if (overridableStates != null)
+            {
+                durableTaskOptions.OverridableExistingInstanceStates = (OverridableStates)overridableStates;
+            }
+
             var optionsWrapper = new OptionsWrapper<DurableTaskOptions>(durableTaskOptions);
             var testNameResolver = new TestNameResolver(nameResolver);
+
             return PlatformSpecificHelpers.CreateJobHost(
                 optionsWrapper,
                 loggerProvider,


### PR DESCRIPTION
Like in v2.0.0, added OverridableStates, a configurable option to allow users to specify which states they would like to override an orchestrator instance if an existing instanceId exists.

Defaults to AnyState to avoid changing behavior.

Resolves #1203 

Related to https://github.com/Azure/azure-functions-durable-extension/pull/987 and https://github.com/Azure/azure-functions-durable-extension/pull/1014