### PR TITLE
Analyzer: Fixed several FunctionAnalyzer bugs

### DIFF
--- a/src/WebJobs.Extensions.DurableTask.Analyzers/Analyzers/ActivityFunction/FunctionReturnTypeAnalyzer.cs
+++ b/src/WebJobs.Extensions.DurableTask.Analyzers/Analyzers/ActivityFunction/FunctionReturnTypeAnalyzer.cs
@@ -55,7 +55,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
                 definitionReturnType = taskTypeArgument;
             }
 
-            return SyntaxNodeUtils.InputMatchesOrCompatibleType(invocationReturnType, definitionReturnType);
+            return SyntaxNodeUtils.InputMatchesOrCompatibleType(invocationReturnType, definitionReturnType)
+                || SyntaxNodeUtils.TypeNodeImplementsOrExtendsType(definitionReturnType, invocationReturnType.ToString());
         }
 
         private static bool TryGetTaskTypeArgument(ITypeSymbol returnType, out ITypeSymbol taskTypeArgument)

--- a/src/WebJobs.Extensions.DurableTask.Analyzers/Analyzers/ActivityFunction/FunctionReturnTypeAnalyzer.cs
+++ b/src/WebJobs.Extensions.DurableTask.Analyzers/Analyzers/ActivityFunction/FunctionReturnTypeAnalyzer.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
                     TryGetInvocationReturnType(semanticModel, activityInvocation, out ITypeSymbol invocationReturnType);
                     TryGetDefinitionReturnType(semanticModel, functionDefinition, out ITypeSymbol definitionReturnType);
 
-                    if (!InputMatchesOrTaskOrCompatibleType(invocationReturnType, definitionReturnType))
+                    if (!IsValidReturnTypeForDefinition(invocationReturnType, definitionReturnType))
                     {
                         var invocationTypeName = SyntaxNodeUtils.GetQualifiedTypeName(invocationReturnType);
                         var functionTypeName = SyntaxNodeUtils.GetQualifiedTypeName(definitionReturnType);
@@ -48,7 +48,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
             }
         }
 
-        private static bool InputMatchesOrTaskOrCompatibleType(ITypeSymbol invocationReturnType, ITypeSymbol definitionReturnType)
+        private static bool IsValidReturnTypeForDefinition(ITypeSymbol invocationReturnType, ITypeSymbol definitionReturnType)
         {
             if (TryGetTaskTypeArgument(definitionReturnType, out ITypeSymbol taskTypeArgument))
             {

--- a/src/WebJobs.Extensions.DurableTask.Analyzers/SyntaxNodeUtils.cs
+++ b/src/WebJobs.Extensions.DurableTask.Analyzers/SyntaxNodeUtils.cs
@@ -343,8 +343,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
             }
 
             return invocationType.Equals(definitionType)
-                || AreEqualTupleTypes(invocationType, definitionType)
                 || AreCompatibleIEnumerableTypes(invocationType, definitionType);
+                //|| AreEqualTupleTypes(invocationType, definitionType);
         }
 
         private static bool AreEqualTupleTypes(ITypeSymbol invocationType, ITypeSymbol definitionType)

--- a/src/WebJobs.Extensions.DurableTask.Analyzers/SyntaxNodeUtils.cs
+++ b/src/WebJobs.Extensions.DurableTask.Analyzers/SyntaxNodeUtils.cs
@@ -67,12 +67,17 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
         {
             if (TryGetMethodDeclaration(node, out SyntaxNode methodDeclaration))
             {
-                returnTypeNode = methodDeclaration.ChildNodes().Where(x => x.IsKind(SyntaxKind.GenericName) || x.IsKind(SyntaxKind.PredefinedType) || x.IsKind(SyntaxKind.IdentifierName) || x.IsKind(SyntaxKind.ArrayType)).FirstOrDefault();
-                return true;
+                return TryGetChildTypeNode(methodDeclaration, out returnTypeNode);
             }
 
             returnTypeNode = null;
             return false;
+        }
+
+        private static bool TryGetChildTypeNode(SyntaxNode node, out SyntaxNode childTypeNode)
+        {
+            childTypeNode = node.ChildNodes().Where(x => x.IsKind(SyntaxKind.IdentifierName) || x.IsKind(SyntaxKind.PredefinedType) || x.IsKind(SyntaxKind.GenericName) || x.IsKind(SyntaxKind.ArrayType) || x.IsKind(SyntaxKind.TupleType)).FirstOrDefault();
+            return childTypeNode != null;
         }
 
         private static bool TryGetAttribute(SyntaxNode node, string attributeName, out SyntaxNode attribute)
@@ -269,8 +274,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
         internal static bool TryGetParameterNodeNextToAttribute(SyntaxNodeAnalysisContext context, AttributeSyntax attributeExpression, out SyntaxNode inputType)
         {
             var parameter = attributeExpression.Parent.Parent;
-            inputType = parameter.ChildNodes().Where(x => x.IsKind(SyntaxKind.IdentifierName) || x.IsKind(SyntaxKind.PredefinedType) || x.IsKind(SyntaxKind.GenericName)).FirstOrDefault();
-            return inputType != null;
+            return TryGetChildTypeNode(parameter, out inputType);
         }
 
         internal static bool TryGetTypeArgumentNode(MemberAccessExpressionSyntax expression, out SyntaxNode identifierNode)
@@ -343,11 +347,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
             }
 
             return invocationType.Equals(definitionType)
-                || AreCompatibleIEnumerableTypes(invocationType, definitionType);
-                //|| AreEqualTupleTypes(invocationType, definitionType);
+                || AreCompatibleIEnumerableTypes(invocationType, definitionType)
+                || AreEqualQualifiedTypeNames(invocationType, definitionType);
         }
 
-        private static bool AreEqualTupleTypes(ITypeSymbol invocationType, ITypeSymbol definitionType)
+        private static bool AreEqualQualifiedTypeNames(ITypeSymbol invocationType, ITypeSymbol definitionType)
         {
             var invocationQualifiedName = GetQualifiedTypeName(invocationType);
             var definitionQualifiedName = GetQualifiedTypeName(definitionType);
@@ -359,11 +363,45 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
         {
             if (AreArrayOrNamedTypes(invocationType, functionType) && UnderlyingTypesMatch(invocationType, functionType))
             {
-                return ((invocationType.AllInterfaces.Any(i => i.Name.Equals("IEnumerable")))
-                    && (functionType.AllInterfaces.Any(i => i.Name.Equals("IEnumerable"))));
+                return TypeNodeImplementsOrExtendsType(invocationType, "IEnumerable")
+                    && TypeNodeImplementsOrExtendsType(functionType, "IEnumerable");
             }
 
             return false;
+        }
+
+        public static bool TypeNodeImplementsOrExtendsType(ITypeSymbol node, string interfaceOrBase)
+        {
+            if (string.IsNullOrEmpty(interfaceOrBase))
+            {
+                return false;
+            }
+
+            return node.AllInterfaces.Any(i => i.Name.Equals(interfaceOrBase))
+                || TypeNodeIsSubclass(node, interfaceOrBase);
+
+        }
+
+        private static bool TypeNodeIsSubclass(ITypeSymbol node, string baseClass)
+        {
+            if (node == null || string.IsNullOrEmpty(baseClass))
+            {
+                return false;
+            }
+
+            var curr = node.BaseType;
+            while (curr != null)
+            {
+                if (curr.ToString().Equals(baseClass))
+                {
+                    return true;
+                }
+
+                curr = curr.BaseType;
+            }
+
+            return false;
+
         }
 
         private static bool AreArrayOrNamedTypes(ITypeSymbol invocationType, ITypeSymbol functionType)

--- a/src/WebJobs.Extensions.DurableTask.Analyzers/SyntaxNodeUtils.cs
+++ b/src/WebJobs.Extensions.DurableTask.Analyzers/SyntaxNodeUtils.cs
@@ -175,7 +175,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
                 return true;
             }
 
-            if (TryGetFunctionNameInConstant(semanticModel, node, out functionName))
+            var newSemanticModel = GetSyntaxTreeSemanticModel(semanticModel, node);
+            if (TryGetFunctionNameInConstant(newSemanticModel, node, out functionName))
             {
                 return true;
             }
@@ -312,7 +313,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
                     var tupleUnderlyingType = namedTypeInfo.TupleUnderlyingType;
                     if (tupleUnderlyingType != null)
                     {
-                        return $"System.Tuple<{string.Join(", ", tupleUnderlyingType.TypeArguments.Select(x => x.ToString()))}>";
+                        return $"({string.Join(", ", tupleUnderlyingType.TypeArguments.Select(x => x.ToString()))})";
                     }
 
                     return typeInfo.ToString();

--- a/src/WebJobs.Extensions.DurableTask.Analyzers/WebJobs.Extensions.DurableTask.Analyzers.csproj
+++ b/src/WebJobs.Extensions.DurableTask.Analyzers/WebJobs.Extensions.DurableTask.Analyzers.csproj
@@ -8,7 +8,7 @@
 
   <PropertyGroup>
     <PackageId>Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers</PackageId>
-    <PackageVersion>0.2.1</PackageVersion>
+    <PackageVersion>0.2.2</PackageVersion>
     <Authors>Microsoft</Authors>
     <PackageLicenseUrl>https://go.microsoft.com/fwlink/?linkid=2028464</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/Azure/azure-functions-durable-extension</PackageProjectUrl>

