### PR TITLE
App Insights Tags for Orchestrators and Entities

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
@@ -1073,5 +1073,27 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
             return payload;
         }
+
+#if !FUNCTIONS_V1
+        /// <summary>
+        /// Tags the current Activity with metadata: DurableFunctionsType, DurableFunctionsInstanceId, DurableFunctionsRuntimeStatus.
+        /// This metadata will show up in Application Insights, if enabled.
+        /// </summary>
+        internal static void TagActivityWithOrchestrationStatus(OrchestrationRuntimeStatus status, string instanceId, bool isEntity = false)
+        {
+            // Adding "Tags" to activity allows using Application Insights to query current state of orchestrations
+            Activity activity = Activity.Current;
+            string functionsType = isEntity ? "Entity" : "Orchestrator";
+
+            // The activity may be null when running unit tests, but should be non-null otherwise
+            if (activity != null)
+            {
+                string statusStr = Enum.GetName(status.GetType(), status);
+                activity.AddTag("DurableFunctionsType", functionsType);
+                activity.AddTag("DurableFunctionsInstanceId", instanceId);
+                activity.AddTag("DurableFunctionsRuntimeStatus", statusStr);
+            }
+        }
+#endif
     }
 }

--- a/src/WebJobs.Extensions.DurableTask/Listener/TaskEntityShim.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/TaskEntityShim.cs
@@ -225,8 +225,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             }
 #if !FUNCTIONS_V1
             var activity = Activity.Current;
-            // activity may be null when running this repo's tests but does not appear
-            // empty when actually running the samples
+            /* activity may be null when running this repo's tests but does not appear
+             * empty when actually running the samples
+             */
             if (activity != null)
             {
                 string state = this.context.State.EntityExists ? $"has state ({this.context.State.EntityState.Length} characters)" : "no state";

--- a/src/WebJobs.Extensions.DurableTask/Listener/TaskEntityShim.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/TaskEntityShim.cs
@@ -228,13 +228,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             /* activity may be null when running this repo's tests but does not appear
              * empty when actually running the samples
              */
-            if (activity != null)
+            /*if (activity != null)
             {
                 string state = this.context.State.EntityExists ? $"has state ({this.context.State.EntityState.Length} characters)" : "no state";
                 activity.AddTag("DurableFunctionsType", "Entity");
                 activity.AddTag("DurableFunctionsInstanceId", this.context.InstanceId);
                 activity.AddTag("DurableFunctionsState", state);
-            }
+            }*/
 #endif
 
             // The return value is not used.

--- a/src/WebJobs.Extensions.DurableTask/Listener/TaskEntityShim.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/TaskEntityShim.cs
@@ -223,19 +223,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     functionType: FunctionType.Entity,
                     isReplay: false);
             }
-            //#if !FUNCTIONS_V1
-            //var activity = Activity.Current;
-            /* activity may be null when running this repo's tests but does not appear
-             * empty when actually running the samples
-             */
-            /*if (activity != null)
-            {
-                string state = this.context.State.EntityExists ? $"has state ({this.context.State.EntityState.Length} characters)" : "no state";
-                activity.AddTag("DurableFunctionsType", "Entity");
-                activity.AddTag("DurableFunctionsInstanceId", this.context.InstanceId);
-                activity.AddTag("DurableFunctionsRuntimeStatus", state);
-            }*/
-            //#endif
 
             // The return value is not used.
             return string.Empty;

--- a/src/WebJobs.Extensions.DurableTask/Listener/TaskEntityShim.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/TaskEntityShim.cs
@@ -223,8 +223,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     functionType: FunctionType.Entity,
                     isReplay: false);
             }
-#if !FUNCTIONS_V1
-            var activity = Activity.Current;
+            //#if !FUNCTIONS_V1
+            //var activity = Activity.Current;
             /* activity may be null when running this repo's tests but does not appear
              * empty when actually running the samples
              */
@@ -233,9 +233,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 string state = this.context.State.EntityExists ? $"has state ({this.context.State.EntityState.Length} characters)" : "no state";
                 activity.AddTag("DurableFunctionsType", "Entity");
                 activity.AddTag("DurableFunctionsInstanceId", this.context.InstanceId);
