### PR TITLE
Abort Durable Task session on Functions runtime failures

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
@@ -463,7 +463,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             }
 
             // 1. Start the functions invocation pipeline (billing, logging, bindings, and timeout tracking).
-            WrappedFunctionResult result = await FunctionExecutionHelper.ExecuteFunctionInOrchestrationMiddleware(
+            WrappedFunctionResult result = await FunctionExecutionHelper.ExecuteFunction(
                 info.Executor,
                 this.hostLifetimeService,
                 new TriggeredFunctionData
@@ -641,7 +641,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             }
 
             // 3. Start the functions invocation pipeline (billing, logging, bindings, and timeout tracking).
-            WrappedFunctionResult result = await FunctionExecutionHelper.ExecuteFunctionInOrchestrationMiddleware(
+            WrappedFunctionResult result = await FunctionExecutionHelper.ExecuteFunction(
                 entityShim.GetFunctionInfo().Executor,
                 this.hostLifetimeService,
                 new TriggeredFunctionData

--- a/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
@@ -62,9 +62,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         private readonly AsyncLock taskHubLock = new AsyncLock();
 
         private readonly bool isOptionsConfigured;
+        private readonly IApplicationLifetimeWrapper hostLifetimeService = HostLifecycleService.NoOp;
+
         private IDurabilityProviderFactory durabilityProviderFactory;
         private INameResolver nameResolver;
-        private IApplicationLifetimeWrapper hostLifetimeService;
         private DurabilityProvider defaultDurabilityProvider;
         private TaskHubWorker taskHubWorker;
         private bool isTaskHubWorkerStarted;
@@ -139,14 +140,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
             this.HttpApiHandler = new HttpApiHandler(this, logger);
 
-#if !FUNCTIONS_V1
             this.hostLifetimeService = hostLifetimeService;
 
+#if !FUNCTIONS_V1
             // The RPC server is started when the extension is initialized.
             // The RPC server is stopped when the host has finished shutting down.
             this.hostLifetimeService.OnStopped.Register(this.StopLocalRcpServer);
-#else
-            this.hostLifetimeService = HostLifecycleService.NoOp;
 #endif
         }
 

--- a/src/WebJobs.Extensions.DurableTask/DurableTaskJobHostConfigurationExtensions.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskJobHostConfigurationExtensions.cs
@@ -118,23 +118,5 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             extensions.RegisterExtension<IExtensionConfigProvider>(listenerConfig);
         }
 #endif
-
-#if !FUNCTIONS_V1
-        private class HostLifecycleService : IApplicationLifetimeWrapper
-        {
-            private readonly IApplicationLifetime appLifetime;
-
-            public HostLifecycleService(IApplicationLifetime appLifetime)
-            {
-                this.appLifetime = appLifetime ?? throw new ArgumentNullException(nameof(appLifetime));
-            }
-
-            public CancellationToken OnStarted => this.appLifetime.ApplicationStarted;
-
-            public CancellationToken OnStopping => this.appLifetime.ApplicationStopping;
-
-            public CancellationToken OnStopped => this.appLifetime.ApplicationStopped;
-        }
-#endif
     }
 }

--- a/src/WebJobs.Extensions.DurableTask/HostLifecycleService.cs
+++ b/src/WebJobs.Extensions.DurableTask/HostLifecycleService.cs
@@ -9,9 +9,9 @@ using Microsoft.Extensions.Hosting;
 
 namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 {
+#if !FUNCTIONS_V1
     internal class HostLifecycleService : IApplicationLifetimeWrapper
     {
-#if !FUNCTIONS_V1
         private readonly IApplicationLifetime appLifetime;
 
         public HostLifecycleService(IApplicationLifetime appLifetime)
@@ -24,16 +24,20 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         public CancellationToken OnStopping => this.appLifetime.ApplicationStopping;
 
         public CancellationToken OnStopped => this.appLifetime.ApplicationStopped;
-#else
-        private readonly CancellationToken startedToken = CancellationToken.None;
-        private readonly CancellationToken stoppingToken = CancellationToken.None;
-        private readonly CancellationToken stoppedToken = CancellationToken.None;
-
-        public CancellationToken OnStarted => this.startedToken;
-
-        public CancellationToken OnStopping => this.stoppingToken;
-
-        public CancellationToken OnStopped => this.stoppedToken;
-#endif
     }
+#else
+    internal class HostLifecycleService
+    {
+        internal static readonly IApplicationLifetimeWrapper NoOp = new NoOpLifetimeWrapper();
+
+        private class NoOpLifetimeWrapper : IApplicationLifetimeWrapper
+        {
+            public CancellationToken OnStarted => CancellationToken.None;
+
+            public CancellationToken OnStopping => CancellationToken.None;
+
+            public CancellationToken OnStopped => CancellationToken.None;
+        }
+    }
+#endif
 }

