### PR TITLE
Updated DurableClient ThrowIfFunctionDoesNotExist calls to work with correctly when calling a function in another app

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableClient.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableClient.cs
@@ -262,11 +262,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 throw new ArgumentNullException(nameof(operationName));
             }
 
-            if (this.client.Equals(client))
-            {
-                this.config.ThrowIfFunctionDoesNotExist(entityId.EntityName, FunctionType.Entity);
-            }
-
             var guid = Guid.NewGuid(); // unique id for this request
             var instanceId = EntityId.GetSchedulerIdFromEntityId(entityId);
             var instance = new OrchestrationInstance() { InstanceId = instanceId };

--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableClient.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableClient.cs
@@ -106,7 +106,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// <inheritdoc />
         async Task<string> IDurableOrchestrationClient.StartNewAsync<T>(string orchestratorFunctionName, string instanceId, T input)
         {
-            this.config.ThrowIfFunctionDoesNotExist(orchestratorFunctionName, FunctionType.Orchestrator);
+            if (this.ClientReferencesCurrentApp(this))
+            {
+                this.config.ThrowIfFunctionDoesNotExist(orchestratorFunctionName, FunctionType.Orchestrator);
+            }
 
             if (string.IsNullOrEmpty(instanceId))
             {
@@ -262,7 +265,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 throw new ArgumentNullException(nameof(operationName));
             }
 
-            if (this.SignalEntityReferencesSameApp(durableClient))
+            if (this.ClientReferencesCurrentApp(durableClient))
             {
                 this.config.ThrowIfFunctionDoesNotExist(entityId.EntityName, FunctionType.Entity);
             }
@@ -297,7 +300,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 isReplay: false);
         }
 
-        private bool SignalEntityReferencesSameApp(DurableClient client)
+        private bool ClientReferencesCurrentApp(DurableClient client)
         {
             return this.TaskHubMatchesCurrentApp(client) && this.ConnectionNameMatchesCurrentApp(client);
         }

--- a/test/Common/DurableClientBaseTests.cs
+++ b/test/Common/DurableClientBaseTests.cs
@@ -57,7 +57,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
         [Theory]
         [Trait("Category", PlatformSpecificHelpers.TestCategory)]
-        [InlineData("")]
         [InlineData("@invalid")]
         [InlineData("/invalid")]
         [InlineData("invalid\\")]

--- a/test/Common/DurableTaskEndToEndTests.cs
+++ b/test/Common/DurableTaskEndToEndTests.cs
@@ -4536,13 +4536,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             taskHubName += PlatformSpecificHelpers.VersionSuffix;
 
             Assert.Equal(
-                $"{notificationUrl}/instances/{instanceId}?taskHub={taskHubName}&connection=Storage&code=mykey",
+                $"{notificationUrl}/instances/{instanceId}?taskHub={taskHubName}&connection=AzureWebJobsStorage&code=mykey",
                 httpManagementPayload.StatusQueryGetUri);
             Assert.Equal(
-                $"{notificationUrl}/instances/{instanceId}/raiseEvent/{{eventName}}?taskHub={taskHubName}&connection=Storage&code=mykey",
+                $"{notificationUrl}/instances/{instanceId}/raiseEvent/{{eventName}}?taskHub={taskHubName}&connection=AzureWebJobsStorage&code=mykey",
                 httpManagementPayload.SendEventPostUri);
             Assert.Equal(
-                $"{notificationUrl}/instances/{instanceId}/terminate?reason={{text}}&taskHub={taskHubName}&connection=Storage&code=mykey",
+                $"{notificationUrl}/instances/{instanceId}/terminate?reason={{text}}&taskHub={taskHubName}&connection=AzureWebJobsStorage&code=mykey",
                 httpManagementPayload.TerminatePostUri);
         }
 

--- a/test/Common/TestHelpers.cs
+++ b/test/Common/TestHelpers.cs
@@ -99,6 +99,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             // Azure Storage specfic tests
             if (string.Equals(storageProviderType, AzureStorageProviderType))
             {
+                options.StorageProvider["ConnectionStringName"] = "AzureWebJobsStorage";
                 options.StorageProvider["fetchLargeMessagesAutomatically"] = autoFetchLargeMessages;
                 if (maxQueuePollingInterval != null)
                 {


### PR DESCRIPTION
resolves #1248 
related to #1281 

Updated ThrowIfDoesNotExist check to only be called if the connectionName matches the connectionName in DurableTaskOptions.StorageProvider. This prevents an exception from being thrown when a user is signaling an entity or starting an orchestrator in another app.