### PR TITLE
Add TaskEventId to function traces

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
@@ -291,6 +291,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 .BindToTrigger(new EntityTriggerAttributeBindingProvider(this, context, storageConnectionString, this.TraceHelper));
 
             this.taskHubWorker = new TaskHubWorker(this.defaultDurabilityProvider, this, this);
+
+            // Add middleware to the DTFx dispatcher so that we can inject our own logic
+            // into and customize the orchestration execution pipeline.
             this.taskHubWorker.AddActivityDispatcherMiddleware(this.ActivityMiddleware);
             this.taskHubWorker.AddOrchestrationDispatcherMiddleware(this.EntityMiddleware);
             this.taskHubWorker.AddOrchestrationDispatcherMiddleware(this.OrchestrationMiddleware);
@@ -466,6 +469,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             return new TaskActivityShim(this, info.Executor, this.hostLifetimeService, name);
         }
 
+        /// <summary>
+        /// This DTFx activity middleware allows us to add context to the activity function shim
+        /// before it actually starts running.
+        /// </summary>
+        /// <param name="dispatchContext">A property bag containing useful DTFx context.</param>
+        /// <param name="next">The handler for running the next middleware in the pipeline.</param>
         private Task ActivityMiddleware(DispatchMiddlewareContext dispatchContext, Func<Task> next)
         {
             if (dispatchContext.GetProperty<TaskActivity>() is TaskActivityShim shim)
@@ -474,9 +483,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 shim.SetTaskEventId(@event?.EventId ?? -1);
             }
 
+            // Move to the next stage of the DTFx pipeline to trigger the activity shim.
             return next();
         }
 
+        /// <summary>
+        /// This DTFx orchestration middleware allows us to initialize Durable Functions-specific context
+        /// and make the execution happen in a way that plays nice with the Azure Functions execution pipeline.
+        /// </summary>
+        /// <param name="dispatchContext">A property bag containing useful DTFx context.</param>
+        /// <param name="next">The handler for running the next middleware in the pipeline.</param>
         private async Task OrchestrationMiddleware(DispatchMiddlewareContext dispatchContext, Func<Task> next)
         {
             TaskOrchestrationShim shim = dispatchContext.GetProperty<TaskOrchestration>() as TaskOrchestrationShim;
@@ -578,6 +594,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             await context.RunDeferredTasks();
         }
 
+        /// <summary>
+        /// This DTFx orchestration middleware (for entities) allows us to add context and set state
+        /// to the entity shim orchestration before it starts executing the actual entity logic.
+        /// </summary>
+        /// <param name="dispatchContext">A property bag containing useful DTFx context.</param>
+        /// <param name="next">The handler for running the next middleware in the pipeline.</param>
         private async Task EntityMiddleware(DispatchMiddlewareContext dispatchContext, Func<Task> next)
         {
             var entityShim = dispatchContext.GetProperty<TaskOrchestration>() as TaskEntityShim;

--- a/src/WebJobs.Extensions.DurableTask/EndToEndTraceHelper.cs
+++ b/src/WebJobs.Extensions.DurableTask/EndToEndTraceHelper.cs
@@ -128,13 +128,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             string instanceId,
             string input,
             FunctionType functionType,
-            bool isReplay)
+            bool isReplay,
+            int taskEventId = -1)
         {
             EtwEventSource.Instance.FunctionStarting(
                 hubName,
                 LocalAppName,
                 LocalSlotName,
                 functionName,
+                taskEventId,
                 instanceId,
                 input,
                 functionType.ToString(),
@@ -144,9 +146,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             if (this.ShouldLogEvent(isReplay))
             {
                 this.logger.LogInformation(
-                    "{instanceId}: Function '{functionName} ({functionType})' started. IsReplay: {isReplay}. Input: {input}. State: {state}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}. SequenceNumber: {sequenceNumber}.",
+                    "{instanceId}: Function '{functionName} ({functionType})' started. IsReplay: {isReplay}. Input: {input}. State: {state}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}. SequenceNumber: {sequenceNumber}. TaskEventId: {taskEventId}",
                     instanceId, functionName, functionType, isReplay, input, FunctionState.Started, hubName,
-                    LocalAppName, LocalSlotName, ExtensionVersion, this.sequenceNumber++);
+                    LocalAppName, LocalSlotName, ExtensionVersion, this.sequenceNumber++, taskEventId);
             }
         }
 
@@ -212,13 +214,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             string output,
             bool continuedAsNew,
             FunctionType functionType,
