### PR TITLE
Resource URL check for ManagedIdentityTokenSource

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/ManagedIdentityTokenSource.cs
+++ b/src/WebJobs.Extensions.DurableTask/ManagedIdentityTokenSource.cs
@@ -32,6 +32,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             {
                 this.Resource = "https://management.core.windows.net/.default";
             }
+
+            if (this.Resource.Equals("https://graph.microsoft.com") || this.Resource.Equals("https://graph.microsoft.com/"))
+            {
+                this.Resource = "https://graph.microsoft.com/.default";
+            }
         }
 
         /// <summary>

--- a/src/WebJobs.Extensions.DurableTask/ManagedIdentityTokenSource.cs
+++ b/src/WebJobs.Extensions.DurableTask/ManagedIdentityTokenSource.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             this.Resource = resource ?? throw new ArgumentNullException(nameof(resource));
             this.Options = options;
 
-            if (this.Resource.Equals("https://management.core.windows.net"))
+            if (this.Resource.Equals("https://management.core.windows.net") || this.Resource.Equals("https://management.core.windows.net/"))
             {
                 this.Resource = "https://management.core.windows.net/.default";
             }

--- a/src/WebJobs.Extensions.DurableTask/ManagedIdentityTokenSource.cs
+++ b/src/WebJobs.Extensions.DurableTask/ManagedIdentityTokenSource.cs
@@ -32,8 +32,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             {
                 this.Resource = "https://management.core.windows.net/.default";
             }
-
-            if (this.Resource.Equals("https://graph.microsoft.com") || this.Resource.Equals("https://graph.microsoft.com/"))
+            else if (this.Resource.Equals("https://graph.microsoft.com") || this.Resource.Equals("https://graph.microsoft.com/"))
             {
                 this.Resource = "https://graph.microsoft.com/.default";
             }

--- a/src/WebJobs.Extensions.DurableTask/ManagedIdentityTokenSource.cs
+++ b/src/WebJobs.Extensions.DurableTask/ManagedIdentityTokenSource.cs
@@ -20,18 +20,23 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// </summary>
         /// <param name="resource">
         /// The Azure Active Directory resource identifier of the web API being invoked.
-        /// For example, <c>https://management.core.windows.net/</c> or <c>https://graph.microsoft.com/</c>.
+        /// For example, <c>https://management.core.windows.net/.default</c> or <c>https://graph.microsoft.com/.default</c>.
         /// </param>
         /// <param name="options">Optional Azure credential options to use when authenticating.</param>
         public ManagedIdentityTokenSource(string resource, ManagedIdentityOptions options = null)
         {
             this.Resource = resource ?? throw new ArgumentNullException(nameof(resource));
             this.Options = options;
+
+            if (this.Resource.Equals("https://management.core.windows.net"))
+            {
+                this.Resource = "https://management.core.windows.net/.default";
+            }
         }
 
         /// <summary>
         /// Gets the Azure Active Directory resource identifier of the web API being invoked.
-        /// For example, <c>https://management.core.windows.net/</c> or <c>https://graph.microsoft.com/</c>.
+        /// For example, <c>https://management.core.windows.net/.default</c> or <c>https://graph.microsoft.com/.default</c>.
         /// </summary>
         [JsonProperty("resource")]
         public string Resource { get; }

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net461.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net461.xml
@@ -2974,14 +2974,14 @@
             </summary>
             <param name="resource">
             The Azure Active Directory resource identifier of the web API being invoked.
-            For example, <c>https://management.core.windows.net/</c> or <c>https://graph.microsoft.com/</c>.
+            For example, <c>https://management.core.windows.net/.default</c> or <c>https://graph.microsoft.com/.default</c>.
             </param>
             <param name="options">Optional Azure credential options to use when authenticating.</param>
         </member>
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.ManagedIdentityTokenSource.Resource">
             <summary>
             Gets the Azure Active Directory resource identifier of the web API being invoked.
-            For example, <c>https://management.core.windows.net/</c> or <c>https://graph.microsoft.com/</c>.
+            For example, <c>https://management.core.windows.net/.default</c> or <c>https://graph.microsoft.com/.default</c>.
             </summary>
         </member>
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.ManagedIdentityTokenSource.Options">

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
@@ -3014,14 +3014,14 @@
             </summary>
             <param name="resource">
             The Azure Active Directory resource identifier of the web API being invoked.
