### PR TITLE
Allows out-of-proc Orchestration to SignalEntity

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableOrchestrationContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableOrchestrationContext.cs
@@ -370,7 +370,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             {
                 throw new ArgumentNullException(nameof(retryOptions));
             }
-            
             return this.CallDurableTaskFunctionAsync<TResult>(functionName, FunctionType.Activity, false, null, null, retryOptions, input, null);
         }
 

--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableOrchestrationContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableOrchestrationContext.cs
@@ -370,6 +370,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             {
                 throw new ArgumentNullException(nameof(retryOptions));
             }
+
             return this.CallDurableTaskFunctionAsync<TResult>(functionName, FunctionType.Activity, false, null, null, retryOptions, input, null);
         }
 

--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableOrchestrationContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableOrchestrationContext.cs
@@ -370,7 +370,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             {
                 throw new ArgumentNullException(nameof(retryOptions));
             }
-
+            
             return this.CallDurableTaskFunctionAsync<TResult>(functionName, FunctionType.Activity, false, null, null, retryOptions, input, null);
         }
 

--- a/src/WebJobs.Extensions.DurableTask/Listener/OutOfProcOrchestrationShim.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/OutOfProcOrchestrationShim.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
@@ -190,9 +189,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
             [JsonProperty("input")]
             internal object Input { get; set; }
-
-            [JsonProperty("instanceIDs")]
-            internal string[] InstanceIDs { get; set; }
 
             [JsonProperty("fireAt")]
             internal DateTime FireAt { get; set; }

--- a/src/WebJobs.Extensions.DurableTask/Listener/OutOfProcOrchestrationShim.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/OutOfProcOrchestrationShim.cs
@@ -40,7 +40,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             CallEntity = 7,
             CallHttp = 8,
             SignalEntity = 9,
-            Lock = 10,
         }
 
         internal async Task HandleOutOfProcExecutionAsync(JObject executionJson)
@@ -132,6 +131,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                                 tasks.Add(this.context.CallEntityAsync(entityId, action.EntityOperation, action.Input));
                                 break;
                             }
+
                         case AsyncActionType.SignalEntity:
                             {
                                 // We do not add a task because this is 'fire and forget'
@@ -139,6 +139,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                                 this.context.SignalEntity(entityId, action.EntityOperation, action.Input);
                                 break;
                             }
+
                         case AsyncActionType.ContinueAsNew:
                             this.context.ContinueAsNew(action.Input);
                             break;
@@ -148,13 +149,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                         case AsyncActionType.CallHttp:
                             tasks.Add(this.context.CallHttpAsync(action.HttpRequest));
                             break;
-                        case AsyncActionType.Lock:
-                            {
-                                var entityIDs = action.InstanceIDs.Select(x =>
-                                    EntityId.GetEntityIdFromSchedulerId(x)).ToArray();
-                                tasks.Add(this.context.LockAsync(entityIDs));
-                                break;
-                            }
                         default:
                             break;
                     }

--- a/src/WebJobs.Extensions.DurableTask/Listener/OutOfProcOrchestrationShim.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/OutOfProcOrchestrationShim.cs
@@ -134,7 +134,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                             }
                         case AsyncActionType.SignalEntity:
                             {
-                                // We do not add a task because this is 'fire and foreget'
+                                // We do not add a task because this is 'fire and forget'
                                 var entityId = EntityId.GetEntityIdFromSchedulerId(action.InstanceId);
                                 this.context.SignalEntity(entityId, action.EntityOperation, action.Input);
                                 break;

--- a/src/WebJobs.Extensions.DurableTask/Listener/OutOfProcOrchestrationShim.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/OutOfProcOrchestrationShim.cs
@@ -39,6 +39,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             CallEntity = 7,
             CallHttp = 8,
             SignalEntity = 9,
+            ScheduledSignalEntity = 10,
         }
 
         internal async Task HandleOutOfProcExecutionAsync(JObject executionJson)
@@ -136,6 +137,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                                 // We do not add a task because this is 'fire and forget'
                                 var entityId = EntityId.GetEntityIdFromSchedulerId(action.InstanceId);
                                 this.context.SignalEntity(entityId, action.EntityOperation, action.Input);
+                                break;
+                            }
+
+                        case AsyncActionType.ScheduledSignalEntity:
+                            {
+                                // We do not add a task because this is 'fire and forget'
+                                var entityId = EntityId.GetEntityIdFromSchedulerId(action.InstanceId);
+                                this.context.SignalEntity(entityId, action.FireAt, action.EntityOperation, action.Input);
                                 break;
                             }
 


### PR DESCRIPTION
This is the C# component of: https://github.com/Azure/azure-functions-durable-js/issues/134

This PR extends the orchestrator shim to accept SignalEntity messages from an out-of-process language like JavaScript. It's quite a _simple_ change but it also contains some preliminary work for requesting Locks from Entities by out-of-process languages. I'd be happy to remove the latter if you all believe it would be better suited for its own PR.

Also, this is my first PR here so I'm happy to take suggestions on formatting and others.