### PR TITLE
Implement state rollback for exceptions inside entity operations

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableEntityContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableEntityContext.cs
@@ -32,7 +32,17 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             this.shim = shim;
         }
 
-        internal bool StateWasAccessed { get; set; }
+        // The last serialized checkpoint of the entity state is always stored in
+        // the fields this.State.EntityExists (a boolean) and this.State.EntityState (a string).
+        // The current state is determined by this.CurrentStateAccess and this.CurrentState.
+        internal enum StateAccess
+        {
+            NotAccessed, // current state is same as last checkpoint in this.State
+            Accessed, // current state is stored in this.CurrentState
+            Deleted, // current state is deleted
+        }
+
+        internal StateAccess CurrentStateAccess { get; set; }
 
         internal object CurrentState { get; set; }
 
@@ -74,9 +84,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             get
             {
                 this.ThrowIfInvalidAccess();
-                return this.State.EntityExists;
+                switch (this.CurrentStateAccess)
+                {
+                    case StateAccess.Accessed: return true;
+                    case StateAccess.Deleted: return false;
+                    default: return this.State.EntityExists;
+                }
             }
         }
+
+        internal int OutboxPosition => this.outbox.Count;
 
 #if !FUNCTIONS_V1
         public FunctionBindingContext FunctionBindingContext { get; set; }
@@ -144,14 +161,23 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             }
         }
 
+        public void Rollback(int outboxPositionBeforeOperation)
+        {
+            // We discard the current state, which means we go back to the last serialized one
+            this.CurrentStateAccess = StateAccess.NotAccessed;
+            this.CurrentState = null;
+
+            // we also roll back the list of outgoing messages,
+            // so any signals sent by this operation are discarded.
+            this.outbox.RemoveRange(outboxPositionBeforeOperation, this.outbox.Count - outboxPositionBeforeOperation);
+        }
+
         void IDurableEntityContext.DeleteState()
         {
             this.ThrowIfInvalidAccess();
 
-            this.StateWasAccessed = false;
+            this.CurrentStateAccess = StateAccess.Deleted;
             this.CurrentState = null;
-            this.State.EntityExists = false;
-            this.State.EntityState = null;
         }
 
         TInput IDurableEntityContext.GetInput<TInput>()
@@ -170,14 +196,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         {
             this.ThrowIfInvalidAccess();
 
-            if (this.StateWasAccessed)
+            if (this.CurrentStateAccess == StateAccess.Accessed)
             {
                 return (TState)this.CurrentState;
             }
 
             TState result;
 
-            if (this.State.EntityExists)
+            if (this.State.EntityExists && this.CurrentStateAccess != StateAccess.Deleted)
             {
                 try
                 {
@@ -207,9 +233,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 }
             }
 
+            this.CurrentStateAccess = StateAccess.Accessed;
             this.CurrentState = result;
-            this.StateWasAccessed = true;
-            this.State.EntityExists = true;
             return result;
         }
 
@@ -218,7 +243,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         {
             this.ThrowIfInvalidAccess();
 
-            if (this.StateWasAccessed)
+            if (this.CurrentStateAccess == StateAccess.Accessed)
             {
                 return (TState)this.CurrentState;
             }
@@ -234,7 +259,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 throw new EntitySchedulerException($"Failed to construct entity state object: {e.Message}", e);
             }
 
-            if (this.State.EntityExists)
+            if (this.State.EntityExists
+                && this.CurrentStateAccess != StateAccess.Deleted)
             {
                 try
                 {
@@ -246,9 +272,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 }
             }
 
+            this.CurrentStateAccess = StateAccess.Accessed;
             this.CurrentState = result;
-            this.StateWasAccessed = true;
-            this.State.EntityExists = true;
             return result;
         }
 
@@ -257,19 +282,25 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             this.ThrowIfInvalidAccess();
 
             this.CurrentState = o;
-            this.StateWasAccessed = true;
-            this.State.EntityExists = true;
+            this.CurrentStateAccess = StateAccess.Accessed;
         }
 