--- a/src/WebJobs.Extensions.DurableTask/HostLifecycleService.cs
+++ b/src/WebJobs.Extensions.DurableTask/HostLifecycleService.cs
@@ -11,7 +11,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 {
 #if !FUNCTIONS_V1
     internal class HostLifecycleService : IApplicationLifetimeWrapper
+#else
+    internal class HostLifecycleService
+#endif
     {
+        internal static readonly IApplicationLifetimeWrapper NoOp = new NoOpLifetimeWrapper();
+#if !FUNCTIONS_V1
         private readonly IApplicationLifetime appLifetime;
 
         public HostLifecycleService(IApplicationLifetime appLifetime)
@@ -24,11 +29,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         public CancellationToken OnStopping => this.appLifetime.ApplicationStopping;
 
         public CancellationToken OnStopped => this.appLifetime.ApplicationStopped;
-    }
-#else
-    internal class HostLifecycleService
-    {
-        internal static readonly IApplicationLifetimeWrapper NoOp = new NoOpLifetimeWrapper();
+#endif
 
         private class NoOpLifetimeWrapper : IApplicationLifetimeWrapper
         {
@@ -39,5 +40,4 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             public CancellationToken OnStopped => CancellationToken.None;
         }
     }
-#endif
 }

--- a/src/WebJobs.Extensions.DurableTask/HostLifecycleService.cs
+++ b/src/WebJobs.Extensions.DurableTask/HostLifecycleService.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+using System.Threading;
+#if !FUNCTIONS_V1
+using Microsoft.Extensions.Hosting;
+#endif
+
+namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
+{
+    internal class HostLifecycleService : IApplicationLifetimeWrapper
+    {
+#if !FUNCTIONS_V1
+        private readonly IApplicationLifetime appLifetime;
+
+        public HostLifecycleService(IApplicationLifetime appLifetime)
+        {
+            this.appLifetime = appLifetime ?? throw new ArgumentNullException(nameof(appLifetime));
+        }
+
+        public CancellationToken OnStarted => this.appLifetime.ApplicationStarted;
+
+        public CancellationToken OnStopping => this.appLifetime.ApplicationStopping;
+
+        public CancellationToken OnStopped => this.appLifetime.ApplicationStopped;
+#else
+        private readonly CancellationToken startedToken = CancellationToken.None;
+        private readonly CancellationToken stoppingToken = CancellationToken.None;
+        private readonly CancellationToken stoppedToken = CancellationToken.None;
+
+        public CancellationToken OnStarted => this.startedToken;
+
+        public CancellationToken OnStopping => this.stoppingToken;
+
+        public CancellationToken OnStopped => this.stoppedToken;
+#endif
+    }
+}

