### PR TITLE
Backwards compatibility for orchestrationClient

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/DurableClientAttribute.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableClientAttribute.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
     [AttributeUsage(AttributeTargets.Parameter)]
     [DebuggerDisplay("TaskHub={TaskHub}, ConnectionName={ConnectionName}")]
     [Binding]
-    public sealed class DurableClientAttribute : Attribute, IEquatable<DurableClientAttribute>
+    public class DurableClientAttribute : Attribute, IEquatable<DurableClientAttribute>
     {
         /// <summary>
         /// Optional. Gets or sets the name of the task hub in which the orchestration data lives.

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net461.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net461.xml
@@ -3427,6 +3427,12 @@
             Boolean value specifying if the replay events should be logged.
             </value>
         </member>
+        <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.OrchestrationClientAttribute">
+            <summary>
+            Deprecated attribute to bind a function parameter to a <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableClient"/>.
+            Here for backwards compatibility. Please use the <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClientAttribute"/> instead.
+            </summary>
+        </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.OrchestrationRuntimeStatus">
             <summary>
             Represents the possible runtime execution status values for an orchestration instance.

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
@@ -3494,6 +3494,12 @@
             Boolean value specifying if the replay events should be logged.
             </value>
         </member>
+        <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.OrchestrationClientAttribute">
+            <summary>
+            Deprecated attribute to bind a function parameter to a <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableClient"/>.
+            Here for backwards compatibility. Please use the <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClientAttribute"/> instead.
+            </summary>
+        </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.OrchestrationRuntimeStatus">
             <summary>
             Represents the possible runtime execution status values for an orchestration instance.

--- a/src/WebJobs.Extensions.DurableTask/OrchestrationClientAttribute.cs
+++ b/src/WebJobs.Extensions.DurableTask/OrchestrationClientAttribute.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+using System.Diagnostics;
+using Microsoft.Azure.WebJobs.Description;
+
+namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
+{
+    /// <summary>
+    /// Deprecated attribute to bind a function parameter to a <see cref="IDurableClient"/>.
+    /// Here for backwards compatibility. Please use the <see cref="DurableClientAttribute"/> instead.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Parameter)]
+    [Binding]
+    [Obsolete("{OrchestrationClientAttribute is obsolete. Use DurableClientAttribute instead.")]
+    public sealed class OrchestrationClientAttribute : DurableClientAttribute
+    {
+    }
+}

--- a/src/WebJobs.Extensions.DurableTask/OrchestrationClientAttribute.cs
+++ b/src/WebJobs.Extensions.DurableTask/OrchestrationClientAttribute.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
     /// </summary>
     [AttributeUsage(AttributeTargets.Parameter)]
     [Binding]
-    [Obsolete("{OrchestrationClientAttribute is obsolete. Use DurableClientAttribute instead.")]
+    [Obsolete("OrchestrationClientAttribute is obsolete. Use DurableClientAttribute instead.")]
     public sealed class OrchestrationClientAttribute : DurableClientAttribute
     {
     }

--- a/test/Common/BindingTests.cs
+++ b/test/Common/BindingTests.cs
@@ -63,6 +63,46 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             }
         }
 
+        /// <summary>
+        /// Tests OrchestrationClient attribute binds a client instance with the IDurableOrchestrationClient interface.
+        /// </summary>
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public async Task IDurableOrchestrationClientBindingBackComp()
+        {
+            using (var host = TestHelpers.GetJobHost(
+                this.loggerProvider,
+                nameof(this.IDurableOrchestrationClientBinding),
+                enableExtendedSessions: false))
+            {
+                await host.StartAsync();
+
+                IDurableOrchestrationClient client = await host.GetOrchestrationClientBindingBackCompTest(this.output);
+
+                await host.StopAsync();
+            }
+        }
+
+        /// <summary>
+        /// Tests OrchestrationClient attribute binds a client instance with the IDurableEntityClient interface.
+        /// </summary>
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public async Task IDurableEntityClientBindingBackComp()
+        {
+            using (var host = TestHelpers.GetJobHost(
+                this.loggerProvider,
+                nameof(this.IDurableEntityClientBinding),
+                enableExtendedSessions: false))
+            {
+                await host.StartAsync();
+
+                IDurableEntityClient client = await host.GetEntityClientBindingBackCompTest(this.output);
+
+                await host.StopAsync();
+            }
+        }
+
         [Theory]
         [Trait("Category", PlatformSpecificHelpers.TestCategory)]
         [Trait("Category", PlatformSpecificHelpers.TestCategory + "_BVT")]

