### PR TITLE
Stop treating warnings as errors in tests

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net461.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net461.xml
@@ -2520,7 +2520,7 @@
         </member>
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.SchedulerState.EntityState">
             <summary>
-            The serialized entity state. This can be stale while CurrentStateView != null.
+            The last serialized entity state.
             </summary>
         </member>
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.SchedulerState.Queue">
@@ -3295,6 +3295,19 @@
             Preview setting for gracefully shutting down to prevent WebJob shutdowns from failing
             activities or orchestrations.
             </summary>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskOptions.RollbackEntityOperationsOnExceptions">
+            <summary>
+            Controls whether an uncaught exception inside an entity operation should roll back the effects of the operation.
+            </summary>
+            <remarks>
+            The rollback undoes all internal effects of an operation
+            (sent signals, and state creation, deletion, or modification).
+            However, it does not roll back external effects (such as I/O that was performed).
+            This setting can affect serialization overhead: if true, the entity state is serialized
+            after each individual operation. If false, the entity state is serialized
+            only after an entire batch of operations completes.
+            </remarks>
         </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskOptions.SetDefaultHubName(System.String)">
             <summary>

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
@@ -2558,7 +2558,7 @@
         </member>
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.SchedulerState.EntityState">
             <summary>
-            The serialized entity state. This can be stale while CurrentStateView != null.
+            The last serialized entity state.
             </summary>
         </member>
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.SchedulerState.Queue">
@@ -3362,6 +3362,19 @@
             Preview setting for gracefully shutting down to prevent WebJob shutdowns from failing
             activities or orchestrations.
             </summary>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskOptions.RollbackEntityOperationsOnExceptions">
+            <summary>
+            Controls whether an uncaught exception inside an entity operation should roll back the effects of the operation.
+            </summary>
+            <remarks>
+            The rollback undoes all internal effects of an operation
+            (sent signals, and state creation, deletion, or modification).
+            However, it does not roll back external effects (such as I/O that was performed).
+            This setting can affect serialization overhead: if true, the entity state is serialized
+            after each individual operation. If false, the entity state is serialized
+            only after an entire batch of operations completes.
+            </remarks>
         </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskOptions.SetDefaultHubName(System.String)">
             <summary>

--- a/test/Common/TestOrchestrations.cs
+++ b/test/Common/TestOrchestrations.cs
@@ -784,7 +784,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
             try
             {
-
                 Assert.False(await ctx.CallEntityAsync<bool>(entityId, "exists"));
 
                 await Assert.ThrowsAsync<EntitySchedulerException>(() => entity.SetToUnserializable());

--- a/test/FunctionsV2/WebJobs.Extensions.DurableTask.Tests.V2.csproj
+++ b/test/FunctionsV2/WebJobs.Extensions.DurableTask.Tests.V2.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netcoreapp2.0|AnyCPU'">
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <WarningsAsErrors />
     <StyleCopTreatErrorsAsWarnings>true</StyleCopTreatErrorsAsWarnings>
   </PropertyGroup>


### PR DESCRIPTION
The introduction of some new test cases add warnings with the analyzers.
To allow the release to continue, we will temporarily stop treating
warnings in test code as reasons to fail a release build.