### PR TITLE
Updated TokenSource serializer

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/DurableHttpRequest.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableHttpRequest.cs
@@ -114,6 +114,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
         private class TokenSourceConverter : JsonConverter
         {
+            private static JsonSerializer tokenSerializer;
+
             private enum TokenSourceType
             {
                 None = 0,
@@ -127,6 +129,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
             public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
             {
+                this.CreateTokenSourceSerializer(serializer);
+
                 JToken json = JToken.ReadFrom(reader);
                 if (json.Type == JTokenType.Null)
                 {
@@ -147,7 +151,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 else if (jsonObject.TryGetValue("$type", StringComparison.Ordinal, out JToken clrTypeValue))
                 {
                     Type runtimeType = Type.GetType((string)clrTypeValue, throwOnError: true);
-                    return jsonObject.ToObject(runtimeType, serializer);
+                    return jsonObject.ToObject(runtimeType, tokenSerializer);
                 }
                 else
                 {
@@ -170,10 +174,57 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 else
                 {
                     // Don't know how to serialize this - use default behavior, forcing TypeNameHandling.Objects to correctly serialize ITokenSource
-                    var currTypeNameSetting = serializer.TypeNameHandling;
-                    serializer.TypeNameHandling = TypeNameHandling.Objects;
-                    serializer.Serialize(writer, value);
-                    serializer.TypeNameHandling = currTypeNameSetting;
+                    this.CreateTokenSourceSerializer(serializer);
+                    tokenSerializer.Serialize(writer, value);
+                }
+            }
+
+            private void CreateTokenSourceSerializer(JsonSerializer serializer)
+            {
+                if (tokenSerializer == null)
+                {
+                    if (serializer.TypeNameHandling == TypeNameHandling.Objects
+                    || serializer.TypeNameHandling == TypeNameHandling.All)
+                    {
+                        tokenSerializer = serializer;
+                        return;
+                    }
+
+                    // Make sure these are all the settings when updating Newtonsoft.Json
+                    tokenSerializer = new JsonSerializer
+                    {
+                        Context = serializer.Context,
+                        Culture = serializer.Culture,
+                        ContractResolver = serializer.ContractResolver,
+                        ConstructorHandling = serializer.ConstructorHandling,
+                        CheckAdditionalContent = serializer.CheckAdditionalContent,
+                        DateFormatHandling = serializer.DateFormatHandling,
+                        DateFormatString = serializer.DateFormatString,
+                        DateParseHandling = serializer.DateParseHandling,
+                        DateTimeZoneHandling = serializer.DateTimeZoneHandling,
+                        DefaultValueHandling = serializer.DefaultValueHandling,
+                        EqualityComparer = serializer.EqualityComparer,
+                        FloatFormatHandling = serializer.FloatFormatHandling,
+                        Formatting = serializer.Formatting,
+                        FloatParseHandling = serializer.FloatParseHandling,
+                        MaxDepth = serializer.MaxDepth,
+                        MetadataPropertyHandling = serializer.MetadataPropertyHandling,
+                        MissingMemberHandling = serializer.MissingMemberHandling,
+                        NullValueHandling = serializer.NullValueHandling,
+                        ObjectCreationHandling = serializer.ObjectCreationHandling,
+                        PreserveReferencesHandling = serializer.PreserveReferencesHandling,
+                        ReferenceResolver = serializer.ReferenceResolver,
+                        ReferenceLoopHandling = serializer.ReferenceLoopHandling,
+                        StringEscapeHandling = serializer.StringEscapeHandling,
+                        TraceWriter = serializer.TraceWriter,
+
+                        // Enforcing TypeNameHandling.Objects to make suire ITokenSource gets serialized/deserialized correctly
+                        TypeNameHandling = TypeNameHandling.Objects,
+                    };
+                    foreach (var converter in serializer.Converters)
+                    {
+                        tokenSerializer.Converters.Add(converter);
+                    }
                 }
             }
         }

--- a/src/WebJobs.Extensions.DurableTask/DurableHttpRequest.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableHttpRequest.cs
@@ -181,50 +181,53 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
             private static JsonSerializer GetTokenSourceSerializer(JsonSerializer serializer)
             {
-                if (tokenSerializer == null)
+                if (tokenSerializer != null)
                 {
-                    if (serializer.TypeNameHandling == TypeNameHandling.Objects
+                    return tokenSerializer
+                }
+
+                if (serializer.TypeNameHandling == TypeNameHandling.Objects
                     || serializer.TypeNameHandling == TypeNameHandling.All)
-                    {
-                        tokenSerializer = serializer;
-                    }
+                {
+                    tokenSerializer = serializer;
+                    return tokenSerializer;
+                }
 
-                    // Make sure these are all the settings when updating Newtonsoft.Json
-                    tokenSerializer = new JsonSerializer
-                    {
-                        Context = serializer.Context,
-                        Culture = serializer.Culture,
-                        ContractResolver = serializer.ContractResolver,
-                        ConstructorHandling = serializer.ConstructorHandling,
-                        CheckAdditionalContent = serializer.CheckAdditionalContent,
-                        DateFormatHandling = serializer.DateFormatHandling,
-                        DateFormatString = serializer.DateFormatString,
-                        DateParseHandling = serializer.DateParseHandling,
-                        DateTimeZoneHandling = serializer.DateTimeZoneHandling,
-                        DefaultValueHandling = serializer.DefaultValueHandling,
-                        EqualityComparer = serializer.EqualityComparer,
-                        FloatFormatHandling = serializer.FloatFormatHandling,
-                        Formatting = serializer.Formatting,
-                        FloatParseHandling = serializer.FloatParseHandling,
-                        MaxDepth = serializer.MaxDepth,
-                        MetadataPropertyHandling = serializer.MetadataPropertyHandling,
-                        MissingMemberHandling = serializer.MissingMemberHandling,
-                        NullValueHandling = serializer.NullValueHandling,
-                        ObjectCreationHandling = serializer.ObjectCreationHandling,
-                        PreserveReferencesHandling = serializer.PreserveReferencesHandling,
-                        ReferenceResolver = serializer.ReferenceResolver,
-                        ReferenceLoopHandling = serializer.ReferenceLoopHandling,
-                        StringEscapeHandling = serializer.StringEscapeHandling,
-                        TraceWriter = serializer.TraceWriter,
+                // Make sure these are all the settings when updating Newtonsoft.Json
+                tokenSerializer = new JsonSerializer
+                {
+                    Context = serializer.Context,
+                    Culture = serializer.Culture,
+                    ContractResolver = serializer.ContractResolver,
+                    ConstructorHandling = serializer.ConstructorHandling,
+                    CheckAdditionalContent = serializer.CheckAdditionalContent,
+                    DateFormatHandling = serializer.DateFormatHandling,
+                    DateFormatString = serializer.DateFormatString,
+                    DateParseHandling = serializer.DateParseHandling,
+                    DateTimeZoneHandling = serializer.DateTimeZoneHandling,
+                    DefaultValueHandling = serializer.DefaultValueHandling,
+                    EqualityComparer = serializer.EqualityComparer,
+                    FloatFormatHandling = serializer.FloatFormatHandling,
+                    Formatting = serializer.Formatting,
+                    FloatParseHandling = serializer.FloatParseHandling,
+                    MaxDepth = serializer.MaxDepth,
+                    MetadataPropertyHandling = serializer.MetadataPropertyHandling,
+                    MissingMemberHandling = serializer.MissingMemberHandling,
+                    NullValueHandling = serializer.NullValueHandling,
+                    ObjectCreationHandling = serializer.ObjectCreationHandling,
+                    PreserveReferencesHandling = serializer.PreserveReferencesHandling,
+                    ReferenceResolver = serializer.ReferenceResolver,
+                    ReferenceLoopHandling = serializer.ReferenceLoopHandling,
+                    StringEscapeHandling = serializer.StringEscapeHandling,
+                    TraceWriter = serializer.TraceWriter,
 
-                        // Enforcing TypeNameHandling.Objects to make sure ITokenSource gets serialized/deserialized correctly
-                        TypeNameHandling = TypeNameHandling.Objects,
-                    };
+                    // Enforcing TypeNameHandling.Objects to make sure ITokenSource gets serialized/deserialized correctly
+                    TypeNameHandling = TypeNameHandling.Objects,
+                };
 
-                    foreach (var converter in serializer.Converters)
-                    {
-                        tokenSerializer.Converters.Add(converter);
-                    }
+                foreach (var converter in serializer.Converters)
+                {
+                    tokenSerializer.Converters.Add(converter);
                 }
 
                 return tokenSerializer;

--- a/src/WebJobs.Extensions.DurableTask/DurableHttpRequest.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableHttpRequest.cs
@@ -183,7 +183,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             {
                 if (tokenSerializer != null)
                 {
-                    return tokenSerializer
+                    return tokenSerializer;
                 }
 
                 if (serializer.TypeNameHandling == TypeNameHandling.Objects


### PR DESCRIPTION
Makes a copy of the input serializer and sets TypeNameHandling to Objects to assure correct serialization of ITokenSource in case customers use their own custom serialization settings.

Updated the past implementation to now copy the input settings and add TypeNameHandling.Objects to avoid changing the input JsonSerializer.