### PR TITLE
DurableClient changes to allow for use of APIs across function apps

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableClient.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableClient.cs
@@ -229,18 +229,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
         /// <inheritdoc />
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1030:UseEventsWhereAppropriate", Justification = "This method does not work with the .NET Framework event model.")]
-        Task IDurableOrchestrationClient.RaiseEventAsync(string instanceId, string eventName, object eventData, DurableConnectionDetails connectionDetails)
-        {
-            if (string.IsNullOrEmpty(eventName))
-            {
-                throw new ArgumentNullException(nameof(eventName));
-            }
-
-            return this.RaiseEventInternalAsync(connectionDetails, instanceId, eventName, eventData);
-        }
-
-        /// <inheritdoc />
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1030:UseEventsWhereAppropriate", Justification = "This method does not work with the .NET Framework event model.")]
         Task IDurableOrchestrationClient.RaiseEventAsync(string taskHubName, string instanceId, string eventName, object eventData, string connectionName)
         {
             if (string.IsNullOrEmpty(taskHubName))
@@ -258,6 +246,18 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 TaskHub = taskHubName,
                 ConnectionName = connectionName,
             };
+
+            return ((IDurableOrchestrationClient)this).RaiseEventAsync(instanceId, eventName, eventData, connectionDetails);
+        }
+
+        /// <inheritdoc />
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1030:UseEventsWhereAppropriate", Justification = "This method does not work with the .NET Framework event model.")]
+        Task IDurableOrchestrationClient.RaiseEventAsync(string instanceId, string eventName, object eventData, DurableConnectionDetails connectionDetails)
+        {
+            if (string.IsNullOrEmpty(eventName))
+            {
+                throw new ArgumentNullException(nameof(eventName));
+            }
 
             return this.RaiseEventInternalAsync(connectionDetails, instanceId, eventName, eventData);
         }
@@ -346,7 +346,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// <inheritdoc />
         Task IDurableOrchestrationClient.RewindAsync(string instanceId, string reason)
         {
+#pragma warning disable CS0618 // Type or member is obsolete
             return ((IDurableOrchestrationClient)this).RewindAsync(instanceId, reason, null);
+#pragma warning restore CS0618 // Type or member is obsolete
         }
 
         /// <inheritdoc />
@@ -390,16 +392,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         }
 
         /// <inheritdoc />
-        Task<PurgeHistoryResult> IDurableOrchestrationClient.PurgeInstanceHistoryAsync(DateTime createdTimeFrom, DateTime? createdTimeTo, IEnumerable<OrchestrationStatus> runtimeStatus)
-        {
-            return ((IDurableOrchestrationClient)this).PurgeInstanceHistoryAsync(createdTimeFrom, createdTimeTo, runtimeStatus, null);
-        }
-
-        /// <inheritdoc />
         async Task<PurgeHistoryResult> IDurableOrchestrationClient.PurgeInstanceHistoryAsync(string instanceId, DurableConnectionDetails connectionDetails)
         {
             var durableClient = this.GetDurableClient(connectionDetails);
             return await durableClient.DurabilityProvider.PurgeInstanceHistoryByInstanceId(instanceId);
+        }
+
+        /// <inheritdoc />
+        Task<PurgeHistoryResult> IDurableOrchestrationClient.PurgeInstanceHistoryAsync(DateTime createdTimeFrom, DateTime? createdTimeTo, IEnumerable<OrchestrationStatus> runtimeStatus)
+        {
+            return ((IDurableOrchestrationClient)this).PurgeInstanceHistoryAsync(createdTimeFrom, createdTimeTo, runtimeStatus, null);
         }
 
         /// <inheritdoc />
@@ -585,25 +587,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// <inheritdoc />
         Task<IList<DurableOrchestrationStatus>> IDurableOrchestrationClient.GetStatusAsync(CancellationToken cancellationToken)
         {
-            return ((IDurableOrchestrationClient)this).GetStatusAsync(cancellationToken, null);
-        }
-
-        /// <inheritdoc />
-        async Task<IList<DurableOrchestrationStatus>> IDurableOrchestrationClient.GetStatusAsync(CancellationToken cancellationToken, DurableConnectionDetails connectionDetails)
-        {
-            return await this.GetAllStatusHelper(connectionDetails, null, null, null, cancellationToken);
+            return this.GetAllStatusHelper(null, null, null, null, cancellationToken);
         }
 
         /// <inheritdoc />
         Task<IList<DurableOrchestrationStatus>> IDurableOrchestrationClient.GetStatusAsync(DateTime createdTimeFrom, DateTime? createdTimeTo, IEnumerable<OrchestrationRuntimeStatus> runtimeStatus, CancellationToken cancellationToken)
         {
-            return ((IDurableOrchestrationClient)this).GetStatusAsync(createdTimeFrom, createdTimeTo, runtimeStatus, cancellationToken, null);
-        }
-
-        /// <inheritdoc />
-        async Task<IList<DurableOrchestrationStatus>> IDurableOrchestrationClient.GetStatusAsync(DateTime createdTimeFrom, DateTime? createdTimeTo, IEnumerable<OrchestrationRuntimeStatus> runtimeStatus, CancellationToken cancellationToken, DurableConnectionDetails connectionDetails)
-        {
-            return await this.GetAllStatusHelper(connectionDetails, createdTimeFrom, createdTimeTo, runtimeStatus, cancellationToken);
+            return this.GetAllStatusHelper(null, createdTimeFrom, createdTimeTo, runtimeStatus, cancellationToken);
         }
 
         private async Task<IList<DurableOrchestrationStatus>> GetAllStatusHelper(DurableConnectionDetails connectionDetails, DateTime? createdTimeFrom, DateTime? createdTimeTo, IEnumerable<OrchestrationRuntimeStatus> runtimeStatus, CancellationToken cancellationToken)
