### PR TITLE
Roslyn Analyzer: Comparing function names which use `nameof()`

### DIFF
--- a/src/WebJobs.Extensions.DurableTask.Analyzers/Analyzers/ActivityFunction/FunctionAnalyzer.cs
+++ b/src/WebJobs.Extensions.DurableTask.Analyzers/Analyzers/ActivityFunction/FunctionAnalyzer.cs
@@ -70,7 +70,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
 
                 calledFunctions.Add(new ActivityFunctionCall
                 {
-                    Name = functionNameNode.ToString().Trim('"'),
+                    Name = functionNameNode.ToString().GetCleanedFunctionName(),
                     NameNode = functionNameNode,
                     ParameterNode = inputNode,
                     ReturnTypeNode = returnTypeNode,

--- a/src/WebJobs.Extensions.DurableTask.Analyzers/Analyzers/ActivityFunction/NameAnalyzer.cs
+++ b/src/WebJobs.Extensions.DurableTask.Analyzers/Analyzers/ActivityFunction/NameAnalyzer.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
         {
             foreach (var activityInvocation in calledFunctions)
             {
-                if (!availableFunctions.Select(x => GetCleanedFunctionName(x.FunctionName)).Contains(GetCleanedFunctionName(activityInvocation.Name)))
+                if (!availableFunctions.Select(x => x.FunctionName).Contains(activityInvocation.Name))
                 {
                     if (SyntaxNodeUtils.TryGetClosestString(activityInvocation.Name, availableFunctions.Select(x => x.FunctionName), out string closestName))
                     {
@@ -50,18 +50,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
                     }
                 }
             }
-        }
-
-        private static string GetCleanedFunctionName(string functionName)
-        {
-            const string nameofStart = "nameof(";
-            const string nameofEnd = ")";
-            if (functionName.StartsWith(nameofStart) && functionName.EndsWith(nameofEnd))
-            {
-                functionName = functionName.Substring(nameofStart.Length, functionName.Length - nameofStart.Length - nameofEnd.Length);
-            }
-
-            return functionName;
         }
     }
 }

--- a/src/WebJobs.Extensions.DurableTask.Analyzers/Analyzers/ActivityFunction/NameAnalyzer.cs
+++ b/src/WebJobs.Extensions.DurableTask.Analyzers/Analyzers/ActivityFunction/NameAnalyzer.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
         {
             foreach (var activityInvocation in calledFunctions)
             {
-                if (!availableFunctions.Select(x => x.FunctionName).Contains(activityInvocation.Name))
+                if (!availableFunctions.Select(x => GetCleanedFunctionName(x.FunctionName)).Contains(GetCleanedFunctionName(activityInvocation.Name)))
                 {
                     if (SyntaxNodeUtils.TryGetClosestString(activityInvocation.Name, availableFunctions.Select(x => x.FunctionName), out string closestName))
                     {
@@ -50,6 +50,18 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
                     }
                 }
             }
+        }
+
+        private static string GetCleanedFunctionName(string functionName)
+        {
+            const string nameofStart = "nameof(";
+            const string nameofEnd = ")";
+            if (functionName.StartsWith(nameofStart) && functionName.EndsWith(nameofEnd))
+            {
+                functionName = functionName.Substring(nameofStart.Length, functionName.Length - nameofStart.Length - nameofEnd.Length);
+            }
+
+            return functionName;
         }
     }
 }

--- a/src/WebJobs.Extensions.DurableTask.Analyzers/StringExtension.cs
+++ b/src/WebJobs.Extensions.DurableTask.Analyzers/StringExtension.cs
@@ -36,5 +36,21 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
             }
             return d[baseLength, comparisonLength];
         }
+
+        public static string GetCleanedFunctionName(this string functionName)
+        {
+            const string nameofStart = "nameof(";
+            const string nameofEnd = ")";
+            if (functionName.StartsWith(nameofStart) && functionName.EndsWith(nameofEnd))
+            {
+                functionName = functionName.Substring(nameofStart.Length, functionName.Length - nameofStart.Length - nameofEnd.Length);
+            }
+            else
+            {
+                functionName = functionName.Trim('"');
+            }
+
+            return functionName;
+        }
     }
 }

