### PR TITLE
Analyzer: FunctionName can be constant in CallActivityAsync, Fixes InvalidCastException

### DIFF
--- a/src/WebJobs.Extensions.DurableTask.Analyzers/Analyzers/ActivityFunction/FunctionAnalyzer.cs
+++ b/src/WebJobs.Extensions.DurableTask.Analyzers/Analyzers/ActivityFunction/FunctionAnalyzer.cs
@@ -104,11 +104,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
 
         private bool TryGetFunctionNameFromActivityInvocation(InvocationExpressionSyntax invocationExpression, out SyntaxNode functionNameNode, out string functionName)
         {
-            functionNameNode = invocationExpression.ArgumentList.Arguments.FirstOrDefault();
-            if (functionNameNode != null)
+            var functionArgument = invocationExpression.ArgumentList.Arguments.FirstOrDefault();
+            if (functionArgument != null)
             {
-                SyntaxNodeUtils.TryGetFunctionName(semanticModel, functionNameNode, out functionName);
-                return functionName != null;
+                functionNameNode = functionArgument.ChildNodes().FirstOrDefault();
+                if (functionNameNode != null)
+                {
+                    SyntaxNodeUtils.TryParseFunctionName(semanticModel, functionNameNode, out functionName);
+                    return functionName != null;
+                }
             }
 
             functionNameNode = null;
@@ -137,7 +141,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
             var attribute = context.Node as AttributeSyntax;
             if (SyntaxNodeUtils.IsActivityTriggerAttribute(attribute))
             {
-                if (!SyntaxNodeUtils.TryGetFunctionNameAndNode(context.SemanticModel, attribute, out SyntaxNode attributeArgument, out string functionName))
+                if (!SyntaxNodeUtils.TryGetFunctionName(context.SemanticModel, attribute, out string functionName))
                 {
                     //Do not store ActivityFunctionDefinition if there is no function name
                     return;

--- a/src/WebJobs.Extensions.DurableTask.Analyzers/Analyzers/Entity/DispatchEntityNameAnalyzer.cs
+++ b/src/WebJobs.Extensions.DurableTask.Analyzers/Analyzers/Entity/DispatchEntityNameAnalyzer.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
 
                     if (SyntaxNodeUtils.TryGetTypeArgumentNode(expression, out SyntaxNode identifierNode))
                     {
-                        if (SyntaxNodeUtils.TryGetFunctionNameAndNode(context.SemanticModel, expression, out SyntaxNode attributeArgument, out string functionName))
+                        if (SyntaxNodeUtils.TryGetFunctionName(context.SemanticModel, expression, out string functionName))
                         {
                             var identifierName = identifierNode.ToString();
                             if (!string.Equals(identifierName, functionName))

--- a/src/WebJobs.Extensions.DurableTask.Analyzers/Analyzers/Entity/StaticFunctionAnalyzer.cs
+++ b/src/WebJobs.Extensions.DurableTask.Analyzers/Analyzers/Entity/StaticFunctionAnalyzer.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
 
         private static bool IsInEntityClass(SemanticModel semanticModel, SyntaxNode methodDeclaration)
         {
-            if (SyntaxNodeUtils.TryGetFunctionNameAndNode(semanticModel, methodDeclaration, out SyntaxNode attributeArgument, out string functionName))
+            if (SyntaxNodeUtils.TryGetFunctionName(semanticModel, methodDeclaration, out string functionName))
             {
                 if (SyntaxNodeUtils.TryGetClassName(methodDeclaration, out string className))
                 {

--- a/src/WebJobs.Extensions.DurableTask.Analyzers/Analyzers/Orchestrator/MethodAnalyzer.cs
+++ b/src/WebJobs.Extensions.DurableTask.Analyzers/Analyzers/Orchestrator/MethodAnalyzer.cs
@@ -89,7 +89,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
                         if (syntaxReference != null)
                         {
                             var declaration = syntaxReference.GetSyntax(context.CancellationToken);
-                            if (declaration != null)
+                            if (declaration != null && !methodDeclaration.Equals(declaration))
                             {
                                 methodInformationList.Add(new MethodInformation(declaration, invocation));
                             }

--- a/src/WebJobs.Extensions.DurableTask.Analyzers/Analyzers/Orchestrator/OrchestratorAnalyzer.cs
+++ b/src/WebJobs.Extensions.DurableTask.Analyzers/Analyzers/Orchestrator/OrchestratorAnalyzer.cs
@@ -60,19 +60,17 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
 
         private void AnalyzeMethod(SyntaxNodeAnalysisContext context)
         {
-            var declaration = (MethodDeclarationSyntax)context.Node;
-            if (!SyntaxNodeUtils.IsInsideOrchestrator(declaration)
-                || !SyntaxNodeUtils.IsInsideFunction(context.SemanticModel, declaration))
+            if (context.Node is MethodDeclarationSyntax declaration
+                && SyntaxNodeUtils.IsInsideOrchestrator(declaration)
+                && SyntaxNodeUtils.IsInsideFunction(context.SemanticModel, declaration))
             {
-                return;
-            }
-            
-            if (this.semanticModel == null)
-            {
-                this.semanticModel = context.SemanticModel;
-            }
+                if (this.semanticModel == null)
+                {
+                    this.semanticModel = context.SemanticModel;
+                }
 
-            this.orchestratorMethodDeclarations.Add(declaration);
+                this.orchestratorMethodDeclarations.Add(declaration);
+            }
         }
     }
 }

--- a/src/WebJobs.Extensions.DurableTask.Analyzers/CodefixProviders/Entity/DispatchEntityNameCodeFixProvider.cs
+++ b/src/WebJobs.Extensions.DurableTask.Analyzers/CodefixProviders/Entity/DispatchEntityNameCodeFixProvider.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
 
             var identifierNode = root.FindNode(diagnosticSpan);
             SemanticModel semanticModel = await context.Document.GetSemanticModelAsync();
-            if (SyntaxNodeUtils.TryGetFunctionNameAndNode(semanticModel, identifierNode, out SyntaxNode functionAttribute, out string functionName))
+            if (SyntaxNodeUtils.TryGetFunctionName(semanticModel, identifierNode, out string functionName))
             {
                 context.RegisterCodeFix(
                 CodeAction.Create(FixDispatchEntityCall.ToString(), cancellationToken => CodeFixProviderUtils.ReplaceWithIdentifierAsync(context.Document, identifierNode, cancellationToken, functionName), nameof(DispatchEntityNameCodeFixProvider)),

--- a/src/WebJobs.Extensions.DurableTask.Analyzers/StringExtension.cs
+++ b/src/WebJobs.Extensions.DurableTask.Analyzers/StringExtension.cs
@@ -36,21 +36,5 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
             }
             return d[baseLength, comparisonLength];
         }
-
-        public static string GetCleanedFunctionName(this string functionName)
-        {
-            const string nameofStart = "nameof(";
-            const string nameofEnd = ")";
-            if (functionName.StartsWith(nameofStart) && functionName.EndsWith(nameofEnd))
-            {
-                functionName = functionName.Substring(nameofStart.Length, functionName.Length - nameofStart.Length - nameofEnd.Length);
-            }
-            else
-            {
-                functionName = functionName.Trim('"');
-            }
-
-            return functionName;
-        }
     }
 }

--- a/src/WebJobs.Extensions.DurableTask.Analyzers/WebJobs.Extensions.DurableTask.Analyzers.csproj
+++ b/src/WebJobs.Extensions.DurableTask.Analyzers/WebJobs.Extensions.DurableTask.Analyzers.csproj
@@ -8,7 +8,7 @@
 
   <PropertyGroup>
     <PackageId>Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers</PackageId>
-    <PackageVersion>0.2.0</PackageVersion>
+    <PackageVersion>0.2.1</PackageVersion>
     <Authors>Microsoft</Authors>
     <PackageLicenseUrl>https://go.microsoft.com/fwlink/?linkid=2028464</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/Azure/azure-functions-durable-extension</PackageProjectUrl>

--- a/test/WebJobs.Extensions.DurableTask.Analyzers.Test/ActivityFunction/NameAnalyzerTests.cs
+++ b/test/WebJobs.Extensions.DurableTask.Analyzers.Test/ActivityFunction/NameAnalyzerTests.cs
@@ -34,6 +34,9 @@ namespace VSSample
 {
     public static class HelloSequence
     {
+        public const string FunctionName = ""SayHelloByConstFuncName"";
+        public const string FunctionNameWithClass = ""SayHelloByConstFuncNameWithClass"";
+
         // Should not flag code on non function
         public static async Task<List<string>> NonFunctionInvalidNames(
             [OrchestrationTrigger] IDurableOrchestrationContext context)
@@ -62,6 +65,10 @@ namespace VSSample
                 outputs.Add(await context.CallActivityAsync<string>(nameof(SayHelloByClassName), ""Amsterdam""));
                 outputs.Add(await context.CallActivityAsync<string>(""SayHelloByMethodName"", ""Amsterdam""));
                 outputs.Add(await context.CallActivityAsync<string>(nameof(SayHelloByMethodName), ""Amsterdam""));
+                outputs.Add(await context.CallActivityAsync<string>(""SayHelloByConstFuncName"", ""Amsterdam""));
+                outputs.Add(await context.CallActivityAsync<string>(""SayHelloByConstFuncNameWithClass"", ""Amsterdam""));
+                outputs.Add(await context.CallActivityAsync<string>(constantSayHelloByConstFuncName, ""Amsterdam""));
+                outputs.Add(await context.CallActivityAsync<string>(HelloSequence.constantSayHelloByConstFuncNameWithClass, ""Amsterdam""));
 
                 return outputs;
             }
@@ -83,13 +90,13 @@ namespace VSSample
         public static string SayHello([ActivityTrigger] IDurableActivityContext context)
         {
             string name = context.GetInput<Object>();
-            return $""Hello Ben!"";
+            return $""Hello World!"";
         }
 
         [FunctionName(""E1_SayHello_Object_DirectInput"")]
         public static string SayHelloDirectInput([ActivityTrigger] Object name)
         {
-            return $""Hello Ben!"";
+            return $""Hello World!"";
         }
 
         [FunctionName(""E1_SayHello_Tuple"")]
@@ -107,6 +114,22 @@ namespace VSSample
         }
 
         [FunctionName(nameof(SayHelloByMethodName))]
+        public static string SayHelloByMethodName([ActivityTrigger] IDurableActivityContext context)
+        {
+            string name = context.GetInput<string>();
+            return $""Hello {name}!"";
+        }
+
+        
+        //constant variable used as functionName
+        [FunctionName(FunctionName)]
+        public static string SayHelloByMethodName([ActivityTrigger] IDurableActivityContext context)
+        {
+            string name = context.GetInput<string>();
+            return $""Hello {name}!"";
+        }
+
+        [FunctionName(HelloSequence.FunctionNameWithClass)]
         public static string SayHelloByMethodName([ActivityTrigger] IDurableActivityContext context)
         {
             string name = context.GetInput<string>();

--- a/test/WebJobs.Extensions.DurableTask.Analyzers.Test/Orchestrator/MethodAnalyzerTests.cs
+++ b/test/WebJobs.Extensions.DurableTask.Analyzers.Test/Orchestrator/MethodAnalyzerTests.cs
@@ -46,11 +46,18 @@ namespace VSSample
         {
             string.ToUpper(""Method not defined in source code"");
             IndirectCall();
+            RecursiveCall();
             return ""Hi"";
         }
 
         public static Object IndirectCall()
         {
+            return new Object();
+        }
+
+        public static Object RecursiveCall()
+        {
+            RecursiveCall();
             return new Object();
         }
     }


### PR DESCRIPTION
resolves #1292 
resolves #1287 
resolves #1310 

Fixes an issue where Orchestrator analyzer threw an InvalidCastException, casting to MethodDeclarationSyntax, when analyzing LocalFunctionStatementSyntax.

Fixes the CallActivityAsync piece of recognizing FunctionNames can be constants in FunctionAnalyzers.

Fixes a bug with MethodAnalyzer that causes a StackOverflowException when analyzing a recursive method.