### PR TITLE
Anaylzer: 0.3.1 bug fixes and small FunctionAnalyzer refactor

### DIFF
--- a/src/WebJobs.Extensions.DurableTask.Analyzers/ActivityFunctionCall.cs
+++ b/src/WebJobs.Extensions.DurableTask.Analyzers/ActivityFunctionCall.cs
@@ -8,9 +8,17 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
     public class ActivityFunctionCall
     {
         public string FunctionName { get; set; }
+
         public SyntaxNode NameNode { get; set; }
-        public SyntaxNode ArgumentNode { get; set; }
+
+        public SyntaxNode InputNode { get; set; }
+
+        public ITypeSymbol InputType { get; set; }
+
         public SyntaxNode ReturnTypeNode { get; set; }
+
+        public ITypeSymbol ReturnType { get; set; }
+
         public SyntaxNode InvocationExpression { get; set; }
     }
 }

--- a/src/WebJobs.Extensions.DurableTask.Analyzers/ActivityFunctionDefinition.cs
+++ b/src/WebJobs.Extensions.DurableTask.Analyzers/ActivityFunctionDefinition.cs
@@ -11,6 +11,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
 
         public SyntaxNode ParameterNode { get; set; }
 
+        public ITypeSymbol InputType { get; set; }
+
         public SyntaxNode ReturnTypeNode { get; set; }
+
+        public ITypeSymbol ReturnType { get; set; }
     }
 }

