### PR TITLE
Fix entity proxy base class so it properly schedules signals

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/EntityScheduler/Proxy/EntityContextProxy.cs
+++ b/src/WebJobs.Extensions.DurableTask/EntityScheduler/Proxy/EntityContextProxy.cs
@@ -24,14 +24,28 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
         public Task CallAsync(EntityId entityId, string operationName, object operationInput)
         {
-            this.context.SignalEntity(entityId, operationName, operationInput);
+            if (this.scheduledTimeForSignal.HasValue)
+            {
+                this.context.SignalEntity(entityId, this.scheduledTimeForSignal.Value, operationName, operationInput);
+            }
+            else
+            {
+                this.context.SignalEntity(entityId, operationName, operationInput);
+            }
 
             return Task.CompletedTask;
         }
 
         public Task<TResult> CallAsync<TResult>(EntityId entityId, string operationName, object operationInput)
         {
-            this.context.SignalEntity(entityId, operationName, operationInput);
+            if (this.scheduledTimeForSignal.HasValue)
+            {
+                this.context.SignalEntity(entityId, this.scheduledTimeForSignal.Value, operationName, operationInput);
+            }
+            else
+            {
+                this.context.SignalEntity(entityId, operationName, operationInput);
+            }
 
             return Task.FromResult(default(TResult));
         }


### PR DESCRIPTION
Fixes the bug found in #1282. 

The conditional that tests whether there is a scheduled time was missing in two of the three methods of the proxy context. Because it was assuming this time is only specified for signals, not for calls. However for interface methods that return a `Task`, the generated proxy is calling not the signal method but one of the call methods so the scheduled time was ignored.

It's an easy fix (just add the missing tests).
