### PR TITLE
Update DTFx and analyzer dependencies

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/AzureStorageDurabilityProviderFactory.cs
+++ b/src/WebJobs.Extensions.DurableTask/AzureStorageDurabilityProviderFactory.cs
@@ -3,6 +3,7 @@
 
 using System;
 using DurableTask.AzureStorage;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Newtonsoft.Json;
 
@@ -15,6 +16,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         private readonly IConnectionStringResolver connectionStringResolver;
         private readonly string defaultConnectionName;
         private readonly INameResolver nameResolver;
+        private readonly ILoggerFactory loggerFactory;
         private AzureStorageDurabilityProvider defaultStorageProvider;
 
         // Must wait to get settings until we have validated taskhub name.
@@ -24,10 +26,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         public AzureStorageDurabilityProviderFactory(
             IOptions<DurableTaskOptions> options,
             IConnectionStringResolver connectionStringResolver,
-            INameResolver nameResolver)
+            INameResolver nameResolver,
+            ILoggerFactory loggerFactory)
         {
             this.options = options.Value;
             this.nameResolver = nameResolver;
+            this.loggerFactory = loggerFactory;
             this.azureStorageOptions = new AzureStorageOptions();
             JsonConvert.PopulateObject(JsonConvert.SerializeObject(this.options.StorageProvider), this.azureStorageOptions);
 
@@ -144,6 +148,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     this.azureStorageOptions.TrackingStoreConnectionStringName),
                 FetchLargeMessageDataEnabled = this.azureStorageOptions.FetchLargeMessagesAutomatically,
                 ThrowExceptionOnInvalidDedupeStatus = true,
+                LoggerFactory = this.loggerFactory,
             };
 
             // When running on App Service VMSS stamps, these environment variables are the best way

--- a/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
+++ b/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
@@ -19,6 +19,8 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>embedded</DebugType>
     <IncludeSymbols>false</IncludeSymbols>
+    <!-- See https://github.com/Azure/azure-functions-durable-extension/issues/1433 -->
+    <NoWarn>NU5125</NoWarn>
   </PropertyGroup>
 
   <!-- 

--- a/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
+++ b/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
@@ -5,8 +5,8 @@
     <AssemblyName>Microsoft.Azure.WebJobs.Extensions.DurableTask</AssemblyName>
     <RootNamespace>Microsoft.Azure.WebJobs.Extensions.DurableTask</RootNamespace>
     <MajorVersion>2</MajorVersion>
-    <MinorVersion>2</MinorVersion>
-    <PatchVersion>2</PatchVersion>
+    <MinorVersion>3</MinorVersion>
+    <PatchVersion>0</PatchVersion>
     <Version>$(MajorVersion).$(MinorVersion).$(PatchVersion)</Version>
     <FileVersion>$(MajorVersion).$(MinorVersion).$(PatchVersion)</FileVersion>
     <AssemblyVersion>$(MajorVersion).0.0.0</AssemblyVersion>
@@ -73,9 +73,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage" Version="1.7.6" />
-    <PackageReference Include="Microsoft.Azure.DurableTask.Core" Version="2.2.5" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers" Version="0.2.3" />
+    <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage" Version="1.8.0" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers" Version="0.3.0" />
     <PackageReference Include="Azure.Identity" Version="1.1.1" />
   </ItemGroup>
 

--- a/test/Common/ClientFunctions.cs
+++ b/test/Common/ClientFunctions.cs
@@ -77,14 +77,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             clientRef[0] = client;
         }
 
