### PR TITLE
fix flaky tests for CleanEntityStorage

### DIFF
--- a/test/Common/DurableTaskEndToEndTests.cs
+++ b/test/Common/DurableTaskEndToEndTests.cs
@@ -3986,6 +3986,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             {
                 await host.StartAsync();
 
+                // before the test, clean storage so we can properly validate the count later
+                var irrelevantEntityId = new EntityId("Counter", "unused"); // we don't access this entity, just use it to construct a client
+                var entityClient = await host.GetEntityClientAsync(irrelevantEntityId, this.output);
+                await entityClient.InnerClient.CleanEntityStorageAsync(true, true, CancellationToken.None);
+
                 // construct unique names for this test
                 string prefix = Guid.NewGuid().ToString("N").Substring(0, 6);
                 var emptyEntityId = new EntityId("Counter", $"{prefix}-empty");
@@ -4047,6 +4052,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 storageProviderType: storageProvider))
             {
                 await host.StartAsync();
+
+                // before the test, clean storage so we can properly validate the count later
+                var irrelevantEntityId = new EntityId("Counter", "unused"); // we don't access this entity, just use it to construct a client
+                var entityClient = await host.GetEntityClientAsync(irrelevantEntityId, this.output);
+                await entityClient.InnerClient.CleanEntityStorageAsync(true, true, CancellationToken.None);
 
                 int numReps = 120; // is above the default page size for queries
 

--- a/test/Common/DurableTaskEndToEndTests.cs
+++ b/test/Common/DurableTaskEndToEndTests.cs
@@ -3986,11 +3986,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             {
                 await host.StartAsync();
 
-                // before the test, clean storage so we can properly validate the count later
-                var irrelevantEntityId = new EntityId("Counter", "unused"); // we don't access this entity, just use it to construct a client
-                var entityClient = await host.GetEntityClientAsync(irrelevantEntityId, this.output);
-                await entityClient.InnerClient.CleanEntityStorageAsync(true, true, CancellationToken.None);
-
                 // construct unique names for this test
                 string prefix = Guid.NewGuid().ToString("N").Substring(0, 6);
                 var emptyEntityId = new EntityId("Counter", $"{prefix}-empty");
@@ -4046,17 +4041,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         {
             using (ITestHost host = TestHelpers.GetJobHost(
                 this.loggerProvider,
-                nameof(this.DurableEntity_CleanEntityStorage),
+                nameof(this.DurableEntity_CleanEntityStorage_Many),
                 enableExtendedSessions: false, // we use a failing replay to create the orphaned lock
                 entityMessageReorderWindowInMinutes: 0, // need to set this to zero so deleted entities can be removed immediately
                 storageProviderType: storageProvider))
             {
                 await host.StartAsync();
-
-                // before the test, clean storage so we can properly validate the count later
-                var irrelevantEntityId = new EntityId("Counter", "unused"); // we don't access this entity, just use it to construct a client
-                var entityClient = await host.GetEntityClientAsync(irrelevantEntityId, this.output);
-                await entityClient.InnerClient.CleanEntityStorageAsync(true, true, CancellationToken.None);
 
                 int numReps = 120; // is above the default page size for queries
 


### PR DESCRIPTION
Fixes the tests I saw failing occasionally in other PRs.

The problem is that these tests check the number of empty entities removed, but this number can be off if other tests that run before these also create empty entities.

The solution is to clean the storage prior to the tests, so it starts with a known count of zero.