### PR TITLE
Swapping Microsoft.Azure.Services.AppAuthentication nuget dependency for Azure.Identity

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/ManagedIdentityTokenSource.cs
+++ b/src/WebJobs.Extensions.DurableTask/ManagedIdentityTokenSource.cs
@@ -3,7 +3,8 @@
 
 using System;
 using System.Threading.Tasks;
-using Microsoft.Azure.Services.AppAuthentication;
+using Azure.Core;
+using Azure.Identity;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 
@@ -36,8 +37,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// <inheritdoc/>
         public async Task<string> GetTokenAsync()
         {
-            var azureServiceTokenProvider = new AzureServiceTokenProvider();
-            string accessToken = await azureServiceTokenProvider.GetAccessTokenAsync(this.Resource);
+            var scopes = new string[] { this.Resource };
+            TokenRequestContext context = new TokenRequestContext(scopes);
+
+            ManagedIdentityCredential credential = new ManagedIdentityCredential();
+            AccessToken token = await credential.GetTokenAsync(context);
+            string accessToken = token.Token;
+
             return accessToken;
         }
     }

--- a/src/WebJobs.Extensions.DurableTask/ManagedIdentityTokenSource.cs
+++ b/src/WebJobs.Extensions.DurableTask/ManagedIdentityTokenSource.cs
@@ -5,7 +5,6 @@ using System;
 using System.Threading.Tasks;
 using Azure.Core;
 using Azure.Identity;
-using Microsoft.Azure.Services.AppAuthentication;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 
@@ -38,7 +37,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// <inheritdoc/>
         public async Task<string> GetTokenAsync()
         {
-
             var scopes = new string[] { this.Resource };
             TokenRequestContext context = new TokenRequestContext(scopes);
 

--- a/src/WebJobs.Extensions.DurableTask/ManagedIdentityTokenSource.cs
+++ b/src/WebJobs.Extensions.DurableTask/ManagedIdentityTokenSource.cs
@@ -5,6 +5,7 @@ using System;
 using System.Threading.Tasks;
 using Azure.Core;
 using Azure.Identity;
+using Microsoft.Azure.Services.AppAuthentication;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 
@@ -37,12 +38,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// <inheritdoc/>
         public async Task<string> GetTokenAsync()
         {
+
             var scopes = new string[] { this.Resource };
             TokenRequestContext context = new TokenRequestContext(scopes);
 
-            ManagedIdentityCredential credential = new ManagedIdentityCredential();
-            AccessToken token = await credential.GetTokenAsync(context);
-            string accessToken = token.Token;
+            DefaultAzureCredential defaultCredential = new DefaultAzureCredential();
+            AccessToken defaultToken = await defaultCredential.GetTokenAsync(context);
+            string accessToken = defaultToken.Token;
 
             return accessToken;
         }

--- a/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
+++ b/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
@@ -75,8 +75,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage" Version="1.7.6" />
     <PackageReference Include="Microsoft.Azure.DurableTask.Core" Version="2.2.5" />
-    <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.0.3" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers" Version="0.2.3" />
+    <PackageReference Include="Azure.Identity" Version="1.1.1" />
   </ItemGroup>
 
   <!-- NuGet Publishing Metadata -->

--- a/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
+++ b/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
@@ -76,7 +76,7 @@
     <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage" Version="1.7.6" />
     <PackageReference Include="Microsoft.Azure.DurableTask.Core" Version="2.2.5" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers" Version="0.2.3" />
-    <PackageReference Include="Azure.Identity" Version="1.1.1" />
+    <PackageReference Include="Azure.Identity" Version="1.2.0-preview.4" />
   </ItemGroup>
 
   <!-- NuGet Publishing Metadata -->

--- a/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
+++ b/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
@@ -76,7 +76,7 @@
     <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage" Version="1.7.6" />
     <PackageReference Include="Microsoft.Azure.DurableTask.Core" Version="2.2.5" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers" Version="0.2.3" />
-    <PackageReference Include="Azure.Identity" Version="1.2.0-preview.4" />
+    <PackageReference Include="Azure.Identity" Version="1.1.1" />
   </ItemGroup>
 
   <!-- NuGet Publishing Metadata -->


### PR DESCRIPTION
Resolves #1232 by using DefaultAzureCredential from Azure.Identity instead of AzureServiceTokenProvider from Microsoft.Azure.Services.AppAuthentication.