### PR TITLE
Adding DefaultAzureCredentialOptions to ManagedIdentityTokenSource()

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/DurableHttpRequest.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableHttpRequest.cs
@@ -150,7 +150,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
                         if (!string.IsNullOrEmpty(optionsString))
                         {
-                            DefaultAzureCredentialOptions options = JsonConvert.DeserializeObject<DefaultAzureCredentialOptions>(optionsString);
+                            ManagedIdentityOptions options = JsonConvert.DeserializeObject<ManagedIdentityOptions>(optionsString);
                             return new ManagedIdentityTokenSource(resourceString, options);
                         }
 

--- a/src/WebJobs.Extensions.DurableTask/DurableHttpRequest.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableHttpRequest.cs
@@ -147,28 +147,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     {
                         string resourceString = (string)jsonObject.GetValue("resource", StringComparison.Ordinal);
 
-                        if (jsonObject.TryGetValue("options", out JToken optionsValue))
+                        if (jsonObject.TryGetValue("options", out JToken optionsToken))
                         {
-                            JObject optionsJObject = (JObject)optionsValue;
-                            string authorityHostValue = (string)optionsJObject.GetValue("authorityhost", StringComparison.Ordinal);
-                            string tenantIdValue = (string)optionsJObject.GetValue("tenantid", StringComparison.Ordinal);
-
-                            if (!string.IsNullOrEmpty(authorityHostValue) || !string.IsNullOrEmpty(tenantIdValue))
-                            {
-                                ManagedIdentityOptions managedIdentityOptions = new ManagedIdentityOptions();
-
-                                if (!string.IsNullOrEmpty(authorityHostValue))
-                                {
-                                    managedIdentityOptions.AuthorityHost = new Uri(authorityHostValue);
-                                }
-
-                                if (!string.IsNullOrEmpty(tenantIdValue))
-                                {
-                                    managedIdentityOptions.TenantId = tenantIdValue;
-                                }
-
-                                return new ManagedIdentityTokenSource(resourceString, managedIdentityOptions);
-                            }
+                            ManagedIdentityOptions managedIdentityOptions = optionsToken.ToObject<JObject>().ToObject<ManagedIdentityOptions>();
+                            return new ManagedIdentityTokenSource(resourceString, managedIdentityOptions);
                         }
 
                         return new ManagedIdentityTokenSource(resourceString);
@@ -198,24 +180,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     writer.WritePropertyName("resource");
                     writer.WriteValue(tokenSource.Resource);
 
-                    if (tokenSource.Options != null && ((tokenSource.Options.AuthorityHost != null) || (!string.IsNullOrEmpty(tokenSource.Options.TenantId))))
+                    if (tokenSource.Options != null)
                     {
                         writer.WritePropertyName("options");
-                        writer.WriteStartObject();
-
-                        if (tokenSource.Options.AuthorityHost != null)
-                        {
-                            writer.WritePropertyName("authorityhost");
-                            writer.WriteValue(tokenSource.Options.AuthorityHost);
-                        }
-
-                        if (!string.IsNullOrEmpty(tokenSource.Options.TenantId))
-                        {
-                            writer.WritePropertyName("tenantid");
-                            writer.WriteValue(tokenSource.Options.TenantId);
-                        }
-
-                        writer.WriteEndObject();
+                        writer.WriteRawValue(JsonConvert.SerializeObject(tokenSource.Options));
                     }
 
                     writer.WriteEndObject();

--- a/src/WebJobs.Extensions.DurableTask/DurableHttpRequest.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableHttpRequest.cs
@@ -146,7 +146,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                         tokenSourceKind == TokenSourceType.AzureManagedIdentity)
                     {
                         string resourceString = (string)jsonObject.GetValue("resource", StringComparison.Ordinal);
-                        string optionsString = (string)jsonObject.GetValue("defaultazurecredentialoptions", StringComparison.Ordinal);
+                        string optionsString = (string)jsonObject.GetValue("options", StringComparison.Ordinal);
 
                         if (!string.IsNullOrEmpty(optionsString))
                         {
@@ -180,7 +180,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     writer.WriteValue(TokenSourceType.AzureManagedIdentity.ToString());
                     writer.WritePropertyName("resource");
                     writer.WriteValue(tokenSource.Resource);
-                    writer.WritePropertyName("defaultazurecredentialoptions");
+                    writer.WritePropertyName("options");
                     writer.WriteValue(JsonConvert.SerializeObject(tokenSource.Options));
                     writer.WriteEndObject();
                 }

--- a/src/WebJobs.Extensions.DurableTask/ITokenSource.cs
+++ b/src/WebJobs.Extensions.DurableTask/ITokenSource.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System.Threading.Tasks;
-using Azure.Identity;
 
 namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 {

--- a/src/WebJobs.Extensions.DurableTask/ITokenSource.cs
+++ b/src/WebJobs.Extensions.DurableTask/ITokenSource.cs
@@ -14,8 +14,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// <summary>
         /// Gets a token for a resource.
         /// </summary>
-        /// <param name="options">azure credential options that the user can configure when authenticating.</param>
         /// <returns>A <see cref="Task{TResult}"/> representing the result of the asynchronous operation.</returns>
-        Task<string> GetTokenAsync(DefaultAzureCredentialOptions options = null);
+        Task<string> GetTokenAsync();
     }
 }