@@ -640,16 +630,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// <inheritdoc />
         Task<OrchestrationStatusQueryResult> IDurableOrchestrationClient.GetStatusAsync(OrchestrationStatusQueryCondition condition, CancellationToken cancellationToken)
         {
-            return ((IDurableOrchestrationClient)this).GetStatusAsync(condition, cancellationToken, null);
-        }
-
-        /// <inheritdoc />
-        Task<OrchestrationStatusQueryResult> IDurableOrchestrationClient.GetStatusAsync(
-            OrchestrationStatusQueryCondition condition,
-            CancellationToken cancellationToken,
-            DurableConnectionDetails connectionDetails)
-        {
-            return ((IDurableOrchestrationClient)this).ListInstancesAsync(condition, cancellationToken, connectionDetails);
+            return ((IDurableOrchestrationClient)this).ListInstancesAsync(condition, cancellationToken, null);
         }
 
         Task<OrchestrationStatusQueryResult> IDurableOrchestrationClient.ListInstancesAsync(OrchestrationStatusQueryCondition condition, CancellationToken cancellationToken)

--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableClient.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableClient.cs
@@ -152,7 +152,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         }
 
         /// <inheritdoc />
-        async Task<string> IDurableOrchestrationClient.StartNewAsync<T>(string orchestratorFunctionName, string instanceId, T input, DurableClientConnectionDetails connectionDetails)
+        Task<string> IDurableOrchestrationClient.StartNewAsync<T>(string orchestratorFunctionName, string instanceId, T input)
+        {
+            return ((IDurableOrchestrationClient)this).StartNewAsync<T>(orchestratorFunctionName, instanceId, input, null);
+        }
+
+        /// <inheritdoc />
+        async Task<string> IDurableOrchestrationClient.StartNewAsync<T>(string orchestratorFunctionName, string instanceId, T input, DurableConnectionDetails connectionDetails)
         {
             if (string.IsNullOrEmpty(instanceId))
             {
@@ -216,9 +222,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             return new OrchestrationStatus[0];
         }
 
+        Task IDurableOrchestrationClient.RaiseEventAsync(string instanceId, string eventName, object eventData)
+        {
+            return ((IDurableOrchestrationClient)this).RaiseEventAsync(instanceId, eventName, eventData, null);
+        }
+
         /// <inheritdoc />
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1030:UseEventsWhereAppropriate", Justification = "This method does not work with the .NET Framework event model.")]
-        Task IDurableOrchestrationClient.RaiseEventAsync(string instanceId, string eventName, object eventData, DurableClientConnectionDetails connectionDetails)
+        Task IDurableOrchestrationClient.RaiseEventAsync(string instanceId, string eventName, object eventData, DurableConnectionDetails connectionDetails)
         {
             if (string.IsNullOrEmpty(eventName))
             {
@@ -242,7 +253,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 throw new ArgumentNullException(nameof(eventName));
             }
 
-            var connectionDetails = new DurableClientConnectionDetails()
+            var connectionDetails = new DurableConnectionDetails()
             {
                 TaskHub = taskHubName,
                 ConnectionName = connectionName,
@@ -252,7 +263,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         }
 
         private async Task RaiseEventInternalAsync(
-            DurableClientConnectionDetails connectionDetails,
+            DurableConnectionDetails connectionDetails,
             string instanceId,
             string eventName,
             object eventData)
@@ -293,7 +304,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         }
 
         /// <inheritdoc />
-        async Task IDurableOrchestrationClient.TerminateAsync(string instanceId, string reason, DurableClientConnectionDetails connectionDetails)
+        Task IDurableOrchestrationClient.TerminateAsync(string instanceId, string reason)
+        {
+            return ((IDurableOrchestrationClient)this).TerminateAsync(instanceId, reason, null);
+        }
+
+        /// <inheritdoc />
+        async Task IDurableOrchestrationClient.TerminateAsync(string instanceId, string reason, DurableConnectionDetails connectionDetails)
         {
             var durableClient = this.GetDurableClient(connectionDetails);
 
@@ -327,7 +344,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         }
 
         /// <inheritdoc />
-        async Task IDurableOrchestrationClient.RewindAsync(string instanceId, string reason, DurableClientConnectionDetails connectionDetails)
+        Task IDurableOrchestrationClient.RewindAsync(string instanceId, string reason)
+        {
+            return ((IDurableOrchestrationClient)this).RewindAsync(instanceId, reason, null);
+        }
+
+        /// <inheritdoc />
+        async Task IDurableOrchestrationClient.RewindAsync(string instanceId, string reason, DurableConnectionDetails connectionDetails)
         {
             var durableClient = this.GetDurableClient(connectionDetails);
 
@@ -361,14 +384,26 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         }
 
         /// <inheritdoc />
-        async Task<PurgeHistoryResult> IDurableOrchestrationClient.PurgeInstanceHistoryAsync(string instanceId, DurableClientConnectionDetails connectionDetails)
+        Task<PurgeHistoryResult> IDurableOrchestrationClient.PurgeInstanceHistoryAsync(string instanceId)
+        {
+            return ((IDurableOrchestrationClient)this).PurgeInstanceHistoryAsync(instanceId, null);
+        }
+
+        /// <inheritdoc />
+        Task<PurgeHistoryResult> IDurableOrchestrationClient.PurgeInstanceHistoryAsync(DateTime createdTimeFrom, DateTime? createdTimeTo, IEnumerable<OrchestrationStatus> runtimeStatus)
+        {
+            return ((IDurableOrchestrationClient)this).PurgeInstanceHistoryAsync(createdTimeFrom, createdTimeTo, runtimeStatus, null);
+        }
+
+        /// <inheritdoc />
+        async Task<PurgeHistoryResult> IDurableOrchestrationClient.PurgeInstanceHistoryAsync(string instanceId, DurableConnectionDetails connectionDetails)
         {
             var durableClient = this.GetDurableClient(connectionDetails);
             return await durableClient.DurabilityProvider.PurgeInstanceHistoryByInstanceId(instanceId);
         }
 
         /// <inheritdoc />
-        async Task<PurgeHistoryResult> IDurableOrchestrationClient.PurgeInstanceHistoryAsync(DateTime createdTimeFrom, DateTime? createdTimeTo, IEnumerable<OrchestrationStatus> runtimeStatus, DurableClientConnectionDetails connectionDetails)
+        async Task<PurgeHistoryResult> IDurableOrchestrationClient.PurgeInstanceHistoryAsync(DateTime createdTimeFrom, DateTime? createdTimeTo, IEnumerable<OrchestrationStatus> runtimeStatus, DurableConnectionDetails connectionDetails)
         {
             var durableClient = this.GetDurableClient(connectionDetails);
             int numInstancesDeleted = await durableClient.DurabilityProvider.PurgeHistoryByFilters(createdTimeFrom, createdTimeTo, runtimeStatus);
@@ -376,7 +411,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         }
 
         /// <inheritdoc />
-        async Task<DurableOrchestrationStatus> IDurableOrchestrationClient.GetStatusAsync(string instanceId, bool showHistory, bool showHistoryOutput, bool showInput, DurableClientConnectionDetails connectionDetails)
+        Task<DurableOrchestrationStatus> IDurableOrchestrationClient.GetStatusAsync(string instanceId, bool showHistory, bool showHistoryOutput, bool showInput)
+        {
+            return ((IDurableOrchestrationClient)this).GetStatusAsync(instanceId, showHistory, showHistoryOutput, showInput, null);
+        }
+
+        /// <inheritdoc />
+        async Task<DurableOrchestrationStatus> IDurableOrchestrationClient.GetStatusAsync(string instanceId, bool showHistory, bool showHistoryOutput, bool showInput, DurableConnectionDetails connectionDetails)
         {
             var durableClient = this.GetDurableClient(connectionDetails);
 
@@ -542,18 +583,30 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         }
 
         /// <inheritdoc />
-        async Task<IList<DurableOrchestrationStatus>> IDurableOrchestrationClient.GetStatusAsync(CancellationToken cancellationToken, DurableClientConnectionDetails connectionDetails)
+        Task<IList<DurableOrchestrationStatus>> IDurableOrchestrationClient.GetStatusAsync(CancellationToken cancellationToken)
+        {
+            return ((IDurableOrchestrationClient)this).GetStatusAsync(cancellationToken, null);
+        }
+
+        /// <inheritdoc />
+        async Task<IList<DurableOrchestrationStatus>> IDurableOrchestrationClient.GetStatusAsync(CancellationToken cancellationToken, DurableConnectionDetails connectionDetails)
         {
             return await this.GetAllStatusHelper(connectionDetails, null, null, null, cancellationToken);
         }
 
         /// <inheritdoc />
-        async Task<IList<DurableOrchestrationStatus>> IDurableOrchestrationClient.GetStatusAsync(DateTime createdTimeFrom, DateTime? createdTimeTo, IEnumerable<OrchestrationRuntimeStatus> runtimeStatus, CancellationToken cancellationToken, DurableClientConnectionDetails connectionDetails)
+        Task<IList<DurableOrchestrationStatus>> IDurableOrchestrationClient.GetStatusAsync(DateTime createdTimeFrom, DateTime? createdTimeTo, IEnumerable<OrchestrationRuntimeStatus> runtimeStatus, CancellationToken cancellationToken)
+        {
+            return ((IDurableOrchestrationClient)this).GetStatusAsync(createdTimeFrom, createdTimeTo, runtimeStatus, cancellationToken, null);
+        }
+
+        /// <inheritdoc />
+        async Task<IList<DurableOrchestrationStatus>> IDurableOrchestrationClient.GetStatusAsync(DateTime createdTimeFrom, DateTime? createdTimeTo, IEnumerable<OrchestrationRuntimeStatus> runtimeStatus, CancellationToken cancellationToken, DurableConnectionDetails connectionDetails)
         {
             return await this.GetAllStatusHelper(connectionDetails, createdTimeFrom, createdTimeTo, runtimeStatus, cancellationToken);
         }
 
-        private async Task<IList<DurableOrchestrationStatus>> GetAllStatusHelper(DurableClientConnectionDetails connectionDetails, DateTime? createdTimeFrom, DateTime? createdTimeTo, IEnumerable<OrchestrationRuntimeStatus> runtimeStatus, CancellationToken cancellationToken)
+        private async Task<IList<DurableOrchestrationStatus>> GetAllStatusHelper(DurableConnectionDetails connectionDetails, DateTime? createdTimeFrom, DateTime? createdTimeTo, IEnumerable<OrchestrationRuntimeStatus> runtimeStatus, CancellationToken cancellationToken)
         {
             var condition = this.CreateConditionFromParameters(createdTimeFrom, createdTimeTo, runtimeStatus);
 
@@ -585,40 +638,39 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         }
 
         /// <inheritdoc />
+        Task<OrchestrationStatusQueryResult> IDurableOrchestrationClient.GetStatusAsync(OrchestrationStatusQueryCondition condition, CancellationToken cancellationToken)
+        {
+            return ((IDurableOrchestrationClient)this).GetStatusAsync(condition, cancellationToken, null);
+        }
+
+        /// <inheritdoc />
         Task<OrchestrationStatusQueryResult> IDurableOrchestrationClient.GetStatusAsync(
             OrchestrationStatusQueryCondition condition,
             CancellationToken cancellationToken,
-            DurableClientConnectionDetails connectionDetails)
+            DurableConnectionDetails connectionDetails)
         {
             return ((IDurableOrchestrationClient)this).ListInstancesAsync(condition, cancellationToken, connectionDetails);
+        }
+
+        Task<OrchestrationStatusQueryResult> IDurableOrchestrationClient.ListInstancesAsync(OrchestrationStatusQueryCondition condition, CancellationToken cancellationToken)
+        {
+            return ((IDurableOrchestrationClient)this).ListInstancesAsync(condition, cancellationToken, null);
         }
 
         /// <inheritdoc />
         Task<OrchestrationStatusQueryResult> IDurableOrchestrationClient.ListInstancesAsync(
             OrchestrationStatusQueryCondition condition,
             CancellationToken cancellationToken,
-            DurableClientConnectionDetails connectionDetails)
+            DurableConnectionDetails connectionDetails)
         {
             var durableClient = this.GetDurableClient(connectionDetails);
             return durableClient.DurabilityProvider.GetOrchestrationStateWithPagination(condition, cancellationToken);
         }
 
         /// <inheritdoc />