-                activity.AddTag("DurableFunctionsState", state);
+                activity.AddTag("DurableFunctionsRuntimeStatus", state);
             }*/
-#endif
+            //#endif
 
             // The return value is not used.
             return string.Empty;

--- a/src/WebJobs.Extensions.DurableTask/Listener/TaskEntityShim.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/TaskEntityShim.cs
@@ -148,10 +148,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
         public override async Task<string> Execute(OrchestrationContext innerContext, string serializedInput)
         {
-#if !FUNCTIONS_V1
-            // for reporting the status of the entity on App Insights
-            OrchestrationRuntimeStatus statusAppInsights;
-#endif
+            // Supress "Variable is assigned but its value is never used" in Functions V1
+#pragma warning disable CS0219
+            OrchestrationRuntimeStatus statusAppInsights; // for reporting the status of the entity on App Insights
+#pragma warning restore CS0219
+
             if (this.operationBatch.Count == 0 && this.lockRequest == null)
             {
                 // we are idle after a ContinueAsNew - the batch is empty.
@@ -171,9 +172,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 this.Config.GetIntputOutputTrace(serializedInput),
                 FunctionType.Entity,
                 isReplay: false);
-#if !FUNCTIONS_V1
-            statusAppInsights = OrchestrationRuntimeStatus.Running;
-#endif
+
             if (this.NumberEventsToReceive > 0)
             {
                 await this.doneProcessingMessages.Task;
@@ -217,9 +216,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     description,
                     functionType: FunctionType.Entity,
                     isReplay: false);
-#if !FUNCTIONS_V1
                 statusAppInsights = OrchestrationRuntimeStatus.Failed;
-#endif
             }
             else
             {
@@ -231,9 +228,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     continuedAsNew: true,
                     functionType: FunctionType.Entity,
                     isReplay: false);
-#if !FUNCTIONS_V1
                 statusAppInsights = OrchestrationRuntimeStatus.Completed;
-#endif
             }
 
 #if !FUNCTIONS_V1

--- a/src/WebJobs.Extensions.DurableTask/Listener/TaskEntityShim.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/TaskEntityShim.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Threading.Tasks;
 using DurableTask.Core;
 using Newtonsoft.Json;