-            bool isReplay)
+            bool isReplay,
+            int taskEventId = -1)
         {
             EtwEventSource.Instance.FunctionCompleted(
                 hubName,
                 LocalAppName,
                 LocalSlotName,
                 functionName,
+                taskEventId,
                 instanceId,
                 output,
                 continuedAsNew,
@@ -229,9 +233,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             if (this.ShouldLogEvent(isReplay))
             {
                 this.logger.LogInformation(
-                    "{instanceId}: Function '{functionName} ({functionType})' completed. ContinuedAsNew: {continuedAsNew}. IsReplay: {isReplay}. Output: {output}. State: {state}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}. SequenceNumber: {sequenceNumber}.",
+                    "{instanceId}: Function '{functionName} ({functionType})' completed. ContinuedAsNew: {continuedAsNew}. IsReplay: {isReplay}. Output: {output}. State: {state}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}. SequenceNumber: {sequenceNumber}. TaskEventId: {taskEventId}",
                     instanceId, functionName, functionType, continuedAsNew, isReplay, output, FunctionState.Completed,
-                    hubName, LocalAppName, LocalSlotName, ExtensionVersion, this.sequenceNumber++);
+                    hubName, LocalAppName, LocalSlotName, ExtensionVersion, this.sequenceNumber++, taskEventId);
             }
         }
 
@@ -297,16 +301,27 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             string instanceId,
             string reason,
             FunctionType functionType,
-            bool isReplay)
+            bool isReplay,
+            int taskEventId = -1)
         {
-            EtwEventSource.Instance.FunctionFailed(hubName, LocalAppName, LocalSlotName, functionName,
-                instanceId, reason, functionType.ToString(), ExtensionVersion, isReplay);
+            EtwEventSource.Instance.FunctionFailed(
+                hubName,
+                LocalAppName,
+                LocalSlotName,
+                functionName,
+                taskEventId,
+                instanceId,
+                reason,
+                functionType.ToString(),
+                ExtensionVersion,
+                isReplay);
+
             if (this.ShouldLogEvent(isReplay))
             {
                 this.logger.LogError(
-                    "{instanceId}: Function '{functionName} ({functionType})' failed with an error. Reason: {reason}. IsReplay: {isReplay}. State: {state}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}. SequenceNumber: {sequenceNumber}.",
+                    "{instanceId}: Function '{functionName} ({functionType})' failed with an error. Reason: {reason}. IsReplay: {isReplay}. State: {state}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}. SequenceNumber: {sequenceNumber}. TaskEventId: {taskEventId}",
                     instanceId, functionName, functionType, reason, isReplay, FunctionState.Failed, hubName,
-                    LocalAppName, LocalSlotName, ExtensionVersion, this.sequenceNumber++);
+                    LocalAppName, LocalSlotName, ExtensionVersion, this.sequenceNumber++, taskEventId);
             }
         }
 

--- a/src/WebJobs.Extensions.DurableTask/EtwEventSource.cs
+++ b/src/WebJobs.Extensions.DurableTask/EtwEventSource.cs
@@ -34,19 +34,20 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             this.WriteEvent(201, TaskHub, AppName, SlotName, FunctionName, InstanceId, Reason, FunctionType, ExtensionVersion, IsReplay);
         }
 
-        [Event(202, Level = EventLevel.Informational, Version = 4)]
+        [Event(202, Level = EventLevel.Informational, Version = 5)]
         public void FunctionStarting(
             string TaskHub,
             string AppName,
             string SlotName,
             string FunctionName,
+            int TaskEventId,
             string InstanceId,
             string Input,
             string FunctionType,
             string ExtensionVersion,
             bool IsReplay)
         {
-            this.WriteEvent(202, TaskHub, AppName, SlotName, FunctionName, InstanceId, Input ?? "(null)", FunctionType, ExtensionVersion, IsReplay);
+            this.WriteEvent(202, TaskHub, AppName, SlotName, FunctionName, TaskEventId, InstanceId, Input ?? "(null)", FunctionType, ExtensionVersion, IsReplay);
         }
 
         [Event(203, Level = EventLevel.Informational, Version = 4)]
@@ -94,12 +95,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             this.WriteEvent(205, TaskHub, AppName, SlotName, FunctionName, InstanceId, EventName, Input ?? "(null)", FunctionType, ExtensionVersion, IsReplay);
         }
 
-        [Event(206, Level = EventLevel.Informational, Version = 4)]
+        [Event(206, Level = EventLevel.Informational, Version = 5)]
         public void FunctionCompleted(
             string TaskHub,
             string AppName,
             string SlotName,
             string FunctionName,
+            int TaskEventId,
             string InstanceId,
             string Output,
             bool ContinuedAsNew,
@@ -107,7 +109,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             string ExtensionVersion,
             bool IsReplay)
         {
-            this.WriteEvent(206, TaskHub, AppName, SlotName, FunctionName, InstanceId, Output ?? "(null)", ContinuedAsNew, FunctionType, ExtensionVersion, IsReplay);
+            this.WriteEvent(206, TaskHub, AppName, SlotName, FunctionName, TaskEventId, InstanceId, Output ?? "(null)", ContinuedAsNew, FunctionType, ExtensionVersion, IsReplay);
         }
 
         [Event(207, Level = EventLevel.Warning, Version = 2)]
