### PR TITLE
WIP: Enabling Linux Telemetry

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/DurableFunctionsLinuxLog.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableFunctionsLinuxLog.cs
@@ -1,0 +1,69 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+using System.Collections.Generic;
+
+namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
+{
+    /// <summary>
+    /// A string-serializable collection of data representing a durable event
+    /// to be logged in Linux.
+    /// </summary>
+    public class DurableFunctionsLinuxLog
+    {
+        /// <summary>
+        /// Turns Log into a string.
+        /// </summary>
+        /// <returns>String-representation of the log.</returns>
+        public static string AsString(Dictionary<string, string> record)
+        {
+            string log = "";
+            List<string> orderedColumns = new List<string>
+            {
+                "Account", "ActiveActivities", "ActiveOrchestrators",
+                "Age", "AppName", "ContinuedAsNew", "CreatedTimeFrom",
+                "CreatedTimeTo", "DequeueCount", "Details", "Duration",
+                "ETag", "Episode", "EventCount", "EventName", "EventType",
+                "Exception", "ExceptionMessage", "ExecutionId", "ExtensionVersion",
+                "FromWorkerName", "FunctionName", "FunctionState", "FunctionType",
+                "Input", "InstanceId", "IsCheckpointComplete", "IsExtendedSession",
+                "IsReplay", "LastCheckpointTime", "LatencyMs", "MessageId", "MessagesRead",
+                "MessagesSent", "MessagesUpdated", "NewEventCount", "NewEvents", "NextVisibleTime",
+                "OperationId", "OperationName", "Output", "PartitionId", "PendingOrchestratorMessages",
+                "PendingOrchestrators", "Reason", "RelatedActivityId", "RequestCount", "RequestId",
+                "RequestingExecutionId", "RequestingInstance", "RequestingInstanceId", "Result",
+                "RuntimeStatus", "SequenceNumber", "SizeInBytes", "SlotName", "StatusCode",
+                "StorageRequests", "Success", "TableEntitiesRead", "TableEntitiesWritten",
+                "TargetExecutionId", "TargetInstanceId", "TaskEventId", "TaskHub", "Token",
+                "TotalEventCount", "Version", "VisibilityTimeoutSeconds", "WorkerName",
+            };
+
+            // to represent the value of a column
+            string value;
+
+            // we write each column in order
+            foreach (string column in orderedColumns)
+            {
+                value = "";
+
+                // Details and ExceptionMessage are double-quote-wrapped
+                // messages, so their default value is '""'
+                if (column == "Details" || column == "ExceptionMessage")
+                {
+                    value = "\"\"";
+                }
+
+                if (record.ContainsKey(column))
+                {
+                    value = record[column];
+                }
+
+                log += value + ",";
+            }
+
+            int logLength = log.Length;
+            log = log.Remove(logLength - 1);
+
+            return log;
+        }
+    }
+}

--- a/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
@@ -132,6 +132,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 durableHttpMessageHandlerFactory = new DurableHttpMessageHandlerFactory();
             }
 
+            if (SystemEnvironment.Instance.IsLinuxConsumtpion())
+            {
+                LinuxEventWriter.FlagLinuxConsumption();
+            }
+            else if (SystemEnvironment.Instance.IsLinuxDedicated())
+            {
+                // TODO: move these magic strings elsewhere
+                LinuxEventWriter.FlagLinuxDedicated("/var/log/functionsLogs", "durableevents");
+            }
+
             DurableHttpClientFactory durableHttpClientFactory = new DurableHttpClientFactory();
             this.durableHttpClient = durableHttpClientFactory.GetClient(durableHttpMessageHandlerFactory);
 

--- a/src/WebJobs.Extensions.DurableTask/EtwEventSource.cs
+++ b/src/WebJobs.Extensions.DurableTask/EtwEventSource.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System.Collections.Generic;
 using System.Diagnostics.Tracing;
 
 namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
@@ -9,13 +10,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
     /// ETW Event Provider for the WebJobs.Extensions.DurableTask extension.
     /// </summary>
     [EventSource(Name = "WebJobs-Extensions-DurableTask")]
-    internal sealed class EtwEventSource : EventSource
+    internal class EtwEventSource : EventSource
     {
         public static readonly EtwEventSource Instance = new EtwEventSource();
 
         // Private .ctor - callers should use the shared static instance.
         private EtwEventSource()
-        { }
+        {
+        }
 
 #pragma warning disable SA1313 // Parameter names should begin with lower-case letter
 
@@ -31,7 +33,26 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             string ExtensionVersion,
             bool IsReplay)
         {
-            this.WriteEvent(201, TaskHub, AppName, SlotName, FunctionName, InstanceId, Reason, FunctionType, ExtensionVersion, IsReplay);
+            if (LinuxEventWriter.IsEnabled())
+            {
+                Dictionary<string, string> record = new Dictionary<string, string>();
+                record["TaskHub"] = TaskHub;
+                record["AppName"] = AppName;
+                record["SlotName"] = SlotName;
+                record["FunctionName"] = FunctionName;
+                record["InstanceId"] = InstanceId;
+                record["Reason"] = Reason;
+                record["FunctionType"] = FunctionType;
+                record["ExtensionVersion"] = ExtensionVersion;
+                record["IsReplay"] = IsReplay.ToString();
+                record["TaskEventId"] = "201";
+                string log = DurableFunctionsLinuxLog.AsString(record);
+                LinuxEventWriter.Write(log);
+            }
+            else
+            {
+                this.WriteEvent(201, TaskHub, AppName, SlotName, FunctionName, InstanceId, Reason, FunctionType, ExtensionVersion, IsReplay);
+            }
         }
 
         [Event(202, Level = EventLevel.Informational, Version = 5)]
@@ -47,7 +68,25 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             string ExtensionVersion,
             bool IsReplay)
         {
-            this.WriteEvent(202, TaskHub, AppName, SlotName, FunctionName, TaskEventId, InstanceId, Input ?? "(null)", FunctionType, ExtensionVersion, IsReplay);
+            if (LinuxEventWriter.IsEnabled())
+            {
+                Dictionary<string, string> record = new Dictionary<string, string>();
+                record["TaskHub"] = TaskHub;
+                record["AppName"] = AppName;
+                record["SlotName"] = SlotName;
+                record["FunctionName"] = FunctionName;
+                record["InstanceId"] = InstanceId;
+                record["Input"] = Input;
+                record["FunctionType"] = FunctionType;
+                record["ExtensionVersion"] = ExtensionVersion;
+                record["IsReplay"] = IsReplay.ToString();
+                record["TaskEventId"] = TaskEventId.ToString();
+                LinuxEventWriter.Write(DurableFunctionsLinuxLog.AsString(record));
+            }
+            else
+            {
+                this.WriteEvent(202, TaskHub, AppName, SlotName, FunctionName, InstanceId, Input ?? "(null)", FunctionType, ExtensionVersion, IsReplay);
+            }
         }
 
         [Event(203, Level = EventLevel.Informational, Version = 4)]
@@ -61,7 +100,24 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             string ExtensionVersion,
             bool IsReplay)
         {
-            this.WriteEvent(203, TaskHub, AppName, SlotName, FunctionName, InstanceId, FunctionType, ExtensionVersion, IsReplay);
+            if (LinuxEventWriter.IsEnabled())
+            {
+                Dictionary<string, string> record = new Dictionary<string, string>();
+                record["TaskHub"] = TaskHub;
+                record["AppName"] = AppName;
+                record["SlotName"] = SlotName;
+                record["FunctionName"] = FunctionName;
+                record["InstanceId"] = InstanceId;
+                record["FunctionType"] = FunctionType;
+                record["ExtensionVersion"] = ExtensionVersion;
+                record["IsReplay"] = IsReplay.ToString();
+                record["TaskEventId"] = "203";
+                LinuxEventWriter.Write(DurableFunctionsLinuxLog.AsString(record));
+            }
+            else
+            {
+                this.WriteEvent(203, TaskHub, AppName, SlotName, FunctionName, InstanceId, FunctionType, ExtensionVersion, IsReplay);
+            }
         }
 
         [Event(204, Level = EventLevel.Informational, Version = 2)]