@@ -147,6 +148,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
         public override async Task<string> Execute(OrchestrationContext innerContext, string serializedInput)
         {
+#if !FUNCTIONS_V1
+            var activity = Activity.Current;
+            activity.AddTag("DurableFunctionsType", "Entity");
+            activity.AddTag("DurableFunctionsInstanceID", this.context.InstanceId);
+            activity.AddTag("DurableFunctionsStatus", this.GetStatus());
+#endif
             if (this.operationBatch.Count == 0 && this.lockRequest == null)
             {
                 // we are idle after a ContinueAsNew - the batch is empty.

--- a/src/WebJobs.Extensions.DurableTask/Listener/TaskEntityShim.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/TaskEntityShim.cs
@@ -151,8 +151,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 #if !FUNCTIONS_V1
             var activity = Activity.Current;
             activity.AddTag("DurableFunctionsType", "Entity");
-            activity.AddTag("DurableFunctionsInstanceID", this.context.InstanceId);
-            activity.AddTag("DurableFunctionsStatus", this.GetStatus());
+            activity.AddTag("DurableEntityInstanceID", this.context.InstanceId);
+            activity.AddTag("DurableEntityStatus", this.GetStatus());
 #endif
             if (this.operationBatch.Count == 0 && this.lockRequest == null)
             {

--- a/src/WebJobs.Extensions.DurableTask/Listener/TaskEntityShim.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/TaskEntityShim.cs
@@ -154,14 +154,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             OrchestrationRuntimeStatus status = OrchestrationRuntimeStatus.Running;
 
             DurableTaskExtension.TagActivityWithOrchestrationStatus(status, this.context.InstanceId, true);
-
-            // The activity may be null when running unit tests, but should be non-null otherwise
-            if (activity != null)
-            {
-                activity.AddTag("DurableFunctionsType", "Entity");
-                activity.AddTag("DurableFunctionsInstanceId", this.context.InstanceId);
-                activity.AddTag("DurableFunctionsRuntimeStatus", Enum.GetName(status.GetType(), status));
-            }
 #endif
 
             if (this.operationBatch.Count == 0 && this.lockRequest == null)

--- a/src/WebJobs.Extensions.DurableTask/Listener/TaskEntityShim.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/TaskEntityShim.cs
@@ -148,12 +148,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
         public override async Task<string> Execute(OrchestrationContext innerContext, string serializedInput)
         {
-#if !FUNCTIONS_V1
-            var activity = Activity.Current;
-            activity.AddTag("DurableFunctionsType", "Entity");
-            activity.AddTag("DurableEntityInstanceID", this.context.InstanceId);
-            activity.AddTag("DurableEntityStatus", this.GetStatus());
-#endif
             if (this.operationBatch.Count == 0 && this.lockRequest == null)
             {
                 // we are idle after a ContinueAsNew - the batch is empty.
@@ -229,6 +223,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     functionType: FunctionType.Entity,
                     isReplay: false);
             }
+#if !FUNCTIONS_V1
+            var activity = Activity.Current;
+            string state = this.context.State.EntityExists ? $"has state ({this.context.State.EntityState.Length} characters)" : "no state";
+            activity.AddTag("DurableFunctionsType", "Entity");
+            activity.AddTag("DurableFunctionsInstanceId", this.context.InstanceId);
+            activity.AddTag("DurableFunctionsState", state);
+#endif
 
             // The return value is not used.
             return string.Empty;

--- a/src/WebJobs.Extensions.DurableTask/Listener/TaskEntityShim.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/TaskEntityShim.cs
@@ -225,10 +225,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             }
 #if !FUNCTIONS_V1
             var activity = Activity.Current;
-            string state = this.context.State.EntityExists ? $"has state ({this.context.State.EntityState.Length} characters)" : "no state";
-            activity.AddTag("DurableFunctionsType", "Entity");
-            activity.AddTag("DurableFunctionsInstanceId", this.context.InstanceId);
-            activity.AddTag("DurableFunctionsState", state);
+            // activity may be null when running this repo's tests but does not appear
+            // empty when actually running the samples
+            if (activity != null)
+            {
+                string state = this.context.State.EntityExists ? $"has state ({this.context.State.EntityState.Length} characters)" : "no state";
+                activity.AddTag("DurableFunctionsType", "Entity");
+                activity.AddTag("DurableFunctionsInstanceId", this.context.InstanceId);
+                activity.AddTag("DurableFunctionsState", state);
+            }
 #endif
 
             // The return value is not used.

--- a/src/WebJobs.Extensions.DurableTask/Listener/TaskEntityShim.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/TaskEntityShim.cs
@@ -148,6 +148,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
         public override async Task<string> Execute(OrchestrationContext innerContext, string serializedInput)
         {
+            string status;
             if (this.operationBatch.Count == 0 && this.lockRequest == null)
             {
                 // we are idle after a ContinueAsNew - the batch is empty.
@@ -167,6 +168,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 this.Config.GetIntputOutputTrace(serializedInput),
                 FunctionType.Entity,
                 isReplay: false);
+            status = "Running";
 
             if (this.NumberEventsToReceive > 0)
             {
@@ -211,6 +213,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     description,
                     functionType: FunctionType.Entity,
                     isReplay: false);
+                status = "Failed";
+
             }
             else
             {
@@ -222,7 +226,21 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     continuedAsNew: true,
                     functionType: FunctionType.Entity,
                     isReplay: false);
+                status = "Completed";
             }
+
+#if !FUNCTIONS_V1
+            // Adding "Tags" to activity allows using App Insights to query current state of entities 
+            var activity = Activity.Current;
+
+            // The activity may be null when running unit tests, but should be non-null otherwise
+            if (activity != null)
+            {
+                activity.AddTag("DurableFunctionsType", "Entity");
+                activity.AddTag("DurableFunctionsInstanceId", this.context.InstanceId);
+                activity.AddTag("DurableFunctionsRuntimeStatus", status);
+            }
+#endif
 
             // The return value is not used.
             return string.Empty;

--- a/src/WebJobs.Extensions.DurableTask/Listener/TaskEntityShim.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/TaskEntityShim.cs
@@ -155,9 +155,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
             DurableTaskExtension.TagActivityWithOrchestrationStatus(status, this.context.InstanceId, true);
 
-            // We have this a function in `TaskOrchestrationShim` via `TagActivity`. It would be
-            // good to use that here instead.
-
             // The activity may be null when running unit tests, but should be non-null otherwise
             if (activity != null)
             {

--- a/src/WebJobs.Extensions.DurableTask/Listener/TaskOrchestrationShim.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/TaskOrchestrationShim.cs
@@ -184,12 +184,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             /* activity may be null when running this repo's tests but does not appear
              * empty when actually running the samples
              */
-            if (activity != null)
+            /*if (activity != null)
             {
                 activity.AddTag("DurableFunctionsType", "Orchestration");
                 activity.AddTag("DurableOrchestrationInstanceId", this.context.InstanceId);
                 activity.AddTag("DurableFunctionState", this.context.GetSerializedCustomStatus());
-            }
+            }*/
 #endif
             return serializedOutput;
         }

--- a/src/WebJobs.Extensions.DurableTask/Listener/TaskOrchestrationShim.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/TaskOrchestrationShim.cs
@@ -84,7 +84,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             if (!innerContext.IsReplaying)
             {
                 DurableTaskExtension.TagActivityWithOrchestrationStatus(status, this.context.InstanceId);
-
             }
 #endif
 

--- a/src/WebJobs.Extensions.DurableTask/Listener/TaskOrchestrationShim.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/TaskOrchestrationShim.cs
@@ -182,7 +182,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 #if !FUNCTIONS_V1
             var activity = Activity.Current;
             /* activity may be null when running this repo's tests but does not appear
-             * empty when actually running the samples
+             * empty when actually running the samples 
              */
             if (activity != null)
             {

--- a/src/WebJobs.Extensions.DurableTask/Listener/TaskOrchestrationShim.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/TaskOrchestrationShim.cs
@@ -47,12 +47,29 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             this.context.RaiseEvent(eventName, serializedEventData);
         }
 
+#if !FUNCTIONS_V1
+        public void ReportToAppInsights(OrchestrationRuntimeStatus status, string instanceId)
+        {
+            // Adding "Tags" to activity allows using App Insights to query current state of orchestrations
+            var activity = Activity.Current;
+
+            // The activity may be null when running unit tests, but should be non-null otherwise
+            if (activity != null)
+            {
+                activity.AddTag("DurableFunctionsType", "Orchestrator");
+                activity.AddTag("DurableFunctionsInstanceId", instanceId);
+                activity.AddTag("DurableFunctionsRuntimeStatus", Enum.GetName(status.GetType(), status));
+            }
+        }
+#endif
+
         public override async Task<string> Execute(OrchestrationContext innerContext, string serializedInput)
         {
-#if !FUNCTIONS_V1
-            // for reporting the status of the orchestration on App Insights
-            OrchestrationRuntimeStatus status;
-#endif
+            // Supress "Variable is assigned but its value is never used" in Functions V1
+#pragma warning disable CS0219
+            OrchestrationRuntimeStatus status; // for reporting the status of the orchestration on App Insights
+#pragma warning restore CS0219
+
             if (this.FunctionInvocationCallback == null)
             {
                 throw new InvalidOperationException($"The {nameof(this.FunctionInvocationCallback)} has not been assigned!");
@@ -73,9 +90,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 this.Config.GetIntputOutputTrace(serializedInput),
                 FunctionType.Orchestrator,
                 this.context.IsReplaying);
-#if !FUNCTIONS_V1
             status = OrchestrationRuntimeStatus.Running;
-#endif
 
             var orchestratorInfo = this.Config.GetOrchestratorInfo(new FunctionName(this.context.Name));
 
@@ -113,9 +128,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     exceptionDetails,
                     FunctionType.Orchestrator,
                     this.context.IsReplaying);
-#if !FUNCTIONS_V1
                 status = OrchestrationRuntimeStatus.Failed;
-#endif
+
                 if (!this.context.IsReplaying)
                 {
                     this.context.AddDeferredTask(() => this.Config.LifeCycleNotificationHelper.OrchestratorFailedAsync(
@@ -131,7 +145,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     Utils.SerializeCause(e, this.config.ErrorDataConverter));
 
                 this.context.OrchestrationException = ExceptionDispatchInfo.Capture(orchestrationException);
-
+#if !FUNCTIONS_V1
+                this.ReportToAppInsights(status, this.context.InstanceId);
+#endif
                 throw orchestrationException;
             }
             finally
@@ -178,9 +194,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 this.context.ContinuedAsNew,
                 FunctionType.Orchestrator,
                 this.context.IsReplaying);
-#if !FUNCTIONS_V1
             status = OrchestrationRuntimeStatus.Completed;
-#endif
+
             if (!this.context.IsReplaying)
             {
                 this.context.AddDeferredTask(() => this.Config.LifeCycleNotificationHelper.OrchestratorCompletedAsync(
@@ -191,18 +206,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     this.context.IsReplaying));
             }
 #if !FUNCTIONS_V1
-            // Adding "Tags" to activity allows using App Insights to query current state of orchestrations
-            var activity = Activity.Current;
-
-            // The activity may be null when running unit tests, but should be non-null otherwise
-            if (activity != null)
-            {
-                activity.AddTag("DurableFunctionsType", "Orchestrator");
-                activity.AddTag("DurableFunctionsInstanceId", this.context.InstanceId);
-                activity.AddTag("DurableFunctionsRuntimeStatus", Enum.GetName(status.GetType(), status));
-            }
+            this.ReportToAppInsights(status, this.context.InstanceId);
 #endif
-
             return serializedOutput;
         }
     }

