### PR TITLE
Updated DurableActivityContext GetInputAsJson to handle TypeNameHandling All

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableActivityContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableActivityContext.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
                 if (objectArray?.Length != 1)
                     {
-                        throw new ArgumentException("The serialized input is expected to be a JSON array with one element.");
+                        throw new ArgumentException("The serialized input is expected to be an object array with one element.");
                     }
 
                 var token = JToken.Parse(this.messageDataConverter.Serialize(objectArray[0]));

--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableActivityContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableActivityContext.cs
@@ -55,30 +55,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         {
             if (this.serializedInput != null && this.parsedJsonInput == null)
             {
-                if (this.messageDataConverter.JsonSettings.TypeNameHandling == TypeNameHandling.All)
-                {
-                    var objectArray = this.messageDataConverter.Deserialize<object[]>(this.serializedInput);
+                var objectArray = this.messageDataConverter.Deserialize<object[]>(this.serializedInput);
 
-                    if (objectArray?.Length != 1)
+                if (objectArray?.Length != 1)
                     {
                         throw new ArgumentException("The serialized input is expected to be a JSON array with one element.");
                     }
 
-                    var token = JToken.Parse(this.messageDataConverter.Serialize(objectArray[0]));
+                var token = JToken.Parse(this.messageDataConverter.Serialize(objectArray[0]));
 
-                    this.parsedJsonInput = token;
-                }
-                else
-                {
-                    JArray array = JArray.Parse(this.serializedInput);
-
-                    if (array?.Count != 1)
-                    {
-                        throw new ArgumentException("The serialized input is expected to be a JSON array with one element.");
-                    }
-
-                    this.parsedJsonInput = array[0];
-                }
+                this.parsedJsonInput = token;
             }
 
             return this.parsedJsonInput;

--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableActivityContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableActivityContext.cs
@@ -55,13 +55,30 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         {
             if (this.serializedInput != null && this.parsedJsonInput == null)
             {
-                JArray array = JArray.Parse(this.serializedInput);
-                if (array?.Count != 1)
+                if (this.messageDataConverter.JsonSettings.TypeNameHandling == TypeNameHandling.All)
                 {
-                    throw new ArgumentException("The serialized input is expected to be a JSON array with one element.");
-                }
+                    var objectArray = this.messageDataConverter.Deserialize<object[]>(this.serializedInput);
 
-                this.parsedJsonInput = array[0];
+                    if (objectArray?.Length != 1)
+                    {
+                        throw new ArgumentException("The serialized input is expected to be a JSON array with one element.");
+                    }
+
+                    var token = JToken.Parse(this.messageDataConverter.Serialize(objectArray[0]));
+
+                    this.parsedJsonInput = token;
+                }
+                else
+                {
+                    JArray array = JArray.Parse(this.serializedInput);
+
+                    if (array?.Count != 1)
+                    {
+                        throw new ArgumentException("The serialized input is expected to be a JSON array with one element.");
+                    }
+
+                    this.parsedJsonInput = array[0];
+                }
             }
 
             return this.parsedJsonInput;

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net461.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net461.xml
@@ -1999,6 +1999,30 @@
             <param name="version">Not used.</param>
             <returns>An activity shim that delegates execution to an activity function.</returns>
         </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.ActivityMiddleware(DurableTask.Core.Middleware.DispatchMiddlewareContext,System.Func{System.Threading.Tasks.Task})">
+            <summary>
+            This DTFx activity middleware allows us to add context to the activity function shim
+            before it actually starts running.
+            </summary>
+            <param name="dispatchContext">A property bag containing useful DTFx context.</param>
+            <param name="next">The handler for running the next middleware in the pipeline.</param>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.OrchestrationMiddleware(DurableTask.Core.Middleware.DispatchMiddlewareContext,System.Func{System.Threading.Tasks.Task})">
+            <summary>
+            This DTFx orchestration middleware allows us to initialize Durable Functions-specific context
+            and make the execution happen in a way that plays nice with the Azure Functions execution pipeline.
+            </summary>
+            <param name="dispatchContext">A property bag containing useful DTFx context.</param>
+            <param name="next">The handler for running the next middleware in the pipeline.</param>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.EntityMiddleware(DurableTask.Core.Middleware.DispatchMiddlewareContext,System.Func{System.Threading.Tasks.Task})">
+            <summary>
+            This DTFx orchestration middleware (for entities) allows us to add context and set state
+            to the entity shim orchestration before it starts executing the actual entity logic.
+            </summary>
+            <param name="dispatchContext">A property bag containing useful DTFx context.</param>
+            <param name="next">The handler for running the next middleware in the pipeline.</param>
+        </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.GetClient(Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClientAttribute)">
             <summary>
             Gets a <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableClient"/> using configuration from a <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClientAttribute"/> instance.
@@ -2907,6 +2931,11 @@
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.TaskActivityShim">
             <summary>
             Task activity implementation which delegates the implementation to a function.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Azure.WebJobs.Extensions.DurableTask.TaskActivityShim.taskEventId">
+            <summary>
+            The DTFx-generated, auto-incrementing ID that uniquely identifies this activity function execution.
             </summary>
         </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.TaskCommonShim">

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
@@ -2021,6 +2021,30 @@
             <param name="version">Not used.</param>
             <returns>An activity shim that delegates execution to an activity function.</returns>
         </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.ActivityMiddleware(DurableTask.Core.Middleware.DispatchMiddlewareContext,System.Func{System.Threading.Tasks.Task})">
+            <summary>
+            This DTFx activity middleware allows us to add context to the activity function shim
+            before it actually starts running.
+            </summary>
+            <param name="dispatchContext">A property bag containing useful DTFx context.</param>
+            <param name="next">The handler for running the next middleware in the pipeline.</param>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.OrchestrationMiddleware(DurableTask.Core.Middleware.DispatchMiddlewareContext,System.Func{System.Threading.Tasks.Task})">
+            <summary>
+            This DTFx orchestration middleware allows us to initialize Durable Functions-specific context
+            and make the execution happen in a way that plays nice with the Azure Functions execution pipeline.
+            </summary>
+            <param name="dispatchContext">A property bag containing useful DTFx context.</param>
+            <param name="next">The handler for running the next middleware in the pipeline.</param>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.EntityMiddleware(DurableTask.Core.Middleware.DispatchMiddlewareContext,System.Func{System.Threading.Tasks.Task})">
+            <summary>
+            This DTFx orchestration middleware (for entities) allows us to add context and set state
+            to the entity shim orchestration before it starts executing the actual entity logic.
+            </summary>
+            <param name="dispatchContext">A property bag containing useful DTFx context.</param>
+            <param name="next">The handler for running the next middleware in the pipeline.</param>
+        </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.GetClient(Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClientAttribute)">
             <summary>
             Gets a <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableClient"/> using configuration from a <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClientAttribute"/> instance.
@@ -2980,6 +3004,11 @@
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.TaskActivityShim">
             <summary>
             Task activity implementation which delegates the implementation to a function.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Azure.WebJobs.Extensions.DurableTask.TaskActivityShim.taskEventId">
+            <summary>
+            The DTFx-generated, auto-incrementing ID that uniquely identifies this activity function execution.
             </summary>
         </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.TaskCommonShim">

--- a/test/Common/DurableTaskEndToEndTests.cs
+++ b/test/Common/DurableTaskEndToEndTests.cs
@@ -4467,7 +4467,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         {
             string[] orchestratorFunctionNames =
             {
-                nameof(TestOrchestrations.SayHelloInline),
+                nameof(TestOrchestrations.SayHelloWithActivity),
             };
 
             using (var host = TestHelpers.GetJobHost(

--- a/test/Common/DurableTaskEndToEndTests.cs
+++ b/test/Common/DurableTaskEndToEndTests.cs
@@ -4463,6 +4463,34 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
         [Fact]
         [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public async Task CustomSerializerSettings_TypeNameHandlingAll()
+        {
+            string[] orchestratorFunctionNames =
+            {
+                nameof(TestOrchestrations.SayHelloInline),
+            };
+
+            using (var host = TestHelpers.GetJobHost(
+                this.loggerProvider,
+                nameof(this.CustomIMessageSerializerSettingsFactory),
+                true,
+                serializerSettings: new CustomTypeNameHandlingSettings()))
+            {
+                await host.StartAsync();
+
+                var client = await host.StartOrchestratorAsync(orchestratorFunctionNames[0], "World", this.output);
+                var status = await client.WaitForCompletionAsync(this.output);
+
+                Assert.Equal(OrchestrationRuntimeStatus.Completed, status?.RuntimeStatus);
+                Assert.Equal("World", status?.Input);
+                Assert.Equal("Hello, World!", status?.Output);
+
+                await host.StopAsync();
+            }
+        }
+
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
         public async Task DefaultIMessageSerializerSettingsFactory()
         {
             string[] orchestratorFunctionNames =
@@ -4741,6 +4769,18 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 serializer.Converters.Add(new StringEnumConverter());
 
                 return serializer;
+            }
+        }
+
+        // JsonSerializerSettings with TypeNameHandling.All
+        private class CustomTypeNameHandlingSettings : IMessageSerializerSettingsFactory
+        {
+            public JsonSerializerSettings CreateJsonSerializerSettings()
+            {
+                return new JsonSerializerSettings()
+                {
+                    TypeNameHandling = TypeNameHandling.All,
+                };
             }
         }
     }


### PR DESCRIPTION
resolves #1389 

When the custom setting TypeNameHandling.All is used, GetInputAsJson would throw an exception when attempting to parse the Json to a JArray. This fix adds a check to handle that case.