@@ -76,7 +132,25 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             string ExtensionVersion,
             bool IsReplay)
         {
-            this.WriteEvent(204, TaskHub, AppName, SlotName, FunctionName, InstanceId, Reason, FunctionType, ExtensionVersion, IsReplay);
+            if (LinuxEventWriter.IsEnabled())
+            {
+                Dictionary<string, string> record = new Dictionary<string, string>();
+                record["TaskHub"] = TaskHub;
+                record["AppName"] = AppName;
+                record["SlotName"] = SlotName;
+                record["FunctionName"] = FunctionName;
+                record["InstanceId"] = InstanceId;
+                record["Reason"] = Reason;
+                record["FunctionType"] = FunctionType;
+                record["ExtensionVersion"] = ExtensionVersion;
+                record["IsReplay"] = IsReplay.ToString();
+                record["TaskEventId"] = "204";
+                LinuxEventWriter.Write(DurableFunctionsLinuxLog.AsString(record));
+            }
+            else
+            {
+                this.WriteEvent(204, TaskHub, AppName, SlotName, FunctionName, InstanceId, Reason, FunctionType, ExtensionVersion, IsReplay);
+            }
         }
 
         [Event(205, Level = EventLevel.Informational, Version = 2)]
@@ -92,7 +166,25 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             string ExtensionVersion,
             bool IsReplay)
         {
-            this.WriteEvent(205, TaskHub, AppName, SlotName, FunctionName, InstanceId, EventName, Input ?? "(null)", FunctionType, ExtensionVersion, IsReplay);
+            if (LinuxEventWriter.IsEnabled())
+            {
+                Dictionary<string, string> record = new Dictionary<string, string>();
+                record["TaskHub"] = TaskHub;
+                record["AppName"] = AppName;
+                record["SlotName"] = SlotName;
+                record["FunctionName"] = FunctionName;
+                record["InstanceId"] = InstanceId;
+                record["EventName"] = EventName;
+                record["FunctionType"] = FunctionType;
+                record["ExtensionVersion"] = ExtensionVersion;
+                record["IsReplay"] = IsReplay.ToString();
+                record["TaskEventId"] = "205";
+                LinuxEventWriter.Write(DurableFunctionsLinuxLog.AsString(record));
+            }
+            else
+            {
+                this.WriteEvent(205, TaskHub, AppName, SlotName, FunctionName, InstanceId, EventName, Input ?? "(null)", FunctionType, ExtensionVersion, IsReplay);
+            }
         }
 
         [Event(206, Level = EventLevel.Informational, Version = 5)]
@@ -109,7 +201,25 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             string ExtensionVersion,
             bool IsReplay)
         {
-            this.WriteEvent(206, TaskHub, AppName, SlotName, FunctionName, TaskEventId, InstanceId, Output ?? "(null)", ContinuedAsNew, FunctionType, ExtensionVersion, IsReplay);
+            if (LinuxEventWriter.IsEnabled())
+            {
+                Dictionary<string, string> record = new Dictionary<string, string>();
+                record["TaskHub"] = TaskHub;
+                record["AppName"] = AppName;
+                record["SlotName"] = SlotName;
+                record["FunctionName"] = FunctionName;
+                record["InstanceId"] = InstanceId;
+                record["Output"] = Output;
+                record["ContinuedAsNew"] = ContinuedAsNew.ToString();
+                record["FunctionType"] = FunctionType;
+                record["IsReplay"] = IsReplay.ToString();
+                record["TaskEventId"] = TaskEventId.ToString();
+                LinuxEventWriter.Write(DurableFunctionsLinuxLog.AsString(record));
+            }
+            else
+            {
+                this.WriteEvent(206, TaskHub, AppName, SlotName, FunctionName, InstanceId, Output ?? "(null)", ContinuedAsNew, FunctionType, ExtensionVersion, IsReplay);
+            }
         }
 
         [Event(207, Level = EventLevel.Warning, Version = 2)]
@@ -124,7 +234,24 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             string ExtensionVersion,
             bool IsReplay)
         {
-            this.WriteEvent(207, TaskHub, AppName, SlotName, FunctionName, InstanceId, Reason, FunctionType, ExtensionVersion, IsReplay);
+            if (LinuxEventWriter.IsEnabled())
+            {
+                Dictionary<string, string> record = new Dictionary<string, string>();
+                record["TaskHub"] = TaskHub;
+                record["AppName"] = AppName;
+                record["SlotName"] = SlotName;
+                record["FunctionName"] = FunctionName;
+                record["InstanceId"] = InstanceId;
+                record["Reason"] = Reason;
+                record["FunctionType"] = FunctionType;
+                record["IsReplay"] = IsReplay.ToString();
+                record["TaskEventId"] = "207";
+                LinuxEventWriter.Write(DurableFunctionsLinuxLog.AsString(record));
+            }
+            else
+            {
+                this.WriteEvent(207, TaskHub, AppName, SlotName, FunctionName, InstanceId, Reason, FunctionType, ExtensionVersion, IsReplay);
+            }
         }
 
         [Event(208, Level = EventLevel.Error, Version = 4)]
@@ -140,7 +267,24 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             string ExtensionVersion,
             bool IsReplay)
         {
-            this.WriteEvent(208, TaskHub, AppName, SlotName, FunctionName, TaskEventId, InstanceId, Reason, FunctionType, ExtensionVersion, IsReplay);
+            if (LinuxEventWriter.IsEnabled())
+            {
+                Dictionary<string, string> record = new Dictionary<string, string>();
+                record["TaskHub"] = TaskHub;
+                record["AppName"] = AppName;
+                record["SlotName"] = SlotName;
+                record["FunctionName"] = FunctionName;
+                record["InstanceId"] = InstanceId;
+                record["Reason"] = Reason;
+                record["FunctionType"] = FunctionType;
+                record["IsReplay"] = IsReplay.ToString();
+                record["TaskEventId"] = TaskEventId.ToString();
+                LinuxEventWriter.Write(DurableFunctionsLinuxLog.AsString(record));
+            }
+            else
+            {
+                this.WriteEvent(208, TaskHub, AppName, SlotName, FunctionName, InstanceId, Reason, FunctionType, ExtensionVersion, IsReplay);
+            }
         }
 
         [Event(209, Level = EventLevel.Informational, Version = 2)]
@@ -155,7 +299,25 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             string ExtensionVersion,
             bool IsReplay)
         {
-            this.WriteEvent(209, TaskHub, AppName, SlotName, FunctionName, InstanceId, Reason, FunctionType, ExtensionVersion, IsReplay);
+            if (LinuxEventWriter.IsEnabled())
+            {
+                Dictionary<string, string> record = new Dictionary<string, string>();
+                record["TaskHub"] = TaskHub;
+                record["AppName"] = AppName;
+                record["SlotName"] = SlotName;
+                record["FunctionName"] = FunctionName;
+                record["InstanceId"] = InstanceId;
+                record["Reason"] = Reason;
+                record["FunctionType"] = FunctionType;
+                record["ExtensionVersion"] = ExtensionVersion;
+                record["IsReplay"] = IsReplay.ToString();
+                record["TaskEventId"] = "209";
+                LinuxEventWriter.Write(DurableFunctionsLinuxLog.AsString(record));
+            }
+            else
+            {
+                this.WriteEvent(209, TaskHub, AppName, SlotName, FunctionName, InstanceId, Reason, FunctionType, ExtensionVersion, IsReplay);
+            }
         }
 
         [Event(210, Level = EventLevel.Informational, Version = 3)]
@@ -174,7 +336,28 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             bool IsReplay,
             long LatencyMs)
         {
-            this.WriteEvent(210, TaskHub, AppName, SlotName, FunctionName, FunctionState, InstanceId, Details, StatusCode, Reason, FunctionType, ExtensionVersion, IsReplay, LatencyMs);
+            if (LinuxEventWriter.IsEnabled())
+            {
+                Dictionary<string, string> record = new Dictionary<string, string>();
+                record["TaskHub"] = TaskHub;
+                record["AppName"] = AppName;
+                record["SlotName"] = SlotName;
+                record["FunctionName"] = FunctionName;
+                record["FunctionState"] = FunctionState.ToString();
+                record["InstanceId"] = InstanceId;
+                record["Details"] = '\"' + Details.Replace('\"', '\'') + '\"';
+                record["StatusCode"] = StatusCode.ToString();
+                record["Reason"] = Reason;
+                record["FunctionType"] = FunctionType.ToString();
+                record["ExtensionVersion"] = ExtensionVersion;
+                record["IsReplay"] = IsReplay.ToString();
+                record["TaskEventId"] = "210";
+                LinuxEventWriter.Write(DurableFunctionsLinuxLog.AsString(record));
+            }
+            else
+            {
+                this.WriteEvent(210, TaskHub, AppName, SlotName, FunctionName, FunctionState, InstanceId, Details, StatusCode, Reason, FunctionType, ExtensionVersion, IsReplay, LatencyMs);
+            }
         }
 
         [Event(211, Level = EventLevel.Error, Version = 3)]
