### PR TITLE
Bugfix: SyntaxNodeUtils.TryGetAttribute throws System.InvalidOperatio…

### DIFF
--- a/src/WebJobs.Extensions.DurableTask.Analyzers/SyntaxNodeUtils.cs
+++ b/src/WebJobs.Extensions.DurableTask.Analyzers/SyntaxNodeUtils.cs
@@ -126,7 +126,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
                 {
                     //An AttributeList will always have a child node Attribute
                     attribute = attributeList.ChildNodes().First();
-                    if (attribute.ChildNodes().First().ToString().Equals(attributeName))
+
+                    if (attribute.ChildNodes().Any() && attribute.ChildNodes().First().ToString().Equals(attributeName))
                     {
                         return true;
                     }

--- a/test/WebJobs.Extensions.DurableTask.Analyzers.Test/Binding/OrchestratorContextAnalyzerTests.cs
+++ b/test/WebJobs.Extensions.DurableTask.Analyzers.Test/Binding/OrchestratorContextAnalyzerTests.cs
@@ -550,6 +550,26 @@ namespace VSSample
             VerifyCSharpFix(test, V2ExpectedFix);
         }
 
+        // Tests SyntaxNodeUtils.TryGetAttribute
+        [TestMethod]
+        public void OrchestrationContext_V2_InvalidOperationTest()
+        {
+            var test = @"
+namespace VSSample
+{
+    public interface ExampleInterface
+    {
+        [return: System.ServiceModel.MessageParameterAttribute(Name = ""getSubscriberInfoReturn"")]
+        string getSubscriberInfo(string request);
+    }
+}
+";
+
+            SyntaxNodeUtils.version = DurableVersion.V2;
+
+            VerifyCSharpDiagnostic(test, new DiagnosticResult[] { });
+        }
+
         protected override CodeFixProvider GetCSharpCodeFixProvider()
         {
             return new OrchestratorContextCodeFixProvider();


### PR DESCRIPTION
…nException

This [System.ServiceModel.MessageParameterAttribute](https://docs.microsoft.com/en-us/dotnet/api/system.servicemodel.messageparameterattribute?view=dotnet-plat-ext-3.1) throws a System.InvalidOperationException in the SyntaxNodeUtils.TryGetAttribute method.

This exception results a failed compilation with the following message.

"CSC : error AD0001: Analyzer 'Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers.OrchestratorContextAnalyzer' threw an exception of type 'System.InvalidOperationException' with message 'Sequence contains no elements'."

Current workaround is to suppress AD0001 for this analyzer. Proposed solution is to perform "grandchild" existence safety check in SyntaxNodeUtils.TryGetAttribute method, to avoid throwing the InvalidOperationException.