+#pragma warning disable CS0618 // Type or member is obsolete ([OrchestrationClient])
         /// <summary>
         /// Helper function for the IDurableOrchestrationClientBindingBackComp test. Gets an IDurableEntityClient.
         /// </summary>
         [NoAutomaticTrigger]
         public static void GetEntityClientBindingBackCompTest(
-#pragma warning disable CS0618 // Type or member is obsolete
             [OrchestrationClient] IDurableEntityClient client,
-#pragma warning restore CS0618 // Type or member is obsolete
             IDurableEntityClient[] clientRef)
         {
             clientRef[0] = client;
@@ -95,13 +94,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         /// </summary>
         [NoAutomaticTrigger]
         public static void GetOrchestrationClientBindingBackCompTest(
-#pragma warning disable CS0618 // Type or member is obsolete
             [OrchestrationClient] IDurableOrchestrationClient client,
-#pragma warning restore CS0618 // Type or member is obsolete
             IDurableOrchestrationClient[] clientRef)
         {
             clientRef[0] = client;
         }
+#pragma warning restore CS0618 // Type or member is obsolete ([OrchestrationClient])
 
         /// <summary>
         /// Helper function for testing the JSON data that gets sent to out-of-proc client functions.

--- a/test/Common/ClientFunctions.cs
+++ b/test/Common/ClientFunctions.cs
@@ -78,6 +78,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         }
 
 #pragma warning disable CS0618 // Type or member is obsolete ([OrchestrationClient])
+
         /// <summary>
         /// Helper function for the IDurableOrchestrationClientBindingBackComp test. Gets an IDurableEntityClient.
         /// </summary>

--- a/test/Common/DurableClientBaseTests.cs
+++ b/test/Common/DurableClientBaseTests.cs
@@ -13,6 +13,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 #endif
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Primitives;
 using Moq;
@@ -241,7 +242,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             var wrappedOptions = new OptionsWrapper<DurableTaskOptions>(options);
             var nameResolver = TestHelpers.GetTestNameResolver();
             var connectionStringResolver = new TestConnectionStringResolver();
-            var serviceFactory = new AzureStorageDurabilityProviderFactory(wrappedOptions, connectionStringResolver, nameResolver);
+            var serviceFactory = new AzureStorageDurabilityProviderFactory(
+                wrappedOptions,
+                connectionStringResolver,
+                nameResolver,
+                NullLoggerFactory.Instance);
             return new DurableTaskExtension(
                 wrappedOptions,
                 new LoggerFactory(),

--- a/test/Common/DurableTaskEndToEndTests.cs
+++ b/test/Common/DurableTaskEndToEndTests.cs
@@ -1566,7 +1566,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 // Strip '\r' characters to make Windows and Unix output identical.
                 string output = status.Output.ToString().Replace("\r", string.Empty);
                 this.output.WriteLine($"Orchestration output string: {output}");
-                Assert.StartsWith($"Orchestrator function '{orchestratorFunctionNames[0]}' failed: The orchestrator function 'ThrowOrchestrator' failed: \"Value cannot be null.\nParameter name: message\"", output);
+                Assert.StartsWith($"Orchestrator function '{orchestratorFunctionNames[0]}' failed: The orchestrator function 'ThrowOrchestrator' failed: \"Value cannot be null.", output);
+                Assert.Contains("message", output);
 
                 string subOrchestrationInstanceId = (string)status.CustomStatus;
                 Assert.NotNull(subOrchestrationInstanceId);
@@ -1615,8 +1616,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 string output = status.Output.ToString().Replace(Environment.NewLine, " ");
                 this.output.WriteLine($"Orchestration output string: {output}");
                 Assert.StartsWith(
-                    $"Orchestrator function '{orchestratorFunctionNames[0]}' failed: Value cannot be null. Parameter name: retryOptions",
+                    $"Orchestrator function '{orchestratorFunctionNames[0]}' failed: Value cannot be null.",
                     output);
+                Assert.Contains("retryOptions", output);
 
                 await host.StopAsync();
             }
@@ -1800,7 +1802,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 this.output.WriteLine($"Orchestration output string: {output}");
                 Assert.Contains(orchestratorFunctionName, output);
                 Assert.Contains("Value cannot be null.", output);
-                Assert.Contains("Parameter name: retryOptions", output);
+                Assert.Contains("retryOptions", output);
 
                 await host.StopAsync();
             }