--- a/src/WebJobs.Extensions.DurableTask/Listener/TaskOrchestrationShim.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/TaskOrchestrationShim.cs
@@ -181,8 +181,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
 #if !FUNCTIONS_V1
             var activity = Activity.Current;
-            // activity may be null when running this repo's tests but does not appear
-            // empty when actually running the samples
+            /* activity may be null when running this repo's tests but does not appear
+             * empty when actually running the samples
+             */
             if (activity != null)
             {
                 activity.AddTag("DurableFunctionsType", "Orchestration");

--- a/src/WebJobs.Extensions.DurableTask/Listener/TaskOrchestrationShim.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/TaskOrchestrationShim.cs
@@ -179,19 +179,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     this.context.IsReplaying));
             }
 
-            //#if !FUNCTIONS_V1
-            //var activity = Activity.Current;
-            /* activity may be null when running this repo's tests but does not appear
-             * empty when actually running the samples
-             */
-            /*if (activity != null) {
-              *
-              *  activity.AddTag("DurableFunctionsType", "Orchestration");
-              *  activity.AddTag("DurableFunctionsInstanceId", this.context.InstanceId);
-              * activity.AddTag("DurableFunctionsRuntimeStatus", this.context.GetSerializedCustomStatus()); 
-              * }
-              */
-            //#endif
             return serializedOutput;
         }
     }

