### PR TITLE
Updated DurableClient ConnectionName matching function and EntityKey validity checks

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableClient.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableClient.cs
@@ -260,6 +260,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
         private async Task SignalEntityAsyncInternal(DurableClient durableClient, string hubName, EntityId entityId, DateTime? scheduledTimeUtc, string operationName, object operationInput)
         {
+            var entityKey = entityId.EntityKey;
+            if (entityKey.Any(IsInvalidCharacter))
+            {
+                throw new ArgumentException(nameof(entityKey), "Entity keys must not contain /, \\, #, ?, or control characters.");
+            }
+
             if (operationName == null)
             {
                 throw new ArgumentNullException(nameof(operationName));
@@ -313,14 +319,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
         private bool ConnectionNameMatchesCurrentApp(DurableClient client)
         {
-            var storageProvider = this.config.Options.StorageProvider;
-            if (storageProvider.TryGetValue("ConnectionStringName", out object connectionName))
-            {
-                var newConnectionName = client.DurabilityProvider.ConnectionName;
-                return newConnectionName.Equals(connectionName);
-            }
-
-            return false;
+            return this.DurabilityProvider.ConnectionNameMatches(client.DurabilityProvider);
         }
 
         /// <inheritdoc />

--- a/src/WebJobs.Extensions.DurableTask/DurabilityProvider.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurabilityProvider.cs
@@ -408,5 +408,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             errorMessage = null;
             return true;
         }
+
+        /// <summary>
+        ///  Returns true if the stored connection string, ConnectionName, matches the input DurabilityProvider ConnectionName.
+        /// </summary>
+        /// <param name="durabilityProvider">The DurabilityProvider used to check for matching connection string names.</param>
+        /// <returns>A boolean indicating whether the connection names match.</returns>
+        public virtual bool ConnectionNameMatches(DurabilityProvider durabilityProvider)
+        {
+            return this.ConnectionName.Equals(durabilityProvider.ConnectionName);
+        }
     }
 }

--- a/src/WebJobs.Extensions.DurableTask/DurabilityProvider.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurabilityProvider.cs
@@ -414,7 +414,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// </summary>
         /// <param name="durabilityProvider">The DurabilityProvider used to check for matching connection string names.</param>
         /// <returns>A boolean indicating whether the connection names match.</returns>
-        public virtual bool ConnectionNameMatches(DurabilityProvider durabilityProvider)
+        internal virtual bool ConnectionNameMatches(DurabilityProvider durabilityProvider)
         {
             return this.ConnectionName.Equals(durabilityProvider.ConnectionName);
         }

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net461.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net461.xml
@@ -1677,6 +1677,13 @@
             <param name="errorMessage">The error message if the timespan is invalid.</param>
             <returns>A boolean indicating whether the time interval is valid.</returns>
         </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurabilityProvider.ConnectionNameMatches(Microsoft.Azure.WebJobs.Extensions.DurableTask.DurabilityProvider)">
+            <summary>
+             Returns true if the stored connection string, ConnectionName, matches the input DurabilityProvider ConnectionName.
+            </summary>
+            <param name="durabilityProvider">The DurabilityProvider used to check for matching connection string names.</param>
+            <returns>A boolean indicating whether the connection names match.</returns>
+        </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClientAttribute">
             <summary>
             Attribute used to bind a function parameter to a <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableClient"/>, <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableEntityClient"/>, or <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableOrchestrationClient"/> instance.

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
@@ -1715,6 +1715,13 @@
             <param name="errorMessage">The error message if the timespan is invalid.</param>
             <returns>A boolean indicating whether the time interval is valid.</returns>
         </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurabilityProvider.ConnectionNameMatches(Microsoft.Azure.WebJobs.Extensions.DurableTask.DurabilityProvider)">
+            <summary>
+             Returns true if the stored connection string, ConnectionName, matches the input DurabilityProvider ConnectionName.
+            </summary>
+            <param name="durabilityProvider">The DurabilityProvider used to check for matching connection string names.</param>
+            <returns>A boolean indicating whether the connection names match.</returns>
+        </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClientAttribute">
             <summary>
             Attribute used to bind a function parameter to a <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableClient"/>, <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableEntityClient"/>, or <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableOrchestrationClient"/> instance.


### PR DESCRIPTION
Moved the logic to determine if the connectionName matches to the DurabilityProvider.

Added a check to SignalEntity to check the EntityKey for validity.
resolves #1425 