@@ -193,7 +376,29 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             bool IsReplay,
             long LatencyMs)
         {
-            this.WriteEvent(211, TaskHub, AppName, SlotName, FunctionName, FunctionState, InstanceId, Details, StatusCode, Reason, FunctionType, ExtensionVersion, IsReplay, LatencyMs);
+            if (LinuxEventWriter.IsEnabled())
+            {
+                Dictionary<string, string> record = new Dictionary<string, string>();
+                record["TaskHub"] = TaskHub;
+                record["AppName"] = AppName;
+                record["SlotName"] = SlotName;
+                record["FunctionName"] = FunctionName;
+                record["FunctionState"] = FunctionState.ToString();
+                record["InstanceId"] = InstanceId;
+                record["Details"] = '\"' + Details.Replace('\"', '\'') + '\"';
+                record["StatusCode"] = StatusCode.ToString();
+                record["Reason"] = Reason;
+                record["FunctionType"] = FunctionType.ToString();
+                record["ExtensionVersion"] = ExtensionVersion;
+                record["IsReplay"] = IsReplay.ToString();
+                record["LatencyMs"] = LatencyMs.ToString();
+                record["TaskEventId"] = "211";
+                LinuxEventWriter.Write(DurableFunctionsLinuxLog.AsString(record));
+            }
+            else
+            {
+                this.WriteEvent(211, TaskHub, AppName, SlotName, FunctionName, FunctionState, InstanceId, Details, StatusCode, Reason, FunctionType, ExtensionVersion, IsReplay, LatencyMs);
+            }
         }
 
         [Event(212, Level = EventLevel.Error)]
@@ -213,7 +418,30 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             bool IsReplay,
             long LatencyMs)
         {
-            this.WriteEvent(212, TaskHub, AppName, SlotName, FunctionName, FunctionState, Version ?? "", InstanceId, Details, exceptionMessage, Reason, FunctionType, ExtensionVersion, IsReplay, LatencyMs);
+            if (LinuxEventWriter.IsEnabled())
+            {
+                Dictionary<string, string> record = new Dictionary<string, string>();
+                record["TaskHub"] = TaskHub;
+                record["AppName"] = AppName;
+                record["SlotName"] = SlotName;
+                record["FunctionName"] = FunctionName;
+                record["FunctionState"] = FunctionState.ToString();
+                record["Version"] = Version;
+                record["InstanceId"] = InstanceId;
+                record["Details"] = '\"' + Details.Replace('\"', '\'') + '\"';
+                record["Reason"] = Reason;
+                record["exceptionMessage"] = '\"' + exceptionMessage.Replace('\"', '\'') + '\"';
+                record["FunctionType"] = FunctionType.ToString();
+                record["ExtensionVersion"] = ExtensionVersion;
+                record["IsReplay"] = IsReplay.ToString();
+                record["LatencyMs"] = LatencyMs.ToString();
+                record["TaskEventId"] = "212";
+                LinuxEventWriter.Write(DurableFunctionsLinuxLog.AsString(record));
+            }
+            else
+            {
+                this.WriteEvent(212, TaskHub, AppName, SlotName, FunctionName, FunctionState, Version ?? "", InstanceId, Details, exceptionMessage, Reason, FunctionType, ExtensionVersion, IsReplay, LatencyMs);
+            }
         }
 
         [Event(213, Level = EventLevel.Informational)]
@@ -226,7 +454,23 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             string Details,
             string ExtensionVersion)
         {
-            this.WriteEvent(213, TaskHub, AppName, SlotName, FunctionName ?? string.Empty, InstanceId ?? string.Empty, Details, ExtensionVersion);
+            if (LinuxEventWriter.IsEnabled())
+            {
+                Dictionary<string, string> record = new Dictionary<string, string>();
+                record["TaskHub"] = TaskHub;
+                record["AppName"] = AppName;
+                record["SlotName"] = SlotName;
+                record["FunctionName"] = FunctionName;
+                record["InstanceId"] = InstanceId;
+                record["Details"] = '\"' + Details.Replace('\"', '\'') + '\"';
+                record["ExtensionVersion"] = ExtensionVersion;
+                record["TaskEventId"] = "213";
+                LinuxEventWriter.Write(DurableFunctionsLinuxLog.AsString(record));
+            }
+            else
+            {
+                this.WriteEvent(213, TaskHub, AppName, SlotName, FunctionName ?? string.Empty, InstanceId ?? string.Empty, Details, ExtensionVersion);
+            }
         }
 
         [Event(214, Level = EventLevel.Warning)]
@@ -239,7 +483,23 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             string Details,
             string ExtensionVersion)
         {
-            this.WriteEvent(214, TaskHub, AppName, SlotName, FunctionName ?? string.Empty, InstanceId ?? string.Empty, Details, ExtensionVersion);
+            if (LinuxEventWriter.IsEnabled())
+            {
+                Dictionary<string, string> record = new Dictionary<string, string>();
+                record["TaskHub"] = TaskHub;
+                record["AppName"] = AppName;
+                record["SlotName"] = SlotName;
+                record["FunctionName"] = FunctionName;
+                record["InstanceId"] = InstanceId;
+                record["Details"] = '\"' + Details.Replace('\"', '\'') + '\"';
+                record["ExtensionVersion"] = ExtensionVersion;
+                record["TaskEventId"] = "214";
+                LinuxEventWriter.Write(DurableFunctionsLinuxLog.AsString(record));
+            }
+            else
+            {
+                this.WriteEvent(214, TaskHub, AppName, SlotName, FunctionName ?? string.Empty, InstanceId ?? string.Empty, Details, ExtensionVersion);
+            }
         }
 
         [Event(215, Level = EventLevel.Informational, Version = 2)]
@@ -254,7 +514,25 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             string ExtensionVersion,
             bool IsReplay)
         {
-            this.WriteEvent(215, TaskHub, AppName, SlotName, FunctionName, InstanceId, EventName, FunctionType, ExtensionVersion, IsReplay);
+            if (LinuxEventWriter.IsEnabled())
+            {
+                Dictionary<string, string> record = new Dictionary<string, string>();
+                record["TaskHub"] = TaskHub;
+                record["AppName"] = AppName;
+                record["SlotName"] = SlotName;
+                record["FunctionName"] = FunctionName;
+                record["InstanceId"] = InstanceId;
+                record["EventName"] = EventName;
+                record["FunctionType"] = FunctionType;
+                record["ExtensionVersion"] = ExtensionVersion;
+                record["IsReplay"] = IsReplay.ToString();
+                record["TaskEventId"] = "215";
+                LinuxEventWriter.Write(DurableFunctionsLinuxLog.AsString(record));
+            }
+            else
+            {
+                this.WriteEvent(215, TaskHub, AppName, SlotName, FunctionName, InstanceId, EventName, FunctionType, ExtensionVersion, IsReplay);
+            }
         }
 
         [Event(216, Level = EventLevel.Informational)]
@@ -269,7 +547,25 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             string ExtensionVersion,
             bool IsReplay)
         {
-            this.WriteEvent(216, TaskHub, AppName, SlotName, FunctionName, InstanceId, Reason ?? string.Empty, FunctionType, ExtensionVersion, IsReplay);
+            if (LinuxEventWriter.IsEnabled())
+            {
+                Dictionary<string, string> record = new Dictionary<string, string>();
+                record["TaskHub"] = TaskHub;
+                record["AppName"] = AppName;
+                record["SlotName"] = SlotName;
+                record["FunctionName"] = FunctionName;
+                record["InstanceId"] = InstanceId;
+                record["Reason"] = Reason;
+                record["FunctionType"] = FunctionType;
+                record["ExtensionVersion"] = ExtensionVersion;
+                record["IsReplay"] = IsReplay.ToString();
+                record["TaskEventId"] = "216";
+                LinuxEventWriter.Write(DurableFunctionsLinuxLog.AsString(record));
+            }
+            else
+            {
+                this.WriteEvent(216, TaskHub, AppName, SlotName, FunctionName, InstanceId, Reason ?? string.Empty, FunctionType, ExtensionVersion, IsReplay);
+            }
         }
 
         [Event(217, Level = EventLevel.Informational)]