--- a/test/WebJobs.Extensions.DurableTask.Analyzers.Test/ActivityFunction/NameAnalyzerTests.cs
+++ b/test/WebJobs.Extensions.DurableTask.Analyzers.Test/ActivityFunction/NameAnalyzerTests.cs
@@ -53,12 +53,12 @@ namespace VSSample
                 var outputs = new List<string>();
 
                 // Matching names
-                outputs.Add(await context.CallActivityAsync<string>(""E1_SayHello"", ""Tokyo""));
-                outputs.Add(await context.CallActivityAsync<string>(""E1_SayHello_DirectInput"", ""London""));
-                outputs.Add(await context.CallActivityAsync<string>(""E1_SayHello_Object"", new Object()));
-                outputs.Add(await context.CallActivityAsync<string>(""E1_SayHello_Object_DirectInput"", new Object()));
-                outputs.Add(await context.CallActivityAsync<string>(""E1_SayHello_Tuple"", (""Seattle"", 4)));
-                outputs.Add(await context.CallActivityAsync<string>(""E1_SayHello_Tuple_OnContext"", (""Seattle"", 4)));
+                //outputs.Add(await context.CallActivityAsync<string>(""E1_SayHello"", ""Tokyo""));
+                //outputs.Add(await context.CallActivityAsync<string>(""E1_SayHello_DirectInput"", ""London""));
+                //outputs.Add(await context.CallActivityAsync<string>(""E1_SayHello_Object"", new Object()));
+                //outputs.Add(await context.CallActivityAsync<string>(""E1_SayHello_Object_DirectInput"", new Object()));
+                //outputs.Add(await context.CallActivityAsync<string>(""E1_SayHello_Tuple"", (""Seattle"", 4)));
+                //outputs.Add(await context.CallActivityAsync<string>(""E1_SayHello_Tuple_OnContext"", (""Seattle"", 4)));
                 outputs.Add(await context.CallActivityAsync<string>(nameof(SayHelloByClassName), ""Amsterdam""));
                 outputs.Add(await context.CallActivityAsync<string>(""SayHelloByMethodName"", ""Amsterdam""));
                 outputs.Add(await context.CallActivityAsync<string>(nameof(SayHelloByMethodName), ""Amsterdam""));
