### PR TITLE
Make E2E tests more robust in CI pipeline

### DIFF
--- a/test/Common/DurableTaskEndToEndTests.cs
+++ b/test/Common/DurableTaskEndToEndTests.cs
@@ -2638,6 +2638,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         [InlineData("taskhubnametesttaskhubnametesttaskhubnametesttaskhubnametesttaskhubnametesttaskhubnametest")]
         public async Task TaskHubName_Throws_ArgumentException(string taskHubName)
         {
+            taskHubName += PlatformSpecificHelpers.VersionSuffix;
             ArgumentException argumentException =
                 await Assert.ThrowsAsync<ArgumentException>(async () =>
                 {
@@ -2654,9 +2655,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
             Assert.NotNull(argumentException);
             Assert.Equal(
-                argumentException.Message.Contains($"{taskHubName}V1")
-                    ? $"Task hub name '{taskHubName}V1' should contain only alphanumeric characters excluding '-' and have length up to 50."
-                    : $"Task hub name '{taskHubName}V2' should contain only alphanumeric characters excluding '-' and have length up to 50.",
+                $"Task hub name '{taskHubName}' should contain only alphanumeric characters excluding '-' and have length up to 50.",
                 argumentException.Message);
         }
 

--- a/test/Common/DurableTaskEndToEndTests.cs
+++ b/test/Common/DurableTaskEndToEndTests.cs
@@ -2643,8 +2643,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 {
                     using (var host = TestHelpers.GetJobHost(
                         this.loggerProvider,
-                        taskHubName,
-                        false))
+                        nameof(this.TaskHubName_Throws_ArgumentException),
+                        false,
+                        exactTaskHubName: taskHubName))
                     {
                         await host.StartAsync();
                         await host.StopAsync();

--- a/test/Common/DurableTaskEndToEndTests.cs
+++ b/test/Common/DurableTaskEndToEndTests.cs
@@ -132,6 +132,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             using (var orchestrationHost = TestHelpers.GetJobHost(
                 this.loggerProvider,
                 nameof(this.HelloWorld_OrchestrationClientTaskHub),
+                exactTaskHubName: taskHubName,
                 enableExtendedSessions: false))
             {
                 await clientHost.StartAsync();
@@ -2245,10 +2246,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 nameof(TestActivities.GetAndReturnHttpManagementPayload),
             };
 
+            string testName = nameof(this.Activity_Gets_HttpManagementPayload);
+            string taskHub = TestHelpers.GetTaskHubNameFromTestName(testName, extendedSessions);
             using (var host = TestHelpers.GetJobHost(
                 this.loggerProvider,
-                nameof(this.Activity_Gets_HttpManagementPayload),
+                testName,
                 extendedSessions,
+                exactTaskHubName: taskHub,
                 notificationUrl: new Uri(TestConstants.NotificationUrl)))
             {
                 await host.StartAsync();
@@ -2258,7 +2262,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
                 Assert.Equal(OrchestrationRuntimeStatus.Completed, status?.RuntimeStatus);
                 HttpManagementPayload httpManagementPayload = status.Output.ToObject<HttpManagementPayload>();
-                ValidateHttpManagementPayload(httpManagementPayload, extendedSessions, "ActivityGetsHttpManagementPayload");
+                ValidateHttpManagementPayload(httpManagementPayload, extendedSessions, taskHub);
 
                 await host.StopAsync();
             }
@@ -2277,10 +2281,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 nameof(TestOrchestrations.SayHelloInline),
             };
 
+            string testName = nameof(this.OrchestrationClient_Gets_HttpManagementPayload);
+            string taskHub = TestHelpers.GetTaskHubNameFromTestName(testName, extendedSessions);
             using (var host = TestHelpers.GetJobHost(
                 this.loggerProvider,
-                nameof(this.OrchestrationClient_Gets_HttpManagementPayload),
+                testName,
                 extendedSessions,
+                exactTaskHubName: taskHub,
                 notificationUrl: new Uri(TestConstants.NotificationUrl)))
             {
                 await host.StartAsync();
@@ -2289,7 +2296,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 var status = await client.WaitForCompletionAsync(this.output);
 
                 HttpManagementPayload httpManagementPayload = client.InnerClient.CreateHttpManagementPayload(status.InstanceId);
-                ValidateHttpManagementPayload(httpManagementPayload, extendedSessions, "OrchestrationClientGetsHttpManagementPayload");
+                ValidateHttpManagementPayload(httpManagementPayload, extendedSessions, taskHub);
 
                 Assert.Equal(OrchestrationRuntimeStatus.Completed, status?.RuntimeStatus);
                 Assert.Equal("World", status?.Input);
@@ -2816,16 +2823,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             Assert.True(await blob.ExistsAsync(), $"Blob named {blob.Uri} is expected to exist.");
         }
 
-        private static void ValidateHttpManagementPayload(HttpManagementPayload httpManagementPayload, bool extendedSessions, string defaultTaskHubName)
+        private static void ValidateHttpManagementPayload(HttpManagementPayload httpManagementPayload, bool extendedSessions, string taskHubName)
         {
             Assert.NotNull(httpManagementPayload);
             Assert.NotEmpty(httpManagementPayload.Id);
             string instanceId = httpManagementPayload.Id;
             string notificationUrl = TestConstants.NotificationUrlBase;
-            string taskHubName = extendedSessions
-                ? $"{defaultTaskHubName}EX"
-                : defaultTaskHubName;
-            taskHubName += PlatformSpecificHelpers.VersionSuffix;
 
             Assert.Equal(
                 $"{notificationUrl}/instances/{instanceId}?taskHub={taskHubName}&connection=Storage&code=mykey",

--- a/test/Common/DurableTaskLifeCycleNotificationTest.cs
+++ b/test/Common/DurableTaskLifeCycleNotificationTest.cs
@@ -49,9 +49,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             Func<HttpRequestMessage, HttpResponseMessage> responseGenerator =
                 (HttpRequestMessage req) => req.CreateResponse(HttpStatusCode.OK, "{\"message\":\"OK!\"}");
 
+            string taskHub = TestHelpers.GetTaskHubNameFromTestName(testName, extendedSessionsEnabled);
             int callCount = 0;
             HttpMessageHandler httpMessageHandler = this.ConfigureEventGridMockHandler(
-                TestHelpers.GetTaskHubNameFromTestName(testName, extendedSessionsEnabled),
+                taskHub,
                 functionName,
                 createdInstanceId,
                 eventGridKeyValue,
@@ -88,7 +89,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 eventGridKeySettingName,
                 mockNameResolver.Object,
                 eventGridEndpoint,
-                eventGridNotificationHandler: httpMessageHandler))
+                eventGridNotificationHandler: httpMessageHandler,
+                exactTaskHubName: taskHub))
             {
                 await host.StartAsync();
 

--- a/test/Common/DurableTaskLifeCycleNotificationTest.cs
+++ b/test/Common/DurableTaskLifeCycleNotificationTest.cs
@@ -127,6 +127,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         {
             var testName = nameof(this.OrchestrationFailed);
             var functionName = nameof(TestOrchestrations.ThrowOrchestrator);
+            var taskHub = TestHelpers.GetTaskHubNameFromTestName(testName, extendedSessionsEnabled);
             var eventGridKeyValue = "testEventGridKey";
             var eventGridKeySettingName = "eventGridKeySettingName";
             var eventGridEndpoint = "http://dymmy.com/";
@@ -139,7 +140,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
             int callCount = 0;
             HttpMessageHandler httpMessageHandler = this.ConfigureEventGridMockHandler(
-                TestHelpers.GetTaskHubNameFromTestName(testName, extendedSessionsEnabled),
+                taskHub,
                 functionName,
                 createdInstanceId,
                 eventGridKeyValue,
@@ -176,6 +177,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 eventGridKeySettingName,
                 mockNameResolver.Object,
                 eventGridEndpoint,
+                exactTaskHubName: taskHub,
                 eventGridNotificationHandler: httpMessageHandler))
             {
                 await host.StartAsync();
@@ -211,6 +213,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         public async Task OrchestrationTerminate(bool extendedSessionsEnabled)
         {
             var testName = nameof(this.OrchestrationTerminate);
+            var taskHub = TestHelpers.GetTaskHubNameFromTestName(testName, extendedSessionsEnabled);
 
             // Using the counter orchestration because it will wait indefinitely for input.
             var functionName = nameof(TestOrchestrations.Counter);
@@ -226,7 +229,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
             int callCount = 0;
             HttpMessageHandler httpMessageHandler = this.ConfigureEventGridMockHandler(
-                TestHelpers.GetTaskHubNameFromTestName(testName, extendedSessionsEnabled),
+                taskHub,
                 functionName,
                 createdInstanceId,
                 eventGridKeyValue,
@@ -263,6 +266,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 eventGridKeySettingName,
                 mockNameResolver.Object,
                 eventGridEndpoint,
+                exactTaskHubName: taskHub,
                 eventGridNotificationHandler: httpMessageHandler))
             {
                 await host.StartAsync();
@@ -314,8 +318,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             Func<HttpRequestMessage, HttpResponseMessage> responseGenerator =
                 (HttpRequestMessage req) => req.CreateResponse(HttpStatusCode.OK, "{\"message\":\"OK!\"}");
 
+            var taskHub = TestHelpers.GetTaskHubNameFromTestName(testName, extendedSessionsEnabled);
             HttpMessageHandler httpMessageHandler = this.ConfigureEventGridMockHandler(
-                TestHelpers.GetTaskHubNameFromTestName(testName, extendedSessionsEnabled),
+                taskHub,
                 functionName,
                 createdInstanceId,
                 eventGridKeyValue,
@@ -336,6 +341,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 eventGridKeySettingName,
                 mockNameResolver.Object,
                 eventGridEndpoint,
+                exactTaskHubName: taskHub,
                 eventGridNotificationHandler: httpMessageHandler,
                 eventGridPublishEventTypes: new[] { "Completed", "Failed" }))
             {
@@ -362,6 +368,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         {
             var testName = nameof(this.OrchestrationStartAndCompleted);
             var functionName = nameof(TestOrchestrations.SayHelloInline);
+            var taskHub = TestHelpers.GetTaskHubNameFromTestName(testName, extendedSessionsEnabled);
             var eventGridKeyValue = "testEventGridKey";
             var eventGridKeySettingName = "eventGridKeySettingName";
             var eventGridEndpoint = "http://dymmy.com/";
@@ -373,7 +380,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 (HttpRequestMessage req) => req.CreateResponse(HttpStatusCode.OK, "{\"message\":\"OK!\"}");
 
             HttpMessageHandler httpMessageHandler = this.ConfigureEventGridMockHandler(
-                TestHelpers.GetTaskHubNameFromTestName(testName, extendedSessionsEnabled),
+                taskHub,
                 functionName,
                 createdInstanceId,
                 eventGridKeyValue,
@@ -394,6 +401,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 eventGridKeySettingName,
                 mockNameResolver.Object,
                 eventGridEndpoint,
+                exactTaskHubName: taskHub,
                 eventGridNotificationHandler: httpMessageHandler,
                 eventGridPublishEventTypes: new[] { "Started", "Failed" }))
             {
@@ -419,6 +427,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         public async Task OrchestrationFailedOptOutOfEvent(bool extendedSessionsEnabled)
         {
             var testName = nameof(this.OrchestrationFailed);
+            var taskHub = TestHelpers.GetTaskHubNameFromTestName(testName, extendedSessionsEnabled);
             var functionName = nameof(TestOrchestrations.ThrowOrchestrator);
             var eventGridKeyValue = "testEventGridKey";
             var eventGridKeySettingName = "eventGridKeySettingName";
@@ -431,7 +440,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 (HttpRequestMessage req) => req.CreateResponse(HttpStatusCode.OK, "{\"message\":\"OK!\"}");
 
             HttpMessageHandler httpMessageHandler = this.ConfigureEventGridMockHandler(
-                TestHelpers.GetTaskHubNameFromTestName(testName, extendedSessionsEnabled),
+                taskHub,
                 functionName,
                 createdInstanceId,
                 eventGridKeyValue,
@@ -452,6 +461,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 eventGridKeySettingName,
                 mockNameResolver.Object,
                 eventGridEndpoint,
+                exactTaskHubName: taskHub,
                 eventGridNotificationHandler: httpMessageHandler,
                 eventGridPublishEventTypes: new[] { "Started", "Completed" }))
             {
@@ -478,6 +488,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         public async Task OrchestrationTerminatedOptOutOfEvent(bool extendedSessionsEnabled)
         {
             var testName = nameof(this.OrchestrationTerminate);
+            var taskHub = TestHelpers.GetTaskHubNameFromTestName(testName, extendedSessionsEnabled);
 
             // Using the counter orchestration because it will wait indefinitely for input.
             var functionName = nameof(TestOrchestrations.Counter);
@@ -492,7 +503,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 (HttpRequestMessage req) => req.CreateResponse(HttpStatusCode.OK, "{\"message\":\"OK!\"}");
 
             HttpMessageHandler httpMessageHandler = this.ConfigureEventGridMockHandler(
-                TestHelpers.GetTaskHubNameFromTestName(testName, extendedSessionsEnabled),
+                taskHub,
                 functionName,
                 createdInstanceId,
                 eventGridKeyValue,
@@ -513,6 +524,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 eventGridKeySettingName,
                 mockNameResolver.Object,
                 eventGridEndpoint,
+                exactTaskHubName: taskHub,
                 eventGridNotificationHandler: httpMessageHandler,
                 eventGridPublishEventTypes: new[] { "Started", "Failed", "Completed" }))
             {
@@ -553,10 +565,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                     HttpStatusCode.InternalServerError,
                     new { message = "Exception has been thrown" });
 
+            string taskHubName = TestHelpers.GetTaskHubNameFromTestName(testName, extendedSessionsEnabled);
             string createdInstanceId = Guid.NewGuid().ToString("N");
             int callCount = 0;
             HttpMessageHandler httpMessageHandler = this.ConfigureEventGridMockHandler(
-                TestHelpers.GetTaskHubNameFromTestName(testName, extendedSessionsEnabled),
+                taskHubName,
                 functionName,
                 createdInstanceId,
                 eventGridKeyValue,
@@ -593,6 +606,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 eventGridKeySettingName,
                 mockNameResolver.Object,
                 eventGridEndpoint,
+                exactTaskHubName: taskHubName,
                 eventGridNotificationHandler: httpMessageHandler))
             {
                 await host.StartAsync();

--- a/test/Common/TestHelpers.cs
+++ b/test/Common/TestHelpers.cs
@@ -113,27 +113,27 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             // Delete blobs
             CloudBlobClient blobClient = storageAccount.CreateCloudBlobClient();
             CloudBlobContainer leases = blobClient.GetContainerReference($"{taskHub}-leases");
-            deletionTasks.Add(leases.DeleteAsync());
+            deletionTasks.Add(leases.DeleteIfExistsAsync());
             CloudBlobContainer largeContainers = blobClient.GetContainerReference($"{taskHub}-largemessages");
-            deletionTasks.Add(largeContainers.DeleteAsync());
+            deletionTasks.Add(largeContainers.DeleteIfExistsAsync());
 
             // Delete queues
             CloudQueueClient queueClient = storageAccount.CreateCloudQueueClient();
             CloudQueue workItemQueue = queueClient.GetQueueReference($"{taskHub}-workitems");
-            deletionTasks.Add(workItemQueue.DeleteAsync());
+            deletionTasks.Add(workItemQueue.DeleteIfExistsAsync());
             for (int i = 0; i < partitionCount; i++)
             {
                 string controlQueueName = $"{taskHub}-control-{i.ToString("00")}";
                 CloudQueue controlQueue = queueClient.GetQueueReference(controlQueueName);
-                deletionTasks.Add(controlQueue.DeleteAsync());
+                deletionTasks.Add(controlQueue.DeleteIfExistsAsync());
             }
 
             // Delete tables
             CloudTableClient tableClient = storageAccount.CreateCloudTableClient();
             CloudTable historyTable = tableClient.GetTableReference($"{taskHub}History");
             CloudTable instancesTable = tableClient.GetTableReference($"{taskHub}Instances");
-            deletionTasks.Add(historyTable.DeleteAsync());
-            deletionTasks.Add(instancesTable.DeleteAsync());
+            deletionTasks.Add(historyTable.DeleteIfExistsAsync());
+            deletionTasks.Add(instancesTable.DeleteIfExistsAsync());
 
             await Task.WhenAll(deletionTasks);
         }

--- a/test/Common/TestHelpers.cs
+++ b/test/Common/TestHelpers.cs
@@ -89,9 +89,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 testNameResolver);
         }
 
+        // Create a valid task hub from the test name, and add a random g
         public static string GetTaskHubNameFromTestName(string testName, bool enableExtendedSessions)
         {
-            return testName.Replace("_", "") + (enableExtendedSessions ? "EX" : "") + PlatformSpecificHelpers.VersionSuffix;
+
+            string strippedTestName = testName.Replace("_", "");
+            string truncatedTestName = strippedTestName.Substring(0, Math.Min(35, strippedTestName.Length));
+            string deterministicSuffix = (enableExtendedSessions ? "EX" : "") + PlatformSpecificHelpers.VersionSuffix;
+            string randomSuffix = Guid.NewGuid().ToString().Substring(0, 4);
+            return truncatedTestName + deterministicSuffix + randomSuffix;
         }
 
         public static ITypeLocator GetTypeLocator()

--- a/test/Common/TestHelpers.cs
+++ b/test/Common/TestHelpers.cs
@@ -36,11 +36,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             string[] eventGridPublishEventTypes = null,
             bool autoFetchLargeMessages = true,
             bool? localRpcEndpointEnabled = false,
-            OverridableStates? overridableStates = null)
+            OverridableStates? overridableStates = null,
+            string exactTaskHubName = null)
         {
             var durableTaskOptions = new DurableTaskOptions
             {
-                HubName = GetTaskHubNameFromTestName(testName, enableExtendedSessions),
+                HubName = exactTaskHubName ?? GetTaskHubNameFromTestName(testName, enableExtendedSessions),
                 TraceInputsAndOutputs = true,
                 EventGridKeySettingName = eventGridKeySettingName,
                 EventGridTopicEndpoint = eventGridTopicEndpoint,
@@ -89,7 +90,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 testNameResolver);
         }
 