@@ -285,7 +581,26 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             string ExtensionVersion,
             bool IsReplay)
         {
-            this.WriteEvent(217, TaskHub, AppName, SlotName, FunctionName, InstanceId, OperationId, OperationName, FunctionType, ExtensionVersion, IsReplay);
+            if (LinuxEventWriter.IsEnabled())
+            {
+                Dictionary<string, string> record = new Dictionary<string, string>();
+                record["TaskHub"] = TaskHub;
+                record["AppName"] = AppName;
+                record["SlotName"] = SlotName;
+                record["FunctionName"] = FunctionName;
+                record["InstanceId"] = InstanceId;
+                record["OperationId"] = OperationId;
+                record["OperationName"] = OperationName;
+                record["FunctionType"] = FunctionType;
+                record["ExtensionVersion"] = ExtensionVersion;
+                record["IsReplay"] = IsReplay.ToString();
+                record["TaskEventId"] = "217";
+                LinuxEventWriter.Write(DurableFunctionsLinuxLog.AsString(record));
+            }
+            else
+            {
+                this.WriteEvent(217, TaskHub, AppName, SlotName, FunctionName, InstanceId, OperationId, OperationName, FunctionType, ExtensionVersion, IsReplay);
+            }
         }
 
         [Event(218, Level = EventLevel.Informational)]
@@ -301,7 +616,26 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             string ExtensionVersion,
             bool IsReplay)
         {
-            this.WriteEvent(218, TaskHub, AppName, SlotName, FunctionName, InstanceId, OperationId, Result ?? "(null)", FunctionType, ExtensionVersion, IsReplay);
+            if (LinuxEventWriter.IsEnabled())
+            {
+                Dictionary<string, string> record = new Dictionary<string, string>();
+                record["TaskHub"] = TaskHub;
+                record["AppName"] = AppName;
+                record["SlotName"] = SlotName;
+                record["FunctionName"] = FunctionName;
+                record["InstanceId"] = InstanceId;
+                record["OperationId"] = OperationId;
+                record["Result"] = Result;
+                record["FunctionType"] = FunctionType;
+                record["ExtensionVersion"] = ExtensionVersion;
+                record["IsReplay"] = IsReplay.ToString();
+                record["TaskEventId"] = "218";
+                LinuxEventWriter.Write(DurableFunctionsLinuxLog.AsString(record));
+            }
+            else
+            {
+                this.WriteEvent(218, TaskHub, AppName, SlotName, FunctionName, InstanceId, OperationId, Result ?? "(null)", FunctionType, ExtensionVersion, IsReplay);
+            }
         }
 
         [Event(219, Level = EventLevel.Informational, Version = 2)]
@@ -318,7 +652,27 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             string ExtensionVersion,
             bool IsReplay)
         {
-            this.WriteEvent(219, TaskHub, AppName, SlotName, FunctionName, InstanceId, RequestingInstanceId, RequestingExecutionId ?? "", RequestId, FunctionType, ExtensionVersion, IsReplay);
+            if (LinuxEventWriter.IsEnabled())
+            {
+                Dictionary<string, string> record = new Dictionary<string, string>();
+                record["TaskHub"] = TaskHub;
+                record["AppName"] = AppName;
+                record["SlotName"] = SlotName;
+                record["FunctionName"] = FunctionName;
+                record["InstanceId"] = InstanceId;
+                record["RequestingInstanceId"] = RequestingInstanceId;
+                record["RequestingExecutionId"] = RequestingExecutionId;
+                record["RequestId"] = RequestId;
+                record["FunctionType"] = FunctionType;
+                record["ExtensionVersion"] = ExtensionVersion;
+                record["IsReplay"] = IsReplay.ToString();
+                record["TaskEventId"] = "219";
+                LinuxEventWriter.Write(DurableFunctionsLinuxLog.AsString(record));
+            }
+            else
+            {
+                this.WriteEvent(219, TaskHub, AppName, SlotName, FunctionName, InstanceId, RequestingInstanceId, RequestingExecutionId ?? "", RequestId, FunctionType, ExtensionVersion, IsReplay);
+            }
         }
 
         [Event(220, Level = EventLevel.Informational)]
@@ -334,7 +688,26 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             string ExtensionVersion,
             bool IsReplay)
         {
-            this.WriteEvent(220, TaskHub, AppName, SlotName, FunctionName, InstanceId, RequestingInstance, RequestId, FunctionType, ExtensionVersion, IsReplay);
+            if (LinuxEventWriter.IsEnabled())
+            {
+                Dictionary<string, string> record = new Dictionary<string, string>();
+                record["TaskHub"] = TaskHub;
+                record["AppName"] = AppName;
+                record["SlotName"] = SlotName;
+                record["FunctionName"] = FunctionName;
+                record["InstanceId"] = InstanceId;
+                record["RequestingInstance"] = RequestingInstance;
+                record["RequestId"] = RequestId;
+                record["FunctionType"] = FunctionType;
+                record["ExtensionVersion"] = ExtensionVersion;
+                record["IsReplay"] = IsReplay.ToString();
+                record["TaskEventId"] = "220";
+                LinuxEventWriter.Write(DurableFunctionsLinuxLog.AsString(record));
+            }
+            else
+            {
+                this.WriteEvent(220, TaskHub, AppName, SlotName, FunctionName, InstanceId, RequestingInstance, RequestId, FunctionType, ExtensionVersion, IsReplay);
+            }
         }
 
         [Event(221, Level = EventLevel.Informational)]
@@ -353,7 +726,29 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             string ExtensionVersion,
             bool IsReplay)
         {
-            this.WriteEvent(221, TaskHub, AppName, SlotName, FunctionName, InstanceId, OperationId, OperationName, Input ?? "(null)", Output ?? "(null)", Duration, FunctionType, ExtensionVersion, IsReplay);
+            if (LinuxEventWriter.IsEnabled())
+            {
+                Dictionary<string, string> record = new Dictionary<string, string>();
+                record["TaskHub"] = TaskHub;
+                record["AppName"] = AppName;
+                record["SlotName"] = SlotName;
+                record["FunctionName"] = FunctionName;
+                record["InstanceId"] = InstanceId;
+                record["OperationId"] = OperationId;
+                record["OperationName"] = OperationName;
+                record["Input"] = Input;
+                record["Output"] = Output;
+                record["Duration"] = Duration.ToString();
+                record["FunctionType"] = FunctionType;
+                record["ExtensionVersion"] = ExtensionVersion;
+                record["IsReplay"] = IsReplay.ToString();
+                record["TaskEventId"] = "221";
+                LinuxEventWriter.Write(DurableFunctionsLinuxLog.AsString(record));
+            }
+            else
+            {
+                this.WriteEvent(221, TaskHub, AppName, SlotName, FunctionName, InstanceId, OperationId, OperationName, Input ?? "(null)", Output ?? "(null)", Duration, FunctionType, ExtensionVersion, IsReplay);
+            }
         }
 
         [Event(222, Level = EventLevel.Error)]
@@ -372,7 +767,29 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             string ExtensionVersion,
             bool IsReplay)
         {
-            this.WriteEvent(222, TaskHub, AppName, SlotName, FunctionName, InstanceId, OperationId, OperationName, Input ?? "(null)", Exception, Duration, FunctionType, ExtensionVersion, IsReplay);
+            if (LinuxEventWriter.IsEnabled())
+            {
+                Dictionary<string, string> record = new Dictionary<string, string>();
+                record["TaskHub"] = TaskHub;
+                record["AppName"] = AppName;
+                record["SlotName"] = SlotName;
+                record["FunctionName"] = FunctionName;
+                record["InstanceId"] = InstanceId;
+                record["OperationId"] = OperationId;
+                record["OperationName"] = OperationName;
+                record["Input"] = Input;
+                record["Exception"] = Exception;
+                record["Duration"] = Duration.ToString();
+                record["FunctionType"] = FunctionType;
+                record["ExtensionVersion"] = ExtensionVersion;
+                record["IsReplay"] = IsReplay.ToString();
+                record["TaskEventId"] = "222";
+                LinuxEventWriter.Write(DurableFunctionsLinuxLog.AsString(record));
+            }
+            else
+            {
+                this.WriteEvent(222, TaskHub, AppName, SlotName, FunctionName, InstanceId, OperationId, OperationName, Input ?? "(null)", Exception, Duration, FunctionType, ExtensionVersion, IsReplay);
+            }
         }
 
         [Event(223, Level = EventLevel.Informational)]
