### PR TITLE
Handle out-of-process exceptions properly

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/Listener/OutOfProcOrchestrationShim.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/OutOfProcOrchestrationShim.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;
 using DurableTask.Core.Exceptions;
@@ -85,7 +84,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             var execution = JsonConvert.DeserializeObject<OutOfProcOrchestratorState>(jObj.ToString());
             if (execution.CustomStatus != null)
             {
-                ((IDurableOrchestrationContext)this.context).SetCustomStatus(execution.CustomStatus);
+                this.context.SetCustomStatus(execution.CustomStatus);
             }
 
             await this.ProcessAsyncActions(execution.Actions);

--- a/src/WebJobs.Extensions.DurableTask/Listener/TaskActivityShim.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/TaskActivityShim.cs
@@ -93,6 +93,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     // without the outer FunctionInvocationException.
                     Exception exceptionToReport = StripFunctionInvocationException(result.Exception);
 
+                    if (OutOfProcExceptionHelpers.TryGetExceptionWithFriendlyMessage(
+                        exceptionToReport,
+                        out Exception friendlyMessageException))
+                    {
+                        exceptionToReport = friendlyMessageException;
+                    }
+
                     this.config.TraceHelper.FunctionFailed(
                         this.config.Options.HubName,
                         this.activityName,

--- a/src/WebJobs.Extensions.DurableTask/Listener/TaskOrchestrationShim.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/TaskOrchestrationShim.cs
@@ -154,7 +154,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                             {
                                 ReturnValue = returnValue,
                             });
-                        } 
+                        }
                         else
                         {
                             this.context.SetOutput(returnValue);
@@ -189,7 +189,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                         this.context.OrchestrationException = ExceptionDispatchInfo.Capture(ex);
                         throw ex;
                     }