@@ -168,6 +168,60 @@ namespace VSSample
             {
                 Id = DiagnosticId,
                 Message = string.Format(Resources.ActivityNameAnalyzerCloseMessageFormat, "E1_SayHey", "E1_SayHello"),
+                Severity = Severity,
+                Locations =
+                 new[] {
+                            new DiagnosticResultLocation("Test0.cs", 23, 69)
+                     }
+            };
+            VerifyCSharpDiagnostic(test, expectedDiagnostics);
+        }
+
+        [TestMethod]
+        public void Name_InvalidFunctionName_NameOfClassDoesNotMatchFunctionName()
+        {
+            var test = @"
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Extensions.DurableTask;
+using Microsoft.WindowsAzure.Storage.Blob;
+using Microsoft.WindowsAzure.Storage.Queue;
+using Microsoft.WindowsAzure.Storage.Table;
+
+namespace VSSample
+{
+    public class HelloSequence
+    {
+        [FunctionName(""E1_HelloSequence"")]
+        public async Task<List<string>> Run(
+            [OrchestrationTrigger] IDurableOrchestrationContext context)
+            {
+                var outputs = new List<string>();
+
+                outputs.Add(await context.CallActivityAsync<string>(nameof(SayHello), 4));
+            
+                return outputs;
+            }
+    }
+
+    public class SayHello
+    {
+        [FunctionName(""SayHi"")]
+        public string Run([ActivityTrigger] IDurableActivityContext context)
+        {
+            string name = context.GetInput<string>();
+            return $""Hello {name}!"";
+        }
+    }
+}";
+            var expectedDiagnostics = new DiagnosticResult
+            {
+                Id = DiagnosticId,
+                Message = string.Format(Resources.ActivityNameAnalyzerCloseMessageFormat, "SayHello", "SayHi"),
                 Severity = Severity,
                 Locations =
                  new[] {

--- a/test/WebJobs.Extensions.DurableTask.Analyzers.Test/ActivityFunction/NameAnalyzerTests.cs
+++ b/test/WebJobs.Extensions.DurableTask.Analyzers.Test/ActivityFunction/NameAnalyzerTests.cs
@@ -59,7 +59,10 @@ namespace VSSample
                 outputs.Add(await context.CallActivityAsync<string>(""E1_SayHello_Object_DirectInput"", new Object()));
                 outputs.Add(await context.CallActivityAsync<string>(""E1_SayHello_Tuple"", (""Seattle"", 4)));
                 outputs.Add(await context.CallActivityAsync<string>(""E1_SayHello_Tuple_OnContext"", (""Seattle"", 4)));
-            
+                outputs.Add(await context.CallActivityAsync<string>(nameof(SayHelloByClassName), ""Amsterdam""));
+                outputs.Add(await context.CallActivityAsync<string>(""SayHelloByMethodName"", ""Amsterdam""));
+                outputs.Add(await context.CallActivityAsync<string>(nameof(SayHelloByMethodName), ""Amsterdam""));
+
                 return outputs;
             }
 
@@ -100,6 +103,23 @@ namespace VSSample
         public static string SayHelloTupleOnContext([ActivityTrigger] IDurableActivityContext context)
         {
             string name = context.GetInput<(string, int)>();
+            return $""Hello {name}!"";
+        }
+
+        [FunctionName(nameof(SayHelloByMethodName))]
+        public static string SayHelloByMethodName([ActivityTrigger] IDurableActivityContext context)
+        {
+            string name = context.GetInput<string>();
+            return $""Hello {name}!"";
+        }
+    }
+
+    public class SayHelloByClassName
+    {
+        [FunctionName(nameof(SayHelloByClassName))]
+        public string Run([ActivityTrigger] IDurableActivityContext context)
+        {
+            string name = context.GetInput<string>();
             return $""Hello {name}!"";
         }
     }

--- a/test/WebJobs.Extensions.DurableTask.Analyzers.Test/ActivityFunction/NameAnalyzerTests.cs
+++ b/test/WebJobs.Extensions.DurableTask.Analyzers.Test/ActivityFunction/NameAnalyzerTests.cs
@@ -53,12 +53,12 @@ namespace VSSample
                 var outputs = new List<string>();
 
                 // Matching names
-                //outputs.Add(await context.CallActivityAsync<string>(""E1_SayHello"", ""Tokyo""));
-                //outputs.Add(await context.CallActivityAsync<string>(""E1_SayHello_DirectInput"", ""London""));
-                //outputs.Add(await context.CallActivityAsync<string>(""E1_SayHello_Object"", new Object()));
-                //outputs.Add(await context.CallActivityAsync<string>(""E1_SayHello_Object_DirectInput"", new Object()));
-                //outputs.Add(await context.CallActivityAsync<string>(""E1_SayHello_Tuple"", (""Seattle"", 4)));
-                //outputs.Add(await context.CallActivityAsync<string>(""E1_SayHello_Tuple_OnContext"", (""Seattle"", 4)));
+                outputs.Add(await context.CallActivityAsync<string>(""E1_SayHello"", ""Tokyo""));
+                outputs.Add(await context.CallActivityAsync<string>(""E1_SayHello_DirectInput"", ""London""));
+                outputs.Add(await context.CallActivityAsync<string>(""E1_SayHello_Object"", new Object()));
+                outputs.Add(await context.CallActivityAsync<string>(""E1_SayHello_Object_DirectInput"", new Object()));
+                outputs.Add(await context.CallActivityAsync<string>(""E1_SayHello_Tuple"", (""Seattle"", 4)));
+                outputs.Add(await context.CallActivityAsync<string>(""E1_SayHello_Tuple_OnContext"", (""Seattle"", 4)));
                 outputs.Add(await context.CallActivityAsync<string>(nameof(SayHelloByClassName), ""Amsterdam""));
                 outputs.Add(await context.CallActivityAsync<string>(""SayHelloByMethodName"", ""Amsterdam""));
                 outputs.Add(await context.CallActivityAsync<string>(nameof(SayHelloByMethodName), ""Amsterdam""));


### PR DESCRIPTION
I got DF0109 warnings when I used `nameof(ActivityFunctionX)` in my `CallActivityAsync` calls. The analyzer tries to compare `"nameof(ActivityFunctionX)"` with `"ActivityFunctionX"`, which fails.

I therefore made a small change to the NameAnalyzer.cs so it compares function names regardless of `nameof()` usage in either the `FunctionNameAttribute` or the `CallActivityAsync` method. I've extended the `Name_NonIssueCalls` unittest with 3 test cases.