--- a/src/WebJobs.Extensions.DurableTask/Listener/TaskOrchestrationShim.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/TaskOrchestrationShim.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
+using System.Diagnostics;
 using System.Runtime.ExceptionServices;
 using System.Threading.Tasks;
 using DurableTask.Core;
@@ -48,6 +49,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
         public override async Task<string> Execute(OrchestrationContext innerContext, string serializedInput)
         {
+#if !FUNCTIONS_V1
+            var activity = Activity.Current;
+            activity.AddTag("DurableFunctionsType", "Orchestration");
+            activity.AddTag("DurableOrchestrationInstanceID", this.context.InstanceId);
+            activity.AddTag("DurableFunctionStatus", this.context.GetSerializedCustomStatus());
+#endif
+
             if (this.FunctionInvocationCallback == null)
             {
                 throw new InvalidOperationException($"The {nameof(this.FunctionInvocationCallback)} has not been assigned!");

--- a/src/WebJobs.Extensions.DurableTask/Listener/TaskOrchestrationShim.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/TaskOrchestrationShim.cs
@@ -182,7 +182,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 #if !FUNCTIONS_V1
             var activity = Activity.Current;
             /* activity may be null when running this repo's tests but does not appear
-             * empty when actually running the samples 
+             * empty when actually running the samples
              */
             if (activity != null)
             {

--- a/src/WebJobs.Extensions.DurableTask/Listener/TaskOrchestrationShim.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/TaskOrchestrationShim.cs
@@ -110,7 +110,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     this.context.IsReplaying);
                 status = "Failed";
 
-
                 if (!this.context.IsReplaying)
                 {
                     this.context.AddDeferredTask(() => this.Config.LifeCycleNotificationHelper.OrchestratorFailedAsync(
@@ -184,7 +183,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     this.context.ContinuedAsNew,
                     this.context.IsReplaying));
             }
-
 #if !FUNCTIONS_V1
             // Adding "Tags" to activity allows using App Insights to query current state of orchestrations 
             var activity = Activity.Current;
@@ -193,7 +191,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             if (activity != null)
             {
                 activity.AddTag("DurableFunctionsType", "Orchestrator");
-                activity.AddTag("DurableFunctionsInstanceId", context.InstanceId);
+                activity.AddTag("DurableFunctionsInstanceId", this.context.InstanceId);
                 activity.AddTag("DurableFunctionsRuntimeStatus", status);
             }
 #endif

--- a/src/WebJobs.Extensions.DurableTask/Listener/TaskOrchestrationShim.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/TaskOrchestrationShim.cs
@@ -49,13 +49,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
         public override async Task<string> Execute(OrchestrationContext innerContext, string serializedInput)
         {
-#if !FUNCTIONS_V1
-            var activity = Activity.Current;
-            activity.AddTag("DurableFunctionsType", "Orchestration");
-            activity.AddTag("DurableOrchestrationInstanceID", this.context.InstanceId);
-            activity.AddTag("DurableFunctionStatus", this.context.GetSerializedCustomStatus());
-#endif
-
             if (this.FunctionInvocationCallback == null)
             {
                 throw new InvalidOperationException($"The {nameof(this.FunctionInvocationCallback)} has not been assigned!");
@@ -186,6 +179,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     this.context.IsReplaying));
             }
 
+#if !FUNCTIONS_V1
+            var activity = Activity.Current;
+            activity.AddTag("DurableFunctionsType", "Orchestration");
+            activity.AddTag("DurableOrchestrationInstanceId", this.context.InstanceId);
+            activity.AddTag("DurableFunctionState", this.context.GetSerializedCustomStatus());
+#endif
             return serializedOutput;
         }
     }