--- a/test/WebJobs.Extensions.DurableTask.Analyzers.Test/ActivityFunction/ArgumentAnalyzerTests.cs
+++ b/test/WebJobs.Extensions.DurableTask.Analyzers.Test/ActivityFunction/ArgumentAnalyzerTests.cs
@@ -60,8 +60,11 @@ namespace VSSample
                 outputs.Add(await context.CallActivityAsync<string>(""E1_SayHello_DirectInput"", ""London""));
                 outputs.Add(await context.CallActivityAsync<string>(""E1_SayHello_Object"", new Object()));
                 outputs.Add(await context.CallActivityAsync<string>(""E1_SayHello_Object_DirectInput"", new Object()));
-                outputs.Add(await context.CallActivityAsync<string>(""E1_SayHello_Tuple"", (""Seattle"", 4)));
-                outputs.Add(await context.CallActivityAsync<string>(""E1_SayHello_Tuple_OnContext"", (""Seattle"", 4)));
+                Tuple<string, int> tuple = new Tuple<string, int>(""Seattle"", 4);
+                outputs.Add(await context.CallActivityAsync<string>(""E1_SayHello_Tuple"", tuple));
+                outputs.Add(await context.CallActivityAsync<string>(""E1_SayHello_Tuple_OnContext"", tuple));
+                outputs.Add(await context.CallActivityAsync<string>(""E1_SayHello_ValueTuple"", (""Seattle"", 4)));
+                outputs.Add(await context.CallActivityAsync<string>(""E1_SayHello_ValueTuple_OnContext"", (""Seattle"", 4)));
 
                 // ArrayType and NamedType (IEnumerable types) match
                 string[] arrayType = new string[] { ""Seattle"", ""Tokyo"" };
@@ -104,7 +107,7 @@ namespace VSSample
             return $""Hello World!"";
         }
 
-        [FunctionName(""E1_SayHello_Tuple"")]
+       [FunctionName(""E1_SayHello_Tuple"")]
         public static string SayHelloTuple([ActivityTrigger] Tuple<string, int> tupleTest)
         {
             string name = tupleTest;
@@ -112,6 +115,20 @@ namespace VSSample
         }
 
         [FunctionName(""E1_SayHello_Tuple_OnContext"")]
+        public static string SayHelloTupleOnContext([ActivityTrigger] IDurableActivityContext context)
+        {
+            string name = context.GetInput<Tuple<string, int>>();
+            return $""Hello {name}!"";
+        }
+
+        [FunctionName(""E1_SayHello_ValueTuple"")]
+        public static string SayHelloTuple([ActivityTrigger] ValueTuple<string, int> tupleTest)
+        {
+            string name = tupleTest;
+            return $""Hello {name}!"";
+        }
+
+        [FunctionName(""E1_SayHello_ValueTuple_OnContext"")]
         public static string SayHelloTupleOnContext([ActivityTrigger] IDurableActivityContext context)
         {
             string name = context.GetInput<(string, int)>();

--- a/test/WebJobs.Extensions.DurableTask.Analyzers.Test/ActivityFunction/ArgumentAnalyzerTests.cs
+++ b/test/WebJobs.Extensions.DurableTask.Analyzers.Test/ActivityFunction/ArgumentAnalyzerTests.cs
@@ -56,27 +56,27 @@ namespace VSSample
                 var outputs = new List<string>();
 
                 // Testing different matching input types
-                outputs.Add(await context.CallActivityAsync<string>(""E1_SayHello"", ""Tokyo""));
-                outputs.Add(await context.CallActivityAsync<string>(""E1_SayHello_DirectInput"", ""London""));
-                outputs.Add(await context.CallActivityAsync<string>(""E1_SayHello_Object"", new Object()));
-                outputs.Add(await context.CallActivityAsync<string>(""E1_SayHello_Object_DirectInput"", new Object()));
+                await context.CallActivityAsync<string>(""E1_SayHello"", ""Tokyo"");
+                await context.CallActivityAsync<string>(""E1_SayHello_DirectInput"", ""London"");
+                await context.CallActivityAsync<string>(""E1_SayHello_Object"", new Object());
+                await context.CallActivityAsync<string>(""E1_SayHello_Object_DirectInput"", new Object());
                 Tuple<string, int> tuple = new Tuple<string, int>(""Seattle"", 4);
-                outputs.Add(await context.CallActivityAsync<string>(""E1_SayHello_Tuple"", tuple));
-                outputs.Add(await context.CallActivityAsync<string>(""E1_SayHello_Tuple_OnContext"", tuple));
-                outputs.Add(await context.CallActivityAsync<string>(""E1_SayHello_ValueTuple"", (""Seattle"", 4)));
-                outputs.Add(await context.CallActivityAsync<string>(""E1_SayHello_ValueTuple_OnContext"", (""Seattle"", 4)));
+                await context.CallActivityAsync<string>(""E1_SayHello_Tuple"", tuple);
+                await context.CallActivityAsync<string>(""E1_SayHello_Tuple_OnContext"", tuple);
+                await context.CallActivityAsync<string>(""E1_SayHello_ValueTuple"", (""Seattle"", 4));
+                await context.CallActivityAsync<string>(""E1_SayHello_ValueTuple_OnContext"", (""Seattle"", 4));
 
                 // ArrayType and NamedType (IEnumerable types) match
                 string[] arrayType = new string[] { ""Seattle"", ""Tokyo"" };
-                outputs.Add(await context.CallActivityAsync<string>(""E1_SayHello_ArrayToNamed"", arrayType));
+                await context.CallActivityAsync<string>(""E1_SayHello_ArrayToNamed"", arrayType);
                 
                 // NamedType and NamedType (IEnumerable types) match
                 List<string> namedType = new List<string>();
-                outputs.Add(await context.CallActivityAsync<string>(""E1_SayHello_NamedToNamed"", namedType));
-                outputs.Add(await context.CallActivityAsync<string>(""E1_SayHello_NamedToNamed_Direct"", namedType));
+                await context.CallActivityAsync<string>(""E1_SayHello_NamedToNamed"", namedType);
+                await context.CallActivityAsync<string>(""E1_SayHello_NamedToNamed_Direct"", namedType);
 
                 // null input when function input not used
-                outputs.Add(await context.CallActivityAsync<string>(""E1_SayHello_NotUsed"", null));
+                await context.CallActivityAsync<string>(""E1_SayHello_NotUsed"", null);
             
                 return outputs;
             }

--- a/test/WebJobs.Extensions.DurableTask.Analyzers.Test/ActivityFunction/ArgumentAnalyzerTests.cs
+++ b/test/WebJobs.Extensions.DurableTask.Analyzers.Test/ActivityFunction/ArgumentAnalyzerTests.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers.Test.Activity
         private static readonly DiagnosticSeverity Severity = ArgumentAnalyzer.Severity;
 
         [TestMethod]