--- a/src/WebJobs.Extensions.DurableTask/Listener/FunctionExecutionHelper.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/FunctionExecutionHelper.cs
@@ -12,7 +12,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Listener
     {
         public static async Task<WrappedFunctionResult> ExecuteFunctionInOrchestrationMiddleware(
             ITriggeredFunctionExecutor executor,
-            IApplicationLifetimeWrapper hostServiceLifetime,
             TriggeredFunctionData triggerInput,
             CancellationToken cancellationToken)
         {
@@ -30,10 +29,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Listener
                 {
                     TriggerValue = triggerInput.TriggerValue,
                     ParentId = triggerInput.ParentId,
-                    InvokeHandler = async userCodeHandler =>
+                    InvokeHandler = userCodeHandler =>
                     {
                         executedUserCode = true;
-                        await triggerInput.InvokeHandler(userCodeHandler);
+                        return triggerInput.InvokeHandler(userCodeHandler);
                     },
 #if !FUNCTIONS_V1
                     TriggerDetails = triggerInput.TriggerDetails,
@@ -42,103 +41,67 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Listener
 #pragma warning restore CS0618
 
                 FunctionResult result = await executor.TryExecuteAsync(triggerInput, cancellationToken);
-                if (!result.Succeeded)
+
+                if (result.Succeeded)
                 {
-                    if (!executedUserCode &&
-                         IsHostStopping(hostServiceLifetime))
-                    {
-                        return new WrappedFunctionResult(
-                            WrappedFunctionResult.FunctionResultStatus.FunctionsRuntimeError,
-                            result.Exception);
-                    }
-                    else
-                    {
-                        return new WrappedFunctionResult(
-                            WrappedFunctionResult.FunctionResultStatus.UserCodeError,
-                            result.Exception);
-                    }
+                    return WrappedFunctionResult.Success();
                 }
-                else
+
+                if (cancellationToken.IsCancellationRequested)
                 {
-                    return new WrappedFunctionResult(
-                        WrappedFunctionResult.FunctionResultStatus.Success,
-                        null);
+                    return WrappedFunctionResult.FunctionRuntimeFailure(result.Exception);
                 }
+
+                if (!executedUserCode)
+                {
+                    WrappedFunctionResult.UserCodeFailure(new InvalidOperationException(
+                         "The function failed to start executing. " +
+                         "For .NET functions, this can happen if an unhandled exception is thrown in the function's class constructor."));
+                }
+
+                return WrappedFunctionResult.UserCodeFailure(result.Exception);
+
             }
             catch (Exception e)
             {
-                return new WrappedFunctionResult(
-                     WrappedFunctionResult.FunctionResultStatus.FunctionsRuntimeError,
-                     e);
+                return WrappedFunctionResult.FunctionRuntimeFailure(e);
             }
         }
 
-        public static async Task<WrappedFunctionResult> ExecuteFunction(
+        public static async Task<WrappedFunctionResult> ExecuteActivityFunction(
             ITriggeredFunctionExecutor executor,
-            IApplicationLifetimeWrapper hostServiceLifetime,
             TriggeredFunctionData triggerInput,
             CancellationToken cancellationToken)
         {
 #pragma warning disable CS0618 // InvokeHandler approved for use by this extension
-            //if (triggerInput.InvokeHandler != null)
-            //{
-            //    // Activity functions cannot use InvokeHandler, because the usage of InvokeHandler prevents the function from
-            //    // returning a value in the way that the Activity shim knows how to handle.
-            //    throw new ArgumentException(
-            //        $"{nameof(ExecuteFunction)} cannot be used when ${nameof(triggerInput)} has a value for ${nameof(TriggeredFunctionData.InvokeHandler)}");
-            //}
+            if (triggerInput.InvokeHandler != null)
+            {
+                // Activity functions cannot use InvokeHandler, because the usage of InvokeHandler prevents the function from
+                // returning a value in the way that the Activity shim knows how to handle.
+                throw new ArgumentException(
+                    $"{nameof(ExecuteActivityFunction)} cannot be used when ${nameof(triggerInput)} has a value for ${nameof(TriggeredFunctionData.InvokeHandler)}");
+            }
 #pragma warning restore CS0618
 
             try
             {
                 FunctionResult result = await executor.TryExecuteAsync(triggerInput, cancellationToken);
+                if (result.Succeeded)
+                {
+                    return WrappedFunctionResult.Success();
+                }
 
-                if (!result.Succeeded)
+                if (cancellationToken.IsCancellationRequested)
                 {
-                    // This is a best effort approach to determine if this is caused by an exception in
-                    // the webjobs pipeline. False positives are alright, as we still only
-                    // will abort the session when the host is performing a shutdown,
-                    // so it will just fail normally on the second execution.
-                    if (IsHostStopping(hostServiceLifetime) &&
-                        IsHostRelatedException(result.Exception))
-                    {
-                        return new WrappedFunctionResult(
-                             WrappedFunctionResult.FunctionResultStatus.FunctionsRuntimeError,
-                             result.Exception);
-                    }
-                    else
-                    {
-                        return new WrappedFunctionResult(
-                            WrappedFunctionResult.FunctionResultStatus.UserCodeError,
-                            result.Exception);
-                    }
+                    return WrappedFunctionResult.FunctionRuntimeFailure(result.Exception);
                 }
-                else
-                {
-                    return new WrappedFunctionResult(WrappedFunctionResult.FunctionResultStatus.Success, null);
-                }
+
+                return WrappedFunctionResult.UserCodeFailure(result.Exception);
             }
             catch (Exception e)
             {
-                return new WrappedFunctionResult(
-                     WrappedFunctionResult.FunctionResultStatus.FunctionsRuntimeError,
-                     e);
+                return WrappedFunctionResult.FunctionRuntimeFailure(e);
             }
-        }
-
-        private static bool IsHostRelatedException(Exception ex)
-        {
-            // We look at any exception thrown in the Microsoft.Azure.WebJobs namespace that is not
-            // an exception thrown by us, as we know there are many reasons that we could
-            // throw an exception that are unrelated to host shutdown.
-            return ex.Source.StartsWith("Microsoft.Azure.WebJobs") &&
-                !ex.Source.StartsWith("Microsoft.Azure.WebJobs.Extensions.DurableTask");
-        }
-
-        private static bool IsHostStopping(IApplicationLifetimeWrapper hostServiceLifetime)
-        {
-            return hostServiceLifetime.OnStopped.IsCancellationRequested
-                || hostServiceLifetime.OnStopping.IsCancellationRequested;
         }
     }
 }