-        internal bool TryWriteback(out ResponseMessage serializationErrorMessage)
+        internal bool TryWriteback(out ResponseMessage serializationErrorMessage, string operation = null)
         {
             serializationErrorMessage = null;
 
-            if (this.StateWasAccessed)
+            if (this.CurrentStateAccess == StateAccess.Deleted)
+            {
+                this.State.EntityState = null;
+                this.State.EntityExists = false;
+                this.CurrentStateAccess = StateAccess.NotAccessed;
+            }
+            else if (this.CurrentStateAccess == StateAccess.Accessed)
             {
                 try
                 {
                     this.State.EntityState = this.dataConverter.MessageConverter.Serialize(this.CurrentState);
+                    this.State.EntityExists = true;
                 }
                 catch (Exception e)
                 {
@@ -279,19 +310,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
                     this.CaptureApplicationError(serializationException);
 
-                    // Since for all of the operations in the batch, their effect on the entity state
-                    // is lost, we don't want the calling orchestrations to think everything is o.k.
-                    // They should be notified, so we replace all non-error operation results
-                    // with an exception result.
-                    serializationErrorMessage = new ResponseMessage()
-                    {
-                        ExceptionType = serializationException.GetType().AssemblyQualifiedName,
-                        Result = this.dataConverter.ErrorConverter.Serialize(serializationException),
-                    };
+                    serializationErrorMessage = new ResponseMessage();
+                    serializationErrorMessage.SetExceptionResult(serializationException, operation, this.dataConverter);
                 }
 
                 this.CurrentState = null;
-                this.StateWasAccessed = false;
+                this.CurrentStateAccess = StateAccess.NotAccessed;
             }
 
             return serializationErrorMessage == null;
@@ -407,7 +431,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 }
                 else
                 {
-                    this.State.MessageSorter.LabelOutgoingMessage(requestMessage, target.InstanceId, DateTime.UtcNow, this.EntityMessageReorderWindow);
                     eventName = EntityMessageEventNames.RequestMessageEventName;
                 }
 