--- a/src/WebJobs.Extensions.DurableTask/ITokenSource.cs
+++ b/src/WebJobs.Extensions.DurableTask/ITokenSource.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System.Threading.Tasks;
+using Azure.Identity;
 
 namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 {
@@ -13,7 +14,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// <summary>
         /// Gets a token for a resource.
         /// </summary>
+        /// <param name="options">azure credential options that the user can configure when authenticating.</param>
         /// <returns>A <see cref="Task{TResult}"/> representing the result of the asynchronous operation.</returns>
-        Task<string> GetTokenAsync();
+        Task<string> GetTokenAsync(DefaultAzureCredentialOptions options = null);
     }
 }

--- a/src/WebJobs.Extensions.DurableTask/ManagedIdentityOptions.cs
+++ b/src/WebJobs.Extensions.DurableTask/ManagedIdentityOptions.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+using Newtonsoft.Json;
+
+namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
+{
+    /// <summary>
+    /// Configuration options for Managed Identity.
+    /// </summary>
+    public class ManagedIdentityOptions
+    {
+       /// <summary>
+        /// Initializes a new instance of the <see cref="ManagedIdentityOptions"/> class.
+        /// </summary>
+        /// <param name="authorityHost">The host of the Azure Active Directory authority.</param>
+        /// <param name="tenantId">The tenant id of the user to authenticate.</param>
+        public ManagedIdentityOptions(Uri authorityHost = null, string tenantId = null)
+        {
+            this.AuthorityHost = authorityHost;
+            this.TenantId = tenantId;
+        }
+
+        /// <summary>
+        /// The host of the Azure Active Directory authority. The default is https://login.microsoftonline.com/.
+        /// </summary>
+        [JsonProperty("authorityhost")]
+        public Uri AuthorityHost { get; set; }
+
+        /// <summary>
+        /// The tenant id of the user to authenticate.
+        /// </summary>
+        [JsonProperty("tenantid")]
+        public string TenantId { get; set; }
+    }
+}

--- a/src/WebJobs.Extensions.DurableTask/ManagedIdentityTokenSource.cs
+++ b/src/WebJobs.Extensions.DurableTask/ManagedIdentityTokenSource.cs
@@ -35,12 +35,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         public string Resource { get; }
 
         /// <inheritdoc/>