@@ -383,7 +800,21 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             string Details,
             string ExtensionVersion)
         {
-            this.WriteEvent(223, TaskHub, AppName, SlotName, Details, ExtensionVersion);
+            if (LinuxEventWriter.IsEnabled())
+            {
+                Dictionary<string, string> record = new Dictionary<string, string>();
+                record["TaskHub"] = TaskHub;
+                record["AppName"] = AppName;
+                record["SlotName"] = SlotName;
+                record["Details"] = '\"' + Details.Replace('\"', '\'') + '\"';
+                record["ExtensionVersion"] = ExtensionVersion;
+                record["TaskEventId"] = "223";
+                LinuxEventWriter.Write(DurableFunctionsLinuxLog.AsString(record));
+            }
+            else
+            {
+                this.WriteEvent(223, TaskHub, AppName, SlotName, Details, ExtensionVersion);
+            }
         }
 
         [Event(224, Level = EventLevel.Warning)]
@@ -398,7 +829,25 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             string ExtensionVersion,
             bool IsReplay)
         {
-            this.WriteEvent(224, TaskHub, AppName, SlotName, FunctionName, InstanceId, Reason, FunctionType, ExtensionVersion, IsReplay);
+            if (LinuxEventWriter.IsEnabled())
+            {
+                Dictionary<string, string> record = new Dictionary<string, string>();
+                record["TaskHub"] = TaskHub;
+                record["AppName"] = AppName;
+                record["SlotName"] = SlotName;
+                record["FunctionName"] = FunctionName;
+                record["InstanceId"] = InstanceId;
+                record["Reason"] = Reason;
+                record["FunctionType"] = FunctionType;
+                record["ExtensionVersion"] = ExtensionVersion;
+                record["IsReplay"] = IsReplay.ToString();
+                record["TaskEventId"] = "224";
+                LinuxEventWriter.Write(DurableFunctionsLinuxLog.AsString(record));
+            }
+            else
+            {
+                this.WriteEvent(224, TaskHub, AppName, SlotName, FunctionName, InstanceId, Reason, FunctionType, ExtensionVersion, IsReplay);
+            }
         }
 #pragma warning restore SA1313 // Parameter names should begin with lower-case letter
     }

--- a/src/WebJobs.Extensions.DurableTask/LinuxDedicatedLogger.cs
+++ b/src/WebJobs.Extensions.DurableTask/LinuxDedicatedLogger.cs
@@ -1,0 +1,173 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Abstractions;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
+{
+    public class LinuxDedicatedLogger
+    {
+        private readonly string logFileName;
+        private readonly string logFileDirectory;
+        private readonly string logFilePath;
+        private readonly BlockingCollection<string> buffer;
+        private readonly List<string> currentBatch;
+        private readonly IFileSystem fileSystem;
+        private readonly CancellationTokenSource cancellationTokenSource;
+        private Task outputTask;
+
+        public LinuxDedicatedLogger(string logFileName, string logFileDirectory, IFileSystem fileSystem, bool startOnCreate = true)
+        {
+            this.logFileName = logFileName;
+            this.logFileDirectory = logFileDirectory;
+            this.logFilePath = Path.Combine(this.logFileDirectory, this.logFileName + ".log");
+            this.buffer = new BlockingCollection<string>(new ConcurrentQueue<string>());
+            this.currentBatch = new List<string>();
+            this.fileSystem = fileSystem;
+            this.cancellationTokenSource = new CancellationTokenSource();
+
+            if (startOnCreate)
+            {
+                this.Start();
+            }
+        }
+
+        // Maximum number of files
+        public int MaxFileCount { get; set; } = 3;
+
+        // Maximum size of individual log file in MB
+        public int MaxFileSizeMb { get; set; } = 10;
+
+        // Maximum time between successive flushes (seconds)
+        public int FlushFrequencySeconds { get; set; } = 30;
+
+        public virtual void Log(string message)
+        {
+            try
+            {
+                buffer.Add(message);
+            }
+            catch (Exception)
+            {
+                // ignored
+            }
+        }
+
+        public void Start()
+        {
+            if (this.outputTask == null)
+            {
+                this.outputTask = Task.Factory.StartNew(this.ProcessLogQueue, null, TaskCreationOptions.LongRunning);
+            }
+        }
+
+        public void Stop(TimeSpan timeSpan)
+        {
+            this.cancellationTokenSource.Cancel();
+
+            try
+            {
+                this.outputTask?.Wait(timeSpan);
+            }
+            catch (Exception)
+            {
+                // ignored
+            }
+        }
+
+        public virtual async Task ProcessLogQueue(object state)
+        {
+            while (!this.cancellationTokenSource.IsCancellationRequested)
+            {
+                await this.InternalProcessLogQueue();
+                await Task.Delay(TimeSpan.FromSeconds(this.FlushFrequencySeconds), this.cancellationTokenSource.Token).ContinueWith(task => { });
+            }
+            // ReSharper disable once FunctionNeverReturns
+        }
+
+        // internal for unittests
+        internal async Task InternalProcessLogQueue()
+        {
+            string currentMessage;
+            while (this.buffer.TryTake(out currentMessage))
+            {
+                this.currentBatch.Add(currentMessage);
+            }
+
+            if (this.currentBatch.Any())
+            {
+                try
+                {
+                    await this.WriteLogs(this.currentBatch);
+                }
+                catch (Exception)
+                {
+                    // Ignored
+                }
+
+                this.currentBatch.Clear();
+            }
+        }
+
+        private async Task WriteLogs(IEnumerable<string> currentBatch)
+        {
+            this.fileSystem.Directory.CreateDirectory(this.logFileDirectory);
+
+            var fileInfo = this.fileSystem.FileInfo.FromFileName(this.logFilePath);
+            if (fileInfo.Exists)
+            {
+                if (fileInfo.Length / (1024 * 1024) >= this.MaxFileSizeMb)
+                {
+                    this.RollFiles();
+                }
+            }
+
+            await this.AppendLogs(this.logFilePath, currentBatch);
+        }
+
+        private async Task AppendLogs(string filePath, IEnumerable<string> logs)
+        {
+            using (var streamWriter = this.fileSystem.File.AppendText(filePath))
+            {
+                foreach (var log in logs)
+                {
+                    await streamWriter.WriteLineAsync(log);
+                }
+            }
+        }
+
+        private void RollFiles()
+        {
+            // Rename current file to older file.
+            // Empty current file.
+            // Delete oldest file if exceeded configured max no. of files.
+
+            this.fileSystem.File.Move(this.logFilePath, this.GetCurrentFileName(DateTime.UtcNow));
+
+            var fileInfoBases = this.ListFiles(this.logFileDirectory, this.logFileName + "*", SearchOption.TopDirectoryOnly);
+
+            if (fileInfoBases.Length >= this.MaxFileCount)
+            {
+                var oldestFile = fileInfoBases.OrderByDescending(f => f.Name).Last();
+                oldestFile.Delete();
+            }
+        }
+
+        private IFileInfo[] ListFiles(string directoryPath, string pattern, SearchOption searchOption)
+        {
+            return this.fileSystem.DirectoryInfo.FromDirectoryName(directoryPath).GetFiles(pattern, searchOption);
+        }
+
+        public string GetCurrentFileName(DateTime dateTime)
+        {
+            return Path.Combine(this.logFileDirectory, $"{this.logFileName}{dateTime:yyyyMMddHHmmss}.log");
+        }
+    }
+}