--- a/src/WebJobs.Extensions.DurableTask/Listener/FunctionExecutionHelper.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/FunctionExecutionHelper.cs
@@ -60,7 +60,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Listener
                 }
 
                 return WrappedFunctionResult.UserCodeFailure(result.Exception);
-
             }
             catch (Exception e)
             {

--- a/src/WebJobs.Extensions.DurableTask/Listener/FunctionExecutionHelper.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/FunctionExecutionHelper.cs
@@ -1,0 +1,140 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Host.Executors;
+
+namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Listener
+{
+    internal static class FunctionExecutionHelper
+    {
+        public static async Task<WrappedFunctionResult> ExecuteFunctionInOrchestrationMiddleware(
+            ITriggeredFunctionExecutor executor,
+            IApplicationLifetimeWrapper hostServiceLifetime,
+            TriggeredFunctionData triggerInput,
+            CancellationToken cancellationToken)
+        {
+#pragma warning disable CS0618 // InvokeHandler approved for use by this extension
+            if (triggerInput.InvokeHandler == null)
+            {
+                throw new ArgumentException(
+                    $"{nameof(ExecuteFunctionInOrchestrationMiddleware)} should only be used when ${nameof(triggerInput)} has a value for ${nameof(TriggeredFunctionData.InvokeHandler)}");
+            }
+
+            try
+            {
+                bool executedUserCode = false;
+                var triggeredFunctionData = new TriggeredFunctionData()
+                {
+                    TriggerValue = triggerInput.TriggerValue,
+                    ParentId = triggerInput.ParentId,
+                    InvokeHandler = async userCodeHandler =>
+                    {
+                        executedUserCode = true;
+                        await triggerInput.InvokeHandler(userCodeHandler);
+                    },
+#if !FUNCTIONS_V1
+                    TriggerDetails = triggerInput.TriggerDetails,
+#endif
+                };
+#pragma warning restore CS0618
+
+                FunctionResult result = await executor.TryExecuteAsync(triggerInput, cancellationToken);
+                if (!result.Succeeded)
+                {
+                    if (!executedUserCode &&
+                         IsHostStopping(hostServiceLifetime))
+                    {
+                        return new WrappedFunctionResult(
+                            WrappedFunctionResult.FunctionResultStatus.FunctionsRuntimeError,
+                            result.Exception);
+                    }
+                    else
+                    {
+                        return new WrappedFunctionResult(
+                            WrappedFunctionResult.FunctionResultStatus.UserCodeError,
+                            result.Exception);
+                    }
+                }
+                else
+                {
+                    return new WrappedFunctionResult(
+                        WrappedFunctionResult.FunctionResultStatus.Success,
+                        null);
+                }
+            }
+            catch (Exception e)
+            {
+                return new WrappedFunctionResult(
+                     WrappedFunctionResult.FunctionResultStatus.FunctionsRuntimeError,
+                     e);
+            }
+        }
+
+        public static async Task<WrappedFunctionResult> ExecuteActivityFunction(
+            ITriggeredFunctionExecutor executor,
+            IApplicationLifetimeWrapper hostServiceLifetime,
+            TriggeredFunctionData triggerInput,
+            CancellationToken cancellationToken)
+        {
+#pragma warning disable CS0618 // InvokeHandler approved for use by this extension
+            if (triggerInput.InvokeHandler != null)
+            {
+                // Activity functions cannot use InvokeHandler, because the usage of InvokeHandler prevents the function from
+                // returning a value in the way that the Activity shim knows how to handle.
+                throw new ArgumentException(
+                    $"{nameof(ExecuteActivityFunction)} cannot be used when ${nameof(triggerInput)} has a value for ${nameof(TriggeredFunctionData.InvokeHandler)}");
+            }
+#pragma warning restore CS0618
+
+            try
+            {
+                FunctionResult result = await executor.TryExecuteAsync(triggerInput, cancellationToken);
+
+                if (!result.Succeeded)
+                {
+                    // Unfortunately, unlike with orchestrations and entities, we have no way
+                    // to know if we hit user code or not. Therefore we need to look at the exception
+                    // thrown by TryExecuteAsync to see if it is related to the host shutdown or not.
+                    if (IsHostStopping(hostServiceLifetime) &&
+                        IsHostShutdownRelatedException(result.Exception))
+                    {
+                        return new WrappedFunctionResult(
+                             WrappedFunctionResult.FunctionResultStatus.FunctionsRuntimeError,
+                             result.Exception);
+                    }
+                    else
+                    {
+                        return new WrappedFunctionResult(
+                            WrappedFunctionResult.FunctionResultStatus.UserCodeError,
+                            result.Exception)
+                    }
+                } else
+                {
+                    return new WrappedFunctionResult(WrappedFunctionResult.FunctionResultStatus.Success, null);
+                }
+            } 
+            catch (Exception e)
+            {
+                return new WrappedFunctionResult(
+                     WrappedFunctionResult.FunctionResultStatus.FunctionsRuntimeError,
+                     e);
+            }
+        }
+
+        private static bool IsHostShutdownRelatedException(Exception ex)
+        {
+            // Currently, we don't have much knowledge of what exceptions are caused by host shutdown.
+            // As we encounter more exceptions due to host shutdowns, we can add conditions here.
+            return false;
+        }
+
+        private static bool IsHostStopping(IApplicationLifetimeWrapper hostServiceLifetime)
+        {
+            return hostServiceLifetime.OnStopped.IsCancellationRequested
+                || hostServiceLifetime.OnStopping.IsCancellationRequested;
+        }
+    }
+}

--- a/src/WebJobs.Extensions.DurableTask/Listener/FunctionExecutionHelper.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/FunctionExecutionHelper.cs
@@ -109,7 +109,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Listener
                     {
                         return new WrappedFunctionResult(
                             WrappedFunctionResult.FunctionResultStatus.UserCodeError,
-                            result.Exception)
+                            result.Exception);
                     }
                 } else
                 {

--- a/src/WebJobs.Extensions.DurableTask/Listener/FunctionExecutionHelper.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/FunctionExecutionHelper.cs
@@ -111,11 +111,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Listener
                             WrappedFunctionResult.FunctionResultStatus.UserCodeError,
                             result.Exception);
                     }
