### PR TITLE
Remove more duplicate task hub names in tests

### DIFF
--- a/test/Common/DurableHttpTests.cs
+++ b/test/Common/DurableHttpTests.cs
@@ -207,7 +207,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
             using (ITestHost host = TestHelpers.GetJobHost(
                 this.loggerProvider,
-                nameof(this.DurableHttpAsync_CheckUserAgentHeader),
+                nameof(this.DurableHttpAsync_CheckRequestAcceptHeaders),
                 enableExtendedSessions: false,
                 storageProviderType: storageProvider,
                 durableHttpMessageHandler: new DurableHttpMessageHandlerFactory(httpMessageHandler)))
@@ -612,13 +612,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         [Theory]
         [Trait("Category", PlatformSpecificHelpers.TestCategory)]
         [MemberData(nameof(TestDataGenerator.GetFullFeaturedStorageProviderOptions), MemberType = typeof(TestDataGenerator))]
-        public async Task DurableHttpAsync_SynchronousAPI_RequestContentTest(string storageProvider)
+        public async Task CallHttpAsync_SynchronousAPI_ReqContentTest(string storageProvider)
         {
             HttpMessageHandler httpMessageHandler = MockHttpMessageHandlerContentType();
 
             using (ITestHost host = TestHelpers.GetJobHost(
                 this.loggerProvider,
-                nameof(this.DurableHttpAsync_AsynchronousAPI_ReturnsOK200),
+                nameof(this.CallHttpAsync_SynchronousAPI_ReqContentTest),
                 enableExtendedSessions: false,
                 storageProviderType: storageProvider,
                 durableHttpMessageHandler: new DurableHttpMessageHandlerFactory(httpMessageHandler)))

--- a/test/Common/DurableTaskEndToEndTests.cs
+++ b/test/Common/DurableTaskEndToEndTests.cs
@@ -3531,7 +3531,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             };
             using (var host = TestHelpers.GetJobHost(
                 this.loggerProvider,
-                nameof(this.DurableEntity_EntityProxy),
+                nameof(this.DurableEntity_EntityProxy_NameResolve),
                 extendedSessions))
             {
                 await host.StartAsync();


### PR DESCRIPTION
Another round of removing duplicate task hub names in our tests to make
our CI more reliable.