### PR TITLE
DurableHttp test name fix

### DIFF
--- a/test/Common/DurableHttpTests.cs
+++ b/test/Common/DurableHttpTests.cs
@@ -1009,7 +1009,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
             using (ITestHost host = TestHelpers.GetJobHost(
                 this.loggerProvider,
-                nameof(this.DurableHttpAsync_AsynchronousAPI_ReturnsOK200),
+                nameof(this.DurableHttpAsync_Asynchronous_AddsBearerToken),
                 enableExtendedSessions: false,
                 storageProviderType: storageProvider,
                 durableHttpMessageHandler: new DurableHttpMessageHandlerFactory(httpMessageHandler)))


### PR DESCRIPTION
Changing the test name passed to `GetJobHost()` to be accurate for the `DurableHttpAsync_Asynchronous_AddsBearerToken` test.