--- a/src/WebJobs.Extensions.DurableTask.Analyzers/Analyzers/ActivityFunction/ArgumentAnalyzer.cs
+++ b/src/WebJobs.Extensions.DurableTask.Analyzers/Analyzers/ActivityFunction/ArgumentAnalyzer.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
                 {
                     if (InvocationInputIsNull(invocation))
                     {
-                        if (DefinitionInputIsValueType(definition))
+                        if (DefinitionInputIsNonNullableValueType(definition))
                         {
                             var diagnostic = Diagnostic.Create(InvalidNullRule, invocation.InputNode.GetLocation(), invocation.FunctionName, definition.InputType.ToString());
 
@@ -70,9 +70,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
             return invocation.InputNode != null && invocation.InputNode.IsKind(SyntaxKind.NullLiteralExpression);
         }
 
-        private static bool DefinitionInputIsValueType(ActivityFunctionDefinition definition)
+        private static bool DefinitionInputIsNonNullableValueType(ActivityFunctionDefinition definition)
         {
-            return definition.InputType != null && definition.InputType.IsValueType;
+            var inputType = definition.InputType;
+            return inputType != null && inputType.IsValueType && !inputType.Name.Equals("Nullable");
         }
 
         private static bool DefinitionInputIsNotUsed(ActivityFunctionDefinition definition)

--- a/src/WebJobs.Extensions.DurableTask.Analyzers/Analyzers/ActivityFunction/ArgumentAnalyzer.cs
+++ b/src/WebJobs.Extensions.DurableTask.Analyzers/Analyzers/ActivityFunction/ArgumentAnalyzer.cs
@@ -5,6 +5,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -16,12 +17,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
         private static readonly LocalizableString Title = new LocalizableResourceString(nameof(Resources.ActivityArgumentAnalyzerTitle), Resources.ResourceManager, typeof(Resources));
         private static readonly LocalizableString MismatchMessageFormat = new LocalizableResourceString(nameof(Resources.ActivityArgumentAnalyzerMessageFormat), Resources.ResourceManager, typeof(Resources));
         private static readonly LocalizableString InputNotUsedMessageFormat = new LocalizableResourceString(nameof(Resources.ActivityArgumentAnalyzerMessageFormatNotUsed), Resources.ResourceManager, typeof(Resources));
+        private static readonly LocalizableString InvalidNullMessageFormat = new LocalizableResourceString(nameof(Resources.ActivityArgumentAnalyzerMessageFormatInvalidNull), Resources.ResourceManager, typeof(Resources));
         private static readonly LocalizableString Description = new LocalizableResourceString(nameof(Resources.ActivityArgumentAnalyzerDescription), Resources.ResourceManager, typeof(Resources));
         private const string Category = SupportedCategories.Activity;
         public const DiagnosticSeverity Severity = DiagnosticSeverity.Warning;
 
         public static readonly DiagnosticDescriptor MismatchRule = new DiagnosticDescriptor(DiagnosticId, Title, MismatchMessageFormat, Category, Severity, isEnabledByDefault: true, description: Description);
         public static readonly DiagnosticDescriptor InputNotUsedRule = new DiagnosticDescriptor(DiagnosticId, Title, InputNotUsedMessageFormat, Category, Severity, isEnabledByDefault: true, description: Description);
+        public static readonly DiagnosticDescriptor InvalidNullRule = new DiagnosticDescriptor(DiagnosticId, Title, InvalidNullMessageFormat, Category, Severity, isEnabledByDefault: true, description: Description);
 
         public static void ReportProblems(
             CompilationAnalysisContext context,
@@ -34,20 +37,26 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
                 var definition = functionDefinitions.Where(x => x.FunctionName == invocation.FunctionName).FirstOrDefault();
                 if (definition != null)
                 {
-                    var isInvokedWithNonNullInput = TryGetInvocationInputType(semanticModel, invocation, out ITypeSymbol invocationInputType);
-                    var functionDefinitionUsesInput = TryGetDefinitionInputType(semanticModel, definition, out ITypeSymbol definitionInputType);
-
-                    if (isInvokedWithNonNullInput && invocationInputType != null)
+                    if (InvocationInputIsNull(invocation))
                     {
-                        if (!functionDefinitionUsesInput)
+                        if (DefinitionInputIsValueType(definition))
                         {
-                            var diagnostic = Diagnostic.Create(InputNotUsedRule, invocation.ArgumentNode.GetLocation(), invocation.FunctionName);
+                            var diagnostic = Diagnostic.Create(InvalidNullRule, invocation.InputNode.GetLocation(), invocation.FunctionName, definition.InputType.ToString());
 
                             context.ReportDiagnostic(diagnostic);
                         }
-                        else if (!IsValidArgumentForDefinition(invocationInputType, definitionInputType))
+                    }
+                    else
+                    {
+                        if (DefinitionInputIsNotUsed(definition))
                         {
-                            var diagnostic = Diagnostic.Create(MismatchRule, invocation.ArgumentNode.GetLocation(), invocation.FunctionName, definitionInputType.ToString(), invocationInputType.ToString());
+                            var diagnostic = Diagnostic.Create(InputNotUsedRule, invocation.InputNode.GetLocation(), invocation.FunctionName);
+
+                            context.ReportDiagnostic(diagnostic);
+                        }
+                        else if (!IsValidArgumentForDefinition(invocation, definition))
+                        {
+                            var diagnostic = Diagnostic.Create(MismatchRule, invocation.InputNode.GetLocation(), invocation.FunctionName, definition.InputType, invocation.InputType);
 
                             context.ReportDiagnostic(diagnostic);
                         }
@@ -56,84 +65,24 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
             }
         }
 
-        private static bool TryGetInvocationInputType(SemanticModel semanticModel, ActivityFunctionCall activityInvocation, out ITypeSymbol invocationInputType)
+        private static bool InvocationInputIsNull(ActivityFunctionCall invocation)
         {
-            var activityInput = activityInvocation.ArgumentNode;
-            if (activityInput == null)
-            {
-                invocationInputType = null;
-                return false;
-            }
-
-            return SyntaxNodeUtils.TryGetITypeSymbol(semanticModel, activityInput, out invocationInputType);
+            return invocation.InputNode != null && invocation.InputNode.IsKind(SyntaxKind.NullLiteralExpression);
         }
 
-        private static bool TryGetDefinitionInputType(SemanticModel semanticModel, ActivityFunctionDefinition functionDefinition, out ITypeSymbol definitionInputType)
+        private static bool DefinitionInputIsValueType(ActivityFunctionDefinition definition)
         {
-            var definitionInput = functionDefinition.ParameterNode;
-            if (definitionInput == null)
-            {
-                definitionInputType = null;
-                return false;
-            }
-
-            if (SyntaxNodeUtils.TryGetITypeSymbol(semanticModel, definitionInput, out definitionInputType))
-            {
-                if (SyntaxNodeUtils.IsDurableActivityContext(definitionInputType))
-                {
-                    return TryGetInputTypeFromContext(semanticModel, definitionInput, out definitionInputType);
-                }
-
-                return true;
-            }
-
-            definitionInputType = null;
-            return false;
+            return definition.InputType != null && definition.InputType.IsValueType;
         }
 
-        private static bool TryGetInputTypeFromContext(SemanticModel semanticModel, SyntaxNode node, out ITypeSymbol definitionInputType)
+        private static bool DefinitionInputIsNotUsed(ActivityFunctionDefinition definition)
         {
-            if (TryGetDurableActivityContextExpression(semanticModel, node, out SyntaxNode durableContextExpression))
-            {
-                if (SyntaxNodeUtils.TryGetTypeArgumentIdentifier((MemberAccessExpressionSyntax)durableContextExpression, out SyntaxNode typeArgument))
-                {
-                    return SyntaxNodeUtils.TryGetITypeSymbol(semanticModel, typeArgument, out definitionInputType);
-                }
-            }
-
-            definitionInputType = null;
-            return false;
+            return definition.InputType == null;
         }
 
-        private static bool TryGetDurableActivityContextExpression(SemanticModel semanticModel, SyntaxNode node, out SyntaxNode durableContextExpression)
+        private static bool IsValidArgumentForDefinition(ActivityFunctionCall invocation, ActivityFunctionDefinition definition)
         {
-            if (SyntaxNodeUtils.TryGetMethodDeclaration(node, out SyntaxNode methodDeclaration))
-            {
-                var memberAccessExpressionList = methodDeclaration.DescendantNodes().Where(x => x.IsKind(SyntaxKind.SimpleMemberAccessExpression));
-                foreach (var memberAccessExpression in memberAccessExpressionList)
-                {
-                    var identifierName = memberAccessExpression.ChildNodes().Where(x => x.IsKind(SyntaxKind.IdentifierName)).FirstOrDefault();
-                    if (identifierName != null)
-                    {
-                        if (SyntaxNodeUtils.TryGetITypeSymbol(semanticModel, identifierName, out ITypeSymbol typeSymbol))
-                        {
-                            if (SyntaxNodeUtils.IsDurableActivityContext(typeSymbol))
-                            {
-                                durableContextExpression = memberAccessExpression;
-                                return true;
-                            }
-                        }
-                    }
-                }
-            }
-
-            durableContextExpression = null;
-            return false;
-        }
-
-        private static bool IsValidArgumentForDefinition(ITypeSymbol invocationInputType, ITypeSymbol definitionInputType)
-        {
-            return SyntaxNodeUtils.IsMatchingDerivedOrCompatibleType(invocationInputType, definitionInputType);
+            return SyntaxNodeUtils.IsMatchingDerivedOrCompatibleType(invocation.InputType, definition.InputType);
         }
     }
 }

--- a/src/WebJobs.Extensions.DurableTask.Analyzers/Analyzers/ActivityFunction/ArgumentAnalyzer.cs
+++ b/src/WebJobs.Extensions.DurableTask.Analyzers/Analyzers/ActivityFunction/ArgumentAnalyzer.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
         {
             foreach (var invocation in functionInvocations)
             {
-                var definition = functionDefinitions.Where(x => x.FunctionName == invocation.FunctionName).FirstOrDefault();
+                var definition = functionDefinitions.FirstOrDefault(x => x.FunctionName == invocation.FunctionName);
                 if (definition != null)
                 {
                     if (InvocationInputIsNull(invocation))

--- a/src/WebJobs.Extensions.DurableTask.Analyzers/Analyzers/ActivityFunction/FunctionAnalyzer.cs
+++ b/src/WebJobs.Extensions.DurableTask.Analyzers/Analyzers/ActivityFunction/FunctionAnalyzer.cs
@@ -67,14 +67,20 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
 
                 SyntaxNodeUtils.TryGetTypeArgumentIdentifier((MemberAccessExpressionSyntax)invocationExpression.Expression, out SyntaxNode returnTypeNode);
 
+                SyntaxNodeUtils.TryGetITypeSymbol(semanticModel, returnTypeNode, out ITypeSymbol returnType);
+
                 TryGetInputNodeFromCallActivityInvocation(invocationExpression, out SyntaxNode inputNode);
+
+                SyntaxNodeUtils.TryGetITypeSymbol(semanticModel, inputNode, out ITypeSymbol inputType);
 
                 calledFunctions.Add(new ActivityFunctionCall
                 {
                     FunctionName = functionName,
                     NameNode = functionNameNode,
-                    ArgumentNode = inputNode,
+                    InputNode = inputNode,
+                    InputType = inputType,
                     ReturnTypeNode = returnTypeNode,
+                    ReturnType = returnType,
                     InvocationExpression = invocationExpression
                 });
             }
@@ -144,10 +150,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
 
         public void FindActivityFunction(SyntaxNodeAnalysisContext context)
         {
+            var semanticModel = context.SemanticModel;
             if (context.Node is AttributeSyntax attribute
                 && SyntaxNodeUtils.IsActivityTriggerAttribute(attribute))
             {
-                if (!SyntaxNodeUtils.TryGetFunctionName(context.SemanticModel, attribute, out string functionName))
+                if (!SyntaxNodeUtils.TryGetFunctionName(semanticModel, attribute, out string functionName))
                 {
                     //Do not store ActivityFunctionDefinition if there is no function name
                     return;
@@ -159,15 +166,77 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
                     return;
                 }
 
+                SyntaxNodeUtils.TryGetITypeSymbol(semanticModel, returnTypeNode, out ITypeSymbol returnType);
+
                 SyntaxNodeUtils.TryGetParameterNodeNextToAttribute(context, attribute, out SyntaxNode parameterNode);
+
+                TryGetDefinitionInputType(semanticModel, parameterNode, out ITypeSymbol inputType);
 
                 availableFunctions.Add(new ActivityFunctionDefinition
                 {
                     FunctionName = functionName,
                     ParameterNode = parameterNode,
-                    ReturnTypeNode = returnTypeNode
+                    InputType = inputType,
+                    ReturnTypeNode = returnTypeNode,
+                    ReturnType = returnType
                 });
             }
+        }
+
+        private static bool TryGetDefinitionInputType(SemanticModel semanticModel, SyntaxNode parameterNode, out ITypeSymbol definitionInputType)
+        {
+            if (SyntaxNodeUtils.TryGetITypeSymbol(semanticModel, parameterNode, out definitionInputType))
+            {
+                if (SyntaxNodeUtils.IsDurableActivityContext(definitionInputType))
+                {
+                    return TryGetInputTypeFromContext(semanticModel, parameterNode, out definitionInputType);
+                }
+
+                return true;
+            }
+
+            definitionInputType = null;
+            return false;
+        }
+
+        private static bool TryGetInputTypeFromContext(SemanticModel semanticModel, SyntaxNode node, out ITypeSymbol definitionInputType)
+        {
+            if (TryGetDurableActivityContextExpression(semanticModel, node, out SyntaxNode durableContextExpression))
+            {
+                if (SyntaxNodeUtils.TryGetTypeArgumentIdentifier((MemberAccessExpressionSyntax)durableContextExpression, out SyntaxNode typeArgument))
+                {
+                    return SyntaxNodeUtils.TryGetITypeSymbol(semanticModel, typeArgument, out definitionInputType);
+                }
+            }
+
+            definitionInputType = null;
+            return false;
+        }
+
+        private static bool TryGetDurableActivityContextExpression(SemanticModel semanticModel, SyntaxNode node, out SyntaxNode durableContextExpression)
+        {
+            if (SyntaxNodeUtils.TryGetMethodDeclaration(node, out SyntaxNode methodDeclaration))
+            {
+                var memberAccessExpressionList = methodDeclaration.DescendantNodes().Where(x => x.IsKind(SyntaxKind.SimpleMemberAccessExpression));
+                foreach (var memberAccessExpression in memberAccessExpressionList)
+                {
+                    var identifierName = memberAccessExpression.ChildNodes().Where(x => x.IsKind(SyntaxKind.IdentifierName)).FirstOrDefault();
+                    if (identifierName != null)
+                    {
+                        if (SyntaxNodeUtils.TryGetITypeSymbol(semanticModel, identifierName, out ITypeSymbol typeSymbol))
+                        {
+                            if (SyntaxNodeUtils.IsDurableActivityContext(typeSymbol))
+                            {
+                                durableContextExpression = memberAccessExpression;
+                                return true;
+                            }
+                        }
+                    }
+                }
+            }
+
+            durableContextExpression = null;
+            return false;
         }
     }
 }

--- a/src/WebJobs.Extensions.DurableTask.Analyzers/Analyzers/ActivityFunction/FunctionAnalyzer.cs
+++ b/src/WebJobs.Extensions.DurableTask.Analyzers/Analyzers/ActivityFunction/FunctionAnalyzer.cs
@@ -220,7 +220,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
                 var memberAccessExpressionList = methodDeclaration.DescendantNodes().Where(x => x.IsKind(SyntaxKind.SimpleMemberAccessExpression));
                 foreach (var memberAccessExpression in memberAccessExpressionList)
                 {
-                    var identifierName = memberAccessExpression.ChildNodes().Where(x => x.IsKind(SyntaxKind.IdentifierName)).FirstOrDefault();
+                    var identifierName = memberAccessExpression.ChildNodes().FirstOrDefault(x => x.IsKind(SyntaxKind.IdentifierName));
                     if (identifierName != null)
                     {
                         if (SyntaxNodeUtils.TryGetITypeSymbol(semanticModel, identifierName, out ITypeSymbol typeSymbol))

--- a/src/WebJobs.Extensions.DurableTask.Analyzers/Analyzers/ActivityFunction/FunctionReturnTypeAnalyzer.cs
+++ b/src/WebJobs.Extensions.DurableTask.Analyzers/Analyzers/ActivityFunction/FunctionReturnTypeAnalyzer.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
         {
             foreach (var invocation in functionInvocations)
             {
-                var definition = functionDefinitions.Where(x => x.FunctionName == invocation.FunctionName).FirstOrDefault();
+                var definition = functionDefinitions.FirstOrDefault(x => x.FunctionName == invocation.FunctionName);
                 if (definition != null && invocation.ReturnTypeNode != null)
                 {
                     if (!IsValidReturnTypeForDefinition(invocation, definition))
@@ -54,7 +54,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
 
         private static bool TryGetTaskTypeArgument(ITypeSymbol returnType, out ITypeSymbol taskTypeArgument)
         {
-            if (returnType != null && returnType.Name.Equals("Task") && returnType is INamedTypeSymbol namedType)
+            if (returnType is INamedTypeSymbol namedType && returnType.Name.Equals("Task"))
             {
                 taskTypeArgument = namedType.TypeArguments.FirstOrDefault();
                 return taskTypeArgument != null;

--- a/src/WebJobs.Extensions.DurableTask.Analyzers/Analyzers/ActivityFunction/FunctionReturnTypeAnalyzer.cs
+++ b/src/WebJobs.Extensions.DurableTask.Analyzers/Analyzers/ActivityFunction/FunctionReturnTypeAnalyzer.cs
@@ -31,33 +31,30 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
                 var definition = functionDefinitions.Where(x => x.FunctionName == invocation.FunctionName).FirstOrDefault();
                 if (definition != null && invocation.ReturnTypeNode != null)
                 {
-                    if (TryGetInvocationReturnType(semanticModel, invocation, out ITypeSymbol invocationReturnType)
-                        && TryGetDefinitionReturnType(semanticModel, definition, out ITypeSymbol definitionReturnType))
+                    if (!IsValidReturnTypeForDefinition(invocation, definition))
                     {
-                        if (!IsValidReturnTypeForDefinition(invocationReturnType, definitionReturnType))
-                        {
-                            var diagnostic = Diagnostic.Create(Rule, invocation.InvocationExpression.GetLocation(), invocation.FunctionName, definitionReturnType.ToString(), invocationReturnType.ToString());
+                        var diagnostic = Diagnostic.Create(Rule, invocation.InvocationExpression.GetLocation(), invocation.FunctionName, definition.ReturnType, invocation.ReturnType);
 
-                            context.ReportDiagnostic(diagnostic);
-                        }
+                        context.ReportDiagnostic(diagnostic);
                     }
                 }
             }
         }
 
-        private static bool IsValidReturnTypeForDefinition(ITypeSymbol invocationReturnType, ITypeSymbol definitionReturnType)
+        private static bool IsValidReturnTypeForDefinition(ActivityFunctionCall invocation, ActivityFunctionDefinition definition)
         {
+            var definitionReturnType = definition.ReturnType;
             if (TryGetTaskTypeArgument(definitionReturnType, out ITypeSymbol taskTypeArgument))
             {
                 definitionReturnType = taskTypeArgument;
             }
 
-            return SyntaxNodeUtils.IsMatchingDerivedOrCompatibleType(definitionReturnType, invocationReturnType);
+            return SyntaxNodeUtils.IsMatchingDerivedOrCompatibleType(definitionReturnType, invocation.ReturnType);
         }
 
         private static bool TryGetTaskTypeArgument(ITypeSymbol returnType, out ITypeSymbol taskTypeArgument)
         {
-            if (returnType.Name.Equals("Task") && returnType is INamedTypeSymbol namedType)
+            if (returnType != null && returnType.Name.Equals("Task") && returnType is INamedTypeSymbol namedType)
             {
                 taskTypeArgument = namedType.TypeArguments.FirstOrDefault();
                 return taskTypeArgument != null;
@@ -65,20 +62,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
 
             taskTypeArgument = null;
             return false;
-        }
-
-        private static bool TryGetInvocationReturnType(SemanticModel semanticModel, ActivityFunctionCall activityInvocation, out ITypeSymbol invocationReturnType)
-        {
-            var invocationReturnNode = activityInvocation.ReturnTypeNode;
-
-            return SyntaxNodeUtils.TryGetITypeSymbol(semanticModel, invocationReturnNode, out invocationReturnType);
-        }
-
-        private static bool TryGetDefinitionReturnType(SemanticModel semanticModel, ActivityFunctionDefinition functionDefinition, out ITypeSymbol definitionReturnType)
-        {
-            var definitionReturnNode = functionDefinition.ReturnTypeNode;
-
-            return SyntaxNodeUtils.TryGetITypeSymbol(semanticModel, definitionReturnNode, out definitionReturnType);
         }
     }
 }

--- a/src/WebJobs.Extensions.DurableTask.Analyzers/Analyzers/Entity/StaticFunctionAnalyzer.cs
+++ b/src/WebJobs.Extensions.DurableTask.Analyzers/Analyzers/Entity/StaticFunctionAnalyzer.cs
@@ -22,13 +22,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
 
         public static void ReportProblems(CompilationAnalysisContext context, SyntaxNode methodDeclaration)
         {
-            var staticKeyword = methodDeclaration.ChildTokens().Where(x => x.IsKind(SyntaxKind.StaticKeyword)).FirstOrDefault();
+            var staticKeyword = methodDeclaration.ChildTokens().FirstOrDefault(x => x.IsKind(SyntaxKind.StaticKeyword));
             if (staticKeyword == null || staticKeyword.IsKind(SyntaxKind.None))
             {
                 SemanticModel semanticModel = context.Compilation.GetSemanticModel(methodDeclaration.SyntaxTree);
                 if (IsInEntityClass(semanticModel, methodDeclaration))
                 {
-                    var methodName = methodDeclaration.ChildTokens().Where(x => x.IsKind(SyntaxKind.IdentifierToken)).FirstOrDefault();
+                    var methodName = methodDeclaration.ChildTokens().FirstOrDefault(x => x.IsKind(SyntaxKind.IdentifierToken));
 
                     if (methodName != null)
                     {

--- a/src/WebJobs.Extensions.DurableTask.Analyzers/Analyzers/EntityInterface/InterfaceAnalyzer.cs
+++ b/src/WebJobs.Extensions.DurableTask.Analyzers/Analyzers/EntityInterface/InterfaceAnalyzer.cs
@@ -115,7 +115,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
 
         private bool IsInterface(SyntaxNode declaration)
         {
-            var interfaceKeyword = declaration.ChildTokens().Where(x => x.IsKind(SyntaxKind.InterfaceKeyword)).FirstOrDefault();
+            var interfaceKeyword = declaration.ChildTokens().FirstOrDefault(x => x.IsKind(SyntaxKind.InterfaceKeyword));
             return interfaceKeyword != null && !interfaceKeyword.IsKind(SyntaxKind.None);
         }
     }

--- a/src/WebJobs.Extensions.DurableTask.Analyzers/Analyzers/EntityInterface/ParameterAnalyzer.cs
+++ b/src/WebJobs.Extensions.DurableTask.Analyzers/Analyzers/EntityInterface/ParameterAnalyzer.cs
@@ -27,12 +27,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
             {
                 if (node.IsKind(SyntaxKind.MethodDeclaration))
                 {
-                    var parameterList = node.ChildNodes().Where(x => x.IsKind(SyntaxKind.ParameterList));
-                    if (!parameterList.Any())
+                    var parameterList = node.ChildNodes().FirstOrDefault(x => x.IsKind(SyntaxKind.ParameterList));
+                    if (parameterList == null)
                     {
                         return;
                     }
-                    var parameters = parameterList.First().ChildNodes().Where(x => x.IsKind(SyntaxKind.Parameter));
+
+                    var parameters = parameterList.ChildNodes().Where(x => x.IsKind(SyntaxKind.Parameter));
                     if (parameters.Count() > 1)
                     {
                         var diagnostic = Diagnostic.Create(Rule, node.GetLocation(), node);

--- a/src/WebJobs.Extensions.DurableTask.Analyzers/Analyzers/Orchestrator/ThreadTaskAnalyzer.cs
+++ b/src/WebJobs.Extensions.DurableTask.Analyzers/Analyzers/Orchestrator/ThreadTaskAnalyzer.cs
@@ -161,18 +161,17 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
                 return false;
             }
 
-            var argumentList = invocationExpression.ChildNodes().Where(x => x.IsKind(SyntaxKind.ArgumentList)).FirstOrDefault();
+            var argumentList = invocationExpression.ChildNodes().FirstOrDefault(x => x.IsKind(SyntaxKind.ArgumentList));
 
             if (argumentList != null)
             {
                 foreach (SyntaxNode argument in argumentList.ChildNodes())
                 {
-                    var simpleMemberAccessExpression = argument.ChildNodes().Where(x => x.IsKind(SyntaxKind.SimpleMemberAccessExpression)).FirstOrDefault();
+                    var simpleMemberAccessExpression = argument.ChildNodes().FirstOrDefault(x => x.IsKind(SyntaxKind.SimpleMemberAccessExpression));
 
                     if (simpleMemberAccessExpression != null)
                     {
                         var identifierNames = simpleMemberAccessExpression.ChildNodes().Where(x => x.IsKind(SyntaxKind.IdentifierName));
-
                         foreach (SyntaxNode identifier in identifierNames)
                         {
                             if (identifier.ToString().Equals("ExecuteSynchronously"))

--- a/src/WebJobs.Extensions.DurableTask.Analyzers/CodeFixProviderUtils.cs
+++ b/src/WebJobs.Extensions.DurableTask.Analyzers/CodeFixProviderUtils.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
         {
             if (SyntaxNodeUtils.TryGetMethodDeclaration(node, out SyntaxNode methodDeclaration))
             {
-                var parameterList = methodDeclaration.ChildNodes().Where(x => x.IsKind(SyntaxKind.ParameterList)).First();
+                var parameterList = methodDeclaration.ChildNodes().First(x => x.IsKind(SyntaxKind.ParameterList));
 
                 foreach (SyntaxNode parameter in parameterList.ChildNodes())
                 {

--- a/src/WebJobs.Extensions.DurableTask.Analyzers/CodefixProviders/Orchestrator/TimerCodeFixProvider.cs
+++ b/src/WebJobs.Extensions.DurableTask.Analyzers/CodefixProviders/Orchestrator/TimerCodeFixProvider.cs
@@ -103,7 +103,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
                 return true;
             }
 
-            invocationExpression = expression.ChildNodes().Where(x => x.IsKind(SyntaxKind.InvocationExpression)).FirstOrDefault();
+            invocationExpression = expression.ChildNodes().FirstOrDefault(x => x.IsKind(SyntaxKind.InvocationExpression));
             return invocationExpression != null;
         }
 
@@ -193,8 +193,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
             }
             
             nodes = argument.ChildNodes().Where(x => x.IsKind(kind));
-            
-            if (nodes.FirstOrDefault() != null)
+            if (nodes.Any())
             {
                 return true;
             }
@@ -214,10 +213,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
             {
                 foreach (SyntaxNode argument in argumentEnumerable)
                 {
-                    var numericLiteralNodeEnumerable = argument.ChildNodes().Where(x => x.IsKind(SyntaxKind.NumericLiteralExpression));
-                    if (numericLiteralNodeEnumerable.Any())
+                    var numericLiteralNodeEnumerable = argument.ChildNodes().FirstOrDefault(x => x.IsKind(SyntaxKind.NumericLiteralExpression));
+                    if (numericLiteralNodeEnumerable != null)
                     {
-                        milliseconds = numericLiteralNodeEnumerable.First().ToString();
+                        milliseconds = numericLiteralNodeEnumerable.ToString();
                         return true;
                     }
                 }
@@ -229,10 +228,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
 
         private bool TryGetArgumentEnumerable(SyntaxNode expression, out IEnumerable<SyntaxNode> arguments)
         {
-            var argumentListEnumerable = expression.ChildNodes().Where(x => x.IsKind(SyntaxKind.ArgumentList));
-            if (argumentListEnumerable.Any())
+            var argumentListEnumerable = expression.ChildNodes().FirstOrDefault(x => x.IsKind(SyntaxKind.ArgumentList));
+            if (argumentListEnumerable != null)
             {
-                var argumentEnumerable = argumentListEnumerable.First().ChildNodes().Where(x => x.IsKind(SyntaxKind.Argument));
+                var argumentEnumerable = argumentListEnumerable.ChildNodes().Where(x => x.IsKind(SyntaxKind.Argument));
                 if (argumentEnumerable.Any())
                 {
                     arguments = argumentEnumerable;

--- a/src/WebJobs.Extensions.DurableTask.Analyzers/Resources.Designer.cs
+++ b/src/WebJobs.Extensions.DurableTask.Analyzers/Resources.Designer.cs
@@ -79,6 +79,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Activity function named &apos;{0}&apos; takes &apos;{1}&apos; but was given null. Cannot pass null on a value type..
+        /// </summary>
+        public static string ActivityArgumentAnalyzerMessageFormatInvalidNull {
+            get {
+                return ResourceManager.GetString("ActivityArgumentAnalyzerMessageFormatInvalidNull", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Activity function named &apos;{0}&apos; doesn&apos;t use its input. Pass null for the input parameter instead..
         /// </summary>
         public static string ActivityArgumentAnalyzerMessageFormatNotUsed {

--- a/src/WebJobs.Extensions.DurableTask.Analyzers/Resources.Designer.cs
+++ b/src/WebJobs.Extensions.DurableTask.Analyzers/Resources.Designer.cs
@@ -70,7 +70,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Activity function named &apos;{0}&apos; takes &apos;{1}&apos; but was given &apos;{2}&apos;..
+        ///   Looks up a localized string similar to Activity function named &apos;{0}&apos; takes a parameter of type &apos;{1}&apos; but was given &apos;{2}&apos;..
         /// </summary>
         public static string ActivityArgumentAnalyzerMessageFormat {
             get {
@@ -79,7 +79,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Activity function named &apos;{0}&apos; takes &apos;{1}&apos; but was given null. Cannot pass null on a value type..
+        ///   Looks up a localized string similar to Activity function named &apos;{0}&apos; takes a parameter of type &apos;{1}&apos; but was given null. Cannot pass null on a value type..
         /// </summary>
         public static string ActivityArgumentAnalyzerMessageFormatInvalidNull {
             get {
@@ -88,7 +88,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Activity function named &apos;{0}&apos; doesn&apos;t use its input. Pass null for the input parameter instead..
+        ///   Looks up a localized string similar to Activity function named &apos;{0}&apos; doesn&apos;t have an input. Pass null for the input parameter instead..
         /// </summary>
         public static string ActivityArgumentAnalyzerMessageFormatNotUsed {
             get {

--- a/src/WebJobs.Extensions.DurableTask.Analyzers/Resources.resx
+++ b/src/WebJobs.Extensions.DurableTask.Analyzers/Resources.resx
@@ -121,13 +121,13 @@
     <value>Activity function call specifies a parameter that doesn't match the function definition parameter.</value>
   </data>
   <data name="ActivityArgumentAnalyzerMessageFormat" xml:space="preserve">
-    <value>Activity function named '{0}' takes '{1}' but was given '{2}'.</value>
+    <value>Activity function named '{0}' takes a parameter of type '{1}' but was given '{2}'.</value>
   </data>
   <data name="ActivityArgumentAnalyzerMessageFormatInvalidNull" xml:space="preserve">
-    <value>Activity function named '{0}' takes '{1}' but was given null. Cannot pass null on a value type.</value>
+    <value>Activity function named '{0}' takes a parameter of type '{1}' but was given null. Cannot pass null on a value type.</value>
   </data>
   <data name="ActivityArgumentAnalyzerMessageFormatNotUsed" xml:space="preserve">
-    <value>Activity function named '{0}' doesn't use its input. Pass null for the input parameter instead.</value>
+    <value>Activity function named '{0}' doesn't have an input. Pass null for the input parameter instead.</value>
   </data>
   <data name="ActivityArgumentAnalyzerTitle" xml:space="preserve">
     <value>Activity function call is using the wrong argument type.</value>

--- a/src/WebJobs.Extensions.DurableTask.Analyzers/Resources.resx
+++ b/src/WebJobs.Extensions.DurableTask.Analyzers/Resources.resx
@@ -123,6 +123,9 @@
   <data name="ActivityArgumentAnalyzerMessageFormat" xml:space="preserve">
     <value>Activity function named '{0}' takes '{1}' but was given '{2}'.</value>
   </data>
+  <data name="ActivityArgumentAnalyzerMessageFormatInvalidNull" xml:space="preserve">
+    <value>Activity function named '{0}' takes '{1}' but was given null. Cannot pass null on a value type.</value>
+  </data>
   <data name="ActivityArgumentAnalyzerMessageFormatNotUsed" xml:space="preserve">
     <value>Activity function named '{0}' doesn't use its input. Pass null for the input parameter instead.</value>
   </data>

--- a/src/WebJobs.Extensions.DurableTask.Analyzers/SyntaxNodeUtils.cs
+++ b/src/WebJobs.Extensions.DurableTask.Analyzers/SyntaxNodeUtils.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
 
         public static bool TryGetSemanticModelForSyntaxTree(SemanticModel model, SyntaxNode node, out SemanticModel newModel)
         {
-            if (model == null || model.SyntaxTree == null || node == null || node.SyntaxTree == null)
+            if (model?.SyntaxTree == null || node?.SyntaxTree == null)
             {
                 newModel = null;
                 return false;
@@ -75,7 +75,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
         {
             if (TryGetMethodDeclaration(node, out SyntaxNode methodDeclaration))
             {
-                var parameterList = methodDeclaration.ChildNodes().Where(x => x.IsKind(SyntaxKind.ParameterList)).First();
+                var parameterList = methodDeclaration.ChildNodes().First(x => x.IsKind(SyntaxKind.ParameterList));
 
                 foreach (SyntaxNode parameter in parameterList.ChildNodes())
                 {
@@ -107,7 +107,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
 
         private static bool TryGetChildTypeNode(SyntaxNode node, out SyntaxNode childTypeNode)
         {
-            childTypeNode = node.ChildNodes().Where(x => x.IsKind(SyntaxKind.IdentifierName) || x.IsKind(SyntaxKind.PredefinedType) || x.IsKind(SyntaxKind.GenericName) || x.IsKind(SyntaxKind.ArrayType) || x.IsKind(SyntaxKind.TupleType) || x.IsKind(SyntaxKind.NullableType)).FirstOrDefault();
+            childTypeNode = node.ChildNodes().FirstOrDefault(
+                x => x.IsKind(SyntaxKind.IdentifierName)
+                || x.IsKind(SyntaxKind.PredefinedType)
+                || x.IsKind(SyntaxKind.GenericName)
+                || x.IsKind(SyntaxKind.ArrayType)
+                || x.IsKind(SyntaxKind.TupleType)
+                || x.IsKind(SyntaxKind.NullableType));
+
             return childTypeNode != null;
         }
 
@@ -244,13 +251,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
         {
             if (node != null && node.IsKind(SyntaxKind.InvocationExpression))
             {
-                var argumentList = node.ChildNodes().Where(x => x.IsKind(SyntaxKind.ArgumentList)).FirstOrDefault();
+                var argumentList = node.ChildNodes().FirstOrDefault(x => x.IsKind(SyntaxKind.ArgumentList));
                 if (argumentList != null)
                 {
-                    var argument = argumentList.ChildNodes().Where(x => x.IsKind(SyntaxKind.Argument)).FirstOrDefault();
+                    var argument = argumentList.ChildNodes().FirstOrDefault(x => x.IsKind(SyntaxKind.Argument));
                     if (argument != null)
                     {
-                        var identifierName = argument.ChildNodes().Where(x => x.IsKind(SyntaxKind.IdentifierName)).FirstOrDefault();
+                        var identifierName = argument.ChildNodes().FirstOrDefault(x => x.IsKind(SyntaxKind.IdentifierName));
                         if (identifierName != null)
                         {
                             functionName = identifierName.ToString();
@@ -274,7 +281,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
         {
             if (node != null && node.IsKind(SyntaxKind.StringLiteralExpression))
             {
-                var stringLiteralToken = node.ChildTokens().Where(x => x.IsKind(SyntaxKind.StringLiteralToken)).FirstOrDefault();
+                var stringLiteralToken = node.ChildTokens().FirstOrDefault(x => x.IsKind(SyntaxKind.StringLiteralToken));
                 if (stringLiteralToken != null)
                 {
                     functionName = stringLiteralToken.ValueText;
@@ -313,7 +320,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
 
         internal static bool TryGetTypeArgumentIdentifier(MemberAccessExpressionSyntax expression, out SyntaxNode identifierNode)
         {
-            var genericName = expression.ChildNodes().Where(x => x.IsKind(SyntaxKind.GenericName)).FirstOrDefault();
+            var genericName = expression.ChildNodes().FirstOrDefault(x => x.IsKind(SyntaxKind.GenericName));
             if (genericName != null)
             {
                 return TryGetTypeArgumentIdentifier((GenericNameSyntax)genericName, out identifierNode);

--- a/src/WebJobs.Extensions.DurableTask.Analyzers/WebJobs.Extensions.DurableTask.Analyzers.csproj
+++ b/src/WebJobs.Extensions.DurableTask.Analyzers/WebJobs.Extensions.DurableTask.Analyzers.csproj
@@ -8,7 +8,7 @@
 
   <PropertyGroup>
     <PackageId>Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers</PackageId>
-    <PackageVersion>0.3.0</PackageVersion>
+    <PackageVersion>0.3.1</PackageVersion>
     <Authors>Microsoft</Authors>
     <PackageLicenseUrl>https://go.microsoft.com/fwlink/?linkid=2028464</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/Azure/azure-functions-durable-extension</PackageProjectUrl>

--- a/test/WebJobs.Extensions.DurableTask.Analyzers.Test/ActivityFunction/ArgumentAnalyzerTests.cs
+++ b/test/WebJobs.Extensions.DurableTask.Analyzers.Test/ActivityFunction/ArgumentAnalyzerTests.cs
@@ -89,9 +89,13 @@ namespace VSSample
                 await context.CallActivityAsync<string>(""Test_ValueType_DirectInput"", new Char());
                 await context.CallActivityAsync<string>(""Test_Object_DirectInput"", new Char());
 
-                // Testing null input when function input not used from context object is valid
+                // Testing null input when function input not used
 
                 await context.CallActivityAsync<string>(""Test_UnusedInputFromContext"", null);
+
+                // Testing null input used with non value type
+
+                await context.CallActivityAsync(""Test_ValidNull"", null);
             
                 return ""Hello World!"";
 
@@ -201,10 +205,18 @@ namespace VSSample
             return $""Hello World!"";
         }
 
-        // Testing null input when function input not used from context object is valid
+        // Testing null input when function input not used
 
         [FunctionName(""Test_UnusedInputFromContext"")]
         public static string TestUnusedInputFromContext([ActivityTrigger] IDurableActivityContext context)
+        {
+            return $""Hello {name}!"";
+        }
+
+        // Testing null input used with non value type
+
+        [FunctionName(""Test_ValidNull"")]
+        public static string TestUnusedInputFromContext([ActivityTrigger] object name)
         {
             return $""Hello {name}!"";
         }
@@ -411,6 +423,54 @@ namespace VSSample
                 Locations =
                  new[] {
                             new DiagnosticResultLocation("Test0.cs", 21, 73)
+                     }
+            };
+            VerifyCSharpDiagnostic(test, expectedDiagnostics);
+        }
+
+        [TestMethod]
+        public void Argument_InputNullWithValueType()
+        {
+            var test = @"
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Extensions.DurableTask;
+using Microsoft.WindowsAzure.Storage.Blob;
+using Microsoft.WindowsAzure.Storage.Queue;
+using Microsoft.WindowsAzure.Storage.Table;
+
+namespace VSSample
+{
+    public static class HelloSequence
+    {
+        [FunctionName(""ArgumentAnalyzerTestCases"")]
+        public static async Task<string> Run(
+            [OrchestrationTrigger] IDurableOrchestrationContext context)
+            {
+                await context.CallActivityAsync<string>(""InvalidNullInput"", null));
+            
+                return ""Hello World!"";
+            }
+
+        [FunctionName(""InvalidNullInput"")]
+        public static string InvalidNullInput([ActivityTrigger] int input)
+        {
+            return $""Hello World!"";
+        }
+    }
+}";
+            var expectedDiagnostics = new DiagnosticResult
+            {
+                Id = DiagnosticId,
+                Message = string.Format(Resources.ActivityArgumentAnalyzerMessageFormatInvalidNull, "InvalidNullInput", "int"),
+                Severity = Severity,
+                Locations =
+                 new[] {
+                            new DiagnosticResultLocation("Test0.cs", 21, 77)
                      }
             };
             VerifyCSharpDiagnostic(test, expectedDiagnostics);

--- a/test/WebJobs.Extensions.DurableTask.Analyzers.Test/ActivityFunction/ArgumentAnalyzerTests.cs
+++ b/test/WebJobs.Extensions.DurableTask.Analyzers.Test/ActivityFunction/ArgumentAnalyzerTests.cs
@@ -216,7 +216,7 @@ namespace VSSample
         // Testing null input used with non value type
 
         [FunctionName(""Test_ValidNull"")]
-        public static string TestUnusedInputFromContext([ActivityTrigger] object name)
+        public static string TestUnusedInputFromContext([ActivityTrigger] int? name)
         {
             return $""Hello {name}!"";
         }

--- a/test/WebJobs.Extensions.DurableTask.Analyzers.Test/ActivityFunction/FunctionReturnTypeAnalyzerTests.cs
+++ b/test/WebJobs.Extensions.DurableTask.Analyzers.Test/ActivityFunction/FunctionReturnTypeAnalyzerTests.cs
@@ -55,16 +55,16 @@ namespace VSSample
             // Testing different matching return types
             // SyntaxKind.PredefinedType (string), SyntaxKind.IdentifierName (Object), and SyntaxKind.ArrayType (string[])
 
-            //await context.CallActivityAsync<string>(""Test_String"", ""Tokyo"");
-            //await context.CallActivityAsync<Object>(""Test_Object"", ""Tokyo"");
-            //await context.CallActivityAsync<string[]>(""Test_Array"", new string[] { ""Minneapolis"" });
+            await context.CallActivityAsync<string>(""Test_String"", ""Tokyo"");
+            await context.CallActivityAsync<Object>(""Test_Object"", ""Tokyo"");
+            await context.CallActivityAsync<string[]>(""Test_Array"", new string[] { ""Minneapolis"" });
 
             // SyntaxKind.GenericType (Tuple and ValueTuple) and SyntaxKind.TupleType (ValueTuple alt format ex (string, int))
 
             Tuple<string, int> tuple = new Tuple<string, int>(""Seattle"", 4);
-            //await context.CallActivityAsync<Tuple<string, int>>(""Test_Tuple"", tuple);
-            //await context.CallActivityAsync<(string, int)>(""Test_ValueTuple"", (""Seattle"", 4));
-            //await context.CallActivityAsync<ValueTuple<string, int>>(""Test_ValueTuple"", (""Seattle"", 4));
+            await context.CallActivityAsync<Tuple<string, int>>(""Test_Tuple"", tuple);
+            await context.CallActivityAsync<(string, int)>(""Test_ValueTuple"", (""Seattle"", 4));
+            await context.CallActivityAsync<ValueTuple<string, int>>(""Test_ValueTuple"", (""Seattle"", 4));
             await context.CallActivityAsync<ValueTuple<string, int>>(""Test_ValueTuple_AltFormat"", (""Seattle"", 4));
                 
             // Testing JsonArray compatible types (IEnumerable Typles)
@@ -83,6 +83,10 @@ namespace VSSample
             // Task return types
             await context.CallActivityAsync<string>(""Test_TaskString"", ""London"");
             await context.CallActivityAsync<string[]>(""Test_TaskList"", ""London"");
+
+            // Nullable types tests
+            await context.CallActivityAsync<int?>(""Test_NullableInt"", null);
+            await context.CallActivityAsync<int?>(""Test_GenericNullableInt"", null);
             
             // Testing no diagnostic on no specified return type
             await context.CallActivityAsync(""Test_String"", ""London"");
@@ -170,6 +174,20 @@ namespace VSSample
         {
             string name = context.GetInput<string>();
             return new List<string>();
+        }
+        
+        // Nullable types tests
+
+        [FunctionName(""Test_NullableInt"")]
+        public static int? TestTaskList([ActivityTrigger] IDurableActivityContext context)
+        {
+            return 4;
+        }
+
+        [FunctionName(""Test_GenericNullableInt"")]
+        public static Nullable<int> TestTaskList([ActivityTrigger] IDurableActivityContext context)
+        {
+            return 4;
         }
     }
 }";


### PR DESCRIPTION
Fixed NullReferenceException when using Nullable types in FunctionAnalyzer by adding a check for them. Added tests to cover Nullable types in ReturnTypeAnalyzerTests. resolves #1428

Fixed another ArgumentException related to SemanticModels. resovles #1457 

Added another error message in ArgumentAnalyzer when using null inputs for a value type. Added tests for this new check.

Refactored FunctionAnalyzer to get ITypeSymbols and store them in ActivityFunctionCall and ActivityFunctionDefinition so the child analyzers no longer have to get that information. Simplified some logic in ArgumentAnalyzer and ReturnTypeAnalyzer.

Incremented the version.