### PR TITLE
Ensure default task hub names are compatible with Azure Tables

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net471.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net471.xml
@@ -135,7 +135,7 @@
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClient.Microsoft#Azure#WebJobs#Extensions#DurableTask#IDurableOrchestrationClient#PurgeInstanceHistoryAsync(System.DateTime,System.Nullable{System.DateTime},System.Collections.Generic.IEnumerable{DurableTask.Core.OrchestrationStatus})">
             <inheritdoc />
         </member>
-        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClient.Microsoft#Azure#WebJobs#Extensions#DurableTask#IDurableOrchestrationClient#GetStatusAsync(Microsoft.Azure.WebJobs.Extensions.DurableTask.OrchestrationStatusQueryCondition,System.Threading.CancellationToken)">
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClient.Microsoft#Azure#WebJobs#Extensions#DurableTask#IDurableOrchestrationClient#ListInstancesAsync(Microsoft.Azure.WebJobs.Extensions.DurableTask.OrchestrationStatusQueryCondition,System.Threading.CancellationToken)">
             <inheritdoc />
         </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClient.Microsoft#Azure#WebJobs#Extensions#DurableTask#IDurableEntityClient#ListEntitiesAsync(Microsoft.Azure.WebJobs.Extensions.DurableTask.EntityQuery,System.Threading.CancellationToken)">
@@ -1017,6 +1017,14 @@
             <returns>Returns an instance of <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.PurgeHistoryResult"/>.</returns>
         </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableOrchestrationClient.GetStatusAsync(Microsoft.Azure.WebJobs.Extensions.DurableTask.OrchestrationStatusQueryCondition,System.Threading.CancellationToken)">
+            <summary>
+            Gets the status of all orchestration instances with paging that match the specified conditions.
+            </summary>
+            <param name="condition">Return orchestration instances that match the specified conditions.</param>
+            <param name="cancellationToken">Cancellation token that can be used to cancel the status query operation.</param>
+            <returns>Returns each page of orchestration status for all instances and continuation token of next page.</returns>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableOrchestrationClient.ListInstancesAsync(Microsoft.Azure.WebJobs.Extensions.DurableTask.OrchestrationStatusQueryCondition,System.Threading.CancellationToken)">
             <summary>
             Gets the status of all orchestration instances with paging that match the specified conditions.
             </summary>
@@ -2400,6 +2408,11 @@
             </summary>
         </member>
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.RequestMessage.ParentInstanceId">
+            <summary>
+            The parent instance that called this operation.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.RequestMessage.ParentExecutionId">
             <summary>
             The parent instance that called this operation.
             </summary>

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
@@ -135,7 +135,7 @@
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClient.Microsoft#Azure#WebJobs#Extensions#DurableTask#IDurableOrchestrationClient#PurgeInstanceHistoryAsync(System.DateTime,System.Nullable{System.DateTime},System.Collections.Generic.IEnumerable{DurableTask.Core.OrchestrationStatus})">
             <inheritdoc />
         </member>
-        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClient.Microsoft#Azure#WebJobs#Extensions#DurableTask#IDurableOrchestrationClient#GetStatusAsync(Microsoft.Azure.WebJobs.Extensions.DurableTask.OrchestrationStatusQueryCondition,System.Threading.CancellationToken)">
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClient.Microsoft#Azure#WebJobs#Extensions#DurableTask#IDurableOrchestrationClient#ListInstancesAsync(Microsoft.Azure.WebJobs.Extensions.DurableTask.OrchestrationStatusQueryCondition,System.Threading.CancellationToken)">
             <inheritdoc />
         </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClient.Microsoft#Azure#WebJobs#Extensions#DurableTask#IDurableEntityClient#ListEntitiesAsync(Microsoft.Azure.WebJobs.Extensions.DurableTask.EntityQuery,System.Threading.CancellationToken)">
@@ -1055,6 +1055,14 @@
             <returns>Returns an instance of <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.PurgeHistoryResult"/>.</returns>
         </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableOrchestrationClient.GetStatusAsync(Microsoft.Azure.WebJobs.Extensions.DurableTask.OrchestrationStatusQueryCondition,System.Threading.CancellationToken)">