--- a/src/WebJobs.Extensions.DurableTask/LinuxEventWriter.cs
+++ b/src/WebJobs.Extensions.DurableTask/LinuxEventWriter.cs
@@ -1,0 +1,104 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics;
+using System;
+using System.IO.Abstractions;
+
+namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
+{
+    /// <summary>
+    /// Produces Telemetry for the Linux App Service offerings.
+    /// </summary>
+    internal class LinuxEventWriter
+    {
+        private static readonly string ConsumptionPrefix = "MS_DURABLE_FUNCTION_EVENTS_LOGS";
+
+        private static LinuxDedicatedLogger logger;
+
+        // TODO: change these vars for a state enum
+        private static bool inLinuxConsumption = false;
+        private static bool inLinuxDedicated = false;
+
+        /// <summary>
+        /// Indicates that logs should be written for Linux Consumption.
+        /// Should be called before the first log is written, when the
+        /// application is initialized.
+        /// </summary>
+        public static void FlagLinuxConsumption()
+        {
+            // TODO: Raise exception if linux dedicated had already been flagged
+            inLinuxConsumption = true;
+            inLinuxDedicated = !inLinuxConsumption;
+        }
+
+        /// <summary>
+        /// Indicates that logs should be written for Linux Dedicated.
+        /// Should be called before the first log is written, when the
+        /// application is initialized.
+        /// </summary>
+        /// <param name="dirPath">Path to directory where log file will reside.</param>
+        /// <param name="fileName">Name of log file.</param>
+        public static void FlagLinuxDedicated(string dirPath, string fileName)
+        {
+            // TODO: Raise exception if linux consumption had already been flagged
+            logger = new LinuxDedicatedLogger(fileName, dirPath, new FileSystem());
+            inLinuxDedicated = true;
+            inLinuxConsumption = !inLinuxDedicated;
+        }
+
+        /// <summary>
+        /// Returns True if running on Linux Consumption or Dedicated. False otherwise.
+        /// </summary>
+        /// <returns>True if running on Linux Consumption or Dedicated. False otherwise.</returns>
+        public static bool IsEnabled()
+        {
+            // TODO: May want to cache this result as it should not change
+            return inLinuxDedicated || inLinuxConsumption;
+        }
+
+        /// <summary>
+        /// Writes a line asynchronously to a file.
+        /// We use this instead of an ILogger because
+        /// we expect to write often and thus need asynchronous
+        /// writing, which ILogger explicitely designs against.
+        /// </summary>
+        /// <param name="line">Line to write to log-file.</param>
+        private static void WriteToFile(string line)
+        {
+            LinuxEventWriter.FlagLinuxDedicated("/var/log/functionsLogs", "durableevents");
+            logger.Log(line);
+        }
+
+        /// <summary>
+        /// Writes a line asynchronously to the console.
+        /// It adds a prefix to the line, so it can get picked up
+        /// by the regex monitoring agent.
+        /// </summary>
+        /// <param name="line">Line to write to console.</param>
+        private static void ConsoleWriter(string line)
+        {
+            line = ConsumptionPrefix + " " + line;
+            Console.WriteLine(line);
+        }
+
+        /// <summary>
+        /// Writes a line asynchronously to either the console
+        /// (linux consumption) or a log file (linux dedicated).
+        /// </summary>
+        /// <param name="line">Line to write.</param>
+        public static void Write(string line)
+        {
+            // TODO: may want to explicitely check for linux consumption
+            // and to raise an error in a catch-all case
+            if (inLinuxDedicated)
+            {
+                WriteToFile(line);
+            }
+            else
+            {
+                ConsoleWriter(line);
+            }
+        }
+    }
+}

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net461.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net461.xml
@@ -1742,6 +1742,18 @@
             The state as either a <c>JToken</c> or <c>null</c> if no state was provided.
             </value>
         </member>
+        <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableFunctionsLinuxLog">
+            <summary>
+            A string-serializable collection of data representing a durable event
+            to be logged in Linux.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableFunctionsLinuxLog.AsString(System.Collections.Generic.Dictionary{System.String,System.String})">
+            <summary>
+            Turns Log into a string.
+            </summary>
+            <returns>String-representation of the log.</returns>
+        </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableHttpRequest">
             <summary>
             Request used to make an HTTP call through Durable Functions.
@@ -1998,6 +2010,30 @@
             <param name="name">The name of the activity to return.</param>
             <param name="version">Not used.</param>
             <returns>An activity shim that delegates execution to an activity function.</returns>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.ActivityMiddleware(DurableTask.Core.Middleware.DispatchMiddlewareContext,System.Func{System.Threading.Tasks.Task})">
+            <summary>
+            This DTFx activity middleware allows us to add context to the activity function shim
+            before it actually starts running.
+            </summary>
+            <param name="dispatchContext">A property bag containing useful DTFx context.</param>
+            <param name="next">The handler for running the next middleware in the pipeline.</param>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.OrchestrationMiddleware(DurableTask.Core.Middleware.DispatchMiddlewareContext,System.Func{System.Threading.Tasks.Task})">
+            <summary>
+            This DTFx orchestration middleware allows us to initialize Durable Functions-specific context
+            and make the execution happen in a way that plays nice with the Azure Functions execution pipeline.
+            </summary>
+            <param name="dispatchContext">A property bag containing useful DTFx context.</param>
+            <param name="next">The handler for running the next middleware in the pipeline.</param>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.EntityMiddleware(DurableTask.Core.Middleware.DispatchMiddlewareContext,System.Func{System.Threading.Tasks.Task})">
+            <summary>
+            This DTFx orchestration middleware (for entities) allows us to add context and set state
+            to the entity shim orchestration before it starts executing the actual entity logic.
+            </summary>
+            <param name="dispatchContext">A property bag containing useful DTFx context.</param>
+            <param name="next">The handler for running the next middleware in the pipeline.</param>
         </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.GetClient(Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClientAttribute)">
             <summary>
@@ -2893,6 +2929,57 @@
             </summary>
             <returns>A <see cref="T:System.Threading.Tasks.Task`1"/> representing the result of the asynchronous operation.</returns>
         </member>
+        <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.LinuxEventWriter">
+            <summary>
+            Produces Telemetry for the Linux App Service offerings.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.LinuxEventWriter.FlagLinuxConsumption">
+            <summary>
+            Indicates that logs should be written for Linux Consumption.
+            Should be called before the first log is written, when the
+            application is initialized.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.LinuxEventWriter.FlagLinuxDedicated(System.String,System.String)">
+            <summary>
+            Indicates that logs should be written for Linux Dedicated.
+            Should be called before the first log is written, when the
+            application is initialized.
+            </summary>
+            <param name="dirPath">Path to directory where log file will reside.</param>
+            <param name="fileName">Name of log file.</param>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.LinuxEventWriter.IsEnabled">
+            <summary>
+            Returns True if running on Linux Consumption or Dedicated. False otherwise.
+            </summary>
+            <returns>True if running on Linux Consumption or Dedicated. False otherwise.</returns>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.LinuxEventWriter.WriteToFile(System.String)">
+            <summary>
+            Writes a line asynchronously to a file.
+            We use this instead of an ILogger because
+            we expect to write often and thus need asynchronous
+            writing, which ILogger explicitely designs against.
+            </summary>
+            <param name="line">Line to write to log-file.</param>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.LinuxEventWriter.ConsoleWriter(System.String)">
+            <summary>
+            Writes a line asynchronously to the console.
+            It adds a prefix to the line, so it can get picked up
+            by the regex monitoring agent.
+            </summary>
+            <param name="line">Line to write to console.</param>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.LinuxEventWriter.Write(System.String)">
+            <summary>
+            Writes a line asynchronously to either the console
+            (linux consumption) or a log file (linux dedicated).
+            </summary>
+            <param name="line">Line to write.</param>
+        </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.OutOfProcOrchestrationShim">
             <summary>
             Not intended for public consumption.
@@ -2907,6 +2994,11 @@
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.TaskActivityShim">
             <summary>
             Task activity implementation which delegates the implementation to a function.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Azure.WebJobs.Extensions.DurableTask.TaskActivityShim.taskEventId">
+            <summary>
+            The DTFx-generated, auto-incrementing ID that uniquely identifies this activity function execution.
             </summary>
         </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.TaskCommonShim">
@@ -3725,6 +3817,56 @@
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.StatusResponsePayload.HistoryEvents">
             <summary>
             JSON object representing history for an orchestration execution.
