### PR TITLE
Updated default JsonSerializerSetting to include DateParseHandling.None

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableActivityContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableActivityContext.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     throw new ArgumentException("The serialized input is expected to be an object array with one element.");
                 }
 
-                this.parsedJsonInput = this.messageDataConverter.ConvertToJToken(this.messageDataConverter.Serialize(objectArray[0]));
+                this.parsedJsonInput = MessagePayloadDataConverter.ConvertToJToken(this.messageDataConverter.Serialize(objectArray[0]));
             }
 
             return this.parsedJsonInput;

--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableActivityContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableActivityContext.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
-using System.IO;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
@@ -59,18 +58,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 var objectArray = this.messageDataConverter.Deserialize<object[]>(this.serializedInput);
 
                 if (objectArray?.Length != 1)
-                    {
-                        throw new ArgumentException("The serialized input is expected to be an object array with one element.");
-                    }
-
-                JToken token;
-                using (var stringReader = new StringReader(this.messageDataConverter.Serialize(objectArray[0])))
-                using (var jsonTextReader = new JsonTextReader(stringReader) { DateParseHandling = this.messageDataConverter.JsonSettings.DateParseHandling })
                 {
-                    token = JToken.ReadFrom(jsonTextReader);
+                    throw new ArgumentException("The serialized input is expected to be an object array with one element.");
                 }
 
-                this.parsedJsonInput = token;
+                this.parsedJsonInput = this.messageDataConverter.ConvertToJToken(this.messageDataConverter.Serialize(objectArray[0]));
             }
 
             return this.parsedJsonInput;

--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableActivityContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableActivityContext.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
+using System.IO;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
@@ -62,7 +63,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                         throw new ArgumentException("The serialized input is expected to be an object array with one element.");
                     }
 
-                var token = JToken.Parse(this.messageDataConverter.Serialize(objectArray[0]));
+                JToken token;
+                using (var stringReader = new StringReader(this.messageDataConverter.Serialize(objectArray[0])))
+                using (var jsonTextReader = new JsonTextReader(stringReader) { DateParseHandling = this.messageDataConverter.JsonSettings.DateParseHandling })
+                {
+                    token = JToken.ReadFrom(jsonTextReader);
+                }
 
                 this.parsedJsonInput = token;
             }

--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableClient.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableClient.cs
@@ -769,7 +769,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 return string.Empty;
             }
 
-            return MessagePayloadDataConverter.ConvertToJToken(value);
+            try
+            {
+                return MessagePayloadDataConverter.ConvertToJToken(value);
+            }
+            catch (JsonReaderException)
+            {
+                // Return the raw string value as the fallback. This is common in terminate scenarios.
+                return value;
+            }
         }
 
         private static void ConvertOutputToJToken(JObject jsonObject, bool showHistoryOutput)

--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableClient.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableClient.cs
@@ -386,7 +386,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 return null;
             }
 
-            return await this.GetDurableOrchestrationStatusAsync(state, this.client, showHistory, showHistoryOutput);
+            return await GetDurableOrchestrationStatusAsync(state, this.client, showHistory, showHistoryOutput);
         }
 
         /// <inheritdoc />
@@ -755,7 +755,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             };
         }
 