--- a/src/WebJobs.Extensions.DurableTask/Listener/TaskOrchestrationShim.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/TaskOrchestrationShim.cs
@@ -181,9 +181,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
 #if !FUNCTIONS_V1
             var activity = Activity.Current;
-            activity.AddTag("DurableFunctionsType", "Orchestration");
-            activity.AddTag("DurableOrchestrationInstanceId", this.context.InstanceId);
-            activity.AddTag("DurableFunctionState", this.context.GetSerializedCustomStatus());
+            // activity may be null when running this repo's tests but does not appear
+            // empty when actually running the samples
+            if (activity != null)
+            {
+                activity.AddTag("DurableFunctionsType", "Orchestration");
+                activity.AddTag("DurableOrchestrationInstanceId", this.context.InstanceId);
+                activity.AddTag("DurableFunctionState", this.context.GetSerializedCustomStatus());
+            }
 #endif
             return serializedOutput;
         }

--- a/src/WebJobs.Extensions.DurableTask/Listener/TaskOrchestrationShim.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/TaskOrchestrationShim.cs
@@ -91,6 +91,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 FunctionType.Orchestrator,
                 this.context.IsReplaying);
             status = OrchestrationRuntimeStatus.Running;
+#if !FUNCTIONS_V1
+            this.ReportToAppInsights(status, this.context.InstanceId);
+#endif
 
             var orchestratorInfo = this.Config.GetOrchestratorInfo(new FunctionName(this.context.Name));
 

