### PR TITLE
Provide batch position and size information inside entity operations

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableEntityContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableEntityContext.cs
@@ -65,6 +65,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
         EntityId IDurableEntityContext.EntityId => this.self;
 
+        int IDurableEntityContext.BatchPosition => this.shim.BatchPosition;
+
+        int IDurableEntityContext.BatchSize => this.shim.OperationBatch.Count;
+
         internal List<RequestMessage> OperationBatch => this.shim.OperationBatch;
 
         internal ExceptionDispatchInfo InternalError { get; set; }

--- a/src/WebJobs.Extensions.DurableTask/ContextInterfaces/IDurableEntityContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextInterfaces/IDurableEntityContext.cs
@@ -48,6 +48,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         bool HasState { get; }
 
         /// <summary>
+        /// The size of the current batch of operations.
+        /// </summary>
+        int BatchSize { get; }
+
+        /// <summary>
+        /// The position of the currently executing operation within the current batch of operations.
+        /// </summary>
+        int BatchPosition { get; }
+
+        /// <summary>
         /// Gets the current state of this entity, for reading and/or updating.
         /// If this entity has no state yet, creates it.
         /// </summary>

--- a/src/WebJobs.Extensions.DurableTask/Listener/TaskEntityShim.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/TaskEntityShim.cs
@@ -53,6 +53,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
         internal List<RequestMessage> OperationBatch => this.operationBatch;
 
+        internal int BatchPosition { get; private set; }
+
         public bool RollbackFailedOperations => this.context.Config.Options.RollbackEntityOperationsOnExceptions;
 
         public void AddOperationToBatch(RequestMessage operationMessage)
@@ -251,8 +253,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             else
             {
                 // call the function once per operation in the batch
-                foreach (var request in this.operationBatch)
+                for (this.BatchPosition = 0; this.BatchPosition < this.operationBatch.Count; this.BatchPosition++)
                 {
+                    var request = this.operationBatch[this.BatchPosition];
                     await this.ProcessOperationRequestAsync(request);
                 }
             }

--- a/test/Common/TestEntities.cs
+++ b/test/Common/TestEntities.cs
@@ -259,6 +259,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             state.Add(context.OperationName);
         }
 
+        //-------------- An entity that records all batch positions and batch sizes -----------------
+
+        public static void BatchEntity(
+            [EntityTrigger(EntityName = "BatchEntity")] IDurableEntityContext context,
+            ILogger logger)
+        {
+            var state = context.GetState(() => new List<(int, int)>());
+            state.Add((context.BatchPosition, context.BatchSize));
+        }
+
         //-------------- an entity that stores text, and whose state is
         //                  saved/restored to/from storage when the entity is deactivated/activated -----------------
         //


### PR DESCRIPTION
Adds two properties to `IDurableEntityContext`:

```csharp
        /// <summary>
        /// The size of the current batch of operations.
        /// </summary>
        int BatchSize { get; }

        /// <summary>
        /// The position of the currently executing operation within the current batch of operations.
        /// </summary>
        int BatchPosition { get; }
```

as discussed in #1456.