### PR TITLE
Support scheduling entity signals without limit on duration

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableClient.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableClient.cs
@@ -299,7 +299,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             }
 
             var jrequest = JToken.FromObject(request, this.messageDataConverter.JsonSerializer);
-            var eventName = scheduledTimeUtc.HasValue ? EntityMessageEventNames.ScheduledRequestMessageEventName(scheduledTimeUtc.Value) : EntityMessageEventNames.RequestMessageEventName;
+            var eventName = scheduledTimeUtc.HasValue
+                ? EntityMessageEventNames.ScheduledRequestMessageEventName(request.GetAdjustedDeliveryTime(this.durabilityProvider))
+                : EntityMessageEventNames.RequestMessageEventName;
             await durableClient.client.RaiseEventAsync(instance, eventName, jrequest);
 
             this.traceHelper.FunctionScheduled(

--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableEntityContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableEntityContext.cs
@@ -24,13 +24,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
         private readonly MessagePayloadDataConverter errorDataConverter;
 
+        private readonly DurabilityProvider durabilityProvider;
+
         private List<OutgoingMessage> outbox = new List<OutgoingMessage>();
 
-        public DurableEntityContext(DurableTaskExtension config, EntityId entity, TaskEntityShim shim)
+        public DurableEntityContext(DurableTaskExtension config, DurabilityProvider durabilityProvider, EntityId entity, TaskEntityShim shim)
             : base(config, entity.EntityName)
         {
             this.messageDataConverter = config.MessageDataConverter;
             this.errorDataConverter = config.ErrorDataConverter;
+            this.durabilityProvider = durabilityProvider;
             this.self = entity;
             this.shim = shim;
         }
@@ -430,7 +433,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
                 if (requestMessage.ScheduledTime.HasValue)
                 {
-                    eventName = EntityMessageEventNames.ScheduledRequestMessageEventName(requestMessage.ScheduledTime.Value);
+                    DateTime adjustedDeliveryTime = requestMessage.GetAdjustedDeliveryTime(this.durabilityProvider);
+                    eventName = EntityMessageEventNames.ScheduledRequestMessageEventName(adjustedDeliveryTime);
                 }
                 else
                 {
@@ -561,6 +565,22 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 }
 
                 this.outbox.Clear();
+            }
+        }
+
+        internal void RescheduleMessages(OrchestrationContext innerContext, List<RequestMessage> messages)
+        {
+            if (messages != null)
+            {
+                foreach (var message in messages)
+                {
+                    var instance = new OrchestrationInstance { InstanceId = this.InstanceId };
+                    DateTime adjustedDeliveryTime = message.GetAdjustedDeliveryTime(this.durabilityProvider);
+                    var eventName = EntityMessageEventNames.ScheduledRequestMessageEventName(adjustedDeliveryTime);
+                    innerContext.SendEvent(instance, eventName, message);
+                }
+
+                messages.Clear();
             }
         }
 

--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableOrchestrationContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableOrchestrationContext.cs
@@ -1123,7 +1123,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             {
                 if (requestMessage.ScheduledTime.HasValue)
                 {
-                    eventName = EntityMessageEventNames.ScheduledRequestMessageEventName(requestMessage.ScheduledTime.Value);
+                    DateTime adjustedDeliveryTime = requestMessage.GetAdjustedDeliveryTime(this.durabilityProvider);
+                    eventName = EntityMessageEventNames.ScheduledRequestMessageEventName(adjustedDeliveryTime);
                 }
                 else
                 {

--- a/src/WebJobs.Extensions.DurableTask/EntityScheduler/RequestMessage.cs
+++ b/src/WebJobs.Extensions.DurableTask/EntityScheduler/RequestMessage.cs
@@ -126,6 +126,26 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             }
         }
 