-        // Create a valid task hub from the test name, and add a random g
+        // Create a valid task hub from the test name, and add a random suffix to avoid conflicts
         public static string GetTaskHubNameFromTestName(string testName, bool enableExtendedSessions)
         {
 

--- a/test/FunctionsV2/PlatformSpecificHelpers.FunctionsV2.cs
+++ b/test/FunctionsV2/PlatformSpecificHelpers.FunctionsV2.cs
@@ -48,18 +48,25 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                     })
                 .Build();
 
-            return new FunctionsV2HostWrapper(host);
+            return new FunctionsV2HostWrapper(host, options, nameResolver);
         }
 
         private class FunctionsV2HostWrapper : ITestHost
         {
             private readonly IHost innerHost;
             private readonly JobHost innerWebJobsHost;
+            private readonly DurableTaskOptions options;
+            private readonly INameResolver nameResolver;
 
-            public FunctionsV2HostWrapper(IHost innerHost)
+            public FunctionsV2HostWrapper(
+                IHost innerHost,
+                IOptions<DurableTaskOptions> options,
+                INameResolver nameResolver)
             {
                 this.innerHost = innerHost ?? throw new ArgumentNullException(nameof(innerHost));
                 this.innerWebJobsHost = (JobHost)this.innerHost.Services.GetService<IJobHost>();
+                this.options = options.Value;
+                this.nameResolver = nameResolver;
             }
 
             public Task CallAsync(string methodName, IDictionary<string, object> args)
@@ -68,7 +75,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             public Task CallAsync(MethodInfo method, IDictionary<string, object> args)
                 => this.innerWebJobsHost.CallAsync(method, args);
 
-            public void Dispose() => this.innerHost.Dispose();
+            public void Dispose()
+            {
+                this.innerHost.Dispose();
+#if !DEBUG
+                string connectionString = this.nameResolver.Resolve(this.options.AzureStorageConnectionStringName ?? "AzureWebJobsStorage");
+                int partitionCount = this.options.PartitionCount;
+                string taskHub = this.options.HubName.ToLowerInvariant();
+                Task.Run(() => TestHelpers.DeleteAllElementsInStorageTaskHubAsync(connectionString, taskHub, partitionCount)).GetAwaiter().GetResult();
+#endif
+            }
 
             public Task StartAsync() => this.innerHost.StartAsync();
 


### PR DESCRIPTION
Our end-to-end tests currently rely on having unique taskhub names so
that tests can be run safely in parallel. This has been proven to be
hard to catch/maintain this restriction, so we add a random 4
alphanumeric suffix to each task hub to make sure that there are never
duplicate taskhub names.