--- a/test/Common/BindingTests.cs
+++ b/test/Common/BindingTests.cs
@@ -77,7 +77,17 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             {
                 await host.StartAsync();
 
-                IDurableOrchestrationClient client = await host.GetOrchestrationClientBindingBackCompTest(this.output);
+                var startFunction = typeof(ClientFunctions)
+                    .GetMethod(nameof(ClientFunctions.GetOrchestrationClientBindingBackCompTest));
+
+                var clientRef = new IDurableOrchestrationClient[1];
+                var args = new Dictionary<string, object>
+                {
+                    { "clientRef", clientRef },
+                };
+
+                await host.CallAsync(startFunction, args);
+                IDurableOrchestrationClient client = clientRef[0];
 
                 await host.StopAsync();
             }
@@ -97,7 +107,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             {
                 await host.StartAsync();
 
-                IDurableEntityClient client = await host.GetEntityClientBindingBackCompTest(this.output);
+                var startFunction = typeof(ClientFunctions)
+                    .GetMethod(nameof(ClientFunctions.GetEntityClientBindingBackCompTest));
+                var clientRef = new IDurableEntityClient[1];
+                var args = new Dictionary<string, object>
+                {
+                    { "clientRef", clientRef },
+                };
+                await host.CallAsync(startFunction, args);
+                IDurableEntityClient client = clientRef[0];
 
                 await host.StopAsync();
             }

--- a/test/Common/ClientFunctions.cs
+++ b/test/Common/ClientFunctions.cs
@@ -78,6 +78,32 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         }
 
         /// <summary>
+        /// Helper function for the IDurableOrchestrationClientBindingBackComp test. Gets an IDurableEntityClient.
+        /// </summary>
+        [NoAutomaticTrigger]
+        public static void GetEntityClientBindingBackCompTest(
+#pragma warning disable CS0618 // Type or member is obsolete
+            [OrchestrationClient] IDurableEntityClient client,
+#pragma warning restore CS0618 // Type or member is obsolete
+            IDurableEntityClient[] clientRef)
+        {
+            clientRef[0] = client;
+        }
+
+        /// <summary>
+        /// Helper function for the IDurableOrchestrationClientBindingBackComp test. Gets an IDurableOrchestrationClient.
+        /// </summary>
+        [NoAutomaticTrigger]
+        public static void GetOrchestrationClientBindingBackCompTest(
+#pragma warning disable CS0618 // Type or member is obsolete
+            [OrchestrationClient] IDurableOrchestrationClient client,
+#pragma warning restore CS0618 // Type or member is obsolete
+            IDurableOrchestrationClient[] clientRef)
+        {
+            clientRef[0] = client;
+        }
+
+        /// <summary>
         /// Helper function for testing the JSON data that gets sent to out-of-proc client functions.
         /// </summary>
 #pragma warning disable DF0203 // DurableClient attribute must be used with either an IDurableClient, IDurableEntityClient, or an IDurableOrchestrationClient.

--- a/test/Common/DurableTaskHostExtensions.cs
+++ b/test/Common/DurableTaskHostExtensions.cs
@@ -105,7 +105,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             ITestOutputHelper output)
         {
             var startFunction = typeof(ClientFunctions)
-                .GetMethod(nameof(ClientFunctions.GetEntityClientBindingTest));
+                .GetMethod(nameof(ClientFunctions.GetEntityClientBindingBackCompTest));
 
             var clientRef = new IDurableEntityClient[1];
             var args = new Dictionary<string, object>
@@ -126,7 +126,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             ITestOutputHelper output)
         {
             var startFunction = typeof(ClientFunctions)
-                .GetMethod(nameof(ClientFunctions.GetOrchestrationClientBindingTest));
+                .GetMethod(nameof(ClientFunctions.GetOrchestrationClientBindingBackCompTest));
 
             var clientRef = new IDurableOrchestrationClient[1];
             var args = new Dictionary<string, object>

--- a/test/Common/DurableTaskHostExtensions.cs
+++ b/test/Common/DurableTaskHostExtensions.cs
@@ -96,47 +96,5 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             IDurableOrchestrationClient client = clientRef[0];
             return client;
         }