-        private static JToken ParseToJToken(string value)
+        internal static JToken ParseToJToken(string value)
         {
             if (value == null)
             {

--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableClient.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableClient.cs
@@ -604,7 +604,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             return result;
         }
 
-        private async Task<DurableOrchestrationStatus> GetDurableOrchestrationStatusAsync(OrchestrationState orchestrationState, TaskHubClient client, bool showHistory, bool showHistoryOutput)
+        private static async Task<DurableOrchestrationStatus> GetDurableOrchestrationStatusAsync(OrchestrationState orchestrationState, TaskHubClient client, bool showHistory, bool showHistoryOutput)
         {
             JArray historyArray = null;
             if (showHistory && orchestrationState.OrchestrationStatus != OrchestrationStatus.Pending)
@@ -640,7 +640,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                                         historyItem.Remove("Result");
                                     }
 
-                                    this.ConvertOutputToJToken(historyItem, showHistoryOutput && eventType == EventType.TaskCompleted);
+                                    ConvertOutputToJToken(historyItem, showHistoryOutput && eventType == EventType.TaskCompleted);
                                     break;
                                 case EventType.SubOrchestrationInstanceCreated:
                                     TrackNameAndScheduledTime(historyItem, eventType, i, eventMapper);
@@ -656,7 +656,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                                         historyItem.Remove("Result");
                                     }
 
-                                    this.ConvertOutputToJToken(historyItem, showHistoryOutput && eventType == EventType.SubOrchestrationInstanceCompleted);
+                                    ConvertOutputToJToken(historyItem, showHistoryOutput && eventType == EventType.SubOrchestrationInstanceCompleted);
                                     break;
                                 case EventType.ExecutionStarted:
                                     var functionName = historyItem["Name"];
@@ -679,7 +679,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                                         historyItem.Remove("Result");
                                     }
 
-                                    this.ConvertOutputToJToken(historyItem, showHistoryOutput);
+                                    ConvertOutputToJToken(historyItem, showHistoryOutput);
                                     break;
                                 case EventType.ExecutionTerminated:
                                     historyItem.Remove("Input");
@@ -779,7 +779,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             return token;
         }
 
-        private void ConvertOutputToJToken(JObject jsonObject, bool showHistoryOutput)
+        private static void ConvertOutputToJToken(JObject jsonObject, bool showHistoryOutput)
         {
             if (!showHistoryOutput)
             {

--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableClient.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableClient.cs
@@ -612,7 +612,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 string history = await client.GetOrchestrationHistoryAsync(orchestrationState.OrchestrationInstance);
                 if (!string.IsNullOrEmpty(history))
                 {
-                    historyArray = JArray.Parse(history);
+                    historyArray = MessagePayloadDataConverter.ConvertToJArray(history);
 
                     var eventMapper = new Dictionary<string, EventIndexDateMapping>();
                     var indexList = new List<int>();
@@ -769,14 +769,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 return string.Empty;
             }
 
-            JToken token;
-            using (var stringReader = new StringReader(value))
-            using (var jsonTextReader = new JsonTextReader(stringReader) { DateParseHandling = DateParseHandling.None })
-            {
-                token = JToken.ReadFrom(jsonTextReader);
-            }
-
-            return token;
+            return MessagePayloadDataConverter.ConvertToJToken(value);
         }
 
         private static void ConvertOutputToJToken(JObject jsonObject, bool showHistoryOutput)

--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableOrchestrationContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableOrchestrationContext.cs
@@ -136,7 +136,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// </returns>
         internal JToken GetInputAsJson()
         {
-            return this.Config.MessageDataConverter.ConvertToJToken(this.RawInput);
+            return MessagePayloadDataConverter.ConvertToJToken(this.RawInput);
         }
 
         /// <inheritdoc />
@@ -935,7 +935,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 {
                     // Need to round-trip serialization since SendEvent always tries to serialize.
                     string rawInput = events.Dequeue();
-                    JToken jsonData = this.Config.MessageDataConverter.ConvertToJToken(rawInput);
+                    JToken jsonData = MessagePayloadDataConverter.ConvertToJToken(rawInput);
                     this.InnerContext.SendEvent(instance, eventName, jsonData);
                 }
             }

--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableOrchestrationContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableOrchestrationContext.cs
@@ -136,7 +136,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// </returns>
         internal JToken GetInputAsJson()
         {
-            return this.RawInput != null ? JToken.Parse(this.RawInput) : null;
+            return this.Config.MessageDataConverter.ConvertToJToken(this.RawInput);
         }
 
         /// <inheritdoc />
