### PR TITLE
Handle constructor failures for non-static functions

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableCommonContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableCommonContext.cs
@@ -43,6 +43,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
         internal TimeSpan EntityMessageReorderWindow { get; private set; }
 
+        internal bool ExecutorCalledBack { get; set; }
+
         internal void AddDeferredTask(Func<Task> function)
         {
             this.deferredTasks.Add(function);

--- a/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
@@ -512,6 +512,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 #pragma warning disable CS0618 // Approved for use by this extension
                     InvokeHandler = async userCodeInvoker =>
                     {
+                        context.ExecutorCalledBack = true;
+
                         // 2. Configure the shim with the inner invoker to execute the user code.
                         shim.SetFunctionInvocationCallback(userCodeInvoker);
 
@@ -526,6 +528,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     },
 #pragma warning restore CS0618
                 },
+                context,
                 this.hostLifetimeService.OnStopping);
 
             if (result.ExecutionStatus == WrappedFunctionResult.FunctionResultStatus.FunctionsRuntimeError)
@@ -688,6 +691,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 #pragma warning disable CS0618 // Approved for use by this extension
                     InvokeHandler = async userCodeInvoker =>
                     {
+                        entityContext.ExecutorCalledBack = true;
+
                         entityShim.SetFunctionInvocationCallback(userCodeInvoker);
 
                         // 3. Run all the operations in the batch
@@ -713,6 +718,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     },
 #pragma warning restore CS0618
                 },
+                entityContext,
                 this.hostLifetimeService.OnStopping);
 
             if (result.ExecutionStatus == WrappedFunctionResult.FunctionResultStatus.FunctionsRuntimeError)

--- a/test/Common/DurableTaskEndToEndTests.cs
+++ b/test/Common/DurableTaskEndToEndTests.cs
@@ -2049,7 +2049,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         {
             using (ITestHost host = TestHelpers.GetJobHost(
                 this.loggerProvider,
-                nameof(this.HandleUncallableOrchestrator),
+                nameof(this.HandleUncallableFunctions),
                 extendedSessions,
                 storageProviderType: storageProvider))
             {

--- a/test/Common/TestHelpers.cs
+++ b/test/Common/TestHelpers.cs
@@ -197,6 +197,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 typeof(TestEntities),
                 typeof(TestEntityClasses),
                 typeof(ClientFunctions),
+                typeof(UnconstructibleClass),
 #if !FUNCTIONS_V1
                 typeof(TestEntityWithDependencyInjectionHelpers),
 #endif

--- a/test/Common/TestOrchestrations.cs
+++ b/test/Common/TestOrchestrations.cs
@@ -987,7 +987,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 var result = await ctx.CallActivityAsync<int>(nameof(UnconstructibleClass.UncallableActivity), null);
             }
 #if FUNCTIONS_V1
-                catch (FunctionFailedException e) when (e.Message == "The activity function 'UncallableActivity' failed: \"Exception has been thrown by the target of an invocation.\". See the function execution logs for additional details.")
+            catch (FunctionFailedException e) when (e.Message == "The activity function 'UncallableActivity' failed: \"Exception has been thrown by the target of an invocation.\". See the function execution logs for additional details.")
 #else
             catch (FunctionFailedException e) when (e.Message == "The activity function 'UncallableActivity' failed: \"Exception of type 'System.Exception' was thrown.\". See the function execution logs for additional details.")
 #endif

--- a/test/Common/TestOrchestrations.cs
+++ b/test/Common/TestOrchestrations.cs
@@ -953,6 +953,50 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             return "ok";
         }
 
+        public static async Task<string> HandleUncallableFunctions([OrchestrationTrigger] IDurableOrchestrationContext ctx)
+        {
+            var entityId = ctx.GetInput<EntityId>();
+
+            // even though the entity function cannot be called the entity can still be used as a lock!
+            using (await ctx.LockAsync(entityId))
+            {
+                try
+                {
+                    var result = await ctx.CallEntityAsync<int>(entityId, "get");
+                }
+#if FUNCTIONS_V1
+                catch (Exception e) when (e.Message == "Exception has been thrown by the target of an invocation.")
+#else
+                catch (Exception e) when (e.Message == "Exception of type 'System.Exception' was thrown.")
+#endif
+                {
+                }
+            }
+
+            // signals fail silently
+            ctx.SignalEntity(entityId, "hello");
+
+            // test that the lock is still available
+            using (await ctx.LockAsync(entityId))
+            {
+            }
+
+            // try an uncallable activity
+            try
+            {
+                var result = await ctx.CallActivityAsync<int>(nameof(UnconstructibleClass.UncallableActivity), null);
+            }
+#if FUNCTIONS_V1
+                catch (FunctionFailedException e) when (e.Message == "The activity function 'UncallableActivity' failed: \"Exception has been thrown by the target of an invocation.\". See the function execution logs for additional details.")
+#else
+            catch (FunctionFailedException e) when (e.Message == "The activity function 'UncallableActivity' failed: \"Exception of type 'System.Exception' was thrown.\". See the function execution logs for additional details.")
+#endif
+            {
+            }
+
+            return "ok";
+        }
+
         public static async Task<string> PollCounterEntity([OrchestrationTrigger] IDurableOrchestrationContext ctx)
         {
             // get the id of the two entities used by this test

--- a/test/Common/UnconstructibleClass.cs
+++ b/test/Common/UnconstructibleClass.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+
+namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
+{
+    public class UnconstructibleClass
+    {
+        public UnconstructibleClass()
+        {
+            throw new Exception();
+        }
+
+        public Task<object> UncallableOrchestrator([OrchestrationTrigger] IDurableOrchestrationContext ctx)
+        {
+            return Task.FromResult<object>(null);
+        }
+
+        public Task<object> UncallableEntity([EntityTrigger] IDurableEntityContext ctx)
+        {
+            return Task.FromResult<object>(null);
+        }
+
+        public Task<object> UncallableActivity([ActivityTrigger] IDurableActivityContext ctx)
+        {
+            return Task.FromResult<object>(null);
+        }
+    }
+}


### PR DESCRIPTION
Fixes a bug where constructor failures for non-static orchestrators or entities lead to incorrect behavior, and added testcases.

The desired behavior is to treat constructor exceptions as if they were thrown by the function call.

For entities this means that general entity behaviors (e.g. locking) keep working  even if the function cannot be constructed.