-        Task IDurableEntityClient.SignalEntityAsync(EntityId entityId, string operationName, object operationInput, DurableClientConnectionDetails connectionDetails)
-        {
-            return this.SignalEntityAsyncInternal(connectionDetails, entityId, null, operationName, operationInput);
-        }
-
-        /// <inheritdoc />
-        Task IDurableEntityClient.SignalEntityAsync(EntityId entityId, DateTime scheduledTimeUtc, string operationName, object operationInput, DurableClientConnectionDetails connectionDetails)
-        {
-            return this.SignalEntityAsyncInternal(connectionDetails, entityId, scheduledTimeUtc, operationName, operationInput);
-        }
-
-        /// <inheritdoc />
         Task IDurableEntityClient.SignalEntityAsync(EntityId entityId, string operationName, object operationInput, string taskHubName, string connectionName)
         {
-            var connectionDetails = new DurableClientConnectionDetails()
+            var connectionDetails = new DurableConnectionDetails()
             {
                 TaskHub = taskHubName,
                 ConnectionName = connectionName,
@@ -630,7 +682,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// <inheritdoc />
         Task IDurableEntityClient.SignalEntityAsync(EntityId entityId, DateTime scheduledTimeUtc, string operationName, object operationInput, string taskHubName, string connectionName)
         {
-            var connectionDetails = new DurableClientConnectionDetails()
+            var connectionDetails = new DurableConnectionDetails()
             {
                 TaskHub = taskHubName,
                 ConnectionName = connectionName,
@@ -639,7 +691,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             return this.SignalEntityAsyncInternal(connectionDetails, entityId, scheduledTimeUtc, operationName, operationInput);
         }
 
-        private async Task SignalEntityAsyncInternal(DurableClientConnectionDetails connectionDetails, EntityId entityId, DateTime? scheduledTimeUtc, string operationName, object operationInput)
+        private async Task SignalEntityAsyncInternal(DurableConnectionDetails connectionDetails, EntityId entityId, DateTime? scheduledTimeUtc, string operationName, object operationInput)
         {
             if (operationName == null)
             {
@@ -684,15 +736,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         }
 
         /// <inheritdoc />
-        Task<EntityStateResponse<T>> IDurableEntityClient.ReadEntityStateAsync<T>(EntityId entityId, DurableClientConnectionDetails connectionDetails)
-        {
-            return this.ReadEntityStateAsyncInternal<T>(connectionDetails, entityId);
-        }
-
-        /// <inheritdoc />
         Task<EntityStateResponse<T>> IDurableEntityClient.ReadEntityStateAsync<T>(EntityId entityId, string taskHubName, string connectionName)
         {
-            var connectionDetails = new DurableClientConnectionDetails
+            var connectionDetails = new DurableConnectionDetails
             {
                 TaskHub = taskHubName,
                 ConnectionName = connectionName,
@@ -701,7 +747,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             return this.ReadEntityStateAsyncInternal<T>(connectionDetails, entityId);
         }
 
-        private async Task<EntityStateResponse<T>> ReadEntityStateAsyncInternal<T>(DurableClientConnectionDetails connectionDetails, EntityId entityId)
+        private async Task<EntityStateResponse<T>> ReadEntityStateAsyncInternal<T>(DurableConnectionDetails connectionDetails, EntityId entityId)
         {
             var durableClient = this.GetDurableClient(connectionDetails);
 
@@ -715,7 +761,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         }
 
         /// <inheritdoc />
-        async Task<EntityQueryResult> IDurableEntityClient.ListEntitiesAsync(EntityQuery query, CancellationToken cancellationToken, DurableClientConnectionDetails connectionDetails)
+        Task<EntityQueryResult> IDurableEntityClient.ListEntitiesAsync(EntityQuery query, CancellationToken cancellationToken)
+        {
+            return ((IDurableEntityClient)this).ListEntitiesAsync(query, cancellationToken, null);
+        }
+
+        /// <inheritdoc />
+        async Task<EntityQueryResult> IDurableEntityClient.ListEntitiesAsync(EntityQuery query, CancellationToken cancellationToken, DurableConnectionDetails connectionDetails)
         {
             var condition = new OrchestrationStatusQueryCondition(query);
             var result = await ((IDurableClient)this).ListInstancesAsync(condition, cancellationToken, connectionDetails);
@@ -723,7 +775,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             return entityResult;
         }
 
-        private DurableClient GetDurableClient(DurableClientConnectionDetails connectionDetails)
+        private DurableClient GetDurableClient(DurableConnectionDetails connectionDetails)
         {
             var attribute = new DurableClientAttribute
             {

--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableClient.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableClient.cs
@@ -809,14 +809,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
         private bool ConnectionNameMatchesCurrentApp(DurableClient client)
         {
-            var storageProvider = this.config.Options.StorageProvider;
-            if (storageProvider.TryGetValue("ConnectionStringName", out object connectionName))
-            {
-                var newConnectionName = client.DurabilityProvider.ConnectionName;
-                return newConnectionName.Equals(connectionName);
-            }
-
-            return false;
+            return this.config.DurabilityProvider.ConnectionNameMatches(client.DurabilityProvider);
         }
 
         internal static JToken ParseToJToken(string value)

--- a/src/WebJobs.Extensions.DurableTask/ContextInterfaces/IDurableEntityClient.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextInterfaces/IDurableEntityClient.cs
@@ -26,9 +26,31 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// <param name="entityId">The target entity.</param>
         /// <param name="operationName">The name of the operation.</param>
         /// <param name="operationInput">The input for the operation.</param>
+        /// <param name="connectionDetails">The storage account connection details.</param>
+        /// <returns>A task that completes when the message has been reliably enqueued.</returns>
+        Task SignalEntityAsync(EntityId entityId, string operationName, object operationInput = null, DurableClientConnectionDetails connectionDetails = null);
+
+        /// <summary>
+        /// Signals an entity to perform an operation, at a specified time.
+        /// </summary>
+        /// <param name="entityId">The target entity.</param>
+        /// <param name="scheduledTimeUtc">The time at which to start the operation.</param>
+        /// <param name="operationName">The name of the operation.</param>
+        /// <param name="operationInput">The input for the operation.</param>
+        /// <param name="connectionDetails">The storage account connection details.</param>
+        /// <returns>A task that completes when the message has been reliably enqueued.</returns>
+        Task SignalEntityAsync(EntityId entityId, DateTime scheduledTimeUtc, string operationName, object operationInput = null, DurableClientConnectionDetails connectionDetails = null);
+
+        /// <summary>
+        /// Signals an entity to perform an operation.
+        /// </summary>
+        /// <param name="entityId">The target entity.</param>
+        /// <param name="operationName">The name of the operation.</param>
+        /// <param name="operationInput">The input for the operation.</param>
         /// <param name="taskHubName">The TaskHubName of the target entity.</param>
         /// <param name="connectionName">The name of the connection string associated with <paramref name="taskHubName"/>.</param>
         /// <returns>A task that completes when the message has been reliably enqueued.</returns>
+        [Obsolete]
         Task SignalEntityAsync(EntityId entityId, string operationName, object operationInput = null, string taskHubName = null, string connectionName = null);
 
         /// <summary>
@@ -41,7 +63,18 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// <param name="taskHubName">The TaskHubName of the target entity.</param>
         /// <param name="connectionName">The name of the connection string associated with <paramref name="taskHubName"/>.</param>
         /// <returns>A task that completes when the message has been reliably enqueued.</returns>
+        [Obsolete]
         Task SignalEntityAsync(EntityId entityId, DateTime scheduledTimeUtc, string operationName, object operationInput = null, string taskHubName = null, string connectionName = null);
+
+        /// <summary>
+        /// Tries to read the current state of an entity. Returns default(<typeparamref name="T"/>) if the entity does not
+        /// exist, or if the JSON-serialized state of the entity is larger than 16KB.
+        /// </summary>
+        /// <typeparam name="T">The JSON-serializable type of the entity.</typeparam>
+        /// <param name="entityId">The target entity.</param>
+        /// <param name="connectionDetails">The storage account connection details.</param>
+        /// <returns>a response containing the current state of the entity.</returns>
+        Task<EntityStateResponse<T>> ReadEntityStateAsync<T>(EntityId entityId, DurableClientConnectionDetails connectionDetails = null);
 
         /// <summary>
         /// Tries to read the current state of an entity. Returns default(<typeparamref name="T"/>) if the entity does not
@@ -52,6 +85,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// <param name="taskHubName">The TaskHubName of the target entity.</param>
         /// <param name="connectionName">The name of the connection string associated with <paramref name="taskHubName"/>.</param>
         /// <returns>a response containing the current state of the entity.</returns>
+        [Obsolete]
         Task<EntityStateResponse<T>> ReadEntityStateAsync<T>(EntityId entityId, string taskHubName = null, string connectionName = null);
 
         /// <summary>
@@ -59,7 +93,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// </summary>
         /// <param name="query">Return entity instances that match the specified query conditions.</param>
         /// <param name="cancellationToken">Cancellation token that can be used to cancel the query operation.</param>
+        /// <param name="connectionDetails">The storage account connection details.</param>
         /// <returns>Returns a page of entity instances and a continuation token for fetching the next page.</returns>
-        Task<EntityQueryResult> ListEntitiesAsync(EntityQuery query, CancellationToken cancellationToken);
+        Task<EntityQueryResult> ListEntitiesAsync(EntityQuery query, CancellationToken cancellationToken, DurableClientConnectionDetails connectionDetails = null);
     }
 }

--- a/src/WebJobs.Extensions.DurableTask/ContextInterfaces/IDurableEntityClient.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextInterfaces/IDurableEntityClient.cs
@@ -26,31 +26,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// <param name="entityId">The target entity.</param>
         /// <param name="operationName">The name of the operation.</param>
         /// <param name="operationInput">The input for the operation.</param>
-        /// <param name="connectionDetails">The storage account connection details.</param>
-        /// <returns>A task that completes when the message has been reliably enqueued.</returns>
-        Task SignalEntityAsync(EntityId entityId, string operationName, object operationInput = null, DurableClientConnectionDetails connectionDetails = null);
-
-        /// <summary>
-        /// Signals an entity to perform an operation, at a specified time.
-        /// </summary>
-        /// <param name="entityId">The target entity.</param>
-        /// <param name="scheduledTimeUtc">The time at which to start the operation.</param>
-        /// <param name="operationName">The name of the operation.</param>
-        /// <param name="operationInput">The input for the operation.</param>
-        /// <param name="connectionDetails">The storage account connection details.</param>
-        /// <returns>A task that completes when the message has been reliably enqueued.</returns>
-        Task SignalEntityAsync(EntityId entityId, DateTime scheduledTimeUtc, string operationName, object operationInput = null, DurableClientConnectionDetails connectionDetails = null);
-
-        /// <summary>
-        /// Signals an entity to perform an operation.
-        /// </summary>
-        /// <param name="entityId">The target entity.</param>
-        /// <param name="operationName">The name of the operation.</param>
-        /// <param name="operationInput">The input for the operation.</param>
         /// <param name="taskHubName">The TaskHubName of the target entity.</param>
         /// <param name="connectionName">The name of the connection string associated with <paramref name="taskHubName"/>.</param>
         /// <returns>A task that completes when the message has been reliably enqueued.</returns>
-        [Obsolete]
         Task SignalEntityAsync(EntityId entityId, string operationName, object operationInput = null, string taskHubName = null, string connectionName = null);
 
         /// <summary>
@@ -63,18 +41,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// <param name="taskHubName">The TaskHubName of the target entity.</param>
         /// <param name="connectionName">The name of the connection string associated with <paramref name="taskHubName"/>.</param>
         /// <returns>A task that completes when the message has been reliably enqueued.</returns>
-        [Obsolete]
         Task SignalEntityAsync(EntityId entityId, DateTime scheduledTimeUtc, string operationName, object operationInput = null, string taskHubName = null, string connectionName = null);
-
-        /// <summary>
-        /// Tries to read the current state of an entity. Returns default(<typeparamref name="T"/>) if the entity does not
-        /// exist, or if the JSON-serialized state of the entity is larger than 16KB.
-        /// </summary>
-        /// <typeparam name="T">The JSON-serializable type of the entity.</typeparam>
-        /// <param name="entityId">The target entity.</param>
-        /// <param name="connectionDetails">The storage account connection details.</param>
-        /// <returns>a response containing the current state of the entity.</returns>
-        Task<EntityStateResponse<T>> ReadEntityStateAsync<T>(EntityId entityId, DurableClientConnectionDetails connectionDetails = null);
 
         /// <summary>
         /// Tries to read the current state of an entity. Returns default(<typeparamref name="T"/>) if the entity does not
@@ -85,7 +52,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// <param name="taskHubName">The TaskHubName of the target entity.</param>
         /// <param name="connectionName">The name of the connection string associated with <paramref name="taskHubName"/>.</param>
         /// <returns>a response containing the current state of the entity.</returns>
-        [Obsolete]
         Task<EntityStateResponse<T>> ReadEntityStateAsync<T>(EntityId entityId, string taskHubName = null, string connectionName = null);
 
         /// <summary>
@@ -95,6 +61,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// <param name="cancellationToken">Cancellation token that can be used to cancel the query operation.</param>
         /// <param name="connectionDetails">The storage account connection details.</param>
         /// <returns>Returns a page of entity instances and a continuation token for fetching the next page.</returns>
-        Task<EntityQueryResult> ListEntitiesAsync(EntityQuery query, CancellationToken cancellationToken, DurableClientConnectionDetails connectionDetails = null);
+        Task<EntityQueryResult> ListEntitiesAsync(EntityQuery query, CancellationToken cancellationToken, DurableConnectionDetails connectionDetails = null);
+
+        /// <summary>
+        /// Gets the status of all entity instances with paging that match the specified query conditions.
+        /// </summary>
+        /// <param name="query">Return entity instances that match the specified query conditions.</param>
+        /// <param name="cancellationToken">Cancellation token that can be used to cancel the query operation.</param>
+        /// <returns>Returns a page of entity instances and a continuation token for fetching the next page.</returns>
+        [Obsolete]
+        Task<EntityQueryResult> ListEntitiesAsync(EntityQuery query, CancellationToken cancellationToken);
     }
 }

--- a/src/WebJobs.Extensions.DurableTask/ContextInterfaces/IDurableOrchestrationClient.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextInterfaces/IDurableOrchestrationClient.cs
@@ -251,6 +251,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// <param name="eventName">The name of the event.</param>
         /// <param name="eventData">The JSON-serializeable data associated with the event.</param>
         /// <returns>A task that completes when the event notification message has been enqueued.</returns>
+        [Obsolete]
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1030:UseEventsWhereAppropriate", Justification = "This method does not work with the .NET Framework event model.")]
         Task RaiseEventAsync(string instanceId, string eventName, object eventData);
 
@@ -327,37 +328,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// <returns>Returns an instance of <see cref="PurgeHistoryResult"/>.</returns>
         [Obsolete]
         Task<PurgeHistoryResult> PurgeInstanceHistoryAsync(DateTime createdTimeFrom, DateTime? createdTimeTo, IEnumerable<OrchestrationStatus> runtimeStatus);
-
-        /// <summary>
-        /// Gets all the status of the orchestration instances.
-        /// </summary>
-        /// <param name="cancellationToken">Cancellation token that can be used to cancel the status query operation.</param>
-        /// <param name="connectionDetails">The storage account connection details.</param>
-        /// <returns>Returns orchestration status for all instances.</returns>
-        [Obsolete]
-        Task<IList<DurableOrchestrationStatus>> GetStatusAsync(CancellationToken cancellationToken = default(CancellationToken), DurableConnectionDetails connectionDetails = null);
-
-        /// <summary>
-        /// Gets the status of all orchestration instances that match the specified conditions.
-        /// </summary>
-        /// <param name="createdTimeFrom">Return orchestration instances which were created after this DateTime.</param>
-        /// <param name="createdTimeTo">Return orchestration instances which were created before this DateTime.</param>
-        /// <param name="runtimeStatus">Return orchestration instances which matches the runtimeStatus.</param>
-        /// <param name="cancellationToken">Cancellation token that can be used to cancel the status query operation.</param>
-        /// <param name="connectionDetails">The storage account connection details.</param>
-        /// <returns>Returns orchestration status for all instances.</returns>
-        [Obsolete]
-        Task<IList<DurableOrchestrationStatus>> GetStatusAsync(DateTime createdTimeFrom, DateTime? createdTimeTo, IEnumerable<OrchestrationRuntimeStatus> runtimeStatus, CancellationToken cancellationToken = default(CancellationToken), DurableConnectionDetails connectionDetails = null);
-
-        /// <summary>
-        /// Gets the status of all orchestration instances with paging that match the specified conditions.
-        /// </summary>
-        /// <param name="condition">Return orchestration instances that match the specified conditions.</param>
-        /// <param name="cancellationToken">Cancellation token that can be used to cancel the status query operation.</param>
-        /// <param name="connectionDetails">The storage account connection details.</param>
-        /// <returns>Returns each page of orchestration status for all instances and continuation token of next page.</returns>
-        [Obsolete]
-        Task<OrchestrationStatusQueryResult> GetStatusAsync(OrchestrationStatusQueryCondition condition, CancellationToken cancellationToken, DurableConnectionDetails connectionDetails = null);
 
         /// <summary>
         /// Gets the status of the specified orchestration instance.

--- a/src/WebJobs.Extensions.DurableTask/ContextInterfaces/IDurableOrchestrationClient.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextInterfaces/IDurableOrchestrationClient.cs
@@ -176,7 +176,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// <para>
         /// A terminated instance will eventually transition into the <see cref="OrchestrationRuntimeStatus.Terminated"/> state.
         /// However, this transition will not happen immediately. Rather, the terminate operation will be queued in the task hub
-        /// along with other operations for that instance. You can use the <see cref="GetStatusAsync(string, bool, bool, bool)"/>
+        /// along with other operations for that instance. You can use the <see cref="GetStatusAsync(string, bool, bool, bool, DurableClientConnectionDetails)"/>
         /// method to know when a terminated instance has actually reached the Terminated state.
         /// </para>
         /// <para>
@@ -197,6 +197,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// </summary>
         /// <param name="instanceId">The ID of the orchestration instance to rewind.</param>
         /// <param name="reason">The reason for rewinding the orchestration instance.</param>
+        /// <param name="connectionDetails">The storage account connection details.</param>
         /// <returns>A task that completes when the rewind message is enqueued.</returns>
         [Obsolete("This feature is in preview.")]
         Task RewindAsync(string instanceId, string reason, DurableClientConnectionDetails connectionDetails = null);
@@ -226,7 +227,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// <param name="showHistory">Boolean marker for including execution history in the response.</param>
         /// <param name="showHistoryOutput">Boolean marker for including input and output in the execution history response.</param>
         /// <param name="showInput">If set, fetch and return the input for the orchestration instance.</param>
-        /// <param name="connectionDetails"></param>
+        /// <param name="connectionDetails">The storage account connection details.</param>
         /// <returns>Returns a task which completes when the status has been fetched.</returns>
         Task<DurableOrchestrationStatus> GetStatusAsync(string instanceId, bool showHistory, bool showHistoryOutput, bool showInput, DurableClientConnectionDetails connectionDetails = null);
 
@@ -234,7 +235,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// Gets all the status of the orchestration instances.
         /// </summary>
         /// <param name="cancellationToken">Cancellation token that can be used to cancel the status query operation.</param>
-        /// <param name="connectionDetails"></param>
+        /// <param name="connectionDetails">The storage account connection details.</param>
         /// <returns>Returns orchestration status for all instances.</returns>
         [Obsolete]
         Task<IList<DurableOrchestrationStatus>> GetStatusAsync(CancellationToken cancellationToken = default(CancellationToken), DurableClientConnectionDetails connectionDetails = null);
@@ -246,6 +247,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// <param name="createdTimeTo">Return orchestration instances which were created before this DateTime.</param>
         /// <param name="runtimeStatus">Return orchestration instances which matches the runtimeStatus.</param>
         /// <param name="cancellationToken">Cancellation token that can be used to cancel the status query operation.</param>
+        /// <param name="connectionDetails">The storage account connection details.</param>
         /// <returns>Returns orchestration status for all instances.</returns>
         [Obsolete]
         Task<IList<DurableOrchestrationStatus>> GetStatusAsync(DateTime createdTimeFrom, DateTime? createdTimeTo, IEnumerable<OrchestrationRuntimeStatus> runtimeStatus, CancellationToken cancellationToken = default(CancellationToken), DurableClientConnectionDetails connectionDetails = null);
@@ -255,6 +257,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// </summary>
         /// <param name="condition">Return orchestration instances that match the specified conditions.</param>
         /// <param name="cancellationToken">Cancellation token that can be used to cancel the status query operation.</param>
+        /// <param name="connectionDetails">The storage account connection details.</param>
         /// <returns>Returns each page of orchestration status for all instances and continuation token of next page.</returns>
         [Obsolete]
         Task<OrchestrationStatusQueryResult> GetStatusAsync(OrchestrationStatusQueryCondition condition, CancellationToken cancellationToken, DurableClientConnectionDetails connectionDetails = null);

--- a/src/WebJobs.Extensions.DurableTask/ContextInterfaces/IDurableOrchestrationClient.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextInterfaces/IDurableOrchestrationClient.cs
@@ -116,13 +116,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// <param name="orchestratorFunctionName">The name of the orchestrator function to start.</param>
         /// <param name="instanceId">The ID to use for the new orchestration instance.</param>
         /// <param name="input">JSON-serializable input value for the orchestrator function.</param>
+        /// <param name="taskHubName">The TaskHubName of the target orchestrator.</param>
+        /// <param name="connectionName">The name of the connection string associated with <paramref name="taskHubName"/>.</param>
         /// <typeparam name="T">The type of the input value for the orchestrator function.</typeparam>
         /// <returns>A task that completes when the orchestration is started. The task contains the instance id of the started
         /// orchestratation instance.</returns>
         /// <exception cref="ArgumentException">
         /// The specified function does not exist, is disabled, or is not an orchestrator function.
         /// </exception>
-        Task<string> StartNewAsync<T>(string orchestratorFunctionName, string instanceId, T input);
+        Task<string> StartNewAsync<T>(string orchestratorFunctionName, string instanceId, T input, string taskHubName = null, string connectionName = null);
 
         /// <summary>
         /// Sends an event notification message to a waiting orchestration instance.

--- a/src/WebJobs.Extensions.DurableTask/DurabilityProvider.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurabilityProvider.cs
@@ -398,5 +398,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             errorMessage = null;
             return true;
         }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="durabilityProvider"></param>
+        /// <returns></returns>
+        public virtual bool ConnectionNameMatches(DurabilityProvider durabilityProvider)
+        {
+            return this.ConnectionName.Equals(durabilityProvider.ConnectionName);
+        }
     }
 }