--- a/test/Common/DurableTaskLifeCycleNotificationTest.cs
+++ b/test/Common/DurableTaskLifeCycleNotificationTest.cs
@@ -10,6 +10,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Host.TestCommon;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Moq;
 using Moq.Protected;
@@ -1230,7 +1231,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 wrappedOptions,
                 new LoggerFactory(),
                 mockNameResolver.Object,
-                new AzureStorageDurabilityProviderFactory(wrappedOptions, connectionStringResolver, mockNameResolver.Object),
+                new AzureStorageDurabilityProviderFactory(
+                    wrappedOptions,
+                    connectionStringResolver,
+                    mockNameResolver.Object,
+                    NullLoggerFactory.Instance),
                 new TestHostShutdownNotificationService());
 
             var eventGridLifeCycleNotification = (EventGridLifeCycleNotificationHelper)extension.LifeCycleNotificationHelper;
@@ -1272,7 +1277,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 wrappedOptions,
                 new LoggerFactory(),
                 nameResolver,
-                new AzureStorageDurabilityProviderFactory(wrappedOptions, new TestConnectionStringResolver(), nameResolver),
+                new AzureStorageDurabilityProviderFactory(
+                    wrappedOptions,
+                    new TestConnectionStringResolver(),
+                    nameResolver,
+                    NullLoggerFactory.Instance),
                 new TestHostShutdownNotificationService());
 
             var lifeCycleNotificationHelper = extension.LifeCycleNotificationHelper;
@@ -1296,7 +1305,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 wrappedOptions,
                 new LoggerFactory(),
                 nameResolver,
-                new AzureStorageDurabilityProviderFactory(wrappedOptions, new TestConnectionStringResolver(), nameResolver),
+                new AzureStorageDurabilityProviderFactory(
+                    wrappedOptions,
+                    new TestConnectionStringResolver(),
+                    nameResolver,
+                    NullLoggerFactory.Instance),
                 new TestHostShutdownNotificationService());
 
             int callCount = 0;

--- a/test/Common/HttpApiHandlerTests.cs
+++ b/test/Common/HttpApiHandlerTests.cs
@@ -12,6 +12,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using DurableTask.Core;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Moq;
 using Newtonsoft.Json;
@@ -1177,7 +1178,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                     new OptionsWrapper<DurableTaskOptions>(options),
                     new LoggerFactory(),
                     TestHelpers.GetTestNameResolver(),
-                    new AzureStorageDurabilityProviderFactory(new OptionsWrapper<DurableTaskOptions>(options), new TestConnectionStringResolver(), TestHelpers.GetTestNameResolver()),
+                    new AzureStorageDurabilityProviderFactory(
+                        new OptionsWrapper<DurableTaskOptions>(options),
+                        new TestConnectionStringResolver(),
+                        TestHelpers.GetTestNameResolver(),
+                        NullLoggerFactory.Instance),
                     new TestHostShutdownNotificationService(),
                     new DurableHttpMessageHandlerFactory())
             {

--- a/test/Common/TestEntityClasses.cs
+++ b/test/Common/TestEntityClasses.cs
@@ -142,6 +142,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             return context.DispatchAsync<SelfSchedulingEntity>();
         }
 
+#pragma warning disable DF0305 // Function named 'ClassBasedFaultyEntity' doesn't have an entity class with the same name defined. Did you mean 'FaultyEntity'?
+#pragma warning disable DF0307 // DispatchAsync must be used with the entity name, equal to the name of the function it's used in.
         [FunctionName("ClassBasedFaultyEntity")]
         public static Task FaultyEntityFunction([EntityTrigger] IDurableEntityContext context)
         {
@@ -252,6 +254,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
             return Task.CompletedTask;
         }
+#pragma warning restore DF0307 // DispatchAsync must be used with the entity name, equal to the name of the function it's used in.
+#pragma warning restore DF0305
 
         //-------------- an entity representing a chat room -----------------
 
@@ -612,7 +616,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             [JsonProperty("endDate")]
             public DateTime EndDate { get; private set; }
 