@@ -935,7 +935,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 {
                     // Need to round-trip serialization since SendEvent always tries to serialize.
                     string rawInput = events.Dequeue();
-                    JToken jsonData = JToken.Parse(rawInput);
+                    JToken jsonData = this.Config.MessageDataConverter.ConvertToJToken(rawInput);
                     this.InnerContext.SendEvent(instance, eventName, jsonData);
                 }
             }

--- a/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
+++ b/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
@@ -774,7 +774,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
             string stringData = await request.Content.ReadAsStringAsync();
 
-            var eventData = this.config.MessageDataConverter.ConvertToJToken(stringData);
+            var eventData = MessagePayloadDataConverter.ConvertToJToken(stringData);
 
             await client.RaiseEventAsync(instanceId, eventName, eventData);
             return request.CreateResponse(HttpStatusCode.Accepted);
@@ -833,7 +833,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 object operationInput;
                 if (string.Equals(mediaType, "application/json", StringComparison.OrdinalIgnoreCase))
                 {
-                    operationInput = this.config.MessageDataConverter.ConvertToJToken(requestContent);
+                    operationInput = MessagePayloadDataConverter.ConvertToJToken(requestContent);
                 }
                 else
                 {

--- a/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
+++ b/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
@@ -774,15 +774,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
             string stringData = await request.Content.ReadAsStringAsync();
 
-            object eventData;
-            try
-            {
-                eventData = !string.IsNullOrEmpty(stringData) ? JToken.Parse(stringData) : null;
-            }
-            catch (JsonReaderException e)
-            {
-                return request.CreateErrorResponse(HttpStatusCode.BadRequest, "Invalid JSON content", e);
-            }
+            var eventData = this.config.MessageDataConverter.ConvertToJToken(stringData);
 
             await client.RaiseEventAsync(instanceId, eventName, eventData);
             return request.CreateResponse(HttpStatusCode.Accepted);
@@ -841,14 +833,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 object operationInput;
                 if (string.Equals(mediaType, "application/json", StringComparison.OrdinalIgnoreCase))
                 {
-                    try
-                    {
-                        operationInput = JToken.Parse(requestContent);
-                    }
-                    catch (JsonException e)
-                    {
-                        return request.CreateErrorResponse(HttpStatusCode.BadRequest, "Could not parse JSON content: " + e.Message);
-                    }
+                    operationInput = this.config.MessageDataConverter.ConvertToJToken(requestContent);
                 }
                 else
                 {

--- a/src/WebJobs.Extensions.DurableTask/MessagePayloadDataConverter.cs
+++ b/src/WebJobs.Extensions.DurableTask/MessagePayloadDataConverter.cs
@@ -71,25 +71,17 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
         public static JToken ConvertToJToken(string input)
         {
-            try
+            JToken token = null;
+            if (input != null)
             {
-                JToken token = null;
-                if (input != null)
+                using (var stringReader = new StringReader(input))
+                using (var jsonTextReader = new JsonTextReader(stringReader) { DateParseHandling = DateParseHandling.None })
                 {
-                    using (var stringReader = new StringReader(input))
-                    using (var jsonTextReader = new JsonTextReader(stringReader) { DateParseHandling = DateParseHandling.None })
-                    {
-                        return token = JToken.Load(jsonTextReader);
-                    }
+                    return token = JToken.Load(jsonTextReader);
                 }
+            }
 
-                return token;
-            }
-            catch (JsonReaderException)
-            {
-                // Return the raw string value as the fallback. This is common in terminate scenarios.
-                return input;
-            }
+            return token;
         }
 
         public static JArray ConvertToJArray(string input)

--- a/src/WebJobs.Extensions.DurableTask/MessagePayloadDataConverter.cs
+++ b/src/WebJobs.Extensions.DurableTask/MessagePayloadDataConverter.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
+using System.IO;
 using System.Text;
 using DurableTask.Core.Serializing;
 using Newtonsoft.Json;
@@ -66,6 +67,21 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             }
 
             return serializedJson;