+        public DateTime GetAdjustedDeliveryTime(DurabilityProvider durabilityProvider)
+        {
+            if (this.ScheduledTime.HasValue)
+            {
+                var now = DateTime.UtcNow;
+                if ((this.ScheduledTime.Value - now) <= durabilityProvider.MaximumDelayTime)
+                {
+                    return this.ScheduledTime.Value;
+                }
+                else
+                {
+                    return now + durabilityProvider.LongRunningTimerIntervalLength;
+                }
+            }
+            else
+            {
+                throw new InvalidOperationException("this is not a delayed message");
+            }
+        }
+
         public override string ToString()
         {
             if (this.IsLockRequest)

--- a/src/WebJobs.Extensions.DurableTask/Listener/TaskEntityShim.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/TaskEntityShim.cs
@@ -29,18 +29,19 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             = new TaskCompletionSource<object>();
 
         // a batch always consists of a (possibly empty) sequence of operations
-        // followed by zero or one lock request
+        // followed by zero or one lock request, and possibly some operations to reschedule
         private readonly List<RequestMessage> operationBatch = new List<RequestMessage>();
         private RequestMessage lockRequest = null;
+        private List<RequestMessage> toBeRescheduled;
 
-        public TaskEntityShim(DurableTaskExtension config, string schedulerId)
+        public TaskEntityShim(DurableTaskExtension config, DurabilityProvider durabilityProvider, string schedulerId)
             : base(config)
         {
             this.messageDataConverter = config.MessageDataConverter;
             this.errorDataConverter = config.ErrorDataConverter;
             this.SchedulerId = schedulerId;
             this.EntityId = EntityId.GetEntityIdFromSchedulerId(schedulerId);
-            this.context = new DurableEntityContext(config, this.EntityId, this);
+            this.context = new DurableEntityContext(config, durabilityProvider, this.EntityId, this);
         }
 
         public override DurableCommonContext Context => this.context;
@@ -63,6 +64,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         public void AddLockRequestToBatch(RequestMessage lockRequest)
         {
             this.lockRequest = lockRequest;
+        }
+
+        public void AddMessageToBeRescheduled(RequestMessage requestMessage)
+        {
+            if (this.toBeRescheduled == null)
+            {
+                this.toBeRescheduled = new List<RequestMessage>();
+            }
+
+            this.toBeRescheduled.Add(requestMessage);
         }
 
         public override RegisteredFunctionInfo GetFunctionInfo()
@@ -156,7 +167,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             DurableTaskExtension.TagActivityWithOrchestrationStatus(status, this.context.InstanceId, true);
 #endif
 
-            if (this.operationBatch.Count == 0 && this.lockRequest == null)
+            if (this.operationBatch.Count == 0
+                && this.lockRequest == null
+                && (this.toBeRescheduled == null || this.toBeRescheduled.Count == 0))
             {
                 // we are idle after a ContinueAsNew - the batch is empty.
                 // Wait for more messages to get here (via extended sessions)
@@ -206,6 +219,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     writeBackSuccessful = this.context.TryWriteback(out serializationErrorMessage);
                 }
 
+                // Reschedule all signals that were received before their time
+                this.context.RescheduleMessages(innerContext, this.toBeRescheduled);
+
                 // Send all buffered outgoing messages
                 this.context.SendOutbox(innerContext, writeBackSuccessful, serializationErrorMessage);
 
@@ -245,8 +261,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         {
             if (this.GetFunctionInfo().IsOutOfProc)
             {
-                // process all operations in the batch using a single function call
-                await this.ExecuteOutOfProcBatch();
+                if (this.operationBatch.Count > 0)
+                {
+                    // process all operations in the batch using a single function call
+                    await this.ExecuteOutOfProcBatch();
+                }
             }
             else
             {


### PR DESCRIPTION
Addresses issue #1463.

If scheduling signals beyond what the durability provider can take responsibility for, the signal is scheduled for a shorter duration. When receiving a signal ahead of the time it is scheduled to execute, it is then rescheduled (instead of being processed). This keeps going until the scheduled time has been reached. 

This implementation uses the same parameters (DurabilityProvider.MaximumDelayTime and DurabilityProvider.LongRunningTimerIntervalLength) as the corresponding functionality for Timers.