### PR TITLE
Add proper storage provider logging

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/AzureStorageDurabilityProvider.cs
+++ b/src/WebJobs.Extensions.DurableTask/AzureStorageDurabilityProvider.cs
@@ -10,6 +10,9 @@ using DurableTask.AzureStorage;
 using DurableTask.AzureStorage.Tracking;
 using DurableTask.Core;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using Newtonsoft.Json.Linq;
+using Newtonsoft.Json.Serialization;
 using AzureStorage = DurableTask.AzureStorage;
 
 namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
@@ -23,12 +26,23 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
         private readonly AzureStorageOrchestrationService serviceClient;
         private readonly string connectionName;
+        private readonly JObject storageOptionsJson;
 
-        public AzureStorageDurabilityProvider(AzureStorageOrchestrationService service, string connectionName)
+        public AzureStorageDurabilityProvider(
+            AzureStorageOrchestrationService service,
+            string connectionName,
+            AzureStorageOptions options)
             : base("Azure Storage", service, service, connectionName)
         {
             this.serviceClient = service;
             this.connectionName = connectionName;
+            this.storageOptionsJson = JObject.FromObject(
+                options,
+                new JsonSerializer
+                {
+                    Converters = { new StringEnumConverter() },
+                    ContractResolver = new CamelCasePropertyNamesContractResolver(),
+                });
         }
 
         public override bool SupportsEntities => true;
@@ -37,6 +51,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// The app setting containing the Azure Storage connection string.
         /// </summary>
         public override string ConnectionName => this.connectionName;
+
+        public override JObject ConfigurationJson => this.storageOptionsJson;
 
         /// <inheritdoc/>
         public async override Task<IList<OrchestrationState>> GetAllOrchestrationStates(CancellationToken cancellationToken)

--- a/src/WebJobs.Extensions.DurableTask/AzureStorageDurabilityProviderFactory.cs
+++ b/src/WebJobs.Extensions.DurableTask/AzureStorageDurabilityProviderFactory.cs
@@ -66,7 +66,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             if (this.defaultStorageProvider == null)
             {
                 var defaultService = new AzureStorageOrchestrationService(this.defaultSettings);
-                this.defaultStorageProvider = new AzureStorageDurabilityProvider(defaultService, this.defaultConnectionName);
+                this.defaultStorageProvider = new AzureStorageDurabilityProvider(
+                    defaultService,
+                    this.defaultConnectionName,
+                    this.azureStorageOptions);
             }
 
             return this.defaultStorageProvider;
@@ -94,7 +97,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             }
             else
             {
-                innerClient = new AzureStorageDurabilityProvider(new AzureStorageOrchestrationService(settings), connectionName);
+                innerClient = new AzureStorageDurabilityProvider(
+                    new AzureStorageOrchestrationService(settings),
+                    connectionName,
+                    this.azureStorageOptions);
             }
 
             return innerClient;

--- a/src/WebJobs.Extensions.DurableTask/DurabilityProvider.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurabilityProvider.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using DurableTask.Core;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 {
@@ -20,6 +21,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
     public class DurabilityProvider : IOrchestrationService, IOrchestrationServiceClient
     {
         internal const string NoConnectionDetails = "default";
+
+        private static readonly JObject EmptyConfig = new JObject();
 
         private readonly string name;
         private readonly IOrchestrationService innerService;
@@ -53,6 +56,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// Specifies whether the durability provider supports Durable Entities.
         /// </summary>
         public virtual bool SupportsEntities => false;
+
+        /// <summary>
+        /// JSON representation of configuration to emit in telemetry.
+        /// </summary>
+        public virtual JObject ConfigurationJson => EmptyConfig;
 
         /// <inheritdoc/>
         public int TaskOrchestrationDispatcherCount => this.GetOrchestrationService().TaskOrchestrationDispatcherCount;

--- a/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
@@ -327,7 +327,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
         private void TraceConfigurationSettings()
         {
-            this.Options.TraceConfiguration(this.TraceHelper);
+            this.Options.TraceConfiguration(
+                this.TraceHelper,
+                this.defaultDurabilityProvider.ConfigurationJson);
         }
 
         private ILifeCycleNotificationHelper CreateLifeCycleNotificationHelper()

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net471.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net471.xml
@@ -1425,6 +1425,11 @@
             Specifies whether the durability provider supports Durable Entities.
             </summary>
         </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurabilityProvider.ConfigurationJson">
+            <summary>
+            JSON representation of configuration to emit in telemetry.
+            </summary>
+        </member>
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurabilityProvider.TaskOrchestrationDispatcherCount">
             <inheritdoc/>
         </member>

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
@@ -1463,6 +1463,11 @@
             Specifies whether the durability provider supports Durable Entities.
             </summary>
         </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurabilityProvider.ConfigurationJson">
+            <summary>
+            JSON representation of configuration to emit in telemetry.
+            </summary>
+        </member>
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurabilityProvider.TaskOrchestrationDispatcherCount">
             <inheritdoc/>
         </member>

--- a/src/WebJobs.Extensions.DurableTask/Options/DurableTaskOptions.cs
+++ b/src/WebJobs.Extensions.DurableTask/Options/DurableTaskOptions.cs
@@ -195,7 +195,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             this.defaultHubName = hubName;
         }
 
-        internal void TraceConfiguration(EndToEndTraceHelper traceHelper)
+        internal void TraceConfiguration(EndToEndTraceHelper traceHelper, JObject storageProviderConfig)
         {
             // Clone the options to avoid making changes to the original.
             // We make updates to the clone rather than to JSON to ensure we're updating what we think we're updating.
@@ -222,6 +222,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     Converters = { new StringEnumConverter() },
                     ContractResolver = new CamelCasePropertyNamesContractResolver(),
                 });
+
+            if (storageProviderConfig.Count != 0)
+            {
+                configurationJson["storageProvider"] = storageProviderConfig;
+            }
 
             // This won't be exactly the same as what is declared in host.json because any unspecified values
             // will have been initialized with their defaults. We need the Functions runtime to handle tracing


### PR DESCRIPTION
Default values for Storage Providers are currently not emitted, which
makes servicability much harder. This change adds a virtual method to
DurabilityProvider that allows the default provider to provide its
configuration in JSON form for us to log. Resolves #1137