-        public async Task<string> GetTokenAsync()
+        public async Task<string> GetTokenAsync(DefaultAzureCredentialOptions options = null)
         {
             var scopes = new string[] { this.Resource };
             TokenRequestContext context = new TokenRequestContext(scopes);
 
-            DefaultAzureCredential defaultCredential = new DefaultAzureCredential();
+            DefaultAzureCredential defaultCredential = new DefaultAzureCredential(options);
             AccessToken defaultToken = await defaultCredential.GetTokenAsync(context);
             string accessToken = defaultToken.Token;
 

--- a/src/WebJobs.Extensions.DurableTask/ManagedIdentityTokenSource.cs
+++ b/src/WebJobs.Extensions.DurableTask/ManagedIdentityTokenSource.cs
@@ -51,24 +51,17 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             DefaultAzureCredential defaultCredential;
             DefaultAzureCredentialOptions defaultAzureCredentialOptions = new DefaultAzureCredentialOptions();
 
-            if (this.Options != null && ((this.Options.AuthorityHost != null) || (!string.IsNullOrEmpty(this.Options.TenantId))))
+            if (this.Options?.AuthorityHost != null)
             {
-                if (this.Options.AuthorityHost != null)
-                {
-                    defaultAzureCredentialOptions.AuthorityHost = this.Options.AuthorityHost;
-                }
-
-                if (!string.IsNullOrEmpty(this.Options.TenantId))
-                {
-                    defaultAzureCredentialOptions.InteractiveBrowserTenantId = this.Options.TenantId;
-                }
-
-                defaultCredential = new DefaultAzureCredential(defaultAzureCredentialOptions);
+                defaultAzureCredentialOptions.AuthorityHost = this.Options.AuthorityHost;
             }
-            else
+
+            if (!string.IsNullOrEmpty(this.Options?.TenantId))
             {
-                defaultCredential = new DefaultAzureCredential();
+                defaultAzureCredentialOptions.InteractiveBrowserTenantId = this.Options.TenantId;
             }
+
+            defaultCredential = this.Options == null ? new DefaultAzureCredential() : new DefaultAzureCredential(defaultAzureCredentialOptions);
 
             AccessToken defaultToken = await defaultCredential.GetTokenAsync(context);
             string accessToken = defaultToken.Token;

--- a/src/WebJobs.Extensions.DurableTask/ManagedIdentityTokenSource.cs
+++ b/src/WebJobs.Extensions.DurableTask/ManagedIdentityTokenSource.cs
@@ -22,9 +22,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// The Azure Active Directory resource identifier of the web API being invoked.
         /// For example, <c>https://management.core.windows.net/</c> or <c>https://graph.microsoft.com/</c>.
         /// </param>
-        public ManagedIdentityTokenSource(string resource)
+        /// <param name="options">azure credential options that the user can configure when authenticating.</param>
+        public ManagedIdentityTokenSource(string resource, DefaultAzureCredentialOptions options = null)
         {
             this.Resource = resource ?? throw new ArgumentNullException(nameof(resource));
+            this.Options = options;
         }
 
         /// <summary>
@@ -34,13 +36,19 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         [JsonProperty("resource")]
         public string Resource { get; }
 
+        /// <summary>
+        /// The azure credential options that a user can configure when authenticating.
+        /// </summary>
+        [JsonProperty("options")]
+        public DefaultAzureCredentialOptions Options { get; }
+
         /// <inheritdoc/>
-        public async Task<string> GetTokenAsync(DefaultAzureCredentialOptions options = null)
+        public async Task<string> GetTokenAsync()
         {
             var scopes = new string[] { this.Resource };
             TokenRequestContext context = new TokenRequestContext(scopes);
 
-            DefaultAzureCredential defaultCredential = new DefaultAzureCredential(options);
+            DefaultAzureCredential defaultCredential = new DefaultAzureCredential(this.Options);
             AccessToken defaultToken = await defaultCredential.GetTokenAsync(context);
             string accessToken = defaultToken.Token;
 

--- a/src/WebJobs.Extensions.DurableTask/ManagedIdentityTokenSource.cs
+++ b/src/WebJobs.Extensions.DurableTask/ManagedIdentityTokenSource.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// The Azure Active Directory resource identifier of the web API being invoked.
         /// For example, <c>https://management.core.windows.net/</c> or <c>https://graph.microsoft.com/</c>.
         /// </param>
-        /// <param name="options">azure credential options that the user can configure when authenticating.</param>
+        /// <param name="options">Optional Azure credential options to use when authenticating.</param>
         public ManagedIdentityTokenSource(string resource, DefaultAzureCredentialOptions options = null)
         {
             this.Resource = resource ?? throw new ArgumentNullException(nameof(resource));
@@ -48,7 +48,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             var scopes = new string[] { this.Resource };
             TokenRequestContext context = new TokenRequestContext(scopes);
 
-            DefaultAzureCredential defaultCredential = new DefaultAzureCredential(this.Options);
+            DefaultAzureCredential defaultCredential = this.Options != null ?
+                new DefaultAzureCredential(this.Options) :
+                new DefaultAzureCredential();
             AccessToken defaultToken = await defaultCredential.GetTokenAsync(context);
             string accessToken = defaultToken.Token;
 

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net461.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net461.xml
@@ -2911,11 +2911,10 @@
             Implementations of this interface can be used to provide authorization tokens for outbound HTTP requests.
             </summary>
         </member>
-        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.ITokenSource.GetTokenAsync(Azure.Identity.DefaultAzureCredentialOptions)">
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.ITokenSource.GetTokenAsync">
             <summary>
             Gets a token for a resource.
             </summary>
-            <param name="options">azure credential options that the user can configure when authenticating.</param>
             <returns>A <see cref="T:System.Threading.Tasks.Task`1"/> representing the result of the asynchronous operation.</returns>
         </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.OutOfProcOrchestrationShim">
@@ -3031,7 +3030,7 @@
             Token Source implementation for Azure Managed Identities.
             </summary>
         </member>
-        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.ManagedIdentityTokenSource.#ctor(System.String)">
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.ManagedIdentityTokenSource.#ctor(System.String,Azure.Identity.DefaultAzureCredentialOptions)">
             <summary>
             Initializes a new instance of the <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.ManagedIdentityTokenSource"/> class.
             </summary>
@@ -3039,6 +3038,7 @@
             The Azure Active Directory resource identifier of the web API being invoked.
             For example, <c>https://management.core.windows.net/</c> or <c>https://graph.microsoft.com/</c>.
             </param>
+            <param name="options">azure credential options that the user can configure when authenticating.</param>
         </member>
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.ManagedIdentityTokenSource.Resource">
             <summary>
@@ -3046,7 +3046,12 @@
             For example, <c>https://management.core.windows.net/</c> or <c>https://graph.microsoft.com/</c>.
             </summary>
         </member>
-        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.ManagedIdentityTokenSource.GetTokenAsync(Azure.Identity.DefaultAzureCredentialOptions)">
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.ManagedIdentityTokenSource.Options">
+            <summary>
+            The azure credential options that a user can configure when authenticating.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.ManagedIdentityTokenSource.GetTokenAsync">
             <inheritdoc/>
         </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.MessagePayloadDataConverter.Serialize(System.Object)">

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net461.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net461.xml
@@ -3025,12 +3025,34 @@
             Task orchestration implementation which delegates the orchestration implementation to a function.
             </summary>
         </member>
+        <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.ManagedIdentityOptions">
+            <summary>
+            Request used to make an HTTP call through Durable Functions.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.ManagedIdentityOptions.#ctor(System.Uri,System.String)">
+            <summary>
+            Initializes a new instance of the <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.ManagedIdentityOptions"/> class.
+            </summary>
+            <param name="authorityHost">The host of the Azure Active Directory authority.</param>
+            <param name="tenantId">The tenant id of the user to authenticate.</param>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.ManagedIdentityOptions.AuthorityHost">
+            <summary>
+            Content passed with the HTTP request made by the Durable Function.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.ManagedIdentityOptions.TenantId">
+            <summary>
+            Content passed with the HTTP request made by the Durable Function.
+            </summary>
+        </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.ManagedIdentityTokenSource">
             <summary>
             Token Source implementation for Azure Managed Identities.
             </summary>
         </member>
-        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.ManagedIdentityTokenSource.#ctor(System.String,Azure.Identity.DefaultAzureCredentialOptions)">
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.ManagedIdentityTokenSource.#ctor(System.String,Microsoft.Azure.WebJobs.Extensions.DurableTask.ManagedIdentityOptions)">
             <summary>
             Initializes a new instance of the <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.ManagedIdentityTokenSource"/> class.
             </summary>

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net461.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net461.xml
@@ -3027,7 +3027,7 @@
         </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.ManagedIdentityOptions">
             <summary>
-            Request used to make an HTTP call through Durable Functions.
+            Configuration options for Managed Identity.
             </summary>
         </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.ManagedIdentityOptions.#ctor(System.Uri,System.String)">
@@ -3039,12 +3039,12 @@
         </member>
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.ManagedIdentityOptions.AuthorityHost">
             <summary>
-            Content passed with the HTTP request made by the Durable Function.
+            The host of the Azure Active Directory authority. The default is https://login.microsoftonline.com/.
             </summary>
         </member>
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.ManagedIdentityOptions.TenantId">
             <summary>
-            Content passed with the HTTP request made by the Durable Function.
+            The tenant id of the user to authenticate.
             </summary>
         </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.ManagedIdentityTokenSource">

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net461.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net461.xml
@@ -3038,7 +3038,7 @@
             The Azure Active Directory resource identifier of the web API being invoked.
             For example, <c>https://management.core.windows.net/</c> or <c>https://graph.microsoft.com/</c>.
             </param>
-            <param name="options">azure credential options that the user can configure when authenticating.</param>
+            <param name="options">Optional Azure credential options to use when authenticating.</param>
         </member>
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.ManagedIdentityTokenSource.Resource">
             <summary>

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net461.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net461.xml
@@ -1999,6 +1999,30 @@
             <param name="version">Not used.</param>
             <returns>An activity shim that delegates execution to an activity function.</returns>
         </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.ActivityMiddleware(DurableTask.Core.Middleware.DispatchMiddlewareContext,System.Func{System.Threading.Tasks.Task})">
+            <summary>
+            This DTFx activity middleware allows us to add context to the activity function shim
+            before it actually starts running.
+            </summary>
+            <param name="dispatchContext">A property bag containing useful DTFx context.</param>
+            <param name="next">The handler for running the next middleware in the pipeline.</param>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.OrchestrationMiddleware(DurableTask.Core.Middleware.DispatchMiddlewareContext,System.Func{System.Threading.Tasks.Task})">
+            <summary>
+            This DTFx orchestration middleware allows us to initialize Durable Functions-specific context
+            and make the execution happen in a way that plays nice with the Azure Functions execution pipeline.
+            </summary>
+            <param name="dispatchContext">A property bag containing useful DTFx context.</param>
+            <param name="next">The handler for running the next middleware in the pipeline.</param>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.EntityMiddleware(DurableTask.Core.Middleware.DispatchMiddlewareContext,System.Func{System.Threading.Tasks.Task})">
+            <summary>
+            This DTFx orchestration middleware (for entities) allows us to add context and set state
+            to the entity shim orchestration before it starts executing the actual entity logic.
+            </summary>
+            <param name="dispatchContext">A property bag containing useful DTFx context.</param>
+            <param name="next">The handler for running the next middleware in the pipeline.</param>
+        </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.GetClient(Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClientAttribute)">
             <summary>
             Gets a <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableClient"/> using configuration from a <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClientAttribute"/> instance.
@@ -2887,10 +2911,11 @@
             Implementations of this interface can be used to provide authorization tokens for outbound HTTP requests.
             </summary>
         </member>
-        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.ITokenSource.GetTokenAsync">
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.ITokenSource.GetTokenAsync(Azure.Identity.DefaultAzureCredentialOptions)">
             <summary>
             Gets a token for a resource.
             </summary>
+            <param name="options">azure credential options that the user can configure when authenticating.</param>
             <returns>A <see cref="T:System.Threading.Tasks.Task`1"/> representing the result of the asynchronous operation.</returns>
         </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.OutOfProcOrchestrationShim">
@@ -2907,6 +2932,11 @@
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.TaskActivityShim">
             <summary>
             Task activity implementation which delegates the implementation to a function.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Azure.WebJobs.Extensions.DurableTask.TaskActivityShim.taskEventId">
+            <summary>
+            The DTFx-generated, auto-incrementing ID that uniquely identifies this activity function execution.
             </summary>
         </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.TaskCommonShim">
@@ -3016,7 +3046,7 @@
             For example, <c>https://management.core.windows.net/</c> or <c>https://graph.microsoft.com/</c>.
             </summary>
         </member>
-        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.ManagedIdentityTokenSource.GetTokenAsync">
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.ManagedIdentityTokenSource.GetTokenAsync(Azure.Identity.DefaultAzureCredentialOptions)">
             <inheritdoc/>
         </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.MessagePayloadDataConverter.Serialize(System.Object)">

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
@@ -3100,7 +3100,7 @@
         </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.ManagedIdentityOptions">
             <summary>
-            Request used to make an HTTP call through Durable Functions.
+            Configuration options for Managed Identity.
             </summary>
         </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.ManagedIdentityOptions.#ctor(System.Uri,System.String)">
@@ -3112,12 +3112,12 @@
         </member>
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.ManagedIdentityOptions.AuthorityHost">
             <summary>
-            Content passed with the HTTP request made by the Durable Function.
+            The host of the Azure Active Directory authority. The default is https://login.microsoftonline.com/.
             </summary>
         </member>
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.ManagedIdentityOptions.TenantId">
             <summary>
-            Content passed with the HTTP request made by the Durable Function.
+            The tenant id of the user to authenticate.
             </summary>
         </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.ManagedIdentityTokenSource">

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
@@ -3111,7 +3111,7 @@
             The Azure Active Directory resource identifier of the web API being invoked.
             For example, <c>https://management.core.windows.net/</c> or <c>https://graph.microsoft.com/</c>.
             </param>
-            <param name="options">azure credential options that the user can configure when authenticating.</param>
+            <param name="options">Optional Azure credential options to use when authenticating.</param>
         </member>
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.ManagedIdentityTokenSource.Resource">
             <summary>

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
@@ -2955,11 +2955,10 @@
             Implementations of this interface can be used to provide authorization tokens for outbound HTTP requests.
             </summary>
         </member>
-        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.ITokenSource.GetTokenAsync(Azure.Identity.DefaultAzureCredentialOptions)">
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.ITokenSource.GetTokenAsync">
             <summary>
             Gets a token for a resource.
             </summary>
-            <param name="options">azure credential options that the user can configure when authenticating.</param>
             <returns>A <see cref="T:System.Threading.Tasks.Task`1"/> representing the result of the asynchronous operation.</returns>
         </member>
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskTriggerMetrics.PartitionCount">
@@ -3104,7 +3103,7 @@
             Token Source implementation for Azure Managed Identities.
             </summary>
         </member>
-        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.ManagedIdentityTokenSource.#ctor(System.String)">
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.ManagedIdentityTokenSource.#ctor(System.String,Azure.Identity.DefaultAzureCredentialOptions)">
             <summary>
             Initializes a new instance of the <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.ManagedIdentityTokenSource"/> class.
             </summary>
@@ -3112,6 +3111,7 @@
             The Azure Active Directory resource identifier of the web API being invoked.
             For example, <c>https://management.core.windows.net/</c> or <c>https://graph.microsoft.com/</c>.
             </param>
+            <param name="options">azure credential options that the user can configure when authenticating.</param>
         </member>
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.ManagedIdentityTokenSource.Resource">
             <summary>
@@ -3119,7 +3119,12 @@
             For example, <c>https://management.core.windows.net/</c> or <c>https://graph.microsoft.com/</c>.
             </summary>
         </member>
-        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.ManagedIdentityTokenSource.GetTokenAsync(Azure.Identity.DefaultAzureCredentialOptions)">
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.ManagedIdentityTokenSource.Options">
+            <summary>
+            The azure credential options that a user can configure when authenticating.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.ManagedIdentityTokenSource.GetTokenAsync">
             <inheritdoc/>
         </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.MessagePayloadDataConverter.Serialize(System.Object)">

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
@@ -3098,12 +3098,34 @@
             Task orchestration implementation which delegates the orchestration implementation to a function.
             </summary>
         </member>
+        <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.ManagedIdentityOptions">
+            <summary>
+            Request used to make an HTTP call through Durable Functions.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.ManagedIdentityOptions.#ctor(System.Uri,System.String)">
+            <summary>
+            Initializes a new instance of the <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.ManagedIdentityOptions"/> class.
+            </summary>
+            <param name="authorityHost">The host of the Azure Active Directory authority.</param>
+            <param name="tenantId">The tenant id of the user to authenticate.</param>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.ManagedIdentityOptions.AuthorityHost">
+            <summary>
+            Content passed with the HTTP request made by the Durable Function.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.ManagedIdentityOptions.TenantId">
+            <summary>
+            Content passed with the HTTP request made by the Durable Function.
+            </summary>
+        </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.ManagedIdentityTokenSource">
             <summary>
             Token Source implementation for Azure Managed Identities.
             </summary>
         </member>
-        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.ManagedIdentityTokenSource.#ctor(System.String,Azure.Identity.DefaultAzureCredentialOptions)">
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.ManagedIdentityTokenSource.#ctor(System.String,Microsoft.Azure.WebJobs.Extensions.DurableTask.ManagedIdentityOptions)">
             <summary>
             Initializes a new instance of the <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.ManagedIdentityTokenSource"/> class.
             </summary>

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
@@ -2021,6 +2021,30 @@
             <param name="version">Not used.</param>
             <returns>An activity shim that delegates execution to an activity function.</returns>
         </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.ActivityMiddleware(DurableTask.Core.Middleware.DispatchMiddlewareContext,System.Func{System.Threading.Tasks.Task})">
+            <summary>
+            This DTFx activity middleware allows us to add context to the activity function shim
+            before it actually starts running.
+            </summary>
+            <param name="dispatchContext">A property bag containing useful DTFx context.</param>
+            <param name="next">The handler for running the next middleware in the pipeline.</param>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.OrchestrationMiddleware(DurableTask.Core.Middleware.DispatchMiddlewareContext,System.Func{System.Threading.Tasks.Task})">
+            <summary>
+            This DTFx orchestration middleware allows us to initialize Durable Functions-specific context
+            and make the execution happen in a way that plays nice with the Azure Functions execution pipeline.
+            </summary>
+            <param name="dispatchContext">A property bag containing useful DTFx context.</param>
+            <param name="next">The handler for running the next middleware in the pipeline.</param>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.EntityMiddleware(DurableTask.Core.Middleware.DispatchMiddlewareContext,System.Func{System.Threading.Tasks.Task})">
+            <summary>
+            This DTFx orchestration middleware (for entities) allows us to add context and set state
+            to the entity shim orchestration before it starts executing the actual entity logic.
+            </summary>
+            <param name="dispatchContext">A property bag containing useful DTFx context.</param>
+            <param name="next">The handler for running the next middleware in the pipeline.</param>
+        </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.GetClient(Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClientAttribute)">
             <summary>
             Gets a <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableClient"/> using configuration from a <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClientAttribute"/> instance.
@@ -2931,10 +2955,11 @@
             Implementations of this interface can be used to provide authorization tokens for outbound HTTP requests.
             </summary>
         </member>
-        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.ITokenSource.GetTokenAsync">
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.ITokenSource.GetTokenAsync(Azure.Identity.DefaultAzureCredentialOptions)">
             <summary>
             Gets a token for a resource.
             </summary>
+            <param name="options">azure credential options that the user can configure when authenticating.</param>
             <returns>A <see cref="T:System.Threading.Tasks.Task`1"/> representing the result of the asynchronous operation.</returns>
         </member>
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskTriggerMetrics.PartitionCount">
@@ -2980,6 +3005,11 @@
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.TaskActivityShim">
             <summary>
             Task activity implementation which delegates the implementation to a function.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Azure.WebJobs.Extensions.DurableTask.TaskActivityShim.taskEventId">
+            <summary>
+            The DTFx-generated, auto-incrementing ID that uniquely identifies this activity function execution.
             </summary>
         </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.TaskCommonShim">
@@ -3089,7 +3119,7 @@
             For example, <c>https://management.core.windows.net/</c> or <c>https://graph.microsoft.com/</c>.
             </summary>
         </member>
-        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.ManagedIdentityTokenSource.GetTokenAsync">
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.ManagedIdentityTokenSource.GetTokenAsync(Azure.Identity.DefaultAzureCredentialOptions)">
             <inheritdoc/>
         </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.MessagePayloadDataConverter.Serialize(System.Object)">

--- a/test/Common/DurableHttpTests.cs
+++ b/test/Common/DurableHttpTests.cs
@@ -1356,7 +1356,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 this.token = token;
             }
 
-            public Task<string> GetTokenAsync(DefaultAzureCredentialOptions options = null)
+            public Task<string> GetTokenAsync()
             {
                 return Task.FromResult(this.token);
             }

--- a/test/Common/DurableHttpTests.cs
+++ b/test/Common/DurableHttpTests.cs
@@ -12,6 +12,7 @@ using System.Runtime.Serialization;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Azure.Identity;
 using Microsoft.Azure.WebJobs.Host.TestCommon;
 using Microsoft.Diagnostics.Tracing;
 using Microsoft.Extensions.Primitives;
@@ -1355,7 +1356,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 this.token = token;
             }
 
-            public Task<string> GetTokenAsync()
+            public Task<string> GetTokenAsync(DefaultAzureCredentialOptions options = null)
             {
                 return Task.FromResult(this.token);
             }

--- a/test/Common/DurableHttpTests.cs
+++ b/test/Common/DurableHttpTests.cs
@@ -216,9 +216,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             string serializedDurableHttpRequest = JsonConvert.SerializeObject(durableHttpRequest);
             DurableHttpRequest deserializedDurableHttpRequest = JsonConvert.DeserializeObject<DurableHttpRequest>(serializedDurableHttpRequest);
 
-            ManagedIdentityTokenSource deserilizedManagedIdentityTokenSource = deserializedDurableHttpRequest.TokenSource as ManagedIdentityTokenSource;
-            Assert.Equal("https://dummy.login.microsoftonline.com/", deserilizedManagedIdentityTokenSource.Options.AuthorityHost.ToString());
-            Assert.Equal("tenant_id", deserilizedManagedIdentityTokenSource.Options.TenantId);
+            ManagedIdentityTokenSource deserializedManagedIdentityTokenSource = deserializedDurableHttpRequest.TokenSource as ManagedIdentityTokenSource;
+            Assert.Equal("https://dummy.login.microsoftonline.com/", deserializedManagedIdentityTokenSource.Options.AuthorityHost.ToString());
+            Assert.Equal("tenant_id", deserializedManagedIdentityTokenSource.Options.TenantId);
         }
 
         /// <summary>