-                } 
+                }
                 else
                 {
                     this.TraceAndSendExceptionNotification(e.ToString());

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net461.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net461.xml
@@ -2904,11 +2904,11 @@
             </summary>
             <param name="context">The orchestration execution context.</param>
         </member>
-        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.OutOfProcOrchestrationShim.ExecuteAsync(Newtonsoft.Json.Linq.JObject)">
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.OutOfProcOrchestrationShim.ScheduleDurableTaskEvents(Microsoft.Azure.WebJobs.Extensions.DurableTask.TaskOrchestrationShim.OrchestrationInvocationResult)">
             <summary>
             Not intended for public consumption.
             </summary>
-            <param name="executionJson">The result of the out-of-proc execution.</param>
+            <param name="result">The result of the out-of-proc execution.</param>
             <returns><c>true</c> if there are more executions to process; <c>false</c> otherwise.</returns>
         </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.TaskActivityShim">

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
@@ -2031,6 +2031,12 @@
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.Microsoft#Azure#WebJobs#IAsyncConverter{System#Net#Http#HttpRequestMessage,System#Net#Http#HttpResponseMessage}#ConvertAsync(System.Net.Http.HttpRequestMessage,System.Threading.CancellationToken)">
             <inheritdoc/>
         </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.TagActivityWithOrchestrationStatus(Microsoft.Azure.WebJobs.Extensions.DurableTask.OrchestrationRuntimeStatus,System.String,System.Boolean)">
+            <summary>
+            Tags the current Activity with metadata: DurableFunctionsType, DurableFunctionsInstanceId, DurableFunctionsRuntimeStatus.
+            This metadata will show up in Application Insights, if enabled.
+            </summary>
+        </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskJobHostConfigurationExtensions">
             <summary>
             Extension for registering a Durable Functions configuration with <c>JobHostConfiguration</c>.
@@ -2971,11 +2977,11 @@
             </summary>
             <param name="context">The orchestration execution context.</param>
         </member>
-        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.OutOfProcOrchestrationShim.ExecuteAsync(Newtonsoft.Json.Linq.JObject)">
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.OutOfProcOrchestrationShim.ScheduleDurableTaskEvents(Microsoft.Azure.WebJobs.Extensions.DurableTask.TaskOrchestrationShim.OrchestrationInvocationResult)">
             <summary>
             Not intended for public consumption.
             </summary>
-            <param name="executionJson">The result of the out-of-proc execution.</param>
+            <param name="result">The result of the out-of-proc execution.</param>
             <returns><c>true</c> if there are more executions to process; <c>false</c> otherwise.</returns>
         </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.TaskActivityShim">

--- a/src/WebJobs.Extensions.DurableTask/OutOfProcExceptionHelpers.cs
+++ b/src/WebJobs.Extensions.DurableTask/OutOfProcExceptionHelpers.cs
@@ -1,0 +1,101 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+
+namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
+{
+    internal static class OutOfProcExceptionHelpers
+    {
+        private const string ResultLabel = "Result:";
+        private const string MessageLabel = "\nException:";
+        private const string StackTraceLabel = "\nStack:";
+
+        private const string OutOfProcDataLabel = "\n\n$OutOfProcData$:";
+
+        /* Extracts <friendly-message> from exceptions with messages of the following form
+         * ------------------------------------------------------------------------------
+         * Result: Failure
+         * Message: <friendly-message>\n\n
+         * $OutOfProcData$<out-of-proc-data-as-json>
+         * Stack:<stack-trace>
+         */
+        public static bool TryGetExceptionWithFriendlyMessage(Exception ex, out Exception friendlyMessageException)
+        {
+            if (!TryGetFullOutOfProcMessage(ex, out string outOfProcMessage))
+            {
+                friendlyMessageException = null;
+                return false;
+            }
+
+            string friendlyMessage;
+            int jsonIndex = outOfProcMessage.IndexOf(OutOfProcDataLabel);
+            if (jsonIndex == -1)
+            {
+                friendlyMessage = outOfProcMessage;
+            }
+            else
+            {
+                friendlyMessage = outOfProcMessage.Substring(0, jsonIndex);
+            }
+
+            friendlyMessageException = new Exception(friendlyMessage, ex);
+            return true;
+        }
+
+        /* Extracts <out-of-proc-data-as-json> from exceptions with messages of the following form
+         * ------------------------------------------------------------------------------
+         * Result: Failure
+         * Message: <friendly-message>\n\n
+         * $OutOfProcData$<out-of-proc-data-as-json>
+         * Stack:<stack-trace>
+         */
+        public static bool TryExtractOutOfProcStateJson(Exception ex, out string stateJson)
+        {
+            if (!TryGetFullOutOfProcMessage(ex, out string outOfProcMessage))
+            {
+                stateJson = null;
+                return false;
+            }
+
+            int jsonIndex = outOfProcMessage.IndexOf(OutOfProcDataLabel);
+            if (jsonIndex == -1)
+            {
+                stateJson = null;
+                return false;
+            }
+            else
+            {
+                int jsonStart = jsonIndex + OutOfProcDataLabel.Length;
+                int jsonLength = outOfProcMessage.Length - jsonStart;
+                stateJson = outOfProcMessage.Substring(jsonStart, jsonLength);
+                return true;
+            }
+        }
+
+        private static bool TryGetFullOutOfProcMessage(Exception ex, out string message)
+        {
+            if (!IsOutOfProcException(ex))
+            {
+                message = null;
+                return false;
+            }
+
+            string rpcExceptionMessage = ex.Message;
+            int messageStart = rpcExceptionMessage.IndexOf(MessageLabel) + MessageLabel.Length;
+            int messageEnd = rpcExceptionMessage.IndexOf(StackTraceLabel);
+            message = rpcExceptionMessage.Substring(messageStart, messageEnd - messageStart);
+            return true;
+        }
+
+        private static bool IsOutOfProcException(Exception ex)
+        {
+            // This is a best effort approach to detect when using RpcException from Azure Functions.
+            // See https://github.com/Azure/azure-functions-host/blob/dev/src/WebJobs.Script/Workers/Rpc/MessageExtensions/RpcException.cs
+            return ex.Message != null
+                && ex.Message.StartsWith(ResultLabel)
+                && ex.Message.Contains(MessageLabel)
+                && ex.Message.Contains(StackTraceLabel);
+        }
+    }
+}

--- a/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
+++ b/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
@@ -7,7 +7,7 @@
     <MajorVersion>2</MajorVersion>
     <MinorVersion>2</MinorVersion>
     <PatchVersion>2</PatchVersion>
-    <Version>$(MajorVersion).$(MinorVersion).$(PatchVersion)-prerelease4</Version>
+    <Version>$(MajorVersion).$(MinorVersion).$(PatchVersion)</Version>
     <FileVersion>$(MajorVersion).$(MinorVersion).$(PatchVersion)</FileVersion>
     <AssemblyVersion>$(MajorVersion).0.0.0</AssemblyVersion>
     <Company>Microsoft Corporation</Company>

--- a/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
+++ b/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
@@ -6,8 +6,8 @@
     <RootNamespace>Microsoft.Azure.WebJobs.Extensions.DurableTask</RootNamespace>
     <MajorVersion>2</MajorVersion>
     <MinorVersion>2</MinorVersion>
-    <PatchVersion>1</PatchVersion>
-    <Version>$(MajorVersion).$(MinorVersion).$(PatchVersion)</Version>
+    <PatchVersion>2</PatchVersion>
+    <Version>$(MajorVersion).$(MinorVersion).$(PatchVersion)-prerelease4</Version>
     <FileVersion>$(MajorVersion).$(MinorVersion).$(PatchVersion)</FileVersion>
     <AssemblyVersion>$(MajorVersion).0.0.0</AssemblyVersion>
     <Company>Microsoft Corporation</Company>

--- a/test/Common/BindingTests.cs
+++ b/test/Common/BindingTests.cs
@@ -102,7 +102,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         {
             using (var host = TestHelpers.GetJobHost(
                 this.loggerProvider,
-                nameof(this.IDurableEntityClientBinding),
+                nameof(this.IDurableEntityClientBindingBackComp),
                 enableExtendedSessions: false))
             {
                 await host.StartAsync();

--- a/test/Common/DurableTaskEndToEndTests.cs
+++ b/test/Common/DurableTaskEndToEndTests.cs
@@ -203,7 +203,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
             using (ITestHost host = TestHelpers.GetJobHost(
                 this.loggerProvider,
-                nameof(this.HelloWorldOrchestration_Inline),
+                nameof(this.ParentInstanceId_Not_Assigned_In_Orchestrator),
                 extendedSessions,
                 storageProviderType: storageProvider))
             {
@@ -1502,7 +1502,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         [InlineData(false)]
         public async Task SubOrchestration_Requires_Different_Id_Than_Parent(bool extendedSessions)
         {
-            const string TaskHub = nameof(this.SubOrchestration_ComplexType);
+            const string TaskHub = nameof(this.SubOrchestration_Requires_Different_Id_Than_Parent);
             using (ITestHost host = TestHelpers.GetJobHost(this.loggerProvider, TaskHub, extendedSessions))
             {
                 await host.StartAsync();
@@ -1994,7 +1994,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         {
             using (ITestHost host = TestHelpers.GetJobHost(
                 this.loggerProvider,
-                nameof(this.Orchestration_OnValidOrchestrator),
+                nameof(this.ThrowExceptionOnLongTimer),
                 extendedSessions,
                 storageProviderType: storageProvider))
             {
@@ -2033,7 +2033,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
             using (ITestHost host = TestHelpers.GetJobHost(
                 this.loggerProvider,
-                nameof(this.Orchestration_OnUnregisteredActivity),
+                nameof(this.Orchestration_OnUnregisteredOrchestrator),
                 extendedSessions,
                 storageProviderType: storageProvider))
             {

--- a/test/Common/DurableTaskLifeCycleNotificationTest.cs
+++ b/test/Common/DurableTaskLifeCycleNotificationTest.cs
@@ -416,7 +416,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         [InlineData(false)]
         public async Task OrchestrationFailedOptOutOfEvent(bool extendedSessionsEnabled)
         {
-            var testName = nameof(this.OrchestrationFailed);
+            var testName = nameof(this.OrchestrationFailedOptOutOfEvent);
             var functionName = nameof(TestOrchestrations.ThrowOrchestrator);
             var eventGridKeyValue = "testEventGridKey";
             var eventGridKeySettingName = "eventGridKeySettingName";

--- a/test/FunctionsV2/OutOfProcTests.cs
+++ b/test/FunctionsV2/OutOfProcTests.cs
@@ -15,6 +15,7 @@ using Moq;
 using Newtonsoft.Json.Linq;
 using Xunit;
 using Xunit.Abstractions;
+using static Microsoft.Azure.WebJobs.Extensions.DurableTask.TaskOrchestrationShim;
 
 namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 {
@@ -67,7 +68,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
             // Feed the out-of-proc execution result JSON to the out-of-proc shim.
             var jsonObject = JObject.Parse(executionJson);
-            bool moreWork = await shim.ExecuteAsync(jsonObject);
+            OrchestrationInvocationResult result = new OrchestrationInvocationResult()
+            {
+                ReturnValue = jsonObject,
+            };
+            bool moreWork = await shim.ScheduleDurableTaskEvents(result);
 
             // The request should not have completed because one additional replay is needed
             // to handle the result of CallHttpAsync. However, this test doesn't care about
@@ -127,7 +132,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
             // Feed the out-of-proc execution result JSON to the out-of-proc shim.
             var jsonObject = JObject.Parse(executionJson);
-            await shim.ExecuteAsync(jsonObject);
+            OrchestrationInvocationResult result = new OrchestrationInvocationResult()
+            {
+                ReturnValue = jsonObject,
+            };
+            bool moreWork = await shim.ScheduleDurableTaskEvents(result);
 
             Assert.NotNull(request);
             Assert.Equal(HttpMethod.Get, request.Method);


### PR DESCRIPTION
In order to prevent non-determinism errors when out-of-proc
orchestrations throw an exception, we need to read state from the
RpcException. We can then properly replay the actions performed by the
out-of-proc orchestration before throwing the exception.

See https://github.com/Azure/azure-functions-durable-extension/pull/1171 for the equivalent PR for Durable 1.x.