### PR TITLE
Add configurable option for partition management strategies

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/AzureStorageDurabilityProviderFactory.cs
+++ b/src/WebJobs.Extensions.DurableTask/AzureStorageDurabilityProviderFactory.cs
@@ -152,6 +152,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 AppLeaseOptions = this.options.AppLeaseOptions,
                 AppName = EndToEndTraceHelper.LocalAppName,
                 LoggerFactory = this.loggerFactory,
+                UseLegacyPartitionManagement = this.azureStorageOptions.UseLegacyPartitionManagement,
             };
 
             // When running on App Service VMSS stamps, these environment variables are the best way

--- a/src/WebJobs.Extensions.DurableTask/Options/AzureStorageOptions.cs
+++ b/src/WebJobs.Extensions.DurableTask/Options/AzureStorageOptions.cs
@@ -121,6 +121,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         public TimeSpan MaxQueuePollingInterval { get; set; } = TimeSpan.FromSeconds(30);
 
         /// <summary>
+        /// Determines whether or not to use the old partition management strategy, or the new
+        /// strategy that is more resilient to split brain problems, at the potential expense
+        /// of scale out performance.
+        /// </summary>
+        /// <value>A boolean indicating whether we use the legacy partition strategy. Defaults to true
+        /// but this will change to false once the new partition management strategy is fully tested. </value>
+        public bool UseLegacyPartitionManagement { get; set; } = true;
+
+        /// <summary>
         /// Throws an exception if the provided hub name violates any naming conventions for the storage provider.
         /// </summary>
         public void ValidateHubName(string hubName)

--- a/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
+++ b/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
@@ -75,7 +75,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage" Version="1.8.0" />
+    <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage" Version="1.8.1" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers" Version="0.3.0" />
     <PackageReference Include="Azure.Identity" Version="1.1.1" />
   </ItemGroup>


### PR DESCRIPTION
DurableTask.AzureStorage now has support for an alternative partition
management strategy that should reduce split brain, but due to the lack
of lease stealing, may be a bit slower for scale out.

Currently default to use legacy partition management, and we will
default to the new approach once it is hardened.