--- a/test/Common/DurableHttpTests.cs
+++ b/test/Common/DurableHttpTests.cs
@@ -129,9 +129,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             Dictionary<string, string> headers = new Dictionary<string, string>();
             headers.Add("Accept", "application/json");
 
-            DefaultAzureCredentialOptions options = new DefaultAzureCredentialOptions();
+            ManagedIdentityOptions options = new ManagedIdentityOptions();
             options.AuthorityHost = new Uri("https://dummy.login.microsoftonline.com/");
-            options.ExcludeEnvironmentCredential = true;
 
             MockTokenSource mockTokenSource = new MockTokenSource("dummy token", options);
 
@@ -143,7 +142,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             string serializedTestDurableHttpRequest = JsonConvert.SerializeObject(request);
 
             Assert.Contains("\"AuthorityHost\":\"https://dummy.login.microsoftonline.com/", serializedTestDurableHttpRequest);
-            Assert.Contains("\"ExcludeEnvironmentCredential\":true", serializedTestDurableHttpRequest);
 
             // Part 2: Check if DefaultAzureCredentialOptions is correctly serialized with DurableHttRequest
             ManagedIdentityTokenSource managedIdentityTokenSource = new ManagedIdentityTokenSource("dummy url", options);
@@ -156,7 +154,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             string serializedDurableHttpRequest = JsonConvert.SerializeObject(durableHttpRequest);
 
             Assert.Contains("\\\"AuthorityHost\\\":\\\"https://dummy.login.microsoftonline.com/", serializedDurableHttpRequest);