-
-        /// <summary>
-        /// Helper function for the IDurableEntityClientBindingBackComp test. Gets an IDurableEntityClient.
-        /// </summary>
-        public static async Task<IDurableEntityClient> GetEntityClientBindingBackCompTest(
-            this ITestHost host,
-            ITestOutputHelper output)
-        {
-            var startFunction = typeof(ClientFunctions)
-                .GetMethod(nameof(ClientFunctions.GetEntityClientBindingBackCompTest));
-
-            var clientRef = new IDurableEntityClient[1];
-            var args = new Dictionary<string, object>
-            {
-                { "clientRef", clientRef },
-            };
-
-            await host.CallAsync(startFunction, args);
-            IDurableEntityClient client = clientRef[0];
-            return client;
-        }
-
-        /// <summary>
-        /// Helper function for the IDurableOrchestrationClientBindingBackComp test. Gets an IDurableOrchestrationClient.
-        /// </summary>
-        public static async Task<IDurableOrchestrationClient> GetOrchestrationClientBindingBackCompTest(
-            this ITestHost host,
-            ITestOutputHelper output)
-        {
-            var startFunction = typeof(ClientFunctions)
-                .GetMethod(nameof(ClientFunctions.GetOrchestrationClientBindingBackCompTest));
-
-            var clientRef = new IDurableOrchestrationClient[1];
-            var args = new Dictionary<string, object>
-            {
-                { "clientRef", clientRef },
-            };
-
-            await host.CallAsync(startFunction, args);
-            IDurableOrchestrationClient client = clientRef[0];
-            return client;
-        }
     }
 }

--- a/test/Common/DurableTaskHostExtensions.cs
+++ b/test/Common/DurableTaskHostExtensions.cs
@@ -96,5 +96,47 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             IDurableOrchestrationClient client = clientRef[0];
             return client;
         }
+
+        /// <summary>
+        /// Helper function for the IDurableEntityClientBindingBackComp test. Gets an IDurableEntityClient.
+        /// </summary>
+        public static async Task<IDurableEntityClient> GetEntityClientBindingBackCompTest(
+            this ITestHost host,
+            ITestOutputHelper output)
+        {
+            var startFunction = typeof(ClientFunctions)
+                .GetMethod(nameof(ClientFunctions.GetEntityClientBindingTest));
+
+            var clientRef = new IDurableEntityClient[1];
+            var args = new Dictionary<string, object>
+            {
+                { "clientRef", clientRef },
+            };
+
+            await host.CallAsync(startFunction, args);
+            IDurableEntityClient client = clientRef[0];
+            return client;
+        }
+
+        /// <summary>
+        /// Helper function for the IDurableOrchestrationClientBindingBackComp test. Gets an IDurableOrchestrationClient.
+        /// </summary>
+        public static async Task<IDurableOrchestrationClient> GetOrchestrationClientBindingBackCompTest(
+            this ITestHost host,
+            ITestOutputHelper output)
+        {
+            var startFunction = typeof(ClientFunctions)
+                .GetMethod(nameof(ClientFunctions.GetOrchestrationClientBindingTest));
+
+            var clientRef = new IDurableOrchestrationClient[1];
+            var args = new Dictionary<string, object>
+            {
+                { "clientRef", clientRef },
+            };
+
+            await host.CallAsync(startFunction, args);
+            IDurableOrchestrationClient client = clientRef[0];
+            return client;
+        }
     }
 }


### PR DESCRIPTION
This PR addresses: https://github.com/Azure/azure-functions-durable-extension/issues/1290

There changes are few and simple (_except I apparently pushed other people's commits, more on this later_):

1. `DurableClientAttribute` is no longer a `sealed` class, so we can subclass it.

2. The declaration of a new dummy subclass of `DurableClientAttribute` named `OrchestrationClientAttribute`

3. A new binding rule in `DurableTaskExtension.cs` that explicitly accepts `OrchestrationClientAttribute`. This solution is less than ideal, because there's a handful of copy-pasted lines from the rule accepting `DurableClientAttribute`. Ideally, we would have a single line allowing us to select between the two attributes. If anyone knows how to do this, *please let me know*

So, while this works, I'm still looking for a solution with less repetition. I'm open to input!

Finally, in  https://github.com/Azure/azure-functions-durable-extension/issues/1290 we discuss the possibility of raising warnings on the logs of `func host start` for JS users using `orchestrationClient` instead of `durableClient`. This PR assumes that this is change we would implement exclusively on the JS side of things. If this is not the case, please let me know.