-        public void Argument_NonIssueCalls()
+        public void Argument_NoDiagnosticTestCases()
         {
             var test = @"
 using System;
@@ -33,130 +33,174 @@ namespace VSSample
 {
     public static class HelloSequence
     {
-        // Should not flag code on non function
-        public static async Task<List<string>> NotInsideFunctionWrongInput(
+        // Testing that no diagnostics are produced when method does not have the FunctionName attribute present
+        public static async Task<string> NotInsideFunctionWrongInput(
             [OrchestrationTrigger] IDurableOrchestrationContext context)
             {
-                var outputs = new List<string>();
-
-                outputs.Add(await context.CallActivityAsync<string>(""E1_SayHello"", 100));
-                outputs.Add(await context.CallActivityAsync<string>(""E1_SayHello_DirectInput"", 100));
-                outputs.Add(await context.CallActivityAsync<string>(""E1_SayHello_Object"", 100));
-                outputs.Add(await context.CallActivityAsync<string>(""E1_SayHello_Object_DirectInput"", 100));
-                outputs.Add(await context.CallActivityAsync<string>(""E1_SayHello_Tuple"", 100));
-                outputs.Add(await context.CallActivityAsync<string>(""E1_SayHello_Tuple_OnContext"", 100));
+                // Incorrect inputs on some test functions used below
+                await context.CallActivityAsync<string>(""Test_String_DirectInput"", 100);
+                await context.CallActivityAsync<string>(""Test_String_OnContext"", 100);
+                await context.CallActivityAsync<string>(""Test_Object_DirectInput"", 100);
+                await context.CallActivityAsync<string>(""Test_Object_OnContext"", 100);
             
-                return outputs;
+                return ""Hello World!"";
             }
 
-        [FunctionName(""E1_HelloSequence"")]
-        public static async Task<List<string>> CorrectInput(
+        [FunctionName(""ArgumentAnalyzerTestCases"")]
+        public static async Task<string> Run(
             [OrchestrationTrigger] IDurableOrchestrationContext context)
             {
-                var outputs = new List<string>();
+                // For a test case below
+                var (jobId, batchNumber) = context.GetInput<(string, int)>();
 
                 // Testing different matching input types
-                await context.CallActivityAsync<string>(""E1_SayHello"", ""Tokyo"");
-                await context.CallActivityAsync<string>(""E1_SayHello_DirectInput"", ""London"");
-                await context.CallActivityAsync<string>(""E1_SayHello_Object"", new Object());
-                await context.CallActivityAsync<string>(""E1_SayHello_Object_DirectInput"", new Object());
+                // SyntaxKind.PredefinedType (string), SyntaxKind.IdentifierName (Object), and SyntaxKind.ArrayType (string[])
+
+                await context.CallActivityAsync<string>(""Test_String_DirectInput"", ""London"");
+                await context.CallActivityAsync<string>(""Test_String_OnContext"", ""Tokyo"");
+                await context.CallActivityAsync<string>(""Test_Object_DirectInput"", new Object());
+                await context.CallActivityAsync<string>(""Test_Object_OnContext"", new Object());
+                await context.CallActivityAsync<string>(""Test_StringArray_DirectInput"", new string[] { ""Minneapolis"" });
+                await context.CallActivityAsync<string>(""Test_StringArray_OnContext"", new string[] { ""Minneapolis"" });
+
+                // SyntaxKind.GenericType (Tuple and ValueTuple) and SyntaxKind.TupleType (ValueTuple alt format ex (string, int))
+
                 Tuple<string, int> tuple = new Tuple<string, int>(""Seattle"", 4);
-                await context.CallActivityAsync<string>(""E1_SayHello_Tuple"", tuple);
-                await context.CallActivityAsync<string>(""E1_SayHello_Tuple_OnContext"", tuple);
-                await context.CallActivityAsync<string>(""E1_SayHello_ValueTuple"", (""Seattle"", 4));
-                await context.CallActivityAsync<string>(""E1_SayHello_ValueTuple_OnContext"", (""Seattle"", 4));
+                await context.CallActivityAsync<string>(""Test_Tuple_DirectInput"", tuple);
+                await context.CallActivityAsync<string>(""Test_Tuple_OnContext"", tuple);
+                await context.CallActivityAsync<string>(""Test_ValueTuple_DirectInput"", (""Seattle"", 4));
+                await context.CallActivityAsync<string>(""Test_ValueTuple_OnContext"", (""Seattle"", 4));
+                await context.CallActivityAsync<string>(""Test_ValueTuple_VariableNames"", (jobId, batchNumber));
 
-                // ArrayType and NamedType (IEnumerable types) match
-                string[] arrayType = new string[] { ""Seattle"", ""Tokyo"" };
-                await context.CallActivityAsync<string>(""E1_SayHello_ArrayToNamed"", arrayType);
+                // Testing JsonArray compatible types (IEnumerable Typles)
+                // IArrayTypeSymbol (array) to INamedTypeSymbol (IList)
+
+                await context.CallActivityAsync<string>(""Test_IListInput_DirectInput"", new string[] { ""Seattle"" });
+                await context.CallActivityAsync<string>(""Test_IListInput_OnContext"", new string[] { ""Seattle"" });
                 
-                // NamedType and NamedType (IEnumerable types) match
-                List<string> namedType = new List<string>();
-                await context.CallActivityAsync<string>(""E1_SayHello_NamedToNamed"", namedType);
-                await context.CallActivityAsync<string>(""E1_SayHello_NamedToNamed_Direct"", namedType);
+                // INamedTypeSymbol (List) and INamedTypeSymbol (Ilist)
 
-                // null input when function input not used
-                await context.CallActivityAsync<string>(""E1_SayHello_NotUsed"", null);
+                List<string> namedType = new List<string>();
+                await context.CallActivityAsync<string>(""Test_IListInput_DirectInput"", namedType);
+                await context.CallActivityAsync<string>(""Test_IListInput_OnContext"", namedType);
+
+                // Testing argument is valid when input is subclass (Object -> ValueType -> Char)
+
+                await context.CallActivityAsync<string>(""Test_ValueType_DirectInput"", new Char());
+                await context.CallActivityAsync<string>(""Test_Object_DirectInput"", new Char());
+
+                // Testing null input when function input not used from context object is valid
+
+                await context.CallActivityAsync<string>(""Test_UnusedInputFromContext"", null);
             
-                return outputs;
+                return ""Hello World!"";
             }
 
-        [FunctionName(""E1_SayHello"")]
-        public static string SayHello([ActivityTrigger] IDurableActivityContext context)
+        // Functions Testing different matching input types
+        // SyntaxKind.PredefinedType (string), SyntaxKind.IdentifierName (Object), and SyntaxKind.ArrayType (string[])
+
+        [FunctionName(""Test_String_DirectInput"")]
+        public static string TestStringDirectInput([ActivityTrigger] string name)
+        {
+            return $""Hello {name}!"";
+        }
+
+        [FunctionName(""Test_String_OnContext"")]
+        public static string TestStringOnContext([ActivityTrigger] IDurableActivityContext context)
         {
             string name = context.GetInput<string>();
             return $""Hello {name}!"";
         }
 
-        [FunctionName(""E1_SayHello_DirectInput"")]
-        public static string SayHelloDirectInput([ActivityTrigger] string name)
+        [FunctionName(""Test_Object_DirectInput"")]
+        public static string TestObjectDirectInput([ActivityTrigger] Object name)
         {
-            return $""Hello {name}!"";
+            return $""Hello World!"";
         }
 
-        [FunctionName(""E1_SayHello_Object"")]
-        public static string SayHello([ActivityTrigger] IDurableActivityContext context)
+        [FunctionName(""Test_Object_OnContext"")]
+        public static string TestObjectOnContext([ActivityTrigger] IDurableActivityContext context)
         {
             string name = context.GetInput<Object>();
             return $""Hello World!"";
         }
 
-        [FunctionName(""E1_SayHello_Object_DirectInput"")]
-        public static string SayHelloDirectInput([ActivityTrigger] Object name)
+        [FunctionName(""Test_StringArray_DirectInput"")]
+        public static string TestStringArrayDirectInput([ActivityTrigger] string[] names)
         {
             return $""Hello World!"";
         }
 
-       [FunctionName(""E1_SayHello_Tuple"")]
-        public static string SayHelloTuple([ActivityTrigger] Tuple<string, int> tupleTest)
+        [FunctionName(""Test_StringArray_OnContext"")]
+        public static string TestStringArrayOnContext([ActivityTrigger] IDurableActivityContext context)
+        {
+            string name = context.GetInput<string[]>();
+            return $""Hello World!"";
+        }
+
+        // SyntaxKind.GenericType (Tuple and ValueTuple) and SyntaxKind.TupleType (ValueTuple alt format ex (string, int))
+
+        [FunctionName(""Test_Tuple_DirectInput"")]
+        public static string TestTupleDirectInput([ActivityTrigger] Tuple<string, int> tupleTest)
         {
             string name = tupleTest;
             return $""Hello {name}!"";
         }
 
-        [FunctionName(""E1_SayHello_Tuple_OnContext"")]
-        public static string SayHelloTupleOnContext([ActivityTrigger] IDurableActivityContext context)
+        [FunctionName(""Test_Tuple_OnContext"")]
+        public static string TestTupleOnContext([ActivityTrigger] IDurableActivityContext context)
         {
             string name = context.GetInput<Tuple<string, int>>();
             return $""Hello {name}!"";
         }
 
-        [FunctionName(""E1_SayHello_ValueTuple"")]
-        public static string SayHelloTuple([ActivityTrigger] ValueTuple<string, int> tupleTest)
+        [FunctionName(""Test_ValueTuple_DirectInput"")]
+        public static string TestValueTupleDirectInput([ActivityTrigger] ValueTuple<string, int> tupleTest)
         {
             string name = tupleTest;
             return $""Hello {name}!"";
         }
 
-        [FunctionName(""E1_SayHello_ValueTuple_OnContext"")]
-        public static string SayHelloTupleOnContext([ActivityTrigger] IDurableActivityContext context)
+        [FunctionName(""Test_ValueTuple_OnContext"")]
+        public static string TestValueTupleOnContext([ActivityTrigger] IDurableActivityContext context)
         {
             string name = context.GetInput<(string, int)>();
             return $""Hello {name}!"";
         }
 
-        [FunctionName(""E1_SayHello_ArrayToNamed"")]
-        public static string SayHelloTuple([ActivityTrigger] IDurableActivityContext context)
+        [FunctionName(""Test_ValueTuple_VariableNames"")]
+        public static string TestValueTupleVariableNames([ActivityTrigger] IDurableActivityContext context)
+        {
+            string name = context.GetInput<(string, int)>();
+            return $""Hello {name}!"";
+        }
+
+        // Testing JsonArray compatible types (IEnumerable Typles)
+
+        [FunctionName(""Test_IListInput_DirectInput"")]
+        public static string TestIListInputDirectInput([ActivityTrigger] IList<string> namedType)
+        {
+            return $""Hello {name}!"";
+        
+
+        [FunctionName(""Test_IListInput_OnContext"")]
+        public static string TestIListInputContext([ActivityTrigger] IDurableActivityContext context)
         {
             string name = context.GetInput<IList<string>>();
             return $""Hello {name}!"";
         }
 
-        [FunctionName(""E1_SayHello_NamedToNamed"")]
-        public static string SayHelloTupleOnContext([ActivityTrigger] IDurableActivityContext context)
+        // Testing argument is valid when input is subclass (Object -> ValueType -> Char)
+         [FunctionName(""Test_ValueType_DirectInput"")]
+        public static string TestValueTypeDirectInput([ActivityTrigger] ValueType input)
         {
-            string name = context.GetInput<IList<string>>();
-            return $""Hello {name}!"";
+            return $""Hello World!"";
         }
 
-        [FunctionName(""E1_SayHello_NamedToNamed_Direct"")]
-        public static string SayHelloTupleOnContext([ActivityTrigger] IList<string> namedType)
-        {
-            return $""Hello {name}!"";
-        }
+        // Testing null input when function input not used from context object is valid
 
-        [FunctionName(""E1_SayHello_NotUsed"")]
-        public static string SayHelloTupleOnContext([ActivityTrigger] IDurableActivityContext context)
+        [FunctionName(""Test_UnusedInputFromContext"")]
+        public static string TestUnusedInputFromContext([ActivityTrigger] IDurableActivityContext context)
         {
             return $""Hello {name}!"";
         }
@@ -166,7 +210,7 @@ namespace VSSample
         }
 
         [TestMethod]
-        public void Argument_Mismatch_IntAndString_OffContext()
+        public void Argument_GivenInt_TakesString_OffContext()
         {
             var test = @"
 using System;
@@ -184,19 +228,17 @@ namespace VSSample
 {
     public static class HelloSequence
     {
-        [FunctionName(""E1_HelloSequence"")]
-        public static async Task<List<string>> Run(
+        [FunctionName(""ArgumentAnalyzerTestCases"")]
+        public static async Task<string> Run(
             [OrchestrationTrigger] IDurableOrchestrationContext context)
             {
-                var outputs = new List<string>();
-
-                outputs.Add(await context.CallActivityAsync<string>(""E1_SayHello"", 4));
+                await context.CallActivityAsync<string>(""Function_Takes_String"", 4);
             
-                return outputs;
+                return ""Hello World!"";
             }
 
-        [FunctionName(""E1_SayHello"")]
-        public static string SayHello([ActivityTrigger] IDurableActivityContext context)
+        [FunctionName(""Function_Takes_String"")]
+        public static string FunctionTakesString([ActivityTrigger] IDurableActivityContext context)
         {
             string name = context.GetInput<string>();
             return $""Hello {name}!"";
@@ -206,18 +248,18 @@ namespace VSSample
             var expectedDiagnostics = new DiagnosticResult
             {
                 Id = DiagnosticId,
-                Message = string.Format(Resources.ActivityArgumentAnalyzerMessageFormat, "E1_SayHello", "string", "int"),
+                Message = string.Format(Resources.ActivityArgumentAnalyzerMessageFormat, "Function_Takes_String", "string", "int"),
                 Severity = Severity,
                 Locations =
                  new[] {
-                            new DiagnosticResultLocation("Test0.cs", 23, 84)
+                            new DiagnosticResultLocation("Test0.cs", 21, 82)
                      }
             };
             VerifyCSharpDiagnostic(test, expectedDiagnostics);
         }
 
         [TestMethod]
-        public void Argument_Mismatch_IntAndString()
+        public void Argument_GivenInt_TakesString_DirectInput()
         {
             var test = @"
 using System;
@@ -235,19 +277,17 @@ namespace VSSample
 {
     public static class HelloSequence
     {
-        [FunctionName(""E1_HelloSequence"")]
-        public static async Task<List<string>> Run(
+        [FunctionName(""ArgumentAnalyzerTestCases"")]
+        public static async Task<string> Run(
             [OrchestrationTrigger] IDurableOrchestrationContext context)
             {
-                var outputs = new List<string>();
-
-                outputs.Add(await context.CallActivityAsync<string>(""E1_SayHello"", 4));
+                await context.CallActivityAsync<string>(""Function_Takes_String"", 4);
             
-                return outputs;
+                return ""Hello World!"";
             }
 
-        [FunctionName(""E1_SayHello"")]
-        public static string SayHello([ActivityTrigger] string name)
+        [FunctionName(""Function_Takes_String"")]
+        public static string FunctionTakesString([ActivityTrigger] string name)
         {
             return $""Hello {name}!"";
         }
@@ -256,18 +296,18 @@ namespace VSSample
             var expectedDiagnostics = new DiagnosticResult
             {
                 Id = DiagnosticId,
-                Message = string.Format(Resources.ActivityArgumentAnalyzerMessageFormat, "E1_SayHello", "string", "int"),
+                Message = string.Format(Resources.ActivityArgumentAnalyzerMessageFormat, "Function_Takes_String", "string", "int"),
                 Severity = Severity,
                 Locations =
                  new[] {
-                            new DiagnosticResultLocation("Test0.cs", 23, 84)
+                            new DiagnosticResultLocation("Test0.cs", 21, 82)
                      }
             };
             VerifyCSharpDiagnostic(test, expectedDiagnostics);
         }
 
         [TestMethod]
-        public void Argument_Mismatch_StringArrayAndString_IEnumerableTypes()
+        public void Argument_GivenArray_TakesString_DirectInput()
         {
             var test = @"
 using System;
@@ -285,20 +325,18 @@ namespace VSSample
 {
     public static class HelloSequence
     {
-        [FunctionName(""E1_HelloSequence"")]
-        public static async Task<List<string>> Run(
+        [FunctionName(""ArgumentAnalyzerTestCases"")]
+        public static async Task<string> Run(
             [OrchestrationTrigger] IDurableOrchestrationContext context)
             {
-                var outputs = new List<string>();
-
                 string[] arrayType = new string[] { ""Seattle"", ""Tokyo"" };
-                outputs.Add(await context.CallActivityAsync<string>(""E1_SayHello"", arrayType));
+                await context.CallActivityAsync<string>(""Function_Takes_String"", arrayType);
             
-                return outputs;
+                return ""Hello World!"";
             }
 
-        [FunctionName(""E1_SayHello"")]
-        public static string SayHello([ActivityTrigger] string name)
+        [FunctionName(""Function_Takes_String"")]
+        public static string FunctionTakesString([ActivityTrigger] string name)
         {
             return $""Hello {name}!"";
         }
@@ -307,18 +345,18 @@ namespace VSSample
             var expectedDiagnostics = new DiagnosticResult
             {
                 Id = DiagnosticId,
-                Message = string.Format(Resources.ActivityArgumentAnalyzerMessageFormat, "E1_SayHello", "string", "System.String[]"),
+                Message = string.Format(Resources.ActivityArgumentAnalyzerMessageFormat, "Function_Takes_String", "string", "System.String[]"),
                 Severity = Severity,
                 Locations =
                  new[] {
-                            new DiagnosticResultLocation("Test0.cs", 24, 84)
+                            new DiagnosticResultLocation("Test0.cs", 22, 82)
                      }
             };
             VerifyCSharpDiagnostic(test, expectedDiagnostics);
         }
 
         [TestMethod]
-        public void Argument_InputNotUsed_NonNullInput()
+        public void Argument_InputNotUsedOnContext_NonNullInput()
         {
             var test = @"
 using System;
@@ -336,19 +374,17 @@ namespace VSSample
 {
     public static class HelloSequence
     {
-        [FunctionName(""E1_HelloSequence"")]
-        public static async Task<List<string>> Run(
+        [FunctionName(""ArgumentAnalyzerTestCases"")]
+        public static async Task<string> Run(
             [OrchestrationTrigger] IDurableOrchestrationContext context)
             {
-                var outputs = new List<string>();
-
-                outputs.Add(await context.CallActivityAsync<string>(""E1_SayHello"", ""World""));
+                await context.CallActivityAsync<string>(""Unused_Input"", ""World""));
             
-                return outputs;
+                return ""Hello World!"";
             }
 
-        [FunctionName(""E1_SayHello"")]
-        public static string SayHello([ActivityTrigger] IDurableActivityContext context)
+        [FunctionName(""Unused_Input"")]
+        public static string UnusedInput([ActivityTrigger] IDurableActivityContext context)
         {
             return $""Hello {name}!"";
         }
@@ -357,11 +393,11 @@ namespace VSSample
             var expectedDiagnostics = new DiagnosticResult
             {
                 Id = DiagnosticId,
-                Message = string.Format(Resources.ActivityArgumentAnalyzerMessageFormatNotUsed, "E1_SayHello"),
+                Message = string.Format(Resources.ActivityArgumentAnalyzerMessageFormatNotUsed, "Unused_Input"),
                 Severity = Severity,
                 Locations =
                  new[] {
-                            new DiagnosticResultLocation("Test0.cs", 23, 84)
+                            new DiagnosticResultLocation("Test0.cs", 21, 73)
                      }
             };
             VerifyCSharpDiagnostic(test, expectedDiagnostics);

--- a/test/WebJobs.Extensions.DurableTask.Analyzers.Test/ActivityFunction/FunctionReturnTypeAnalyzerTests.cs
+++ b/test/WebJobs.Extensions.DurableTask.Analyzers.Test/ActivityFunction/FunctionReturnTypeAnalyzerTests.cs
@@ -56,16 +56,20 @@ namespace VSSample
                 await context.CallActivityAsync<string>(""E1_SayHello"", ""Tokyo"");
                 await context.CallActivityAsync<string[]>(""E1_SayHello_Array"", ""Tokyo"");
                 await context.CallActivityAsync<Object>(""E1_SayHey"", ""Tokyo"");
-                await context.CallActivityAsync<Tuple<string, int>>(""E1_SayHello_Tuple"", (""Seattle"", 4));
+                Tuple<string, int> tuple = new Tuple<string, int>(""Seattle"", 4);
+                await context.CallActivityAsync<Tuple<string, int>>(""E1_SayHello_Tuple"", tuple);
+                await context.CallActivityAsync<(string, int)>(""E1_SayHello_ValueTuple"", (""Seattle"", 4));
+                await context.CallActivityAsync<ValueTuple<string, int>>(""E1_SayHello_ValueTuple"", (""Seattle"", 4));
 
                 // Should always be valid without specifying return type
                 await context.CallActivityAsync(""E1_SayHello_ReturnsString"", ""London"");
-
-                // ArrayType and NamedType (IEnumerable types) match
-                await context.CallActivityAsync<string[]>(""E1_SayHello_ArrayAndNamedType"", (""Seattle"", 4));
                 
                 // NamedType and NamedType (IEnumerable types) match
                 await context.CallActivityAsync<List<string>>(""E1_SayHello_NamedType"", ""London"");
+
+                // ArrayType and NamedType (IEnumerable types) match and Task return type
+                await context.CallActivityAsync<string[]>(""E1_SayHello_ArrayAndNamedType"", (""Seattle"", 4));
+                await context.CallActivityAsync<string[]>(""E1_SayHello_Task_ArrayAndNamedType"", (""Seattle"", 4));
 
                 // string and Task<string>
                 await context.CallActivityAsync<string>(""E1_SayHello_Task"", ""London"");
@@ -100,6 +104,12 @@ namespace VSSample
             return tuple;
         }
 
+        [FunctionName(""E1_SayHello_ValueTuple"")]
+        public static ValueTuple<string, int> SayHelloTuple([ActivityTrigger] ValueTuple<string, int> tuple)
+        {
+            return tuple;
+        }
+
         [FunctionName(""E1_SayHello_ReturnsString"")]
         public static string SayHelloDirectInput([ActivityTrigger] string name)
         {
@@ -107,7 +117,7 @@ namespace VSSample
         }
 
         [FunctionName(""E1_SayHello_ArrayAndNamedType"")]
-        public static List<string> SayHelloTuple([ActivityTrigger] Tuple<string, int> tuple)
+        public static List<string> SayHelloTuple([ActivityTrigger] ValueTuple<string, int> tuple)
         {
             return new List<string>();
         }
@@ -120,6 +130,12 @@ namespace VSSample
 
         [FunctionName(""E1_SayHello_Task"")]
         public static Task<string> SayHelloDirectInput([ActivityTrigger] string name)
+        {
+            return $""Hello {name}!"";
+        }
+
+        [FunctionName(""E1_SayHello_Task_ArrayAndNamedType"")]
+        public static Task<List<string>> SayHelloDirectInput([ActivityTrigger] ValueTuple<string, int> tuple)
         {
             return $""Hello {name}!"";
         }

--- a/test/WebJobs.Extensions.DurableTask.Analyzers.Test/ActivityFunction/FunctionReturnTypeAnalyzerTests.cs
+++ b/test/WebJobs.Extensions.DurableTask.Analyzers.Test/ActivityFunction/FunctionReturnTypeAnalyzerTests.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers.Test.Activity
         private static readonly DiagnosticSeverity Severity = FunctionReturnTypeAnalyzer.Severity;
 
         [TestMethod]
-        public void ReturnType_NonIssueCalls()
+        public void ReturnType_NoDiagnosticTestCases()
         {
             var test = @"
 using System;
@@ -33,111 +33,143 @@ namespace VSSample
 {
     public static class HelloSequence
     {
-        // Should not flag code on non function
-        public static async Task<List<string>> NonFunctionWrongReturnType(
-            [OrchestrationTrigger] IDurableOrchestrationContext context)
-            {
-                var outputs = new List<string>();
-
-                await context.CallActivityAsync<int>(""E1_SayHello"", ""Tokyo"");
-                await context.CallActivityAsync<int>(""E1_SayHey"", ""Tokyo"");
-                await context.CallActivityAsync<int>(""E1_SayHello_Tuple"", (""Seattle"", 4));
+        // Testing that no diagnostics are produced when method does not have the FunctionName attribute present
+        public static async Task<string> NonFunctionWrongReturnType(
+        [OrchestrationTrigger] IDurableOrchestrationContext context)
+        {
+            // Incorrect return types on some test functions used below
+            await context.CallActivityAsync<int>(""Test_String"", ""Tokyo"");
+            await context.CallActivityAsync<int>(""Test_Object"", ""Tokyo"");
+            await context.CallActivityAsync<int>(""Test_Array"", new string[] { ""Minneapolis"" });
+            await context.CallActivityAsync<int>(""Test_Tuple"", (""Seattle"", 4));
             
-                return outputs;
-            }
+            return ""Hello World!"";
+        }
 
-        [FunctionName(""E1_HelloSequence"")]
-        public static async Task<List<string>> CorrectReturnType(
-            [OrchestrationTrigger] IDurableOrchestrationContext context)
-            {
-                var outputs = new List<string>();
+        [FunctionName(""ReturnTypeAnalyzerTestCases"")]
+        public static async Task<string> Run(
+        [OrchestrationTrigger] IDurableOrchestrationContext context)
+        {
+            var outputs = new List<string>();
 
-                // Testing different matching return types
-                await context.CallActivityAsync<string>(""E1_SayHello"", ""Tokyo"");
-                await context.CallActivityAsync<string[]>(""E1_SayHello_Array"", ""Tokyo"");
-                await context.CallActivityAsync<Object>(""E1_SayHey"", ""Tokyo"");
-                Tuple<string, int> tuple = new Tuple<string, int>(""Seattle"", 4);
-                await context.CallActivityAsync<Tuple<string, int>>(""E1_SayHello_Tuple"", tuple);
-                await context.CallActivityAsync<(string, int)>(""E1_SayHello_ValueTuple"", (""Seattle"", 4));
-                await context.CallActivityAsync<ValueTuple<string, int>>(""E1_SayHello_ValueTuple"", (""Seattle"", 4));
+            // Testing different matching return types
+            // SyntaxKind.PredefinedType (string), SyntaxKind.IdentifierName (Object), and SyntaxKind.ArrayType (string[])
 
-                // Should always be valid without specifying return type
-                await context.CallActivityAsync(""E1_SayHello_ReturnsString"", ""London"");
+            //await context.CallActivityAsync<string>(""Test_String"", ""Tokyo"");
+            //await context.CallActivityAsync<Object>(""Test_Object"", ""Tokyo"");
+            //await context.CallActivityAsync<string[]>(""Test_Array"", new string[] { ""Minneapolis"" });
+
+            // SyntaxKind.GenericType (Tuple and ValueTuple) and SyntaxKind.TupleType (ValueTuple alt format ex (string, int))
+
+            Tuple<string, int> tuple = new Tuple<string, int>(""Seattle"", 4);
+            //await context.CallActivityAsync<Tuple<string, int>>(""Test_Tuple"", tuple);
+            //await context.CallActivityAsync<(string, int)>(""Test_ValueTuple"", (""Seattle"", 4));
+            //await context.CallActivityAsync<ValueTuple<string, int>>(""Test_ValueTuple"", (""Seattle"", 4));
+            await context.CallActivityAsync<ValueTuple<string, int>>(""Test_ValueTuple_AltFormat"", (""Seattle"", 4));
                 
-                // NamedType and NamedType (IEnumerable types) match
-                await context.CallActivityAsync<List<string>>(""E1_SayHello_NamedType"", ""London"");
+            // Testing JsonArray compatible types (IEnumerable Typles)
+            // IArrayTypeSymbol (array) to INamedTypeSymbol (IList)
+                
+            await context.CallActivityAsync<string[]>(""Test_IList"", ""Seattle"");
 
-                // ArrayType and NamedType (IEnumerable types) match and Task return type
-                await context.CallActivityAsync<string[]>(""E1_SayHello_ArrayAndNamedType"", (""Seattle"", 4));
-                await context.CallActivityAsync<string[]>(""E1_SayHello_Task_ArrayAndNamedType"", (""Seattle"", 4));
+            // INamedTypeSymbol (List) to INamedTypeSymbol (IList)
+            await context.CallActivityAsync<List<string>>(""Test_IList"", ""London"");
 
-                // string and Task<string>
-                await context.CallActivityAsync<string>(""E1_SayHello_Task"", ""London"");
+            // Testing argument is valid when input is subclass (Object -> ValueType -> Char)
+
+            await context.CallActivityAsync<Object>(""Test_ValueType"", ""Minneapolis"");
+            await context.CallActivityAsync<Object>(""Test_Char"", ""Minneapolis"");
+
+            // Task return types
+            await context.CallActivityAsync<string>(""Test_TaskString"", ""London"");
+            await context.CallActivityAsync<string[]>(""Test_TaskList"", ""London"");
             
-                return outputs;
-            }
+            // Testing no diagnostic on no specified return type
+            await context.CallActivityAsync(""Test_String"", ""London"");
 
-        [FunctionName(""E1_SayHello"")]
-        public static string SayHello([ActivityTrigger] IDurableActivityContext context)
+            return ""Hello World!"";
+        }
+        
+        // Testing different matching return types
+        // SyntaxKind.PredefinedType (string), SyntaxKind.IdentifierName (Object), and SyntaxKind.ArrayType (string[])
+
+        [FunctionName(""Test_String"")]
+        public static string TestString([ActivityTrigger] IDurableActivityContext context)
         {
             string name = context.GetInput<string>();
             return $""Hello {name}!"";
         }
 
-        [FunctionName(""E1_SayHello_Array"")]
-        public static string[] SayHello([ActivityTrigger] IDurableActivityContext context)
-        {
-            string name = context.GetInput<string>();
-            return new [] { $@""Hello {name}!"" };
-        }
-
-        [FunctionName(""E1_SayHey"")]
-        public static Object SayHello([ActivityTrigger] IDurableActivityContext context)
+        [FunctionName(""Test_Object"")]
+        public static Object TestObject([ActivityTrigger] IDurableActivityContext context)
         {
             string name = context.GetInput<string>();
             return new Object();
         }
 
-        [FunctionName(""E1_SayHello_Tuple"")]
-        public static Tuple<string, int> SayHelloTuple([ActivityTrigger] Tuple<string, int> tuple)
+        [FunctionName(""Test_Array"")]
+        public static string[] TestArray([ActivityTrigger] string[] input)
+        {
+            return input;
+        }
+
+        // SyntaxKind.GenericType (Tuple and ValueTuple) and SyntaxKind.TupleType (ValueTuple alt format ex (string, int))
+
+        [FunctionName(""Test_Tuple"")]
+        public static Tuple<string, int> TestTuple([ActivityTrigger] Tuple<string, int> tuple)
         {
             return tuple;
         }
 
-        [FunctionName(""E1_SayHello_ValueTuple"")]
-        public static ValueTuple<string, int> SayHelloTuple([ActivityTrigger] ValueTuple<string, int> tuple)
+        [FunctionName(""Test_ValueTuple"")]
+        public static ValueTuple<string, int> TestValueTuple([ActivityTrigger] ValueTuple<string, int> tuple)
         {
             return tuple;
         }
 
-        [FunctionName(""E1_SayHello_ReturnsString"")]
-        public static string SayHelloDirectInput([ActivityTrigger] string name)
+        [FunctionName(""Test_ValueTuple_AltFormat"")]
+        public static (string, int) TestValueTupleAltFormat([ActivityTrigger] ValueTuple<string, int> tuple)
         {
-            return $""Hello {name}!"";
+            return tuple;
         }
+        
+        // Testing JsonArray compatible types (IEnumerable Typles)
 
-        [FunctionName(""E1_SayHello_ArrayAndNamedType"")]
-        public static List<string> SayHelloTuple([ActivityTrigger] ValueTuple<string, int> tuple)
+        [FunctionName(""Test_IList"")]
+        public static IList<string> TestIList([ActivityTrigger] IDurableActivityContext context)
         {
+            string name = context.GetInput<string>();
             return new List<string>();
         }
 
-        [FunctionName(""E1_SayHello_NamedType"")]
-        public static IList<string> SayHelloDirectInput([ActivityTrigger] string name)
+        // Testing argument is valid when input is subclass (Object -> ValueType -> Char)
+
+        [FunctionName(""Test_ValueType"")]
+        public static ValueType TestValueType([ActivityTrigger] string name)
         {
+            return new Char();
+        }
+
+        [FunctionName(""Test_Char"")]
+        public static Char TestChar([ActivityTrigger] string name)
+        {
+            return new Char();
+        }
+
+        // Task return types
+        
+        [FunctionName(""Test_TaskString"")]
+        public static Task<string> TestTaskString([ActivityTrigger] IDurableActivityContext context)
+        {
+            string name = context.GetInput<string>();
+            return $""Hello {name}!"";
+        }
+
+        [FunctionName(""Test_TaskList"")]
+        public static Task<List<string>> TestTaskList([ActivityTrigger] IDurableActivityContext context)
+        {
+            string name = context.GetInput<string>();
             return new List<string>();
-        }
-
-        [FunctionName(""E1_SayHello_Task"")]
-        public static Task<string> SayHelloDirectInput([ActivityTrigger] string name)
-        {
-            return $""Hello {name}!"";
-        }
-
-        [FunctionName(""E1_SayHello_Task_ArrayAndNamedType"")]
-        public static Task<List<string>> SayHelloDirectInput([ActivityTrigger] ValueTuple<string, int> tuple)
-        {
-            return $""Hello {name}!"";
         }
     }
 }";
@@ -145,7 +177,7 @@ namespace VSSample
         }
 
         [TestMethod]
-        public void ReturnType_Mismatch_StringAndInt()
+        public void ReturnType_ExpectsInt_ReturnsString()
         {
             var test = @"
 using System;
@@ -163,19 +195,17 @@ namespace VSSample
 {
     public static class HelloSequence
     {
-        [FunctionName(""E1_HelloSequence"")]
-        public static async Task<List<string>> Run(
+        [FunctionName(""ReturnTypeAnalyzerTestCases"")]
+        public static async Task<string> Run(
             [OrchestrationTrigger] IDurableOrchestrationContext context)
             {
-                var outputs = new List<string>();
-
-                await context.CallActivityAsync<int>(""E1_SayHello"", ""test"");
+                await context.CallActivityAsync<int>(""Function_Returns_String"", ""test"");
             
-                return outputs;
+                return ""Hello World!"";
             }
 
-        [FunctionName(""E1_SayHello"")]
-        public static string SayHello([ActivityTrigger] IDurableActivityContext context)
+        [FunctionName(""Function_Returns_String"")]
+        public static string FunctionReturnsString([ActivityTrigger] IDurableActivityContext context)
         {
             string name = context.GetInput<string>();
             return $""Hello {name}!"";
@@ -185,18 +215,18 @@ namespace VSSample
             var expectedDiagnostics = new DiagnosticResult
             {
                 Id = DiagnosticId,
-                Message = string.Format(Resources.ActivityReturnTypeAnalyzerMessageFormat, "E1_SayHello", "string", "int"),
+                Message = string.Format(Resources.ActivityReturnTypeAnalyzerMessageFormat, "Function_Returns_String", "string", "int"),
                 Severity = Severity,
                 Locations =
                  new[] {
-                            new DiagnosticResultLocation("Test0.cs", 23, 23)
+                            new DiagnosticResultLocation("Test0.cs", 21, 23)
                      }
             };
             VerifyCSharpDiagnostic(test, expectedDiagnostics);
         }
 
         [TestMethod]
-        public void ReturnType_Mismatch_IEnumerableTypes_StringAndList()
+        public void ReturnType_ExpectsString_ReturnsList()
         {
             var test = @"
 using System;
@@ -214,40 +244,38 @@ namespace VSSample
 {
     public static class HelloSequence
     {
-        [FunctionName(""E1_HelloSequence"")]
-        public static async Task<List<string>> Run(
+        [FunctionName(""ReturnTypeAnalyzerTestCases"")]
+        public static async Task<string> Run(
             [OrchestrationTrigger] IDurableOrchestrationContext context)
             {
-                var outputs = new List<string>();
-
-                await context.CallActivityAsync<string>(""E1_SayHello"", ""test"");
+                await context.CallActivityAsync<string>(""Function_Returns_ListOfString"", ""test"");
             
-                return outputs;
+                return ""Hello World!"";
             }
 
-        [FunctionName(""E1_SayHello"")]
-        public static List<string> SayHello([ActivityTrigger] IDurableActivityContext context)
+        [FunctionName(""Function_Returns_ListOfString"")]
+        public static List<string> FunctionReturnsListOfString([ActivityTrigger] IDurableActivityContext context)
         {
             string name = context.GetInput<string>();
-            return $""Hello {name}!"";
+            return new List<string>() { name };
         }
     }
 }";
             var expectedDiagnostics = new DiagnosticResult
             {
                 Id = DiagnosticId,
-                Message = string.Format(Resources.ActivityReturnTypeAnalyzerMessageFormat, "E1_SayHello", "System.Collections.Generic.List<string>", "string"),
+                Message = string.Format(Resources.ActivityReturnTypeAnalyzerMessageFormat, "Function_Returns_ListOfString", "System.Collections.Generic.List<string>", "string"),
                 Severity = Severity,
                 Locations =
                  new[] {
-                            new DiagnosticResultLocation("Test0.cs", 23, 23)
+                            new DiagnosticResultLocation("Test0.cs", 21, 23)
                      }
             };
             VerifyCSharpDiagnostic(test, expectedDiagnostics);
         }
 
         [TestMethod]
-        public void ReturnType_Mismatch_StringAndTask()
+        public void ReturnType_ExpectsString_ReturnsTask()
         {
             var test = @"
 using System;
@@ -265,19 +293,17 @@ namespace VSSample
 {
     public static class HelloSequence
     {
-        [FunctionName(""E1_HelloSequence"")]
-        public static async Task<List<string>> Run(
+        [FunctionName(""ReturnTypeAnalyzerTestCases"")]
+        public static async Task<string> Run(
             [OrchestrationTrigger] IDurableOrchestrationContext context)
             {
-                var outputs = new List<string>();
-
-                outputs.Add(await context.CallActivityAsync<string>(""E1_SayHello"", ""World""));
+                await context.CallActivityAsync<string>(""Function_Returns_Task"", ""World"");
             
-                return outputs;
+                return ""Hello World!"";
             }
 
-        [FunctionName(""E1_SayHello"")]
-        public static Task SayHello([ActivityTrigger] string name)
+        [FunctionName(""Function_Returns_Task"")]
+        public static Task FunctionReturnsTask([ActivityTrigger] string name)
         {
             return $""Hello {name}!"";
         }
@@ -286,11 +312,11 @@ namespace VSSample
             var expectedDiagnostics = new DiagnosticResult
             {
                 Id = DiagnosticId,
-                Message = string.Format(Resources.ActivityReturnTypeAnalyzerMessageFormat, "E1_SayHello", "System.Threading.Tasks.Task", "string"),
+                Message = string.Format(Resources.ActivityReturnTypeAnalyzerMessageFormat, "Function_Returns_Task", "System.Threading.Tasks.Task", "string"),
                 Severity = Severity,
                 Locations =
                  new[] {
-                            new DiagnosticResultLocation("Test0.cs", 23, 35)
+                            new DiagnosticResultLocation("Test0.cs", 21, 23)
                      }
             };
             VerifyCSharpDiagnostic(test, expectedDiagnostics);

--- a/test/WebJobs.Extensions.DurableTask.Analyzers.Test/ActivityFunction/NameAnalyzerTests.cs
+++ b/test/WebJobs.Extensions.DurableTask.Analyzers.Test/ActivityFunction/NameAnalyzerTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers.Test.Activity
         private static readonly DiagnosticSeverity Severity = NameAnalyzer.Severity;
 
         [TestMethod]
-        public void Name_NonIssueCalls()
+        public void Name_NoDiagnosticTestCases()
         {
             var test = @"
 using System;
@@ -34,129 +34,98 @@ namespace VSSample
 {
     public static class HelloSequence
     {
-        public const string FunctionName = ""SayHelloByConstFuncName"";
-        public const string FunctionNameWithClass = ""SayHelloByConstFuncNameWithClass"";
+        // For test cases below
+        public const string TestFunctionUsesConstant = ""TestFunctionNameWithConstant"";
+        public const string TestFunctionNameWithClass = ""TestFunctionNameWithClass"";
 
-        // Should not flag code on non function
-        public static async Task<List<string>> NonFunctionInvalidNames(
+        // Testing that no diagnostics are produced when method does not have the FunctionName attribute present
+        public static async Task<string> NonFunctionInvalidNames(
             [OrchestrationTrigger] IDurableOrchestrationContext context)
-            {
-                var outputs = new List<string>();
-
-                outputs.Add(await context.CallActivityAsync<string>(""NotAFunction"", ""Tokyo""));
-                outputs.Add(await context.CallActivityAsync<string>(""DefinitelyNotAFunction"", new Object()));
+        {
+            // Non existing function names
+            await context.CallActivityAsync<string>(""NotAFunction"", ""Tokyo"");
+            await context.CallActivityAsync<string>(""DefinitelyNotAFunction"", new Object());
             
-                return outputs;
-            }
+            return ""Hello World"";
+        }
 
-        [FunctionName(""E1_HelloSequence"")]
-        public static async Task<List<string>> CorrectNames(
+        [FunctionName(""NameAnalyzerTestCases"")]
+        public static async Task<string> Run(
             [OrchestrationTrigger] IDurableOrchestrationContext context)
-            {
-                var outputs = new List<string>();
+        {
+            // Matching names (strings)
 
-                // Matching names
-                outputs.Add(await context.CallActivityAsync<string>(""E1_SayHello"", ""Tokyo""));
-                outputs.Add(await context.CallActivityAsync<string>(""E1_SayHello_DirectInput"", ""London""));
-                outputs.Add(await context.CallActivityAsync<string>(""E1_SayHello_Object"", new Object()));
-                outputs.Add(await context.CallActivityAsync<string>(""E1_SayHello_Object_DirectInput"", new Object()));
-                Tuple<string, int> tuple = new Tuple<string, int>(""Seattle"", 4);
-                outputs.Add(await context.CallActivityAsync<string>(""E1_SayHello_Tuple"", tuple));
-                outputs.Add(await context.CallActivityAsync<string>(""E1_SayHello_Tuple_OnContext"", tuple));
-                outputs.Add(await context.CallActivityAsync<string>(""E1_SayHello_ValueTuple"", (""Seattle"", 4)));
-                outputs.Add(await context.CallActivityAsync<string>(""E1_SayHello_ValueTuple_OnContext"", (""Seattle"", 4)));
-                outputs.Add(await context.CallActivityAsync<string>(nameof(SayHelloByClassName), ""Amsterdam""));
-                outputs.Add(await context.CallActivityAsync<string>(""SayHelloByMethodName"", ""Amsterdam""));
-                outputs.Add(await context.CallActivityAsync<string>(nameof(SayHelloByMethodName), ""Amsterdam""));
-                outputs.Add(await context.CallActivityAsync<string>(""SayHelloByConstFuncName"", ""Amsterdam""));
-                outputs.Add(await context.CallActivityAsync<string>(""SayHelloByConstFuncNameWithClass"", ""Amsterdam""));
-                outputs.Add(await context.CallActivityAsync<string>(constantSayHelloByConstFuncName, ""Amsterdam""));
-                outputs.Add(await context.CallActivityAsync<string>(HelloSequence.constantSayHelloByConstFuncNameWithClass, ""Amsterdam""));
+            await context.CallActivityAsync<string>(""Test_MatchingStrings"", ""Tokyo"");
 
-                return outputs;
-            }
+            // Invocation and function using nameof()
 
-        [FunctionName(""E1_SayHello"")]
-        public static string SayHello([ActivityTrigger] IDurableActivityContext context)
+            await context.CallActivityAsync<string>(nameof(TestFunctionUsesNameOfClassName), ""Amsterdam"");
+
+            // Invocation uses string, function uses nameof()
+
+            await context.CallActivityAsync<string>(""TestFunctionUsesNameOfMethodName"", ""Amsterdam"");
+
+            // Invocation uses string, function uses constant
+
+            await context.CallActivityAsync<string>(""TestFunctionNameWithConstant"", ""Amsterdam"");
+
+            // Invocation uses string, function uses constant prefaced with class name
+
+            await context.CallActivityAsync<string>(""TestFunctionNameWithClass"", ""Amsterdam"");
+
+            // Invocation uses constant, function uses constant
+
+            await context.CallActivityAsync<string>(TestFunctionUsesConstant, ""Amsterdam"");
+
+            // Invocation uses constant prefaced with class name, function uses nameof()
+
+            await context.CallActivityAsync<string>(HelloSequence.TestFunctionNameWithClass, ""Amsterdam"");
+
+            return ""Hello World!"";
+        }
+
+        // Matching names (strings)
+
+        [FunctionName(""Test_MatchingStrings"")]
+        public static string TestMatchingStrings([ActivityTrigger] IDurableActivityContext context)
         {
             string name = context.GetInput<string>();
             return $""Hello {name}!"";
         }
-
-        [FunctionName(""E1_SayHello_DirectInput"")]
-        public static string SayHelloDirectInput([ActivityTrigger] string name)
-        {
-            return $""Hello {name}!"";
-        }
-
-        [FunctionName(""E1_SayHello_Object"")]
-        public static string SayHello([ActivityTrigger] IDurableActivityContext context)
-        {
-            string name = context.GetInput<Object>();
-            return $""Hello World!"";
-        }
-
-        [FunctionName(""E1_SayHello_Object_DirectInput"")]
-        public static string SayHelloDirectInput([ActivityTrigger] Object name)
-        {
-            return $""Hello World!"";
-        }
-
-        [FunctionName(""E1_SayHello_Tuple"")]
-        public static string SayHelloTuple([ActivityTrigger] Tuple<string, int> tupleTest)
-        {
-            string name = tupleTest;
-            return $""Hello {name}!"";
-        }
-
-        [FunctionName(""E1_SayHello_Tuple_OnContext"")]
-        public static string SayHelloTupleOnContext([ActivityTrigger] IDurableActivityContext context)
-        {
-            string name = context.GetInput<Tuple<string, int>>();
-            return $""Hello {name}!"";
-        }
-
-        [FunctionName(""E1_SayHello_ValueTuple"")]
-        public static string SayHelloTuple([ActivityTrigger] ValueTuple<string, int> tupleTest)
-        {
-            string name = tupleTest;
-            return $""Hello {name}!"";
-        }
-
-        [FunctionName(""E1_SayHello_ValueTuple_OnContext"")]
-        public static string SayHelloTupleOnContext([ActivityTrigger] IDurableActivityContext context)
-        {
-            string name = context.GetInput<(string, int)>();
-            return $""Hello {name}!"";
-        }
-
-        [FunctionName(nameof(SayHelloByMethodName))]
-        public static string SayHelloByMethodName([ActivityTrigger] IDurableActivityContext context)
-        {
-            string name = context.GetInput<string>();
-            return $""Hello {name}!"";
-        }
-
         
-        //constant variable used as functionName
-        [FunctionName(FunctionName)]
-        public static string SayHelloByMethodName([ActivityTrigger] IDurableActivityContext context)
+        // Invocation uses string and nameof(), function uses nameof()
+
+        [FunctionName(nameof(TestFunctionUsesNameOfMethodName))]
+        public static string TestFunctionUsesNameOfMethodName([ActivityTrigger] IDurableActivityContext context)
         {
             string name = context.GetInput<string>();
             return $""Hello {name}!"";
         }
 
-        [FunctionName(HelloSequence.FunctionNameWithClass)]
-        public static string SayHelloByMethodName([ActivityTrigger] IDurableActivityContext context)
+        // Invocation uses string, function uses constant
+
+        [FunctionName(TestFunctionUsesConstant)]
+        public static string TestFunctionWithConstant([ActivityTrigger] IDurableActivityContext context)
+        {
+            string name = context.GetInput<string>();
+            return $""Hello {name}!"";
+        }
+
+        // Invocation uses string, function uses constant prefaced with class name
+
+        [FunctionName(HelloSequence.TestFunctionNameWithClass)]
+        public static string TestFunctionNameClass([ActivityTrigger] IDurableActivityContext context)
         {
             string name = context.GetInput<string>();
             return $""Hello {name}!"";
         }
     }
 
-    public class SayHelloByClassName
+    // Invocation uses nameof() and constant with class name prefix and function using nameof()
+
+    public class TestFunctionUsesNameOfClassName
     {
-        [FunctionName(nameof(SayHelloByClassName))]
+        [FunctionName(nameof(TestFunctionUsesNameOfClassName))]
         public string Run([ActivityTrigger] IDurableActivityContext context)
         {
             string name = context.GetInput<string>();
@@ -168,7 +137,7 @@ namespace VSSample
         }
         
         [TestMethod]
-        public void Name_InvalidFunctionName_Close()
+        public void Name_InvalidName_CloseRule()
         {
             var test = @"
 using System;
@@ -186,15 +155,13 @@ namespace VSSample
 {
     public static class HelloSequence
     {
-        [FunctionName(""E1_HelloSequence"")]
-        public static async Task<List<string>> Run(
+        [FunctionName(""NameAnalyzerTestCases"")]
+        public static async Task<string> Run(
             [OrchestrationTrigger] IDurableOrchestrationContext context)
             {
-                var outputs = new List<string>();
-
-                outputs.Add(await context.CallActivityAsync<string>(""E1_SayHey"", 4));
+                await context.CallActivityAsync<string>(""E1_SayHey"", 4);
             
-                return outputs;
+                return ""Hello World!"";
             }
 
         [FunctionName(""E1_SayHello"")]
@@ -211,68 +178,14 @@ namespace VSSample
                 Severity = Severity,
                 Locations =
                  new[] {
-                            new DiagnosticResultLocation("Test0.cs", 23, 69)
+                            new DiagnosticResultLocation("Test0.cs", 21, 57)
                      }
             };
             VerifyCSharpDiagnostic(test, expectedDiagnostics);
         }
 
         [TestMethod]
-        public void Name_InvalidFunctionName_NameOfClassDoesNotMatchFunctionName()
-        {
-            var test = @"
-using System;
-using System.Collections.Generic;
-using System.Net;
-using System.Net.Http;
-using System.Threading;
-using System.Threading.Tasks;
-using Microsoft.Azure.WebJobs.Extensions.DurableTask;
-using Microsoft.WindowsAzure.Storage.Blob;
-using Microsoft.WindowsAzure.Storage.Queue;
-using Microsoft.WindowsAzure.Storage.Table;
-
-namespace VSSample
-{
-    public class HelloSequence
-    {
-        [FunctionName(""E1_HelloSequence"")]
-        public async Task<List<string>> Run(
-            [OrchestrationTrigger] IDurableOrchestrationContext context)
-            {
-                var outputs = new List<string>();
-
-                outputs.Add(await context.CallActivityAsync<string>(nameof(SayHello), 4));
-            
-                return outputs;
-            }
-    }
-
-    public class SayHello
-    {
-        [FunctionName(""SayHi"")]
-        public string Run([ActivityTrigger] IDurableActivityContext context)
-        {
-            string name = context.GetInput<string>();
-            return $""Hello {name}!"";
-        }
-    }
-}";
-            var expectedDiagnostics = new DiagnosticResult
-            {
-                Id = DiagnosticId,
-                Message = string.Format(Resources.ActivityNameAnalyzerCloseMessageFormat, "SayHello", "SayHi"),
-                Severity = Severity,
-                Locations =
-                 new[] {
-                            new DiagnosticResultLocation("Test0.cs", 23, 69)
-                     }
-            };
-            VerifyCSharpDiagnostic(test, expectedDiagnostics);
-        }
-
-        [TestMethod]
-        public void Name_InvalidFunctionName_Missing()
+        public void Name_InvalidName_MissingRule()
         {
             var test = @"
 using System;
@@ -290,15 +203,13 @@ namespace VSSample
 {
     public static class HelloSequence
     {
-        [FunctionName(""E1_HelloSequence"")]
-        public static async Task<List<string>> Run(
+        [FunctionName(""NameAnalyzerTestCases"")]
+        public static async Task<string> Run(
             [OrchestrationTrigger] IDurableOrchestrationContext context)
             {
-                var outputs = new List<string>();
-
-                outputs.Add(await context.CallActivityAsync<string>(""E1_SayHello"", ""Ben""));
+                await context.CallActivityAsync<string>(""E1_SayHello"", ""AppService"");
             
-                return outputs;
+                return ""Hello World!"";
             }
     }
 }";
@@ -309,14 +220,14 @@ namespace VSSample
                 Severity = Severity,
                 Locations =
                  new[] {
-                            new DiagnosticResultLocation("Test0.cs", 23, 69)
+                            new DiagnosticResultLocation("Test0.cs", 21, 57)
                      }
             };
             VerifyCSharpDiagnostic(test, expectedDiagnostics);
         }
 
         [TestMethod]
-        public void Name_InvalidFunctionName_Missing_UsingConst()
+        public void Name_InvalidName_MissingRule_UsingConstant()
         {
             var test = @"
 using System;
@@ -341,7 +252,7 @@ namespace VSSample
             {
                 var outputs = new List<string>();
 
-                outputs.Add(await context.CallActivityAsync<string>(""E1_SayHello"", ""Ben""));
+                outputs.Add(await context.CallActivityAsync<string>(""E1_SayHello"", ""AppService""));
             
                 return outputs;
             }
@@ -355,55 +266,6 @@ namespace VSSample
                 Locations =
                  new[] {
                             new DiagnosticResultLocation("Test0.cs", 24, 69)
-                     }
-            };
-            VerifyCSharpDiagnostic(test, expectedDiagnostics);
-        }
-
-        [TestMethod]
-        public void Name_InvalidFunctionName_Missing_UsingConstAndClass()
-        {
-            var test = @"
-using System;
-using System.Collections.Generic;
-using System.Net;
-using System.Net.Http;
-using System.Threading;
-using System.Threading.Tasks;
-using Microsoft.Azure.WebJobs.Extensions.DurableTask;
-using Microsoft.WindowsAzure.Storage.Blob;
-using Microsoft.WindowsAzure.Storage.Queue;
-using Microsoft.WindowsAzure.Storage.Table;
-
-namespace VSSample
-{
-    public static class Consts
-    {
-        public const string FunctionName = ""E1_HelloSequence"";
-    }
-
-    public static class HelloSequence
-    {
-        [FunctionName(Consts.FunctionName)]
-        public static async Task<List<string>> Run(
-            [OrchestrationTrigger] IDurableOrchestrationContext context)
-            {
-                var outputs = new List<string>();
-
-                outputs.Add(await context.CallActivityAsync<string>(""E1_SayHello"", ""Ben""));
-            
-                return outputs;
-            }
-    }
-}";
-            var expectedDiagnostics = new DiagnosticResult
-            {
-                Id = DiagnosticId,
-                Message = string.Format(Resources.ActivityNameAnalyzerMissingMessageFormat, "E1_SayHello"),
-                Severity = Severity,
-                Locations =
-                 new[] {
-                            new DiagnosticResultLocation("Test0.cs", 28, 69)
                      }
             };
             VerifyCSharpDiagnostic(test, expectedDiagnostics);

--- a/test/WebJobs.Extensions.DurableTask.Analyzers.Test/ActivityFunction/NameAnalyzerTests.cs
+++ b/test/WebJobs.Extensions.DurableTask.Analyzers.Test/ActivityFunction/NameAnalyzerTests.cs
@@ -60,8 +60,11 @@ namespace VSSample
                 outputs.Add(await context.CallActivityAsync<string>(""E1_SayHello_DirectInput"", ""London""));
                 outputs.Add(await context.CallActivityAsync<string>(""E1_SayHello_Object"", new Object()));
                 outputs.Add(await context.CallActivityAsync<string>(""E1_SayHello_Object_DirectInput"", new Object()));
-                outputs.Add(await context.CallActivityAsync<string>(""E1_SayHello_Tuple"", (""Seattle"", 4)));
-                outputs.Add(await context.CallActivityAsync<string>(""E1_SayHello_Tuple_OnContext"", (""Seattle"", 4)));
+                Tuple<string, int> tuple = new Tuple<string, int>(""Seattle"", 4);
+                outputs.Add(await context.CallActivityAsync<string>(""E1_SayHello_Tuple"", tuple));
+                outputs.Add(await context.CallActivityAsync<string>(""E1_SayHello_Tuple_OnContext"", tuple));
+                outputs.Add(await context.CallActivityAsync<string>(""E1_SayHello_ValueTuple"", (""Seattle"", 4)));
+                outputs.Add(await context.CallActivityAsync<string>(""E1_SayHello_ValueTuple_OnContext"", (""Seattle"", 4)));
                 outputs.Add(await context.CallActivityAsync<string>(nameof(SayHelloByClassName), ""Amsterdam""));
                 outputs.Add(await context.CallActivityAsync<string>(""SayHelloByMethodName"", ""Amsterdam""));
                 outputs.Add(await context.CallActivityAsync<string>(nameof(SayHelloByMethodName), ""Amsterdam""));
@@ -107,6 +110,20 @@ namespace VSSample
         }
 
         [FunctionName(""E1_SayHello_Tuple_OnContext"")]
+        public static string SayHelloTupleOnContext([ActivityTrigger] IDurableActivityContext context)
+        {
+            string name = context.GetInput<Tuple<string, int>>();
+            return $""Hello {name}!"";
+        }
+
+        [FunctionName(""E1_SayHello_ValueTuple"")]
+        public static string SayHelloTuple([ActivityTrigger] ValueTuple<string, int> tupleTest)
+        {
+            string name = tupleTest;
+            return $""Hello {name}!"";
+        }
+
+        [FunctionName(""E1_SayHello_ValueTuple_OnContext"")]
         public static string SayHelloTupleOnContext([ActivityTrigger] IDurableActivityContext context)
         {
             string name = context.GetInput<(string, int)>();


### PR DESCRIPTION
Made several FunctionAnalyzer changes and bug fixes:
resolves #1320 -- 'System.ArgumentException' with message 'Syntax node is not within syntax tree'. due to SemanticModel being passed around without getting new SemanticModel for the node being analyzed

resolves #1322 -- Bug where ReturnTypeAnalyzer didn't properly handle function return types of Task<T> when T was a mismatch JsonArray serialized type (types that implement IEnumerable)

resolves #1324 -- Bug where ValueTuples would be incorrectly labeled as Tuples causing incorrect warnings when using ValueTuples

Adds logic to ArgumentAnalyzer to allow passed input to be a subclass or implementation of the defined input.
Adds logic to ReturnTypeAnalzyer to allow expected return type to be a base/interface for the defined return type.

Updated all FunctionAnalyzer tests to remove clutter and to clearly define test cases. This change will make adding to tests easier and, especially, reading and reviewing test code to be a much more enjoyable process.