--- a/src/WebJobs.Extensions.DurableTask/DurabilityProvider.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurabilityProvider.cs
@@ -400,10 +400,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         }
 
         /// <summary>
-        /// 
+        ///  Returns true if the stored connection string, ConnectionName, matches the input DurabilityProvider ConnectionName.
         /// </summary>
-        /// <param name="durabilityProvider"></param>
-        /// <returns></returns>
+        /// <param name="durabilityProvider">The DurabilityProvider used to check for matching connection string names.</param>
+        /// <returns>A boolean indicating whether the connection names match.</returns>
         public virtual bool ConnectionNameMatches(DurabilityProvider durabilityProvider)
         {
             return this.ConnectionName.Equals(durabilityProvider.ConnectionName);

--- a/src/WebJobs.Extensions.DurableTask/DurableClientConnectionDetails.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableClientConnectionDetails.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    public class DurableClientConnectionDetails
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        public string TaskHub { get; set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public string ConnectionName { get; set; }
+    }
+}

--- a/src/WebJobs.Extensions.DurableTask/DurableConnectionDetails.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableConnectionDetails.cs
@@ -4,17 +4,17 @@
 namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 {
     /// <summary>
-    /// 
+    /// Storage account connection details to perform operations on orchestrator and entity functions across function apps.
     /// </summary>
-    public class DurableClientConnectionDetails
+    public class DurableConnectionDetails
     {
         /// <summary>
-        /// 
+        /// The task hub name associated with the target function.
         /// </summary>
         public string TaskHub { get; set; }
 
         /// <summary>
-        /// 
+        /// The connection name associated with the target function.
         /// </summary>
         public string ConnectionName { get; set; }
     }

--- a/test/Common/DurableClientMock.cs
+++ b/test/Common/DurableClientMock.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
         public int Counter { get; set; }
 
-        Task<DurableOrchestrationStatus> IDurableOrchestrationClient.GetStatusAsync(string instanceId, bool showHistory, bool showHistoryOutput, bool showInput)
+        Task<DurableOrchestrationStatus> IDurableOrchestrationClient.GetStatusAsync(string instanceId, bool showHistory, bool showHistoryOutput, bool showInput, DurableConnectionDetails connectionDetails)
         {
             var runtimeStatus = OrchestrationRuntimeStatus.Running;
             switch (instanceId)


### PR DESCRIPTION
Allows all orchestrator and entity operations to work across function apps.

These changes include significant IDurableOrchestrationClient and IDurableEntityClient changes, adding new APIs that include a DurableConnectionDetails optional parameter and marking the old APIs as Obsolete. The old APIs have been retained to avoid breaking changes.

resolves #1281 