### PR TITLE
Fix duplicate task hub names in tests

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net461.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net461.xml
@@ -2904,13 +2904,6 @@
             </summary>
             <param name="context">The orchestration execution context.</param>
         </member>
-        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.OutOfProcOrchestrationShim.ScheduleDurableTaskEvents(Microsoft.Azure.WebJobs.Extensions.DurableTask.TaskOrchestrationShim.OrchestrationInvocationResult)">
-            <summary>
-            Not intended for public consumption.
-            </summary>
-            <param name="result">The result of the out-of-proc execution.</param>
-            <returns><c>true</c> if there are more executions to process; <c>false</c> otherwise.</returns>
-        </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.TaskActivityShim">
             <summary>
             Task activity implementation which delegates the implementation to a function.

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
@@ -2977,13 +2977,6 @@
             </summary>
             <param name="context">The orchestration execution context.</param>
         </member>
-        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.OutOfProcOrchestrationShim.ScheduleDurableTaskEvents(Microsoft.Azure.WebJobs.Extensions.DurableTask.TaskOrchestrationShim.OrchestrationInvocationResult)">
-            <summary>
-            Not intended for public consumption.
-            </summary>
-            <param name="result">The result of the out-of-proc execution.</param>
-            <returns><c>true</c> if there are more executions to process; <c>false</c> otherwise.</returns>
-        </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.TaskActivityShim">
             <summary>
             Task activity implementation which delegates the implementation to a function.

