### PR TITLE
Application Insights Telemetry - Handle Client Termination

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableClient.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableClient.cs
@@ -336,6 +336,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 await this.client.TerminateInstanceAsync(state.OrchestrationInstance, reason);
 
                 this.traceHelper.FunctionTerminated(this.TaskHubName, state.Name, instanceId, reason);
+#if !FUNCTIONS_V1
+                DurableTaskExtension.TagActivityWithOrchestrationStatus(OrchestrationRuntimeStatus.Terminated, instanceId);
+#endif
+
             }
             else
             {


### PR DESCRIPTION
Currently a 1-line PR 😄 , will include more changes if necessary.

This is a follow-up to https://github.com/Azure/azure-functions-durable-extension/pull/1301
In short, this PR handles the case where an activity makes a forceful termination of the orchestrator via ` client.TerminateAsync`. A reproducer may be found [here](https://github.com/anthonychu/azure-functions-durable-extension/blob/df-monitoring/samples/durable-monitoring/HelloOrchestrator.cs#L53).

Previously, we did not log anything to Application Insights when this occurred, giving the impression that the orchestration was still running. Now we report that the orchestration was terminated.

To discuss:
- Are we ok with making a distinction between `Terminated` and `Completed` in the logs? May make it cumbersome for users to write queries about whether or not their orchestrations are _done_.
