### PR TITLE
Durable Entity proxy with multiple interfaces

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/EntityScheduler/Proxy/EntityProxyFactory.cs
+++ b/src/WebJobs.Extensions.DurableTask/EntityScheduler/Proxy/EntityProxyFactory.cs
@@ -88,7 +88,17 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
         private static void BuildMethods(TypeBuilder typeBuilder, Type interfaceType)
         {
-            var methods = interfaceType.GetMethods(BindingFlags.Instance | BindingFlags.Public);
+            var methods = interfaceType.GetMethods(BindingFlags.Instance | BindingFlags.Public).ToList();
+
+            // Interfaces can inherit from other interfaces, getting those methods too
+            var interfaces = interfaceType.GetInterfaces();
+            if (interfaces.Length > 0)
+            {
+                foreach (var inter in interfaces)
+                {
+                    methods.AddRange(inter.GetMethods(BindingFlags.Instance | BindingFlags.Public));
+                }
+            }
 
             var entityProxyMethods = typeof(EntityProxy).GetMethods(BindingFlags.NonPublic | BindingFlags.Instance);
 

--- a/src/WebJobs.Extensions.DurableTask/EntityScheduler/TypedInvocationExtensions.cs
+++ b/src/WebJobs.Extensions.DurableTask/EntityScheduler/TypedInvocationExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
+using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
 
@@ -101,11 +102,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             var type = typeof(T);
 
             var interfaces = type.GetInterfaces();
-            if (interfaces.Length > 1)
-            {
-                throw new InvalidOperationException("Only a single interface can be implemented on an entity");
-            }
-
             const BindingFlags bindingFlags = BindingFlags.IgnoreCase | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance;
 
             var method = type.GetMethod(context.OperationName, bindingFlags);
@@ -114,8 +110,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 return method;
             }
 
-            var entityInterface = interfaces[0];
-            return entityInterface.GetMethod(context.OperationName, bindingFlags);
+            var methods = interfaces.SelectMany(i => i.GetMethods(bindingFlags));
+            return methods.FirstOrDefault(m => m.Name.Equals(context.OperationName));
         }
     }
 }

--- a/src/WebJobs.Extensions.DurableTask/EntityScheduler/TypedInvocationExtensions.cs
+++ b/src/WebJobs.Extensions.DurableTask/EntityScheduler/TypedInvocationExtensions.cs
@@ -110,8 +110,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 return method;
             }
 
-            var methods = interfaces.SelectMany(i => i.GetMethods(bindingFlags));
-            return methods.FirstOrDefault(m => m.Name.Equals(context.OperationName));
+            return interfaces.Select(i => i.GetMethod(context.OperationName, bindingFlags)).FirstOrDefault(m => m != null);
         }
     }
 }

--- a/test/Common/DurableTaskEndToEndTests.cs
+++ b/test/Common/DurableTaskEndToEndTests.cs
@@ -3260,6 +3260,39 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         [Trait("Category", PlatformSpecificHelpers.TestCategory)]
         [InlineData(true)]
         [InlineData(false)]
+        public async Task DurableEntity_EntityProxy_MultipleInterfaces(bool extendedSessions)
+        {
+            string[] orchestratorFunctionNames =
+            {
+                nameof(TestOrchestrations.EntityProxy_MultipleInterfaces),
+            };
+            using (var host = TestHelpers.GetJobHost(
+                this.loggerProvider,
+                nameof(this.DurableEntity_EntityProxy_MultipleInterfaces),
+                extendedSessions))
+            {
+                await host.StartAsync();
+
+                var counter = new EntityId(nameof(TestEntityClasses.JobWithProxyMultiInterface), Guid.NewGuid().ToString());
+
+                var client = await host.StartOrchestratorAsync(orchestratorFunctionNames[0], counter, this.output);
+
+                var status = await client.WaitForCompletionAsync(this.output);
+
+                Assert.Equal(OrchestrationRuntimeStatus.Completed, status?.RuntimeStatus);
+                Assert.Equal(true, status?.Output);
+
+                await host.StopAsync();
+            }
+        }
+
+        /// <summary>
+        /// End-to-end test which validates basic use of the object dispatch feature.
+        /// </summary>
+        [Theory]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        [InlineData(true)]
+        [InlineData(false)]
         public async Task DurableEntity_EntityProxy_UsesBindings(bool extendedSessions)
         {
             string[] orchestratorFunctionNames =

--- a/test/Common/TestEntityClasses.cs
+++ b/test/Common/TestEntityClasses.cs
@@ -50,6 +50,24 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             void Delete();
         }
 