@@ -125,19 +127,20 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             this.WriteEvent(207, TaskHub, AppName, SlotName, FunctionName, InstanceId, Reason, FunctionType, ExtensionVersion, IsReplay);
         }
 
-        [Event(208, Level = EventLevel.Error, Version = 3)]
+        [Event(208, Level = EventLevel.Error, Version = 4)]
         public void FunctionFailed(
             string TaskHub,
             string AppName,
             string SlotName,
             string FunctionName,
+            int TaskEventId,
             string InstanceId,
             string Reason,
             string FunctionType,
             string ExtensionVersion,
             bool IsReplay)
         {
-            this.WriteEvent(208, TaskHub, AppName, SlotName, FunctionName, InstanceId, Reason, FunctionType, ExtensionVersion, IsReplay);
+            this.WriteEvent(208, TaskHub, AppName, SlotName, FunctionName, TaskEventId, InstanceId, Reason, FunctionType, ExtensionVersion, IsReplay);
         }
 
         [Event(209, Level = EventLevel.Informational, Version = 2)]

--- a/src/WebJobs.Extensions.DurableTask/Listener/TaskActivityShim.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/TaskActivityShim.cs
@@ -23,6 +23,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         private readonly IApplicationLifetimeWrapper hostServiceLifetime;
         private readonly string activityName;
 
+        private int taskEventId = -1;
+
         public TaskActivityShim(
             DurableTaskExtension config,
             ITriggeredFunctionExecutor executor,
@@ -56,7 +58,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 instanceId,
                 this.config.GetIntputOutputTrace(rawInput),
                 functionType: FunctionType.Activity,
-                isReplay: false);
+                isReplay: false,
+                taskEventId: this.taskEventId);
 
             WrappedFunctionResult result = await FunctionExecutionHelper.ExecuteActivityFunction(
                 this.executor,
@@ -74,7 +77,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                         this.config.GetIntputOutputTrace(serializedOutput),
                         continuedAsNew: false,
                         functionType: FunctionType.Activity,
-                        isReplay: false);
+                        isReplay: false,
+                        taskEventId: this.taskEventId);
 
                     return serializedOutput;
                 case WrappedFunctionResult.FunctionResultStatus.FunctionsRuntimeError:
@@ -106,7 +110,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                         instanceId,
                         exceptionToReport?.ToString() ?? string.Empty,
                         functionType: FunctionType.Activity,
-                        isReplay: false);
+                        isReplay: false,
+                        taskEventId: this.taskEventId);
 
                     throw new TaskFailureException(
                             $"Activity function '{this.activityName}' failed: {exceptionToReport.Message}",
@@ -120,6 +125,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         {
             // This won't get called as long as we've implemented RunAsync.
             throw new NotImplementedException();
+        }
+
+        internal void SetTaskEventId(int taskEventId)
+        {
+            this.taskEventId = taskEventId;
         }
 
         private static Exception StripFunctionInvocationException(Exception e)

--- a/src/WebJobs.Extensions.DurableTask/Listener/TaskActivityShim.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/TaskActivityShim.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
-using System.Threading;
 using System.Threading.Tasks;
 using DurableTask.Core;
 using DurableTask.Core.Common;
@@ -23,6 +22,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         private readonly IApplicationLifetimeWrapper hostServiceLifetime;
         private readonly string activityName;
 
+        /// <summary>
+        /// The DTFx-generated, auto-incrementing ID that uniquely identifies this activity function execution.
+        /// </summary>
         private int taskEventId = -1;
 
         public TaskActivityShim(
@@ -129,6 +131,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
         internal void SetTaskEventId(int taskEventId)
         {
+            // We don't have the DTFx task event ID at TaskActivityShim-creation time
+            // so we have to set it here, before DTFx calls the RunAsync method.
             this.taskEventId = taskEventId;
         }
 


### PR DESCRIPTION
Resolves #1382.

With this PR, both our ETW traces and the Application Insight traces will have a new `TaskEventId` column for activity function executions. The `TaskEventId` integer value can be used to distinguish two different activity function executions that have the same name. For example, in the `HelloSequence` example, you'd see that each `SayHello` execution has a different `TaskEventId` value (0, 1, and 2).

For orchestrator and entity functions, this value will always be -1 since there isn't a way to associate a single event to a single orchestration function execution (there could be multiple events corresponding to a single execution).

We already have this data in the **DurableTask-AzureStorage** traces. This PR adds the same data to the **WebJobs-Extensions-DurableTask** traces (and to AppInsights).