### PR TITLE
support for cleaning entity storage

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/CleanEntityStorageResult.cs
+++ b/src/WebJobs.Extensions.DurableTask/CleanEntityStorageResult.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
+{
+    /// <summary>
+    /// The result of a clean entity storage operation.
+    /// </summary>
+    public struct CleanEntityStorageResult
+    {
+        /// <summary>
+        /// The number of orphaned locks that were removed.
+        /// </summary>
+        public int NumberOfOrphanedLocksRemoved;
+
+        /// <summary>
+        /// The number of entities whose metadata was removed from storage.
+        /// </summary>
+        public int NumberOfEmptyEntitiesRemoved;
+    }
+}

--- a/src/WebJobs.Extensions.DurableTask/ContextInterfaces/IDurableEntityClient.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextInterfaces/IDurableEntityClient.cs
@@ -99,5 +99,19 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// <param name="cancellationToken">Cancellation token that can be used to cancel the query operation.</param>
         /// <returns>Returns a page of entity instances and a continuation token for fetching the next page.</returns>
         Task<EntityQueryResult> ListEntitiesAsync(EntityQuery query, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Removes empty entities from storage and releases orphaned locks.
+        /// </summary>
+        /// <remarks>An entity is considered empty, and is removed, if it has no state, is not locked, and has
+        /// been idle for more than <see cref="DurableTaskOptions.EntityMessageReorderWindowInMinutes"/> minutes.
+        /// Locks are considered orphaned, and are released, if the orchestration that holds them is not in state <see cref="OrchestrationRuntimeStatus.Running"/>. This
+        /// should not happen under normal circumstances, but can occur if the orchestration instance holding the lock
+        /// exhibits replay nondeterminism failures, or if it is explicitly purged.</remarks>
+        /// <param name="removeEmptyEntities">Whether to remove empty entities.</param>
+        /// <param name="releaseOrphanedLocks">Whether to release orphaned locks.</param>
+        /// <param name="cancellationToken">Cancellation token that can be used to cancel the operation.</param>
+        /// <returns>A task that completes when the operation is finished.</returns>
+        Task<CleanEntityStorageResult> CleanEntityStorageAsync(bool removeEmptyEntities, bool releaseOrphanedLocks, CancellationToken cancellationToken);
     }
 }

--- a/test/Common/TestHelpers.cs
+++ b/test/Common/TestHelpers.cs
@@ -51,7 +51,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             IMessageSerializerSettingsFactory serializerSettings = null,
             bool? localRpcEndpointEnabled = false,
             DurableTaskOptions options = null,
-            bool rollbackEntityOperationsOnExceptions = true)
+            bool rollbackEntityOperationsOnExceptions = true,
+            int entityMessageReorderWindowInMinutes = 30)
         {
             switch (storageProviderType)
             {
@@ -96,6 +97,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             options.NotificationHandler = eventGridNotificationHandler;
             options.LocalRpcEndpointEnabled = localRpcEndpointEnabled;
             options.RollbackEntityOperationsOnExceptions = rollbackEntityOperationsOnExceptions;
+            options.EntityMessageReorderWindowInMinutes = entityMessageReorderWindowInMinutes;
 
             // Azure Storage specfic tests
             if (string.Equals(storageProviderType, AzureStorageProviderType))


### PR DESCRIPTION
Add support for cleaning empty entities and releasing orphaned entity locks.

Addresses the issues discussed in #1325 and #1065.