### PR TITLE
DurableHttpRequest Content exception during location polling

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableOrchestrationContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableOrchestrationContext.cs
@@ -292,7 +292,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 method: HttpMethod.Get,
                 uri: new Uri(locationUri),
                 headers: durableHttpRequest.Headers,
-                content: durableHttpRequest.Content,
                 tokenSource: durableHttpRequest.TokenSource);
 
             // Do not copy over the x-functions-key header, as in many cases, the


### PR DESCRIPTION
This change resolves #1344 . The location polling request is a GET request, so removing the content should be fine.