-            public void SetId(string Id) => this.Id = Id;
+            public void SetId(string id) => this.Id = id;
 
             public void SetEndDate(DateTime date) => this.EndDate = date;
 
@@ -625,10 +629,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             public void Delete()
             {
                 Entity.Current.DeleteState();
-            }
-
-            public JobWithProxyMultiInterface()
-            {
             }
 
             [FunctionName(nameof(JobWithProxyMultiInterface))]

--- a/test/FunctionsV1/PlatformSpecificHelpers.FunctionsV1.cs
+++ b/test/FunctionsV1/PlatformSpecificHelpers.FunctionsV1.cs
@@ -38,7 +38,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             var loggerFactory = new LoggerFactory();
             loggerFactory.AddProvider(loggerProvider);
 
-            IDurabilityProviderFactory orchestrationServiceFactory = new AzureStorageDurabilityProviderFactory(options, connectionResolver, nameResolver);
+            IDurabilityProviderFactory orchestrationServiceFactory = new AzureStorageDurabilityProviderFactory(
+                options,
+                connectionResolver,
+                nameResolver,
+                loggerFactory);
 
             var extension = new DurableTaskExtension(
                 options,

--- a/test/FunctionsV1/WebJobs.Extensions.DurableTask.Tests.V1.csproj
+++ b/test/FunctionsV1/WebJobs.Extensions.DurableTask.Tests.V1.csproj
@@ -8,7 +8,7 @@
     <AssemblyOriginatorKeyFile>..\..\sign.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net471|AnyCPU'">
+  <PropertyGroup Condition="'$(Configuration)'=='Release'">
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsAsErrors />
     <StyleCopTreatErrorsAsWarnings>true</StyleCopTreatErrorsAsWarnings>
@@ -16,16 +16,15 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="4.19.4" />
-    <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage" Version="1.7.6" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="2.3.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" Version="2.3.0" />
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.33" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="Moq" Version="4.7.145" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.*" PrivateAssets="All" />
-    <PackageReference Include="Serilog.Extensions.Logging" Version="2.0.2" />
     <PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.5.24" />
   </ItemGroup>
 

--- a/test/FunctionsV2/AzureStorageDurabilityProviderFactoryTests.cs
+++ b/test/FunctionsV2/AzureStorageDurabilityProviderFactoryTests.cs
@@ -1,25 +1,20 @@
-﻿using Microsoft.Azure.WebJobs;
-using Microsoft.Azure.WebJobs.Extensions.DurableTask;
-using Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests;
-using Microsoft.Extensions.Options;
-using Moq;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
 using System;
 using System.Collections.Generic;
-using System.Text;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Extensions.DurableTask;
+using Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace WebJobs.Extensions.DurableTask.Tests.V2
 {
     public class AzureStorageDurabilityProviderFactoryTests
     {
-        private readonly ITestOutputHelper output;
-
-        public AzureStorageDurabilityProviderFactoryTests(ITestOutputHelper output)
-        {
-            this.output = output;
-        }
-
         [Fact]
         [Trait("Category", PlatformSpecificHelpers.TestCategory)]
         public void DefaultWorkerId_IsMachineName()
@@ -27,7 +22,11 @@ namespace WebJobs.Extensions.DurableTask.Tests.V2
             var connectionStringResolver = new TestConnectionStringResolver();
             var mockOptions = new OptionsWrapper<DurableTaskOptions>(new DurableTaskOptions());
             var nameResolver = new Mock<INameResolver>().Object;
-            var factory = new AzureStorageDurabilityProviderFactory(mockOptions, connectionStringResolver, nameResolver);
+            var factory = new AzureStorageDurabilityProviderFactory(
+                mockOptions,
+                connectionStringResolver,
+                nameResolver,
+                NullLoggerFactory.Instance);
 
             var settings = factory.GetAzureStorageOrchestrationServiceSettings();
 
@@ -36,7 +35,6 @@ namespace WebJobs.Extensions.DurableTask.Tests.V2
 
         [Fact]
         [Trait("Category", PlatformSpecificHelpers.TestCategory)]
-
         public void EnvironmentIsVMSS_WorkerIdFromEnvironmentVariables()
         {
             var connectionStringResolver = new TestConnectionStringResolver();
@@ -47,7 +45,11 @@ namespace WebJobs.Extensions.DurableTask.Tests.V2
                 { "RoleInstanceId", "dw0SmallDedicatedWebWorkerRole_hr0HostRole-3-VM-13" },
             });
 
-            var factory = new AzureStorageDurabilityProviderFactory(mockOptions, connectionStringResolver, nameResolver);
+            var factory = new AzureStorageDurabilityProviderFactory(
+                mockOptions,
+                connectionStringResolver,
+                nameResolver,
+                NullLoggerFactory.Instance);
 
             var settings = factory.GetAzureStorageOrchestrationServiceSettings();
 

--- a/test/FunctionsV2/AzureStorageShortenedTimerDurabilityProviderFactory.cs
+++ b/test/FunctionsV2/AzureStorageShortenedTimerDurabilityProviderFactory.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
@@ -11,8 +12,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         public AzureStorageShortenedTimerDurabilityProviderFactory(
             IOptions<DurableTaskOptions> options,
             IConnectionStringResolver connectionStringResolver,
-            INameResolver nameResolver)
-            : base(options, connectionStringResolver, nameResolver)
+            INameResolver nameResolver,
+            ILoggerFactory loggerFactory)
+            : base(options, connectionStringResolver, nameResolver, loggerFactory)
         {
         }
 

--- a/test/FunctionsV2/DurableTaskListenerTests.cs
+++ b/test/FunctionsV2/DurableTaskListenerTests.cs
@@ -5,6 +5,7 @@ using System;
 using Microsoft.Azure.WebJobs.Host.Executors;
 using Microsoft.Azure.WebJobs.Host.Scale;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Moq;
 using Xunit;
@@ -56,7 +57,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             var wrappedOptions = new OptionsWrapper<DurableTaskOptions>(options);
             var nameResolver = TestHelpers.GetTestNameResolver();
             var connectionStringResolver = new TestConnectionStringResolver();
-            var serviceFactory = new AzureStorageDurabilityProviderFactory(wrappedOptions, connectionStringResolver, nameResolver);
+            var serviceFactory = new AzureStorageDurabilityProviderFactory(
+                wrappedOptions,
+                connectionStringResolver,
+                nameResolver,
+                NullLoggerFactory.Instance);
             return new DurableTaskExtension(
                 wrappedOptions,
                 new LoggerFactory(),

--- a/test/FunctionsV2/WebJobs.Extensions.DurableTask.Tests.V2.csproj
+++ b/test/FunctionsV2/WebJobs.Extensions.DurableTask.Tests.V2.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <Company>Microsoft Corporation</Company>
     <NoWarn>SA0001;SA1600;SA1615</NoWarn>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\sign.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netcoreapp2.0|AnyCPU'">
+  <PropertyGroup Condition="'$(Configuration)'=='Release'">
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <WarningsAsErrors />
     <StyleCopTreatErrorsAsWarnings>true</StyleCopTreatErrorsAsWarnings>
@@ -16,12 +16,11 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="4.19.4" />
-    <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage" Version="1.7.6" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.14" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="3.0.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" Version="3.0.0" />
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.33" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.5" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="Moq" Version="4.7.145" />
     <PackageReference Include="xunit" Version="2.4.1" />


### PR DESCRIPTION
Updates the following dependencies:
* Microsoft.Azure.WebJobs.Extensions.DurableTask --> 2.3.0
* Microsoft.Azure.WebJobs.Extensions.Analyzers --> 0.3.0
* Microsoft.Azure.DurableTask.AzureStorage --> 1.8.0
* Microsoft.Azure.DurableTask.Core --> 2.4.0

This PR also enables the new structured logging changes by passing in the Azure Functions `ILoggerFactory` into the `TaskHubWorker` and `TaskHubClient` objects we internally manage.