+            <summary>
+            Gets the status of all orchestration instances with paging that match the specified conditions.
+            </summary>
+            <param name="condition">Return orchestration instances that match the specified conditions.</param>
+            <param name="cancellationToken">Cancellation token that can be used to cancel the status query operation.</param>
+            <returns>Returns each page of orchestration status for all instances and continuation token of next page.</returns>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableOrchestrationClient.ListInstancesAsync(Microsoft.Azure.WebJobs.Extensions.DurableTask.OrchestrationStatusQueryCondition,System.Threading.CancellationToken)">
             <summary>
             Gets the status of all orchestration instances with paging that match the specified conditions.
             </summary>
@@ -2438,6 +2446,11 @@
             </summary>
         </member>
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.RequestMessage.ParentInstanceId">
+            <summary>
+            The parent instance that called this operation.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.RequestMessage.ParentExecutionId">
             <summary>
             The parent instance that called this operation.
             </summary>

--- a/src/WebJobs.Extensions.DurableTask/Options/AzureStorageOptions.cs
+++ b/src/WebJobs.Extensions.DurableTask/Options/AzureStorageOptions.cs
@@ -155,7 +155,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
             if (!validHubNameCharacters.Any())
             {
-                sanitizedHubName = TaskHubPadding;
+                sanitizedHubName = "DefaultTaskHub";
                 return false;
             }
 

--- a/test/Common/DurableTaskEndToEndTests.cs
+++ b/test/Common/DurableTaskEndToEndTests.cs
@@ -4035,6 +4035,40 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         }
 
         /// <summary>
+        /// Tests default and custom values for task hub name/>.
+        /// </summary>
+        [Theory]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        [InlineData("Task-Hub-Name-Test", "TaskHubNameTest")]
+        [InlineData("1TaskHubNameTest", "t1TaskHubNameTest")]
+        [InlineData("-taskhubnametest", "taskhubnametest")]
+        [InlineData("-1taskhubnametest", "t1taskhubnametest")]
+        public void TaskHubName_DefaultHubName_UseSanitized(string siteName, string expectedHubName)
+        {
+            string currSiteName = Environment.GetEnvironmentVariable("WEBSITE_SITE_NAME");
+            string currSlotName = Environment.GetEnvironmentVariable("WEBSITE_SLOT_NAME");
+
+            try
+            {
+                Environment.SetEnvironmentVariable("WEBSITE_SITE_NAME", siteName);
+                Environment.SetEnvironmentVariable("WEBSITE_SLOT_NAME", "Production");
+
+                var options = new DurableTaskOptions();
+                options.LocalRpcEndpointEnabled = false;
+
+                using (var host = TestHelpers.GetJobHostWithOptions(this.loggerProvider, options))
+                {
+                    Assert.Equal(expectedHubName, options.HubName);
+                }
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("WEBSITE_SITE_NAME", currSiteName);
+                Environment.SetEnvironmentVariable("WEBSITE_SLOT_NAME", currSlotName);
+            }
+        }
+
+        /// <summary>
         /// Tests that an attempt to use a default task hub name while in a test slot will throw an exception <see cref="InvalidOperationException"/>.
         /// </summary>
         [Fact]

--- a/test/Common/DurableTaskEndToEndTests.cs
+++ b/test/Common/DurableTaskEndToEndTests.cs
@@ -3985,8 +3985,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             Assert.NotNull(argumentException);
             Assert.Equal(
                 argumentException.Message.Contains($"{taskHubName}V1")
-                    ? $"Task hub name '{taskHubName}V1' should contain only alphanumeric characters and have length between 3 and 45."
-                    : $"Task hub name '{taskHubName}V2' should contain only alphanumeric characters and have length between 3 and 45.",
+                    ? $"Task hub name '{taskHubName}V1' should contain only alphanumeric characters, start with a letter, and have length between 3 and 45."
+                    : $"Task hub name '{taskHubName}V2' should contain only alphanumeric characters, start with a letter, and have length between 3 and 45.",
                 argumentException.Message);
         }
 