-            Assert.Contains("\\\"ExcludeEnvironmentCredential\\\":true", serializedDurableHttpRequest);
         }
 
         /// <summary>
@@ -988,7 +985,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             {
                 await host.StartAsync();
 
-                DefaultAzureCredentialOptions credentialOptions = new DefaultAzureCredentialOptions();
+                ManagedIdentityOptions credentialOptions = new ManagedIdentityOptions();
                 credentialOptions.AuthorityHost = new Uri("https://dummy.login.microsoftonline.com/");
 
                 Dictionary<string, string> headers = new Dictionary<string, string>();
@@ -1033,7 +1030,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             {
                 await host.StartAsync();
 
-                DefaultAzureCredentialOptions credentialOptions = new DefaultAzureCredentialOptions();
+                ManagedIdentityOptions credentialOptions = new ManagedIdentityOptions();
                 credentialOptions.AuthorityHost = new Uri("https://dummy.login.microsoftonline.com/");
 
                 Dictionary<string, string> headers = new Dictionary<string, string>();
@@ -1479,9 +1476,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             private readonly string testToken;
 
             [DataMember]
-            private readonly DefaultAzureCredentialOptions options;
+            private readonly ManagedIdentityOptions options;
 
-            public MockTokenSource(string token, DefaultAzureCredentialOptions options = null)
+            public MockTokenSource(string token, ManagedIdentityOptions options = null)
             {
                 this.testToken = token;
                 this.options = options;
@@ -1492,7 +1489,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 return Task.FromResult(this.testToken);
             }
 
-            public DefaultAzureCredentialOptions GetOptions()
+            public ManagedIdentityOptions GetOptions()
             {
                 return this.options;
             }

--- a/test/Common/DurableHttpTests.cs
+++ b/test/Common/DurableHttpTests.cs
@@ -12,7 +12,6 @@ using System.Runtime.Serialization;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using Azure.Identity;
 using Microsoft.Azure.WebJobs.Host.TestCommon;
 using Microsoft.Diagnostics.Tracing;
 using Microsoft.Extensions.Primitives;

--- a/test/Common/DurableHttpTests.cs
+++ b/test/Common/DurableHttpTests.cs
@@ -123,14 +123,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
         [Fact]
         [Trait("Category", PlatformSpecificHelpers.TestCategory)]
-        public void SerializeDefaultAzureCredentialOptions()
+        public void SerializeManagedIdentityOptions()
         {
-            // Part 1: Check if DefaultAzureCredentialOptions is correctly serialized with TestDurableHttRequest
+            // Part 1: Check if ManagedIdentityOptions is correctly serialized with TestDurableHttRequest
             Dictionary<string, string> headers = new Dictionary<string, string>();
             headers.Add("Accept", "application/json");
 
             ManagedIdentityOptions options = new ManagedIdentityOptions();
             options.AuthorityHost = new Uri("https://dummy.login.microsoftonline.com/");
+            options.TenantId = "tenant_id";
 
             MockTokenSource mockTokenSource = new MockTokenSource("dummy token", options);
 
@@ -141,9 +142,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
             string serializedTestDurableHttpRequest = JsonConvert.SerializeObject(request);
 
-            Assert.Contains("\"AuthorityHost\":\"https://dummy.login.microsoftonline.com/", serializedTestDurableHttpRequest);
+            Assert.Contains("\"authorityhost\":\"https://dummy.login.microsoftonline.com/", serializedTestDurableHttpRequest);
+            Assert.Contains("\"tenantid\":\"tenant_id\"", serializedTestDurableHttpRequest);
 
-            // Part 2: Check if DefaultAzureCredentialOptions is correctly serialized with DurableHttRequest
+            // Part 2: Check if ManagedIdentityOptions is correctly serialized with DurableHttRequest
             ManagedIdentityTokenSource managedIdentityTokenSource = new ManagedIdentityTokenSource("dummy url", options);
             TestDurableHttpRequest testDurableHttpRequest = new TestDurableHttpRequest(
                 httpMethod: HttpMethod.Get,
@@ -153,7 +155,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             DurableHttpRequest durableHttpRequest = TestOrchestrations.ConvertTestRequestToDurableHttpRequest(testDurableHttpRequest);
             string serializedDurableHttpRequest = JsonConvert.SerializeObject(durableHttpRequest);
 
-            Assert.Contains("\\\"AuthorityHost\\\":\\\"https://dummy.login.microsoftonline.com/", serializedDurableHttpRequest);
+            Assert.Contains("\\\"authorityhost\\\":\\\"https://dummy.login.microsoftonline.com/", serializedDurableHttpRequest);
+            Assert.Contains("\\\"tenantid\\\":\\\"tenant_id", serializedDurableHttpRequest);
         }
 
         /// <summary>
@@ -966,7 +969,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
         /// <summary>
         /// End-to-end test which checks if the CallHttpAsync Orchestrator returns an OK (200) status code
-        /// when the MockTokenSource object takes in a DefaultAzureCredentialsOptions object and
+        /// when the MockTokenSource object takes in a ManagedIdentityOptions object and
         /// a Bearer Token is added to the DurableHttpRequest object.
         /// </summary>
         [Theory]
@@ -987,6 +990,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
                 ManagedIdentityOptions credentialOptions = new ManagedIdentityOptions();
                 credentialOptions.AuthorityHost = new Uri("https://dummy.login.microsoftonline.com/");
+                credentialOptions.TenantId = "tenant_id";
 
                 Dictionary<string, string> headers = new Dictionary<string, string>();
                 headers.Add("Accept", "application/json");
@@ -1010,7 +1014,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
         /// <summary>
         /// End-to-end test which checks if the CallHttpAsync Orchestrator returns an OK (200) status code
-        /// when the MockTokenSource object takes in a DefaultAzureCredentialsOptions object,
+        /// when the MockTokenSource object takes in a ManagedIdentityOptions object,
         /// a Bearer Token is added to the DurableHttpRequest object, and follows the
         /// asynchronous pattern.
         /// </summary>
@@ -1032,6 +1036,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
                 ManagedIdentityOptions credentialOptions = new ManagedIdentityOptions();
                 credentialOptions.AuthorityHost = new Uri("https://dummy.login.microsoftonline.com/");
+                credentialOptions.TenantId = "tenant_id";
 
                 Dictionary<string, string> headers = new Dictionary<string, string>();
                 headers.Add("Accept", "application/json");


### PR DESCRIPTION
These changes resolve #1279 by adding an optional `ManagedIdentityOptions` parameter to `ManagedIdentityTokenSource()`. `ManagedIdentityOptions` is a new type that is introduced with these changes.

The issue mentioned wanted the ability to configure `azureAdInstance` and `tenantId`. `ManagedIdentityOptions.AuthorityHost` is equivalent to `azureAdInstance` and `ManagedIdentityOptions.TenantId` is equivalent to `tenantId`.