### PR TITLE
EndToEndTraceHelper should respect TraceReplayEvents setting

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/EndToEndTraceHelper.cs
+++ b/src/WebJobs.Extensions.DurableTask/EndToEndTraceHelper.cs
@@ -111,7 +111,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 reason,
                 functionType.ToString(),
                 ExtensionVersion,
-                IsReplay: isReplay);
+                isReplay);
 
             if (this.ShouldLogEvent(isReplay))
             {
@@ -139,7 +139,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 input,
                 functionType.ToString(),
                 ExtensionVersion,
-                IsReplay: isReplay);
+                isReplay);
 
             if (this.ShouldLogEvent(isReplay))
             {
@@ -165,7 +165,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 instanceId,
                 functionType.ToString(),
                 ExtensionVersion,
-                IsReplay: isReplay);
+                isReplay);
 
             if (this.ShouldLogEvent(isReplay))
             {
@@ -194,7 +194,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 reason,
                 functionType.ToString(),
                 ExtensionVersion,
-                IsReplay: isReplay);
+                isReplay);
 
             if (this.ShouldLogEvent(isReplay))
             {
@@ -224,7 +224,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 continuedAsNew,
                 functionType.ToString(),
                 ExtensionVersion,
-                IsReplay: isReplay);
+                isReplay);
 
             if (this.ShouldLogEvent(isReplay))
             {
@@ -242,6 +242,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             string reason)
         {
             FunctionType functionType = FunctionType.Orchestrator;
+            bool isReplay = false;
 
             EtwEventSource.Instance.FunctionTerminated(
                 hubName,
@@ -252,9 +253,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 reason,
                 functionType.ToString(),
                 ExtensionVersion,
-                IsReplay: false);
+                isReplay);
 
-            if (this.ShouldLogEvent(isReplay: false))
+            if (this.ShouldLogEvent(isReplay))
             {
                 this.logger.LogWarning(
                     "{instanceId}: Function '{functionName} ({functionType})' was terminated. Reason: {reason}. State: {state}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}. SequenceNumber: {sequenceNumber}.",
@@ -270,6 +271,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             string reason)
         {
             FunctionType functionType = FunctionType.Orchestrator;
+            bool isReplay = false;
 
             EtwEventSource.Instance.FunctionRewound(
                 hubName,
@@ -280,9 +282,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 reason,
                 functionType.ToString(),
                 ExtensionVersion,
-                IsReplay: false);
+                isReplay);
 
-            if (this.ShouldLogEvent(isReplay: false))
+            if (this.ShouldLogEvent(isReplay))
             {
                 this.logger.LogWarning(
                     "{instanceId}: Function '{functionName} ({functionType})' was rewound. Reason: {reason}. State: {state}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}. SequenceNumber: {sequenceNumber}.",
@@ -424,7 +426,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 input,
                 functionType.ToString(),
                 ExtensionVersion,
-                IsReplay: isReplay);
+                isReplay);
 
             if (this.ShouldLogEvent(isReplay))
             {
@@ -452,7 +454,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 eventName,
                 functionType.ToString(),
                 ExtensionVersion,
-                IsReplay: isReplay);
+                isReplay);
 
             if (this.ShouldLogEvent(isReplay))
             {
@@ -509,9 +511,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 operationName,
                 functionType.ToString(),
                 ExtensionVersion,
-                IsReplay: isReplay);
+                isReplay);
 
-            if (this.ShouldLogEvent(isReplay: isReplay))
+            if (this.ShouldLogEvent(isReplay))
             {
                 this.logger.LogInformation(
                     "{instanceId}: Function '{functionName} ({functionType})' queued '{operationName}' operation {operationId}. State: {state}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}. SequenceNumber: {sequenceNumber}.",
@@ -539,9 +541,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 result,
                 functionType.ToString(),
                 ExtensionVersion,
-                IsReplay: isReplay);
+                isReplay);
 
-            if (this.ShouldLogEvent(isReplay: isReplay))
+            if (this.ShouldLogEvent(isReplay))
             {
                 this.logger.LogInformation(
                     "{instanceId}: Function '{functionName} ({functionType})' received an entity response. OperationId: {operationId}. State: {state}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}. SequenceNumber: {sequenceNumber}.",
@@ -572,9 +574,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 requestId,
                 FunctionType.Entity.ToString(),
                 ExtensionVersion,
-                IsReplay: isReplay);
+                isReplay);
 