+            </summary>
+        </member>
+        <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.SystemEnvironment">
+            <summary>
+            Provides utilities for inspecting the process enviroment and platform, currently mostly
+            for checking if we are running on a Linux enviroment or not.
+            </summary>
+            Mostly duplicated functionality from:
+            https://github.com/Azure/azure-functions-host/blob/dev/src/WebJobs.Script/Environment/EnvironmentExtensions.cs
+            We should consider abstracting away this functionality from both repos, to avoid code duplication.
+        </member>
+        <member name="F:Microsoft.Azure.WebJobs.Extensions.DurableTask.SystemEnvironment.PrivInstance">
+            <summary>
+            Private and lazily constructed singleton instance of SystemEnvironment.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.SystemEnvironment.#ctor">
+            <summary>
+            Private constructor, clients should obtain an instance via the `Instance` static attribute.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.SystemEnvironment.Instance">
+            <summary>
+            The singleton instance of SystemEnvironment, no explicit constructor is exported.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.SystemEnvironment.IsLinuxConsumtpion">
+            <summary>
+            Gets a value indicating whether the application is running in a Linux Consumption (dynamic)
+            App Service environment.
+            </summary>
+            <returns>true if running in a Linux Consumption App Service app; otherwise, false.</returns>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.SystemEnvironment.IsLinuxDedicated">
+            <summary>
+            Gets a value indicating whether the application is running in a Linux App Service
+            environment (Dedicated Linux).
+            </summary>
+            <returns>true if running in a Linux Azure App Service; otherwise, false.</returns>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.SystemEnvironment.IsAppService">
+            <summary>
+            Gets a value indicating whether the application is running in App Service
+            (Windows Consumption, Windows Dedicated or Linux Dedicated).
+            </summary>
+            <returns>true if running in a Azure App Service; otherwise, false.</returns>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.SystemEnvironment.GetEnvironmentVariable(System.String)">
+            <summary>
+            Retrieves the value from an environment variable from the current process.
             </summary>
         </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.ActivityTriggerAttribute">

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
@@ -1780,6 +1780,18 @@
             The state as either a <c>JToken</c> or <c>null</c> if no state was provided.
             </value>
         </member>
+        <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableFunctionsLinuxLog">
+            <summary>
+            A string-serializable collection of data representing a durable event
+            to be logged in Linux.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableFunctionsLinuxLog.AsString(System.Collections.Generic.Dictionary{System.String,System.String})">
+            <summary>
+            Turns Log into a string.
+            </summary>
+            <returns>String-representation of the log.</returns>
+        </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableHttpRequest">
             <summary>
             Request used to make an HTTP call through Durable Functions.
@@ -2020,6 +2032,30 @@
             <param name="name">The name of the activity to return.</param>
             <param name="version">Not used.</param>
             <returns>An activity shim that delegates execution to an activity function.</returns>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.ActivityMiddleware(DurableTask.Core.Middleware.DispatchMiddlewareContext,System.Func{System.Threading.Tasks.Task})">
+            <summary>
+            This DTFx activity middleware allows us to add context to the activity function shim
+            before it actually starts running.
+            </summary>
+            <param name="dispatchContext">A property bag containing useful DTFx context.</param>
+            <param name="next">The handler for running the next middleware in the pipeline.</param>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.OrchestrationMiddleware(DurableTask.Core.Middleware.DispatchMiddlewareContext,System.Func{System.Threading.Tasks.Task})">
+            <summary>
+            This DTFx orchestration middleware allows us to initialize Durable Functions-specific context
+            and make the execution happen in a way that plays nice with the Azure Functions execution pipeline.
+            </summary>
+            <param name="dispatchContext">A property bag containing useful DTFx context.</param>
+            <param name="next">The handler for running the next middleware in the pipeline.</param>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.EntityMiddleware(DurableTask.Core.Middleware.DispatchMiddlewareContext,System.Func{System.Threading.Tasks.Task})">
+            <summary>
+            This DTFx orchestration middleware (for entities) allows us to add context and set state
+            to the entity shim orchestration before it starts executing the actual entity logic.
+            </summary>
+            <param name="dispatchContext">A property bag containing useful DTFx context.</param>
+            <param name="next">The handler for running the next middleware in the pipeline.</param>
         </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.GetClient(Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClientAttribute)">
             <summary>
@@ -2937,6 +2973,57 @@
             </summary>
             <returns>A <see cref="T:System.Threading.Tasks.Task`1"/> representing the result of the asynchronous operation.</returns>
         </member>
+        <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.LinuxEventWriter">
+            <summary>
+            Produces Telemetry for the Linux App Service offerings.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.LinuxEventWriter.FlagLinuxConsumption">
+            <summary>
+            Indicates that logs should be written for Linux Consumption.
+            Should be called before the first log is written, when the
+            application is initialized.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.LinuxEventWriter.FlagLinuxDedicated(System.String,System.String)">
+            <summary>
+            Indicates that logs should be written for Linux Dedicated.
+            Should be called before the first log is written, when the
+            application is initialized.
+            </summary>
+            <param name="dirPath">Path to directory where log file will reside.</param>
+            <param name="fileName">Name of log file.</param>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.LinuxEventWriter.IsEnabled">
+            <summary>
+            Returns True if running on Linux Consumption or Dedicated. False otherwise.
+            </summary>
+            <returns>True if running on Linux Consumption or Dedicated. False otherwise.</returns>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.LinuxEventWriter.WriteToFile(System.String)">
+            <summary>
+            Writes a line asynchronously to a file.
+            We use this instead of an ILogger because
+            we expect to write often and thus need asynchronous
+            writing, which ILogger explicitely designs against.
+            </summary>
+            <param name="line">Line to write to log-file.</param>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.LinuxEventWriter.ConsoleWriter(System.String)">
+            <summary>
+            Writes a line asynchronously to the console.
+            It adds a prefix to the line, so it can get picked up
+            by the regex monitoring agent.
+            </summary>
+            <param name="line">Line to write to console.</param>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.LinuxEventWriter.Write(System.String)">
+            <summary>
+            Writes a line asynchronously to either the console
+            (linux consumption) or a log file (linux dedicated).
+            </summary>
+            <param name="line">Line to write.</param>
+        </member>
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskTriggerMetrics.PartitionCount">
             <summary>
             The number of partitions in the task hub.
@@ -2980,6 +3067,11 @@
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.TaskActivityShim">
             <summary>
             Task activity implementation which delegates the implementation to a function.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Azure.WebJobs.Extensions.DurableTask.TaskActivityShim.taskEventId">
+            <summary>
+            The DTFx-generated, auto-incrementing ID that uniquely identifies this activity function execution.
             </summary>
         </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.TaskCommonShim">
@@ -3798,6 +3890,56 @@
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.StatusResponsePayload.HistoryEvents">
             <summary>
             JSON object representing history for an orchestration execution.
+            </summary>
+        </member>
+        <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.SystemEnvironment">
+            <summary>
+            Provides utilities for inspecting the process enviroment and platform, currently mostly
+            for checking if we are running on a Linux enviroment or not.
+            </summary>
+            Mostly duplicated functionality from:
+            https://github.com/Azure/azure-functions-host/blob/dev/src/WebJobs.Script/Environment/EnvironmentExtensions.cs
+            We should consider abstracting away this functionality from both repos, to avoid code duplication.
+        </member>
+        <member name="F:Microsoft.Azure.WebJobs.Extensions.DurableTask.SystemEnvironment.PrivInstance">
+            <summary>
+            Private and lazily constructed singleton instance of SystemEnvironment.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.SystemEnvironment.#ctor">
+            <summary>
+            Private constructor, clients should obtain an instance via the `Instance` static attribute.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.SystemEnvironment.Instance">
+            <summary>
+            The singleton instance of SystemEnvironment, no explicit constructor is exported.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.SystemEnvironment.IsLinuxConsumtpion">
+            <summary>
+            Gets a value indicating whether the application is running in a Linux Consumption (dynamic)
+            App Service environment.
+            </summary>
+            <returns>true if running in a Linux Consumption App Service app; otherwise, false.</returns>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.SystemEnvironment.IsLinuxDedicated">
+            <summary>
+            Gets a value indicating whether the application is running in a Linux App Service
+            environment (Dedicated Linux).
+            </summary>
+            <returns>true if running in a Linux Azure App Service; otherwise, false.</returns>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.SystemEnvironment.IsAppService">
+            <summary>
+            Gets a value indicating whether the application is running in App Service
+            (Windows Consumption, Windows Dedicated or Linux Dedicated).
+            </summary>
+            <returns>true if running in a Azure App Service; otherwise, false.</returns>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.SystemEnvironment.GetEnvironmentVariable(System.String)">
+            <summary>
+            Retrieves the value from an environment variable from the current process.
             </summary>
         </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.ActivityTriggerAttribute">