-                } else
+                }
+                else
                 {
                     return new WrappedFunctionResult(WrappedFunctionResult.FunctionResultStatus.Success, null);
                 }
-            } 
+            }
             catch (Exception e)
             {
                 return new WrappedFunctionResult(

--- a/src/WebJobs.Extensions.DurableTask/Listener/TaskActivityShim.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/TaskActivityShim.cs
@@ -58,11 +58,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 functionType: FunctionType.Activity,
                 isReplay: false);
 
-            WrappedFunctionResult result = await FunctionExecutionHelper.ExecuteFunction(
+            WrappedFunctionResult result = await FunctionExecutionHelper.ExecuteActivityFunction(
                 this.executor,
-                this.hostServiceLifetime,
                 triggerInput,
-                CancellationToken.None);
+                this.hostServiceLifetime.OnStopping);
 
             switch (result.ExecutionStatus)
             {

--- a/src/WebJobs.Extensions.DurableTask/Listener/TaskActivityShim.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/TaskActivityShim.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 functionType: FunctionType.Activity,
                 isReplay: false);
 
-            WrappedFunctionResult result = await FunctionExecutionHelper.ExecuteActivityFunction(
+            WrappedFunctionResult result = await FunctionExecutionHelper.ExecuteFunction(
                 this.executor,
                 this.hostServiceLifetime,
                 triggerInput,

--- a/src/WebJobs.Extensions.DurableTask/Listener/WrappedFunctionResult.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/WrappedFunctionResult.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Listener
 {
     internal class WrappedFunctionResult
     {
-        internal WrappedFunctionResult(
+        private WrappedFunctionResult(
             FunctionResultStatus status,
             Exception ex)
         {
@@ -25,5 +25,20 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Listener
         internal Exception Exception { get; }
 
         internal FunctionResultStatus ExecutionStatus { get; }
+
+        public static WrappedFunctionResult Success()
+        {
+            return new WrappedFunctionResult(FunctionResultStatus.Success, null);
+        }
+
+        public static WrappedFunctionResult FunctionRuntimeFailure(Exception ex)
+        {
+            return new WrappedFunctionResult(FunctionResultStatus.FunctionsRuntimeError, ex);
+        }
+
+        public static WrappedFunctionResult UserCodeFailure(Exception ex)
+        {
+            return new WrappedFunctionResult(FunctionResultStatus.UserCodeError, ex);
+        }
     }
 }

--- a/src/WebJobs.Extensions.DurableTask/Listener/WrappedFunctionResult.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/WrappedFunctionResult.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+
+namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Listener
+{
+    internal class WrappedFunctionResult
+    {
+        internal WrappedFunctionResult(
+            FunctionResultStatus status,
+            Exception ex)
+        {
+            this.Exception = ex;
+            this.ExecutionStatus = status;
+        }
+
+        internal enum FunctionResultStatus
+        {
+            Success = 0,
+            UserCodeError = 1,
+            FunctionsRuntimeError = 2,
+        }
+
+        internal Exception Exception { get; }
+
+        internal FunctionResultStatus ExecutionStatus { get; }
+    }
+}

--- a/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
+++ b/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
@@ -7,7 +7,7 @@
     <MajorVersion>2</MajorVersion>
     <MinorVersion>2</MinorVersion>
     <PatchVersion>0</PatchVersion>
-    <Version>$(MajorVersion).$(MinorVersion).$(PatchVersion)-test8</Version>
+    <Version>$(MajorVersion).$(MinorVersion).$(PatchVersion)</Version>
     <FileVersion>$(MajorVersion).$(MinorVersion).$(PatchVersion)</FileVersion>
     <AssemblyVersion>$(MajorVersion).0.0.0</AssemblyVersion>
     <Company>Microsoft Corporation</Company>

--- a/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
+++ b/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
@@ -7,7 +7,7 @@
     <MajorVersion>2</MajorVersion>
     <MinorVersion>2</MinorVersion>
     <PatchVersion>0</PatchVersion>
-    <Version>$(MajorVersion).$(MinorVersion).$(PatchVersion)</Version>
+    <Version>$(MajorVersion).$(MinorVersion).$(PatchVersion)-test8</Version>
     <FileVersion>$(MajorVersion).$(MinorVersion).$(PatchVersion)</FileVersion>
     <AssemblyVersion>$(MajorVersion).0.0.0</AssemblyVersion>
     <Company>Microsoft Corporation</Company>

--- a/test/Common/TestHostShutdownNotificationService.cs
+++ b/test/Common/TestHostShutdownNotificationService.cs
@@ -12,9 +12,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
         public CancellationToken OnStopped => this.cts.Token;
 
-        public CancellationToken OnStarted => throw new NotImplementedException();
+        public CancellationToken OnStarted => this.cts.Token;
 
-        public CancellationToken OnStopping => throw new NotImplementedException();
+        public CancellationToken OnStopping => this.cts.Token;
 
         public void SignalShutdown() => this.cts.Cancel();
     }


### PR DESCRIPTION
When the Functions JobHost is shutting down, there are often exceptions
occuring in the function execution pipeline unrelated to customer code.
This can lead to cases where the orchestration fails unecessarily, or
in some cases where the exception is largely swallowed, can lead to
orchestrations stuck in an eternally pending state.

We now utilize common logic to try to differentiate between actual user
code failures, and when the failures come from the function pipeline. In
the case where it is a failure in the functions pipeline, we abort the
session, so that Durable Task will try again later.

Resolves #1081