-            if (this.ShouldLogEvent(isReplay: isReplay))
+            if (this.ShouldLogEvent(isReplay))
             {
                 this.logger.LogInformation(
                     "{instanceId}: Function '{functionName} ({functionType})' granted lock to request {requestId} by instance {requestingInstanceId}, execution {requestingExecutionId}. State: {state}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}. SequenceNumber: {sequenceNumber}.",
@@ -603,9 +605,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 requestId,
                 FunctionType.Entity.ToString(),
                 ExtensionVersion,
-                IsReplay: isReplay);
+                isReplay);
 
-            if (this.ShouldLogEvent(isReplay: isReplay))
+            if (this.ShouldLogEvent(isReplay))
             {
                 this.logger.LogInformation(
                     "{instanceId}: Function '{functionName} ({functionType})' released lock held by request {requestId} by instance {requestingInstance}. State: {state}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}. SequenceNumber: {sequenceNumber}.",
@@ -642,7 +644,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 isReplay,
                 latencyMs);
 
-            if (this.ShouldLogEvent(isReplay: false))
+            if (this.ShouldLogEvent(isReplay))
             {
                 this.logger.LogInformation(
                     "{instanceId}: Function '{functionName} ({functionType})' sent a '{functionState}' notification event to Azure Event Grid. Status code: {statusCode}. Details: {details}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}. SequenceNumber: {sequenceNumber}. Latency: {latencyMs} ms.",
@@ -679,7 +681,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 isReplay,
                 latencyMs);
 
-            if (this.ShouldLogEvent(isReplay: false))
+            if (this.ShouldLogEvent(isReplay))
             {
                 this.logger.LogError(
                     "{instanceId}: Function '{functionName} ({functionType})' failed to send a '{functionState}' notification event to Azure Event Grid. Status code: {statusCode}. Details: {details}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}. SequenceNumber: {sequenceNumber}. Latency: {latencyMs} ms.",
@@ -742,7 +744,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 expirationTimeString,
                 functionType.ToString(),
                 ExtensionVersion,
-                IsReplay: isReplay);
+                isReplay);
             if (this.ShouldLogEvent(isReplay))
             {
                 this.logger.LogInformation(

--- a/src/WebJobs.Extensions.DurableTask/EndToEndTraceHelper.cs
+++ b/src/WebJobs.Extensions.DurableTask/EndToEndTraceHelper.cs
@@ -426,7 +426,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 ExtensionVersion,
                 IsReplay: isReplay);
 
-            if (this.ShouldLogEvent(isReplay: false))
+            if (this.ShouldLogEvent(isReplay))
             {
                 this.logger.LogInformation(
                     "{instanceId}: Function '{functionName} ({functionType})' received a '{eventName}' event. State: {state}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}. SequenceNumber: {sequenceNumber}.",
@@ -454,7 +454,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 ExtensionVersion,
                 IsReplay: isReplay);
 
-            if (this.ShouldLogEvent(isReplay: false))
+            if (this.ShouldLogEvent(isReplay))
             {
                 this.logger.LogInformation(
                     "{instanceId}: Function '{functionName} ({functionType})' saved a '{eventName}' event to an in-memory queue. State: {state}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}. SequenceNumber: {sequenceNumber}.",
@@ -743,7 +743,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 functionType.ToString(),
                 ExtensionVersion,
                 IsReplay: isReplay);
-            if (this.ShouldLogEvent(isReplay: false))
+            if (this.ShouldLogEvent(isReplay))
             {
                 this.logger.LogInformation(
                     "{instanceId}: Function '{functionName} ({functionType})' was resumed by a timer scheduled for '{expirationTime}'. IsReplay: {isReplay}. State: {state}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}. SequenceNumber: {sequenceNumber}.",


### PR DESCRIPTION
Due to what appears to be copy-paste errors, some event types were always being logged, even when replay logging is disabled (ExternalEventRaised, ExternalEventSaved, and TimerExpired).  This PR fixes those three event types to pass in the value of `isReplay` to `ShouldLogEvent`, and also cleans up some of the other code in the file to be more consistent (and hopefully avoid copy-paste failures in the future).

Resolves #1351