+        }
+
+        public JToken ConvertToJToken(string input)
+        {
+            JToken token = null;
+            if (input != null)
+            {
+                using (var stringReader = new StringReader(input))
+                using (var jsonTextReader = new JsonTextReader(stringReader) { DateParseHandling = this.JsonSettings.DateParseHandling })
+                {
+                    token = JToken.ReadFrom(jsonTextReader);
+                }
+            }
+
+            return token;
         }
     }
 }

--- a/src/WebJobs.Extensions.DurableTask/MessagePayloadDataConverter.cs
+++ b/src/WebJobs.Extensions.DurableTask/MessagePayloadDataConverter.cs
@@ -69,19 +69,42 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             return serializedJson;
         }
 
-        public JToken ConvertToJToken(string input)
+        public static JToken ConvertToJToken(string input)
         {
-            JToken token = null;
+            try
+            {
+                JToken token = null;
+                if (input != null)
+                {
+                    using (var stringReader = new StringReader(input))
+                    using (var jsonTextReader = new JsonTextReader(stringReader) { DateParseHandling = DateParseHandling.None })
+                    {
+                        return token = JToken.Load(jsonTextReader);
+                    }
+                }
+
+                return token;
+            }
+            catch (JsonReaderException)
+            {
+                // Return the raw string value as the fallback. This is common in terminate scenarios.
+                return input;
+            }
+        }
+
+        public static JArray ConvertToJArray(string input)
+        {
+            JArray jArray = null;
             if (input != null)
             {
                 using (var stringReader = new StringReader(input))
-                using (var jsonTextReader = new JsonTextReader(stringReader) { DateParseHandling = this.JsonSettings.DateParseHandling })
+                using (var jsonTextReader = new JsonTextReader(stringReader) { DateParseHandling = DateParseHandling.None })
                 {
-                    token = JToken.ReadFrom(jsonTextReader);
+                    jArray = JArray.Load(jsonTextReader);
                 }
             }
 
-            return token;
+            return jArray;
         }
     }
 }

--- a/src/WebJobs.Extensions.DurableTask/MessageSerializerSettingsFactory.cs
+++ b/src/WebJobs.Extensions.DurableTask/MessageSerializerSettingsFactory.cs
@@ -28,6 +28,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 this.jsonSerializerSettings = new JsonSerializerSettings
                 {
                     TypeNameHandling = TypeNameHandling.None,
+                    DateParseHandling = DateParseHandling.None,
                 };
             }
 

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net461.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net461.xml
@@ -3275,6 +3275,16 @@
             only after an entire batch of operations completes.
             </remarks>
         </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskOptions.UseAppLease">
+            <summary>
+            If true, takes a lease on the task hub container, allowing for only one app to process messages in a task hub at a time.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskOptions.AppLeaseOptions">
+            <summary>
+            If UseAppLease is true, gets or sets the AppLeaaseOptions used for acquiring the lease to start the application.
+            </summary>
+        </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskOptions.SetDefaultHubName(System.String)">
             <summary>
             Sets HubName to a value that is considered a default value.

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
@@ -3315,6 +3315,16 @@
             only after an entire batch of operations completes.
             </remarks>
         </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskOptions.UseAppLease">
+            <summary>
+            If true, takes a lease on the task hub container, allowing for only one app to process messages in a task hub at a time.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskOptions.AppLeaseOptions">
+            <summary>
+            If UseAppLease is true, gets or sets the AppLeaaseOptions used for acquiring the lease to start the application.
+            </summary>
+        </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskOptions.SetDefaultHubName(System.String)">
             <summary>
             Sets HubName to a value that is considered a default value.


### PR DESCRIPTION
This change prevents strings that look like dates from being serialized into DateTime objects.

related to Azure/azure-functions-durable-js#208