--- a/test/Common/DurableTaskEndToEndTests.cs
+++ b/test/Common/DurableTaskEndToEndTests.cs
@@ -1096,7 +1096,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             var extendedSessions = false;
             using (ITestHost host = TestHelpers.GetJobHost(
                 this.loggerProvider,
-                nameof(this.WaitForExternalEventWithTimeout),
+                nameof(this.WaitForExternalEventWithTooLargeTimeout),
                 extendedSessions))
             {
                 await host.StartAsync();
@@ -1344,7 +1344,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         [MemberData(nameof(TestDataGenerator.GetFullFeaturedStorageProviderOptions), MemberType = typeof(TestDataGenerator))]
         public async Task SubOrchestration_ComplexType(string storageProvider)
         {
-            await this.SubOrchestration_ComplexType_Main_Logic(storageProvider);
+            await this.SubOrchestration_ComplexType_Main_Logic(nameof(this.SubOrchestration_ComplexType), storageProvider);
         }
 
         /// <summary>
@@ -1355,7 +1355,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         [MemberData(nameof(TestDataGenerator.GetFullFeaturedStorageProviderOptions), MemberType = typeof(TestDataGenerator))]
         public async Task SubOrchestration_ComplexType_History(string storageProvider)
         {
-            await this.SubOrchestration_ComplexType_Main_Logic(storageProvider, showHistory: true);
+            await this.SubOrchestration_ComplexType_Main_Logic(nameof(this.SubOrchestration_ComplexType_History), storageProvider, showHistory: true);
         }
 
         /// <summary>
@@ -1366,7 +1366,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         [MemberData(nameof(TestDataGenerator.GetFullFeaturedStorageProviderOptions), MemberType = typeof(TestDataGenerator))]
         public async Task SubOrchestration_ComplexType_HistoryInputOutput(string storageProvider)
         {
-            await this.SubOrchestration_ComplexType_Main_Logic(storageProvider, showHistory: true, showHistoryOutput: true);
+            await this.SubOrchestration_ComplexType_Main_Logic(nameof(this.SubOrchestration_ComplexType_HistoryInputOutput), storageProvider, showHistory: true, showHistoryOutput: true);
         }
 
         /// <summary>
@@ -1377,7 +1377,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         [MemberData(nameof(TestDataGenerator.GetBooleanAndFullFeaturedStorageProviderOptions), MemberType = typeof(TestDataGenerator))]
         public async Task SubOrchestration_Has_Valid_ParentInstanceId_Assigned(bool extendedSessions, string storageProvider)
         {
-            const string TaskHub = nameof(this.SubOrchestration_ComplexType);
+            const string TaskHub = nameof(this.SubOrchestration_Has_Valid_ParentInstanceId_Assigned);
             using (ITestHost host = TestHelpers.GetJobHost(this.loggerProvider, TaskHub, extendedSessions, storageProviderType: storageProvider))
             {
                 await host.StartAsync();
@@ -1403,10 +1403,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             }
         }
 
-        private async Task SubOrchestration_ComplexType_Main_Logic(string storageProvider, bool showHistory = false, bool showHistoryOutput = false)
+        private async Task SubOrchestration_ComplexType_Main_Logic(string taskHub, string storageProvider, bool showHistory = false, bool showHistoryOutput = false)
         {
-            const string TaskHub = nameof(this.SubOrchestration_ComplexType);
-            using (ITestHost host = TestHelpers.GetJobHost(this.loggerProvider, TaskHub, enableExtendedSessions: false, storageProviderType: storageProvider))
+            using (ITestHost host = TestHelpers.GetJobHost(this.loggerProvider, taskHub, enableExtendedSessions: false, storageProviderType: storageProvider))
             {
                 await host.StartAsync();
 

--- a/test/Common/DurableTaskEndToEndTests.cs
+++ b/test/Common/DurableTaskEndToEndTests.cs
@@ -1375,9 +1375,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         [Theory]
         [Trait("Category", PlatformSpecificHelpers.TestCategory)]
         [MemberData(nameof(TestDataGenerator.GetBooleanAndFullFeaturedStorageProviderOptions), MemberType = typeof(TestDataGenerator))]
-        public async Task SubOrchestration_Has_Valid_ParentInstanceId_Assigned(bool extendedSessions, string storageProvider)
+        public async Task SubOrchestration_ParentInstanceId_Assigned(bool extendedSessions, string storageProvider)
         {
-            const string TaskHub = nameof(this.SubOrchestration_Has_Valid_ParentInstanceId_Assigned);
+            const string TaskHub = nameof(this.SubOrchestration_ParentInstanceId_Assigned);
             using (ITestHost host = TestHelpers.GetJobHost(this.loggerProvider, TaskHub, extendedSessions, storageProviderType: storageProvider))
             {
                 await host.StartAsync();

--- a/test/Common/DurableTaskLifeCycleNotificationTest.cs
+++ b/test/Common/DurableTaskLifeCycleNotificationTest.cs
@@ -300,7 +300,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         [InlineData(false)]
         public async Task OrchestrationStartedOptOutOfEvent(bool extendedSessionsEnabled)
         {
-            var testName = nameof(this.OrchestrationStartAndCompleted);
+            var testName = nameof(this.OrchestrationStartedOptOutOfEvent);
             var functionName = nameof(TestOrchestrations.SayHelloInline);
             var eventGridKeyValue = "testEventGridKey";
             var eventGridKeySettingName = "eventGridKeySettingName";
@@ -358,7 +358,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         [InlineData(false)]
         public async Task OrchestrationCompletedOptOutOfEvent(bool extendedSessionsEnabled)
         {
-            var testName = nameof(this.OrchestrationStartAndCompleted);
+            var testName = nameof(this.OrchestrationCompletedOptOutOfEvent);
             var functionName = nameof(TestOrchestrations.SayHelloInline);
             var eventGridKeyValue = "testEventGridKey";
             var eventGridKeySettingName = "eventGridKeySettingName";

--- a/test/FunctionsV2/EntityDependencyInjectionTests.cs
+++ b/test/FunctionsV2/EntityDependencyInjectionTests.cs
@@ -72,7 +72,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         [Trait("Category", PlatformSpecificHelpers.TestCategory)]
         [InlineData(true)]
         [InlineData(false)]
-        public async Task DurableEntity_EntityWithDependencyInjectionAndBindings(bool extendedSessions)
+        public async Task DurableEntity_DependencyInjectionAndBindings(bool extendedSessions)
         {
             string[] orchestratorFunctionNames =
             {
@@ -88,7 +88,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
             using (var host = TestHelpers.GetJobHost(
                 this.loggerProvider,
-                nameof(this.DurableEntity_EntityWithDependencyInjectionAndBindings),
+                nameof(this.DurableEntity_DependencyInjectionAndBindings),
                 extendedSessions,
                 nameResolver: new TestEntityWithDependencyInjectionHelpers.DummyEnvironmentVariableResolver()))
             {

--- a/test/FunctionsV2/EntityDependencyInjectionTests.cs
+++ b/test/FunctionsV2/EntityDependencyInjectionTests.cs
@@ -88,7 +88,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
             using (var host = TestHelpers.GetJobHost(
                 this.loggerProvider,
-                nameof(this.DurableEntity_EntityWithDependencyInjection),
+                nameof(this.DurableEntity_EntityWithDependencyInjectionAndBindings),
                 extendedSessions,
                 nameResolver: new TestEntityWithDependencyInjectionHelpers.DummyEnvironmentVariableResolver()))
             {

--- a/test/FunctionsV2/OutOfProcTests.cs
+++ b/test/FunctionsV2/OutOfProcTests.cs
@@ -158,7 +158,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
             using (ITestHost host = TestHelpers.GetJobHost(
                 this.loggerProvider,
-                nameof(this.BindToDurableClientAsString),
+                nameof(this.BindToDurableClientAsString) + localRcpEnabled.ToString(),
                 enableExtendedSessions: false,
                 localRpcEndpointEnabled: localRcpEnabled,
                 notificationUrl: testNotificationUrl))


### PR DESCRIPTION
CIs run tests heavily in parallel, meaning duplciate task hub names on
the storage account will cause tests to conflict with each other. This
is causing the CI to hang indefinitely until the hour time limit
expires. This is odd, as most of the tests have built in timeouts, but
it is best practice to fix the duplicate task hubs anyways.