@@ -424,11 +447,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         {
             lock (this.outbox)
             {
-                if (message is RequestMessage requestMessage)
-                {
-                    this.State.MessageSorter.LabelOutgoingMessage(requestMessage, target.InstanceId, DateTime.UtcNow, this.EntityMessageReorderWindow);
-                }
-
                 this.outbox.Add(new ResultMessage()
                 {
                     Target = target,
@@ -487,7 +505,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     }
                     else if (message is ResultMessage resultMessage)
                     {
-                        // non-error result messages are replaced with the writeback failed response
+                        // Since for all of the operations in the batch, their effect on the entity state
+                        // is lost, we don't want the calling orchestrations to think everything is o.k.
+                        // They should be notified, so we replace all non-error operation results
+                        // with an exception result.
                         if (!writeBackSuccessful && !resultMessage.IsError)
                         {
                             resultMessage.EventContent = serializationErrorMessage;
@@ -509,6 +530,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     }
                     else if (message is OperationMessage operationMessage)
                     {
+                        if (!operationMessage.EventContent.ScheduledTime.HasValue)
+                        {
+                            this.State.MessageSorter.LabelOutgoingMessage(operationMessage.EventContent, operationMessage.Target.InstanceId, DateTime.UtcNow, this.EntityMessageReorderWindow);
+                        }
+
                         this.Config.TraceHelper.SendingEntityMessage(
                             this.InstanceId,
                             this.ExecutionId,
@@ -554,7 +580,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
             public string EventName { get; set; }
 
-            public object EventContent { get; set; }
+            public RequestMessage EventContent { get; set; }
         }
 
         private class ResultMessage : OutgoingMessage

--- a/src/WebJobs.Extensions.DurableTask/EntityScheduler/ResponseMessage.cs
+++ b/src/WebJobs.Extensions.DurableTask/EntityScheduler/ResponseMessage.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             }
         }
 
-        public void SetExceptionResult(Exception exception, string operation, EntityId entity, MessagePayloadDataConverter dataConverter)
+        public void SetExceptionResult(Exception exception, string operation, MessagePayloadDataConverter dataConverter)
         {
             this.ExceptionType = exception.GetType().AssemblyQualifiedName;
 
@@ -44,7 +44,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 // sometimes, exceptions cannot be serialized. In that case we create a serializable wrapper
                 // exception which lets the caller know something went wrong.
 
-                var wrapper = new OperationErrorException($"{this.ExceptionType} in operation '{operation}': {exception.Message}");
+                var wrapper = string.IsNullOrEmpty(operation) ?
+                      new OperationErrorException($"{this.ExceptionType} while processing operations: {exception.Message}")
+                    : new OperationErrorException($"{this.ExceptionType} in operation '{operation}': {exception.Message}");
+
                 this.ExceptionType = wrapper.GetType().AssemblyQualifiedName;
                 this.Result = dataConverter.ErrorConverter.Serialize(wrapper);
             }

--- a/src/WebJobs.Extensions.DurableTask/EntityScheduler/SchedulerState.cs
+++ b/src/WebJobs.Extensions.DurableTask/EntityScheduler/SchedulerState.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         public bool EntityExists { get; set; }
 
         /// <summary>
-        /// The serialized entity state. This can be stale while CurrentStateView != null.
+        /// The last serialized entity state.
         /// </summary>
         [JsonProperty(PropertyName = "state", DefaultValueHandling = DefaultValueHandling.Ignore)]
         public string EntityState { get; set; }

--- a/src/WebJobs.Extensions.DurableTask/Options/DurableTaskOptions.cs
+++ b/src/WebJobs.Extensions.DurableTask/Options/DurableTaskOptions.cs
@@ -182,6 +182,19 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// </summary>
         public bool UseGracefulShutdown { get; set; } = false;
 
+        /// <summary>
+        /// Controls whether an uncaught exception inside an entity operation should roll back the effects of the operation.
+        /// </summary>
+        /// <remarks>
+        /// The rollback undoes all internal effects of an operation
+        /// (sent signals, and state creation, deletion, or modification).
+        /// However, it does not roll back external effects (such as I/O that was performed).
+        /// This setting can affect serialization overhead: if true, the entity state is serialized
+        /// after each individual operation. If false, the entity state is serialized
+        /// only after an entire batch of operations completes.
+        /// </remarks>
+        public bool RollbackEntityOperationsOnExceptions { get; set; } = true;
+
         // Used for mocking the lifecycle notification helper.
         internal HttpMessageHandler NotificationHandler { get; set; }
 

--- a/test/Common/DurableTaskEndToEndTests.cs
+++ b/test/Common/DurableTaskEndToEndTests.cs
@@ -2531,6 +2531,84 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         }
 
         /// <summary>
+        /// End-to-end test which validates exception handling in entity operations.
+        /// </summary>
+        [Theory]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        [InlineData(true, true, true)]
+        [InlineData(false, true, true)]
+        [InlineData(true, false, true)]
+        [InlineData(false, false, true)]
+        [InlineData(true, true, false)]
+        [InlineData(false, true, false)]
+        [InlineData(true, false, false)]
+        [InlineData(false, false, false)]
+        public async Task DurableEntity_CallFaultyEntity(bool extendedSessions, bool useClassBasedEntity, bool rollbackOnExceptions)
+        {
+            string[] orchestratorFunctionNames =
+            {
+                nameof(TestOrchestrations.CallFaultyEntity),
+            };
+
+            using (var host = TestHelpers.GetJobHost(
+                this.loggerProvider,
+                nameof(this.DurableEntity_CallFaultyEntity),
+                extendedSessions,
+                rollbackEntityOperationsOnExceptions: rollbackOnExceptions))
+            {
+                await host.StartAsync();
+                var entityName = useClassBasedEntity ? "ClassBasedFaultyEntity" : "FunctionBasedFaultyEntity";
+                var entityId = new EntityId(entityName, Guid.NewGuid().ToString());
+
+                var client = await host.StartOrchestratorAsync(orchestratorFunctionNames[0], (entityId, rollbackOnExceptions), this.output);
+                var status = await client.WaitForCompletionAsync(this.output);
+
+                Assert.Equal(OrchestrationRuntimeStatus.Completed, status?.RuntimeStatus);
+                Assert.Equal("ok", status?.Output);
+
+                await host.StopAsync();
+            }
+        }
+
+        /// <summary>
+        /// End-to-end test which validates rollback of sent signals on exceptions.
+        /// </summary>
+        [Theory]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        [InlineData(true, true)]
+        [InlineData(false, true)]
+        [InlineData(true, false)]
+        [InlineData(false, false)]
+        public async Task DurableEntity_RollbackSignalsOnExceptions(bool extendedSessions, bool useClassBasedEntity)
+        {
+            using (var host = TestHelpers.GetJobHost(
+                this.loggerProvider,
+                nameof(this.DurableEntity_RollbackSignalsOnExceptions),
+                extendedSessions,
+                rollbackEntityOperationsOnExceptions: true))
+            {
+                await host.StartAsync();
+                var entityName = useClassBasedEntity ? "ClassBasedFaultyEntity" : "FunctionBasedFaultyEntity";
+                var entityKey = Guid.NewGuid().ToString();
+                var entityId = new EntityId(entityName, entityKey);
+
+                var client = await host.StartOrchestratorAsync(nameof(TestOrchestrations.RollbackSignalsOnExceptions), entityId, this.output);
+                var status = await client.WaitForCompletionAsync(this.output);
+
+                Assert.Equal(OrchestrationRuntimeStatus.Completed, status?.RuntimeStatus);
+                Assert.Equal("ok", status?.Output);
+
+                var receiverEntityId = new EntityId(nameof(TestEntities.SchedulerEntity), entityKey);
+                TestEntityClient receiverClient = await host.GetEntityClientAsync(receiverEntityId, this.output);
+                var timeout = Debugger.IsAttached ? TimeSpan.FromMinutes(5) : TimeSpan.FromSeconds(30);
+                var state = await receiverClient.WaitForEntityState<List<string>>(this.output, timeout, curstate => curstate.Count >= 7 ? null : "expect 11 messages");
+                Assert.Equal(new string[] { "1:56", "2:100", "3:100", "4:10", "5:10", "6:10", "7:11" }, state);
+
+                await host.StopAsync();
+            }
+        }
+
+        /// <summary>
         /// End-to-end test which validates a simple entity scenario which sends a signal
         /// to a relay which forwards it to counter, and polls until the signal is delivered.
         /// </summary>

--- a/test/Common/TestEntityClasses.cs
+++ b/test/Common/TestEntityClasses.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Runtime.Serialization;
 using System.Threading.Tasks;
 using Microsoft.WindowsAzure.Storage.Blob;
 using Newtonsoft.Json;
@@ -50,6 +51,37 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             void Delete();
         }
 
+        public interface IFaultyEntity
+        {
+            Task<int> Get();
+
+            Task<int> GetNumberIncrementsSent();
+
+            Task Set(int value);
+
+            Task SetToUnserializable();
+
+            Task SetToUnDeserializable();
+
+            Task SetThenThrow(int value);
+
+            Task Send(EntityId target);
+
+            Task SendThenThrow(EntityId target);
+
+            Task SendThenMakeUnserializable(EntityId target);
+
+            Task Delete();
+
+            Task DeleteThenThrow();
+
+            Task Throw();
+
+            Task ThrowUnserializable();
+
+            Task ThrowUnDeserializable();
+        }
+
         [FunctionName(nameof(ChatRoom))]
         public static Task ChatRoomFunction([EntityTrigger] IDurableEntityContext context)
         {
@@ -66,6 +98,117 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         public static Task StorageBackedCounterFunction([EntityTrigger] IDurableEntityContext context, [Blob(BlobContainerPath)] CloudBlobContainer blobContainer)
         {
             return context.DispatchAsync<StorageBackedCounter>(blobContainer);
+        }
+
+        [FunctionName("ClassBasedFaultyEntity")]
+        public static Task FaultyEntityFunction([EntityTrigger] IDurableEntityContext context)
+        {
+            // we use an untyped call to test existence without creating the entity
+            if (context.OperationName == "exists")
+            {
+                context.Return(context.HasState);
+                return Task.CompletedTask;
+            }
+            else if (context.OperationName == "deletewithoutreading")
+            {
+                context.DeleteState();
+                return Task.CompletedTask;
+            }
+
+            return context.DispatchAsync<FaultyEntity>();
+        }
+
+        [FunctionName("FunctionBasedFaultyEntity")]
+        public static Task FaultyEntityFunctionWithoutDispatch([EntityTrigger] IDurableEntityContext context)
+        {
+            switch (context.OperationName)
+            {
+                case "exists":
+                    context.Return(context.HasState);
+                    break;
+
+                case "deletewithoutreading":
+                    context.DeleteState();
+                    break;
+
+                case "Get":
+                    if (!context.HasState)
+                    {
+                        context.Return(0);
+                    }
+                    else
+                    {
+                        context.Return(context.GetState<FaultyEntity>().Value);
+                    }
+
+                    break;
+
+                case "GetNumberIncrementsSent":
+                    context.Return(context.GetState<FaultyEntity>().NumberIncrementsSent);
+                    break;
+
+                case "Set":
+                    var state = context.GetState<FaultyEntity>() ?? new FaultyEntity();
+                    state.Value = context.GetInput<int>();
+                    context.SetState(state);
+                    break;
+
+                case "SetToUnserializable":
+                    var state1 = context.GetState<FaultyEntity>() ?? new FaultyEntity();
+                    state1.SetToUnserializable();
+                    context.SetState(state1);
+                    break;
+
+                case "SetToUnDeserializable":
+                    var state2 = context.GetState<FaultyEntity>() ?? new FaultyEntity();
+                    state2.SetToUnDeserializable();
+                    context.SetState(state2);
+                    break;
+
+                case "SetThenThrow":
+                    var state3 = context.GetState<FaultyEntity>() ?? new FaultyEntity();
+                    state3.Value = context.GetInput<int>();
+                    context.SetState(state3);
+                    throw new FaultyEntity.SerializableKaboom();
+
+                case "Send":
+                    var state4 = context.GetState<FaultyEntity>() ?? new FaultyEntity();
+                    state4.Send(context.GetInput<EntityId>());
+                    context.SetState(state4);
+                    return Task.CompletedTask;
+
+                case "SendThenThrow":
+                    var state5 = context.GetState<FaultyEntity>() ?? new FaultyEntity();
+                    state5.Send(context.GetInput<EntityId>());
+                    context.SetState(state5);
+                    throw new FaultyEntity.SerializableKaboom();
+
+                case "SendThenMakeUnserializable":
+                    var state6 = context.GetState<FaultyEntity>() ?? new FaultyEntity();
+                    state6.Send(context.GetInput<EntityId>());
+                    context.SetState(state6);
+                    state6.SetToUnserializable();
+                    return Task.CompletedTask;
+
+                case "Delete":
+                    context.DeleteState();
+                    break;
+
+                case "DeleteThenThrow":
+                    context.DeleteState();
+                    throw new FaultyEntity.SerializableKaboom();
+
+                case "Throw":
+                    throw new FaultyEntity.SerializableKaboom();
+
+                case "ThrowUnserializable":
+                    throw new FaultyEntity.UnserializableKaboom();
+
+                case "ThrowUnDeserializable":
+                    throw new FaultyEntity.UnDeserializableKaboom();
+            }
+
+            return Task.CompletedTask;
         }
 
         //-------------- an entity representing a chat room -----------------
@@ -131,6 +274,177 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             public void Delete()
             {
                 Entity.Current.DeleteState();
+            }
+        }
+
+        //-------------- An entity that throws exceptions -----------------
+
+        [JsonObject(MemberSerialization = MemberSerialization.OptIn)]
+        public class FaultyEntity : IFaultyEntity
+        {
+            [JsonProperty]
+            public int Value { get; set; }
+
+            [JsonProperty]
+            [JsonConverter(typeof(CustomJsonConverter))]
+            public object ObjectWithFaultySerialization { get; set; }
+
+            [JsonProperty]
+            public int NumberIncrementsSent { get; set; }
+
+            public Task<int> Get()
+            {
+                return Task.FromResult(this.Value);
+            }
+
+            public Task<int> GetNumberIncrementsSent()
+            {
+                return Task.FromResult(this.NumberIncrementsSent);
+            }
+
+            public Task Set(int value)
+            {
+                this.Value = value;
+                return Task.CompletedTask;
+            }
+
+            public Task Delete()
+            {
+                Entity.Current.DeleteState();
+                return Task.CompletedTask;
+            }
+
+            public Task SetToUnserializable()
+            {
+                this.ObjectWithFaultySerialization = new UnserializableKaboom();
+                return Task.CompletedTask;
+            }
+
+            public Task SetToUnDeserializable()
+            {
+                this.ObjectWithFaultySerialization = new UnDeserializableKaboom();
+                return Task.CompletedTask;
+            }
+
+            public Task Send(EntityId target)
+            {
+                var desc = $"{++this.NumberIncrementsSent}:{this.Value}";
+                Entity.Current.SignalEntity(target, desc);
+                return Task.CompletedTask;
+            }
+
+            public Task Throw()
+            {
+                this.Throw(true, true);
+                return Task.CompletedTask;
+            }
+
+            public Task ThrowUnserializable()
+            {
+                this.Throw(false, false);
+                return Task.CompletedTask;
+            }
+
+            public Task ThrowUnDeserializable()
+            {
+                this.Throw(true, false);
+                return Task.CompletedTask;
+            }
+
+            public Task SetThenThrow(int value)
+            {
+                this.Value = value;
+                this.Throw(false, false);
+                return Task.CompletedTask;
+            }
+
+            public Task SendThenThrow(EntityId target)
+            {
+                this.Send(target);
+                this.Throw(false, false);
+                return Task.CompletedTask;
+            }
+
+            public Task SendThenMakeUnserializable(EntityId target)
+            {
+                this.Send(target);
+                this.ObjectWithFaultySerialization = new UnserializableKaboom();
+                return Task.CompletedTask;
+            }
+
+            public Task DeleteThenThrow()
+            {
+                Entity.Current.DeleteState();
+                this.Throw(false, false);
+                return Task.CompletedTask;
+            }
+
+            private Task Throw(bool serializable, bool deserializable)
+            {
+                if (serializable)
+                {
+                    if (deserializable)
+                    {
+                        throw new SerializableKaboom();
+                    }
+                    else
+                    {
+                        throw new UnDeserializableKaboom();
+                    }
+                }
+                else
+                {
+                    throw new UnserializableKaboom();
+                }
+            }
+
+            public class CustomJsonConverter : JsonConverter
+            {
+                public override bool CanConvert(Type objectType)
+                {
+                    return objectType == typeof(SerializableKaboom)
+                        || objectType == typeof(UnserializableKaboom)
+                        || objectType == typeof(UnDeserializableKaboom);
+                }
+
+                public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+                {
+                    if (reader.TokenType == JsonToken.Null)
+                    {
+                        return null;
+                    }
+
+                    var typename = serializer.Deserialize<string>(reader);
+
+                    if (typename != nameof(SerializableKaboom))
+                    {
+                        throw new JsonSerializationException("not deserializable");
+                    }
+
+                    return new SerializableKaboom();
+                }
+
+                public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+                {
+                    if (value is UnserializableKaboom)
+                    {
+                        throw new JsonSerializationException("not serializable");
+                    }
+
+                    serializer.Serialize(writer, value.GetType().Name);
+                }
+            }
+
+            public class UnserializableKaboom : Exception
+            {
+            }
+
+            public class SerializableKaboom : Exception
+            {
+            }
+
+            public class UnDeserializableKaboom : Exception
+            {
             }
         }
 

--- a/test/Common/TestHelpers.cs
+++ b/test/Common/TestHelpers.cs
@@ -49,7 +49,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             ILifeCycleNotificationHelper lifeCycleNotificationHelper = null,
             IMessageSerializerSettingsFactory serializerSettings = null,
             bool? localRpcEndpointEnabled = false,
-            DurableTaskOptions options = null)
+            DurableTaskOptions options = null,
+            bool rollbackEntityOperationsOnExceptions = true)
         {
             switch (storageProviderType)
             {
@@ -93,6 +94,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             options.MaxConcurrentActivityFunctions = 200;
             options.NotificationHandler = eventGridNotificationHandler;
             options.LocalRpcEndpointEnabled = localRpcEndpointEnabled;
+            options.RollbackEntityOperationsOnExceptions = rollbackEntityOperationsOnExceptions;
 
             // Azure Storage specfic tests
             if (string.Equals(storageProviderType, AzureStorageProviderType))


### PR DESCRIPTION
This is the feature we discussed in #1223. It is configurable as an option `RollbackEntityStateOnExceptions` which is true by default.

With rollback enabled, exceptions inside entity operations cause the state of the entity to be rolled back to what it was before the operation. This rollback also undoes creation and deletion of state, and discards any signals sent by the operation.  

To make this possible, the entity state is serialized after each individual operation that accesses the state, which makes it possible to restore that state if the next operation fails. If rollback is disabled (which is the previous behavior), the entity state is not serialized after each individual operation, but only after an entire batch of operations completes, which can be faster.

This PR also includes tests for this feature, both for class-based and function-based entities.