### PR TITLE
Check for interface methods after we've found them

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/EntityScheduler/Proxy/EntityProxyFactory.cs
+++ b/src/WebJobs.Extensions.DurableTask/EntityScheduler/Proxy/EntityProxyFactory.cs
@@ -60,11 +60,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             {
                 throw new InvalidOperationException($"Interface '{interfaceType.FullName}' defines properties. Entity proxy interfaces with properties are not supported.");
             }
-
-            if (interfaceType.GetMethods(BindingFlags.Instance | BindingFlags.Public).Length == 0)
-            {
-                throw new InvalidOperationException($"Interface '{interfaceType.FullName}' has no methods defined.");
-            }
         }
 
         private static void BuildConstructor(TypeBuilder typeBuilder)
@@ -98,6 +93,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 {
                     methods.AddRange(inter.GetMethods(BindingFlags.Instance | BindingFlags.Public));
                 }
+            }
+
+            if (methods.Count == 0)
+            {
+                throw new InvalidOperationException($"Interface '{interfaceType.FullName}' has no methods defined.");
             }
 
             var entityProxyMethods = typeof(EntityProxy).GetMethods(BindingFlags.NonPublic | BindingFlags.Instance);


### PR DESCRIPTION
It's possible that an interface might only implement another interface, consider for example:

```csharp
public interface IPhoneToUser : ISignalEntityIndex<UserId> {}
```

where `ISignalEntityIndex<UserId>` contains methods to signal. There may be no need for `IPhoneToUser` to expose methods itself.

This PR checks for methods after we've discovered all the methods on the interface and will throw if there are no methods.