@@ -4043,6 +4043,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         [InlineData("1TaskHubNameTest", "t1TaskHubNameTest")]
         [InlineData("-taskhubnametest", "taskhubnametest")]
         [InlineData("-1taskhubnametest", "t1taskhubnametest")]
+        [InlineData("--------", "DefaultTaskHub")]
+        [InlineData("bb", "bbHub")]
         public void TaskHubName_DefaultHubName_UseSanitized(string siteName, string expectedHubName)
         {
             string currSiteName = Environment.GetEnvironmentVariable("WEBSITE_SITE_NAME");
@@ -4162,7 +4164,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
             Assert.NotNull(exception);
             Assert.Equal(
-                $"Task hub name '{taskHubName}' should contain only alphanumeric characters and have length between 3 and 45.",
+                $"Task hub name '{taskHubName}' should contain only alphanumeric characters, start with a letter, and have length between 3 and 45.",
                 exception.Message);
         }
 
@@ -4247,34 +4249,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
         [Fact]
         [Trait("Category", PlatformSpecificHelpers.TestCategory)]
-        public void TaskHubName_DefaultNameSiteWithDashes_UsesSanitizedHubName()
-        {
-            string currSiteName = Environment.GetEnvironmentVariable("WEBSITE_SITE_NAME");
-            string currSlotName = Environment.GetEnvironmentVariable("WEBSITE_SLOT_NAME");
-
-            try
-            {
-                Environment.SetEnvironmentVariable("WEBSITE_SITE_NAME", "Test-Site-Name");
-                Environment.SetEnvironmentVariable("WEBSITE_SLOT_NAME", null);
-
-                var options = new DurableTaskOptions();
-
-                var expectedHubName = "TestSiteName";
-
-                using (var host = TestHelpers.GetJobHostWithOptions(this.loggerProvider, options))
-                {
-                    Assert.Equal(expectedHubName, options.HubName);
-                }
-            }
-            finally
-            {
-                Environment.SetEnvironmentVariable("WEBSITE_SITE_NAME", currSiteName);
-                Environment.SetEnvironmentVariable("WEBSITE_SLOT_NAME", currSlotName);
-            }
-        }
-
-        [Fact]
-        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
         public void TaskHubName_DefaultNameSiteTooLong_UsesSanitizedHubName()
         {
             string currSiteName = Environment.GetEnvironmentVariable("WEBSITE_SITE_NAME");
@@ -4288,34 +4262,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 var options = new DurableTaskOptions();
 
                 var expectedHubName = new string('a', 45);
-
-                using (var host = TestHelpers.GetJobHostWithOptions(this.loggerProvider, options))
-                {
-                    Assert.Equal(expectedHubName, options.HubName);
-                }
-            }
-            finally
-            {
-                Environment.SetEnvironmentVariable("WEBSITE_SITE_NAME", currSiteName);
-                Environment.SetEnvironmentVariable("WEBSITE_SLOT_NAME", currSlotName);
-            }
-        }
-
-        [Fact]
-        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
-        public void TaskHubName_DefaultNameSiteTooShort_UsesSanitizedHubName()
-        {
-            string currSiteName = Environment.GetEnvironmentVariable("WEBSITE_SITE_NAME");
-            string currSlotName = Environment.GetEnvironmentVariable("WEBSITE_SLOT_NAME");
-
-            try
-            {
-                Environment.SetEnvironmentVariable("WEBSITE_SITE_NAME", new string('b', 2));
-                Environment.SetEnvironmentVariable("WEBSITE_SLOT_NAME", null);
-
-                var options = new DurableTaskOptions();
-
-                var expectedHubName = "bbHub";
 
                 using (var host = TestHelpers.GetJobHostWithOptions(this.loggerProvider, options))
                 {


### PR DESCRIPTION
Azure Table storage requires names that do not begin with a number. The
current default task hub name does not account for this. We now prepend
't' to the front of the default task hub if it would start with a
number.

Resolves #1210