### PR TITLE
Allow for dynamic port usage for local rpc endpoint if 17071 in use

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/LocalHttpListener.cs
+++ b/src/WebJobs.Extensions.DurableTask/LocalHttpListener.cs
@@ -83,7 +83,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
         private int GetAvailablePort()
         {
-            // If we are able to successfully start a listener looking on the default port without 
+            // If we are able to successfully start a listener looking on the default port without
             // an exception, we can use the default port. Otherwise, let the TcpListener class decide for us.
             try
             {

--- a/src/WebJobs.Extensions.DurableTask/LocalHttpListener.cs
+++ b/src/WebJobs.Extensions.DurableTask/LocalHttpListener.cs
@@ -5,7 +5,9 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Net;
 using System.Net.Http;
+using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
@@ -18,19 +20,35 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 {
     internal class LocalHttpListener : IDisposable
     {
+        private const int DefaultPort = 17071;
+
         private readonly DurableTaskExtension extension;
         private readonly IWebHost localWebHost;
         private readonly Func<HttpRequestMessage, Task<HttpResponseMessage>> handler;
 
         public LocalHttpListener(
             DurableTaskExtension extension,
-            Uri listenUri,
             Func<HttpRequestMessage, Task<HttpResponseMessage>> handler)
         {
             this.extension = extension ?? throw new ArgumentNullException(nameof(extension));
             this.handler = handler ?? throw new ArgumentNullException(nameof(handler));
-            this.localWebHost = this.CreateWebHost(listenUri);
+#if !FUNCTIONS_V1
+            this.InternalRpcUri = new Uri($"http://127.0.0.1:{this.GetAvailablePort()}/durabletask/");
+            var listenUri = new Uri(this.InternalRpcUri.GetLeftPart(UriPartial.Authority));
+            this.localWebHost = new WebHostBuilder()
+                .UseKestrel()
+                .UseUrls(listenUri.OriginalString)
+                .Configure(a => a.Run(this.HandleRequestAsync))
+                .Build();
+#else
+            // Just use default port for internal Uri. No need to check for port availability since
+            // we won't be listening to this endpoint.
+            this.InternalRpcUri = new Uri($"http://127.0.0.1:{DefaultPort}/durabletask/");
+            this.localWebHost = new NoOpWebHost();
+#endif
         }
+
+        public Uri InternalRpcUri { get; }
 
         public bool IsListening { get; private set; }
 
@@ -45,11 +63,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
 #if !FUNCTIONS_V1
             await this.localWebHost.StartAsync();
+            this.IsListening = true;
 #else
             // no-op: this is dummy code to make build warnings go away
             await Task.Yield();
 #endif
-            this.IsListening = true;
         }
 
         public async Task StopAsync()
@@ -63,27 +81,27 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             this.IsListening = false;
         }
 
-        private IWebHost CreateWebHost(Uri listenUri)
+        private int GetAvailablePort()
         {
-            if (listenUri == null)
+            // If we are able to successfully start a listener looking on the default port without 
+            // an exception, we can use the default port. Otherwise, let the TcpListener class decide for us.
+            try
             {
-                throw new ArgumentNullException(nameof(listenUri));
+                var listener = new TcpListener(IPAddress.Loopback, DefaultPort);
+                listener.Start();
+                listener.Stop();
+                return DefaultPort;
             }
-
-            if (listenUri.AbsolutePath.Length > 1)
+            catch (SocketException)
             {
-                throw new ArgumentException($"The listen URL must not contain a path.", nameof(listenUri));
+                // Following guidance of this stack overflow answer
+                // to find available port: https://stackoverflow.com/a/150974/9035640
+                var listener = new TcpListener(IPAddress.Loopback, 0);
+                listener.Start();
+                int availablePort = ((IPEndPoint)listener.LocalEndpoint).Port;
+                listener.Stop();
+                return availablePort;
             }
-
-#if !FUNCTIONS_V1
-            return new WebHostBuilder()
-                .UseKestrel()
-                .UseUrls(listenUri.OriginalString)
-                .Configure(a => a.Run(this.HandleRequestAsync))
-                .Build();
-#else
-            return new NoOpWebHost();
-#endif
         }
 
         private async Task HandleRequestAsync(HttpContext context)

--- a/test/Common/DurableTaskEndToEndTests.cs
+++ b/test/Common/DurableTaskEndToEndTests.cs
@@ -4064,6 +4064,38 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             }
         }
 
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public async Task MultipleHostsLocalRpcSameDevice()
+        {
+            ITestHost host1 = TestHelpers.GetJobHost(
+                    this.loggerProvider,
+                    nameof(this.MultipleHostsLocalRpcSameDevice) + "1",
+                    false,
+                    localRpcEndpointEnabled: true);
+            await host1.StartAsync();
+            ITestHost host2 = TestHelpers.GetJobHost(
+                    this.loggerProvider,
+                    nameof(this.MultipleHostsLocalRpcSameDevice) + "2",
+                    false,
+                    localRpcEndpointEnabled: true);
+            try
+            {
+                await host2.StartAsync();
+            }
+            catch (Exception)
+            {
+                Assert.True(false, "Could not start up two hosts on the same device in parallel");
+            }
+            finally
+            {
+                await host1.StopAsync();
+                host1.Dispose();
+                await host2.StopAsync();
+                host2.Dispose();
+            }
+        }
+
         /// <summary>
         /// End-to-end test which validates that bad input for task hub name throws instance of <see cref="ArgumentException"/>.
         /// </summary>


### PR DESCRIPTION
Our initial implementation of Local HTTP for out-of-proc languages always uses the port 17071. This can cause issues with slots, as well as caused some noisy telemetry when hosts would shut down occasionally.

We now check to see if the default port is available before attempting to bind to it. There is still some degree of race condition if the extensions are instantiated before the port is being listened to, but in general the OS should provide some protections against this.