--- a/src/WebJobs.Extensions.DurableTask/Listener/TaskOrchestrationShim.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/TaskOrchestrationShim.cs
@@ -184,12 +184,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             /* activity may be null when running this repo's tests but does not appear
              * empty when actually running the samples
              */
-            /*if (activity != null)
-            {
-                activity.AddTag("DurableFunctionsType", "Orchestration");
-                activity.AddTag("DurableFunctionsInstanceId", this.context.InstanceId);
-                activity.AddTag("DurableFunctionsRuntimeStatus", this.context.GetSerializedCustomStatus());
-            }*/
+            /*if (activity != null) {
+              *
+              *  activity.AddTag("DurableFunctionsType", "Orchestration");
+              *  activity.AddTag("DurableFunctionsInstanceId", this.context.InstanceId);
+              * activity.AddTag("DurableFunctionsRuntimeStatus", this.context.GetSerializedCustomStatus()); 
+              * }
+              */
             //#endif
             return serializedOutput;
         }

--- a/src/WebJobs.Extensions.DurableTask/Listener/TaskOrchestrationShim.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/TaskOrchestrationShim.cs
@@ -179,18 +179,18 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     this.context.IsReplaying));
             }
 
-#if !FUNCTIONS_V1
-            var activity = Activity.Current;
+            //#if !FUNCTIONS_V1
+            //var activity = Activity.Current;
             /* activity may be null when running this repo's tests but does not appear
              * empty when actually running the samples
              */
             /*if (activity != null)
             {
                 activity.AddTag("DurableFunctionsType", "Orchestration");
-                activity.AddTag("DurableOrchestrationInstanceId", this.context.InstanceId);
-                activity.AddTag("DurableFunctionState", this.context.GetSerializedCustomStatus());
+                activity.AddTag("DurableFunctionsInstanceId", this.context.InstanceId);
+                activity.AddTag("DurableFunctionsRuntimeStatus", this.context.GetSerializedCustomStatus());
             }*/
-#endif
+            //#endif
             return serializedOutput;
         }
     }

--- a/src/WebJobs.Extensions.DurableTask/Listener/TaskOrchestrationShim.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/TaskOrchestrationShim.cs
@@ -2,8 +2,6 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
-using System.Diagnostics;
-using System.Linq;
 using System.Runtime.ExceptionServices;
 using System.Threading.Tasks;
 using DurableTask.Core;


### PR DESCRIPTION
This addresses: https://github.com/Azure/azure-functions-durable-extension/issues/1172

This PR aims to add custom App Insights dimensions to enable querying recent orchestrators and entity calls.

For Orchestrators, we add the following fields:
- `DurableFunctionsType` as "Orchestrator"
- `DurableFunctionsInstanceID`
- `DurableFunctionsStatus`

For Entities, we add the following fields:
- `DurableFunctionsType` as "Entity".  I believe this tag name is a confusing, I'm open to improvements. Overall, it was unclear to me if these tags should also be prefixed with `DurableFunctions-` or `DurableEntity`
- `DurableEntityInstanceID`
- `DurableEntityStatus`

I added these tags at the beginning of the "execute" methods, but if mid-execution their state is changed, then maybe this is not a good idea. Please let me know what you think. Overall, the current approach is rather naive so I expect to iterate on this.

Also, I realize that `DurableEntityStatus` returns a string-version of what are really JSON-codified fields. I'd be happy to expand those into proper tags as well.

**Update 1:**
Below is a screenshot of how the changes look for Entities. I'm keep the screenshot small as to avoid leaking any sensitive information. This is the counter entity from the precompiled samples.
[
![appInsights1](https://user-images.githubusercontent.com/9623336/78308638-dc500100-74fd-11ea-916c-fefd47f039fb.PNG)
](url)
