### PR TITLE
Make worker ids unique when running in App Service VMSS environment

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
@@ -359,7 +359,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             ILogger logger = context.Config.LoggerFactory.CreateLogger(LoggerCategoryName);
             this.TraceHelper = new EndToEndTraceHelper(logger, this.Options.Tracing.TraceReplayEvents);
             this.connectionStringResolver = new WebJobsConnectionStringProvider();
-            this.durabilityProviderFactory = new AzureStorageDurabilityProviderFactory(new OptionsWrapper<DurableTaskOptions>(this.Options), this.connectionStringResolver);
+            this.durabilityProviderFactory = new AzureStorageDurabilityProviderFactory(new OptionsWrapper<DurableTaskOptions>(this.Options), this.connectionStringResolver, this.nameResolver);
             this.defaultDurabilityProvider = this.durabilityProviderFactory.GetDurabilityProvider();
             this.LifeCycleNotificationHelper = this.CreateLifeCycleNotificationHelper();
             var messageSerializerSettingsFactory = new MessageSerializerSettingsFactory();

--- a/test/Common/DurableClientBaseTests.cs
+++ b/test/Common/DurableClientBaseTests.cs
@@ -239,12 +239,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             options.HubName = "DurableTaskHub";
             options.NotificationUrl = new Uri("https://sampleurl.net");
             var wrappedOptions = new OptionsWrapper<DurableTaskOptions>(options);
+            var nameResolver = TestHelpers.GetTestNameResolver();
             var connectionStringResolver = new TestConnectionStringResolver();
-            var serviceFactory = new AzureStorageDurabilityProviderFactory(wrappedOptions, connectionStringResolver);
+            var serviceFactory = new AzureStorageDurabilityProviderFactory(wrappedOptions, connectionStringResolver, nameResolver);
             return new DurableTaskExtension(
                 wrappedOptions,
                 new LoggerFactory(),
-                TestHelpers.GetTestNameResolver(),
+                nameResolver,
                 serviceFactory,
                 new TestHostShutdownNotificationService(),
                 new DurableHttpMessageHandlerFactory());

--- a/test/Common/DurableTaskLifeCycleNotificationTest.cs
+++ b/test/Common/DurableTaskLifeCycleNotificationTest.cs
@@ -1230,7 +1230,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 wrappedOptions,
                 new LoggerFactory(),
                 mockNameResolver.Object,
-                new AzureStorageDurabilityProviderFactory(wrappedOptions, connectionStringResolver),
+                new AzureStorageDurabilityProviderFactory(wrappedOptions, connectionStringResolver, mockNameResolver.Object),
                 new TestHostShutdownNotificationService());
 
             var eventGridLifeCycleNotification = (EventGridLifeCycleNotificationHelper)extension.LifeCycleNotificationHelper;
@@ -1267,11 +1267,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             options.HubName = "DurableTaskHub";
 
             var wrappedOptions = new OptionsWrapper<DurableTaskOptions>(options);
+            var nameResolver = new SimpleNameResolver();
             var extension = new DurableTaskExtension(
                 wrappedOptions,
                 new LoggerFactory(),
-                new SimpleNameResolver(),
-                new AzureStorageDurabilityProviderFactory(wrappedOptions, new TestConnectionStringResolver()),
+                nameResolver,
+                new AzureStorageDurabilityProviderFactory(wrappedOptions, new TestConnectionStringResolver(), nameResolver),
                 new TestHostShutdownNotificationService());
 
             var lifeCycleNotificationHelper = extension.LifeCycleNotificationHelper;
@@ -1290,11 +1291,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             };
 
             var wrappedOptions = new OptionsWrapper<DurableTaskOptions>(options);
+            var nameResolver = new SimpleNameResolver();
             var extension = new DurableTaskExtension(
                 wrappedOptions,
                 new LoggerFactory(),
-                new SimpleNameResolver(),
-                new AzureStorageDurabilityProviderFactory(wrappedOptions, new TestConnectionStringResolver()),
+                nameResolver,
+                new AzureStorageDurabilityProviderFactory(wrappedOptions, new TestConnectionStringResolver(), nameResolver),
                 new TestHostShutdownNotificationService());
 
             int callCount = 0;

--- a/test/Common/HttpApiHandlerTests.cs
+++ b/test/Common/HttpApiHandlerTests.cs
@@ -1177,7 +1177,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                     new OptionsWrapper<DurableTaskOptions>(options),
                     new LoggerFactory(),
                     TestHelpers.GetTestNameResolver(),