+        public interface IJob
+        {
+            void SetStartDate(DateTime date);
+
+            void SetEndDate(DateTime date);
+
+            Task<TimeSpan> GetDuration();
+
+            void Delete();
+        }
+
+        public interface IPrimaryJob : IJob
+        {
+            void SetId(string Id);
+
+            Task<string> GetId();
+        }
+
         [FunctionName(nameof(ChatRoom))]
         public static Task ChatRoomFunction([EntityTrigger] IDurableEntityContext context)
         {
@@ -60,6 +78,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         public static Task CounterFunction([EntityTrigger] IDurableEntityContext context)
         {
             return context.DispatchAsync<CounterWithProxy>();
+        }
+
+        [FunctionName(nameof(JobWithProxyMultiInterface))]
+        public static Task JobFunction([EntityTrigger] IDurableEntityContext context)
+        {
+            return context.DispatchAsync<JobWithProxyMultiInterface>();
         }
 
         [FunctionName(nameof(StorageBackedCounter))]
@@ -195,6 +219,46 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             public void Delete()
             {
                 Entity.Current.DeleteState();
+            }
+        }
+
+        //-------------- An entity representing a job object with multiple interfaces -----------------
+        [JsonObject(MemberSerialization = MemberSerialization.OptIn)]
+        public class JobWithProxyMultiInterface : IPrimaryJob
+        {
+            [JsonProperty("id")]
+            public string Id { get; private set; }
+
+            [JsonProperty("startDate")]
+            public DateTime StartDate { get; private set; }
+
+            [JsonProperty("endDate")]
+            public DateTime EndDate { get; private set; }
+
+            public void SetId(string Id) => this.Id = Id;
+
+            public void SetEndDate(DateTime date) => this.EndDate = date;
+
+            public void SetStartDate(DateTime date) => this.StartDate = date;
+
+            public Task<string> GetId() => Task.FromResult(this.Id);
+
+            public Task<TimeSpan> GetDuration() => Task.FromResult(this.EndDate - this.StartDate);
+
+            public void Delete()
+            {
+                Entity.Current.DeleteState();
+            }
+
+            public JobWithProxyMultiInterface()
+            {
+            }
+
+            [FunctionName(nameof(JobWithProxyMultiInterface))]
+            public static Task Run(
+            [EntityTrigger] IDurableEntityContext context)
+            {
+                return context.DispatchAsync<JobWithProxyMultiInterface>();
             }
         }
     }

--- a/test/Common/TestEntityClasses.cs
+++ b/test/Common/TestEntityClasses.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
         public interface IPrimaryJob : IJob
         {
-            void SetId(string Id);
+            void SetId(string id);
 
             Task<string> GetId();
         }

--- a/test/Common/TestOrchestrations.cs
+++ b/test/Common/TestOrchestrations.cs
@@ -1086,21 +1086,21 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         {
             var job = ctx.GetInput<EntityId>();
 
-            //var jobEntity = ctx.CreateEntityProxy<TestEntityClasses.IJob>(job);
+            var jobEntity = ctx.CreateEntityProxy<TestEntityClasses.IJob>(job);
             var primaryJobEntity = ctx.CreateEntityProxy<TestEntityClasses.IPrimaryJob>(job);
             var date = DateTime.MinValue;
 
             // set start date
-            primaryJobEntity.SetStartDate(date);
+            jobEntity.SetStartDate(date);
 
             // set job id
             primaryJobEntity.SetId(ctx.InstanceId);
 
             // set end date
-            primaryJobEntity.SetEndDate(date.AddMinutes(10));
+            jobEntity.SetEndDate(date.AddMinutes(10));
 
             var id = await primaryJobEntity.GetId();
-            var duration = await primaryJobEntity.GetDuration();
+            var duration = await jobEntity.GetDuration();
 
             // destruct
             primaryJobEntity.Delete();

--- a/test/Common/TestOrchestrations.cs
+++ b/test/Common/TestOrchestrations.cs
@@ -1082,6 +1082,32 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             return result == 16;
         }
 
+        public static async Task<bool> EntityProxy_MultipleInterfaces([OrchestrationTrigger] IDurableOrchestrationContext ctx)
+        {
+            var job = ctx.GetInput<EntityId>();
+
+            //var jobEntity = ctx.CreateEntityProxy<TestEntityClasses.IJob>(job);
+            var primaryJobEntity = ctx.CreateEntityProxy<TestEntityClasses.IPrimaryJob>(job);
+            var date = DateTime.MinValue;
+
+            // set start date
+            primaryJobEntity.SetStartDate(date);
+
+            // set job id
+            primaryJobEntity.SetId(ctx.InstanceId);
+
+            // set end date
+            primaryJobEntity.SetEndDate(date.AddMinutes(10));
+
+            var id = await primaryJobEntity.GetId();
+            var duration = await primaryJobEntity.GetDuration();
+
+            // destruct
+            primaryJobEntity.Delete();
+
+            return id == ctx.InstanceId && duration == TimeSpan.FromMinutes(10);
+        }
+
         public static async Task<bool> EntityProxy_NameResolve([OrchestrationTrigger] IDurableOrchestrationContext ctx)
         {
             var entityKey = ctx.GetInput<string>();


### PR DESCRIPTION
Addresses #1276 

This PR allows for Durable Entities classes to be proxied by more than one implemented interface. This current restriction is not explicitly defined on [documentation](https://docs.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-dotnet-entities#restrictions-on-entity-interfaces).

All tests are passing, except for [`ReplaySafeLogger_LogsOnlyOnce`](https://github.com/Azure/azure-functions-durable-extension/blob/dev/test/Common/DurableTaskEndToEndTests.cs#L4310-L4336) on tests for V1 (not sure how to/if address it).
![image](https://user-images.githubusercontent.com/12413808/76941898-1bc2fe80-68fd-11ea-9948-05575e4ef0da.png)

@cgillum @ConnorMcMahon 