-            For example, <c>https://management.core.windows.net/</c> or <c>https://graph.microsoft.com/</c>.
+            For example, <c>https://management.core.windows.net/.default</c> or <c>https://graph.microsoft.com/.default</c>.
             </param>
             <param name="options">Optional Azure credential options to use when authenticating.</param>
         </member>
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.ManagedIdentityTokenSource.Resource">
             <summary>
             Gets the Azure Active Directory resource identifier of the web API being invoked.
-            For example, <c>https://management.core.windows.net/</c> or <c>https://graph.microsoft.com/</c>.
+            For example, <c>https://management.core.windows.net/.default</c> or <c>https://graph.microsoft.com/.default</c>.
             </summary>
         </member>
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.ManagedIdentityTokenSource.Options">

--- a/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
+++ b/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
@@ -5,7 +5,7 @@
     <AssemblyName>Microsoft.Azure.WebJobs.Extensions.DurableTask</AssemblyName>
     <RootNamespace>Microsoft.Azure.WebJobs.Extensions.DurableTask</RootNamespace>
     <MajorVersion>2</MajorVersion>
-    <MinorVersion>3</MinorVersion>
+    <MinorVersion>4</MinorVersion>
     <PatchVersion>0</PatchVersion>
     <Version>$(MajorVersion).$(MinorVersion).$(PatchVersion)</Version>
     <FileVersion>$(MajorVersion).$(MinorVersion).$(PatchVersion)</FileVersion>

--- a/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
+++ b/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
@@ -5,7 +5,7 @@
     <AssemblyName>Microsoft.Azure.WebJobs.Extensions.DurableTask</AssemblyName>
     <RootNamespace>Microsoft.Azure.WebJobs.Extensions.DurableTask</RootNamespace>
     <MajorVersion>2</MajorVersion>
-    <MinorVersion>4</MinorVersion>
+    <MinorVersion>3</MinorVersion>
     <PatchVersion>0</PatchVersion>
     <Version>$(MajorVersion).$(MinorVersion).$(PatchVersion)</Version>
     <FileVersion>$(MajorVersion).$(MinorVersion).$(PatchVersion)</FileVersion>

--- a/test/FunctionsV2/OutOfProcTests.cs
+++ b/test/FunctionsV2/OutOfProcTests.cs
@@ -123,7 +123,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 ""uri"": ""https://example.com"",
                 ""tokenSource"": {
                     ""kind"": ""AzureManagedIdentity"",
-                    ""resource"": ""https://management.core.windows.net""
+                    ""resource"": ""https://management.core.windows.net/.default""
                 }
             }
         }]
@@ -145,7 +145,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
             Assert.NotNull(request.TokenSource);
             ManagedIdentityTokenSource tokenSource = Assert.IsType<ManagedIdentityTokenSource>(request.TokenSource);
-            Assert.Equal("https://management.core.windows.net", tokenSource.Resource);
+            Assert.Equal("https://management.core.windows.net/.default", tokenSource.Resource);
         }
 
         [Fact]
@@ -174,7 +174,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 ""uri"": ""https://example.com"",
                 ""tokenSource"": {
                     ""kind"": ""AzureManagedIdentity"",
-                    ""resource"": ""https://management.core.windows.net"",
+                    ""resource"": ""https://management.core.windows.net/.default"",
                     ""options"": {
                         ""authorityhost"": ""https://login.microsoftonline.com/"",
                         ""tenantid"": ""example_tenant_id""
@@ -200,7 +200,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
             Assert.NotNull(request.TokenSource);
             ManagedIdentityTokenSource tokenSource = Assert.IsType<ManagedIdentityTokenSource>(request.TokenSource);
-            Assert.Equal("https://management.core.windows.net", tokenSource.Resource);
+            Assert.Equal("https://management.core.windows.net/.default", tokenSource.Resource);
             Assert.Equal("https://login.microsoftonline.com/", tokenSource.Options.AuthorityHost.ToString());
             Assert.Equal("example_tenant_id", tokenSource.Options.TenantId);
         }


### PR DESCRIPTION
Resolves #1481. This change supports docs that use `https://management.core.windows.net`, `https://management.core.windows.net/`, `https://graph.microsoft.com`, or `https://graph.microsoft.com/` as the `ManagedIdentityTokenSource` resource URL. It replaces those URLs with `https://management.core.windows.net/.default` and `https://graph.microsoft.com/.default` which are the resource URLs used in the new Azure.Identity libraries.