-                    new AzureStorageDurabilityProviderFactory(new OptionsWrapper<DurableTaskOptions>(options), new TestConnectionStringResolver()),
+                    new AzureStorageDurabilityProviderFactory(new OptionsWrapper<DurableTaskOptions>(options), new TestConnectionStringResolver(), TestHelpers.GetTestNameResolver()),
                     new TestHostShutdownNotificationService(),
                     new DurableHttpMessageHandlerFactory())
             {

--- a/test/FunctionsV1/PlatformSpecificHelpers.FunctionsV1.cs
+++ b/test/FunctionsV1/PlatformSpecificHelpers.FunctionsV1.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             var loggerFactory = new LoggerFactory();
             loggerFactory.AddProvider(loggerProvider);
 
-            IDurabilityProviderFactory orchestrationServiceFactory = new AzureStorageDurabilityProviderFactory(options, connectionResolver);
+            IDurabilityProviderFactory orchestrationServiceFactory = new AzureStorageDurabilityProviderFactory(options, connectionResolver, nameResolver);
 
             var extension = new DurableTaskExtension(
                 options,

--- a/test/FunctionsV2/AzureStorageDurabilityProviderFactoryTests.cs
+++ b/test/FunctionsV2/AzureStorageDurabilityProviderFactoryTests.cs
@@ -1,0 +1,57 @@
+﻿using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Extensions.DurableTask;
+using Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests;
+using Microsoft.Extensions.Options;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace WebJobs.Extensions.DurableTask.Tests.V2
+{
+    public class AzureStorageDurabilityProviderFactoryTests
+    {
+        private readonly ITestOutputHelper output;
+
+        public AzureStorageDurabilityProviderFactoryTests(ITestOutputHelper output)
+        {
+            this.output = output;
+        }
+
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public void DefaultWorkerId_IsMachineName()
+        {
+            var connectionStringResolver = new TestConnectionStringResolver();
+            var mockOptions = new OptionsWrapper<DurableTaskOptions>(new DurableTaskOptions());
+            var nameResolver = new Mock<INameResolver>().Object;
+            var factory = new AzureStorageDurabilityProviderFactory(mockOptions, connectionStringResolver, nameResolver);
+
+            var settings = factory.GetAzureStorageOrchestrationServiceSettings();
+
+            Assert.Equal(Environment.MachineName, settings.WorkerId);
+        }
+
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+
+        public void EnvironmentIsVMSS_WorkerIdFromEnvironmentVariables()
+        {
+            var connectionStringResolver = new TestConnectionStringResolver();
+            var mockOptions = new OptionsWrapper<DurableTaskOptions>(new DurableTaskOptions());
+            var nameResolver = new SimpleNameResolver(new Dictionary<string, string>()
+            {
+                { "WEBSITE_CURRENT_STAMPNAME", "waws-prod-euapbn1-003" },
+                { "RoleInstanceId", "dw0SmallDedicatedWebWorkerRole_hr0HostRole-3-VM-13" },
+            });
+
+            var factory = new AzureStorageDurabilityProviderFactory(mockOptions, connectionStringResolver, nameResolver);
+
+            var settings = factory.GetAzureStorageOrchestrationServiceSettings();
+
+            Assert.Equal("waws-prod-euapbn1-003:dw0SmallDedicatedWebWorkerRole_hr0HostRole-3-VM-13", settings.WorkerId);
+        }
+    }
+}

--- a/test/FunctionsV2/DurableTaskListenerTests.cs
+++ b/test/FunctionsV2/DurableTaskListenerTests.cs
@@ -54,12 +54,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             options.HubName = "DurableTaskHub";
             options.NotificationUrl = new Uri("https://sampleurl.net");
             var wrappedOptions = new OptionsWrapper<DurableTaskOptions>(options);
+            var nameResolver = TestHelpers.GetTestNameResolver();
             var connectionStringResolver = new TestConnectionStringResolver();
-            var serviceFactory = new AzureStorageDurabilityProviderFactory(wrappedOptions, connectionStringResolver);
+            var serviceFactory = new AzureStorageDurabilityProviderFactory(wrappedOptions, connectionStringResolver, nameResolver);
             return new DurableTaskExtension(
                 wrappedOptions,
                 new LoggerFactory(),
-                TestHelpers.GetTestNameResolver(),
+                nameResolver,
                 serviceFactory,
                 new TestHostShutdownNotificationService(),
                 new DurableHttpMessageHandlerFactory());


### PR DESCRIPTION
Worker ids are used to generate unique lease ids for partition
management. Currently this uses Environment.MachineName, which is
currently not unique when running in Azure App Service VMSS
environments.

The App Service on VMSS team is working to make these more unique, but
this will only help within a stamp. Environment.MachineName is
guaranteed to be non-unique across stamps, so we should use a safer
value based on environment varibles present in that environment.

Addresses #1323