--- a/src/WebJobs.Extensions.DurableTask/SystemEnvironment.cs
+++ b/src/WebJobs.Extensions.DurableTask/SystemEnvironment.cs
@@ -1,0 +1,80 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+
+namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
+{
+    /// <summary>
+    /// Provides utilities for inspecting the process enviroment and platform, currently mostly
+    /// for checking if we are running on a Linux enviroment or not.
+    /// </summary>
+    /// Mostly duplicated functionality from:
+    /// https://github.com/Azure/azure-functions-host/blob/dev/src/WebJobs.Script/Environment/EnvironmentExtensions.cs
+    /// We should consider abstracting away this functionality from both repos, to avoid code duplication.
+    internal class SystemEnvironment
+    {
+        // Enviroment variable names. Consider moving these to a separate file if they get too big.
+        // Duplicated from: https://github.com/Azure/azure-functions-host/blob/dev/src/WebJobs.Script/Environment/EnvironmentSettingNames.cs
+        // `FunctionsLogsMountPath` is set dynamically by the platform when it is safe to specialize the host instance (eg. file system is ready)
+        public const string ContainerName = "CONTAINER_NAME";
+        public const string AzureWebsiteInstanceId = "WEBSITE_INSTANCE_ID";
+        public const string FunctionsLogsMountPath = "FUNCTIONS_LOGS_MOUNT_PATH";
+
+        /// <summary>
+        /// Private and lazily constructed singleton instance of SystemEnvironment.
+        /// </summary>
+        private static readonly Lazy<SystemEnvironment> PrivInstance =
+            new Lazy<SystemEnvironment>(() => new SystemEnvironment());
+
+        /// <summary>
+        /// Private constructor, clients should obtain an instance via the `Instance` static attribute.
+        /// </summary>
+        private SystemEnvironment()
+        {
+        }
+
+        /// <summary>
+        /// The singleton instance of SystemEnvironment, no explicit constructor is exported.
+        /// </summary>
+        public static SystemEnvironment Instance => PrivInstance.Value;
+
+        /// <summary>
+        /// Gets a value indicating whether the application is running in a Linux Consumption (dynamic)
+        /// App Service environment.
+        /// </summary>
+        /// <returns>true if running in a Linux Consumption App Service app; otherwise, false.</returns>
+        public bool IsLinuxConsumtpion()
+        {
+            return !this.IsAppService() && !string.IsNullOrEmpty(this.GetEnvironmentVariable(ContainerName));
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether the application is running in a Linux App Service
+        /// environment (Dedicated Linux).
+        /// </summary>
+        /// <returns>true if running in a Linux Azure App Service; otherwise, false.</returns>
+        public bool IsLinuxDedicated()
+        {
+            return this.IsAppService() && !string.IsNullOrEmpty(this.GetEnvironmentVariable(FunctionsLogsMountPath));
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether the application is running in App Service
+        /// (Windows Consumption, Windows Dedicated or Linux Dedicated).
+        /// </summary>
+        /// <returns>true if running in a Azure App Service; otherwise, false.</returns>
+        private bool IsAppService()
+        {
+            return !string.IsNullOrEmpty(this.GetEnvironmentVariable(AzureWebsiteInstanceId));
+        }
+
+        /// <summary>
+        /// Retrieves the value from an environment variable from the current process.
+        /// </summary>
+        public string GetEnvironmentVariable(string name)
+        {
+            return Environment.GetEnvironmentVariable(name);
+        }
+    }
+}

--- a/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
+++ b/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
@@ -77,6 +77,7 @@
     <PackageReference Include="Microsoft.Azure.DurableTask.Core" Version="2.2.5" />
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.0.3" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers" Version="0.2.3" />
+    <PackageReference Include="System.IO.Abstractions" Version="11.0.4" />
   </ItemGroup>
 
   <!-- NuGet Publishing Metadata -->


### PR DESCRIPTION
**Do not merge, this PR is here for discussion**

### Summary and Intent
This PR contains a naive first-attempt at enabling telemetry to be forwarded to Kusto in Azure's Linux offerings in App Service. This PR is by no means the _right_ way to implement this and so my hope is to use it as a way to communicate what it takes to write telemetry in our Linux servers and to use that to design a cleaner, and more robust, alternative.

### How to produce telemetry in the App Service Linux instances

#### Linux Dedicated
In Linux Dedicated, we write our logs to the file `/var/log/functionsLogs/durableevents.log`. A background process monitors changes to this file and, informed by the configuration we made in that codebase, those logs get redirected to Kusto. So really the job on the Durable Functions - side of things is fairly easy: _write a structured log to the specified file every time we want to emit a telemetry event_. Every line in  `/var/log/functionsLogs/durableevents.log` needs be parseable by a regular expression, which is available in the azure-internal changes we've made, and our code needs to produce new lines where the fields are ordered as per the regular expression's expectations. 

### Linux Consumption
The story is rather similar for Linux Consumption. The **only** difference is that, instead of writing to a file, we write our logs to `STDOUT` and provide a unique prefix to our logged lines which tells Azure what kind of log this is and, therefore, to which Kusto table to send it to.

### Problem Areas with the code

Our events can contain many kinds of fields: over 20 if I'm not mistaken. This means that it is not easy to elegantly generate the regex-parseable string that Azure expects. Currently, my "solution" is to dynamically populate a `DurableFunctionsLinuxLog` object, which exports a public dictionary that the object-user can populate by mapping a field (e.g. `FunctionName`) to its value (e.g. `DavidsFunction`), and then to produce the regex-parseable string via a `AsString` method.

This method implementation also bothers me because, in order to preserve the ordering of fields, I need to create this large array of strings (the fields) and use their position in the array to enforce the order in which values are written to the log-string.

Finally, this approach greatly expands the amount of work that the `ETWEventSource` class needs to do, as now we need to manually populate that dictionary.

### Performance
As it's been mentioned before, Durable Functions Telemetry is "quite chatty" and so I/O operations will probably need to be batched for performance reasons. The `azure-functions-host` codebase implemented a batching strategy for Linux Dedicated in this [file](https://github.com/Azure/azure-functions-host/blob/35cf323fa3464a08b410a518bcab006e801301fe/src/WebJobs.Script.WebHost/Diagnostics/LinuxAppServiceFileLogger.cs). There seem to be many hand-tuned parameters in it and so, for the sake of making progress, I just borrowed it directly to our codebase and called it `LinuxDedicatedLogger`. I've intentionally left it mostly un-modified because we may want to understand it better, and "make it our own". 

We currently do not have a "batching" strategy for Linux Consumption. There may already be one in `azure-functions-host` as well, but I have not seen it yet.

As an aside, the comments in this PR currently claim that I'm writing asynchronously to the console or to the log-file, but this is not the case yet. Again, this is just a naive _first_ attempt.

### On propagating this to DTFx
To enable Telemetry at the DTFx level, we'll need similar changes. In my opinion, once we design a clean solution, we should **move** these classes and their initialization to DTFx and simply export them to the extension (this repo) so that they can be used.

### A potential clean solution
At its core, the problem here is that `EventSource` is not natively supported at the Azure-level in its Linux offerings, so we have to do all this manual work that needs to be replicated at every `EventSource` subclass. 

So, in my mind, an ideal solution would be to create a drop-in replacement for `EventSource`. This replacement would be a  **subclass** of `EventSource` named, say, `MultiPlatformEventSource` which, on a windows machine, would simply act as `EventSource` (its parent) would. Otherwise, it would _do the right thing_ and print either to the console or write to the log file. Afterwards, all we'd need to enable Linux Telemetry for us, or for any other project, would be to change all `EventSource` inheritors to inherit from `MultiPlatformEventSource`. It'd be _like magic_.

To figure out what to print in `MultiPlatformEventSource`, we could leverage **reflection** on the parameter names of the `EventSource` method that's getting called and use that to, in the worst case scenario, generate the log-line via our current `DurableFunctionsLinuxLog`-based strategy. 

This is what I originally tried to do, but reflection is hard, and I'm under the impression that it is not very efficient in C#, which would defeat the purpose.


Please let me know your thoughts! Finally, another friendly reminder that this PR is deliberately naive because the time-pressing part was to make the Azure-internal changes. Thanks!