### PR TITLE
Adding Missing Fields to Linux Logger: ProviderName, TaskName, ActivityId, RelatedActivityId, StampName, etc

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/LinuxAppServiceLogger.cs
+++ b/src/WebJobs.Extensions.DurableTask/LinuxAppServiceLogger.cs
@@ -35,7 +35,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         // logging metadata
         private readonly JToken roleInstance;
         private readonly JToken tenant;
-        private readonly JToken sourceMoniker;
         private readonly JToken procID;
 
         // if true, we write to console (linux consumption), else to a file (linux dedicated).
@@ -59,8 +58,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             this.roleInstance = JToken.FromObject("App-" + containerName);
             this.tenant = JToken.FromObject(tenant);
 
-            this.sourceMoniker = JToken.FromObject(
-                string.IsNullOrEmpty(stampName) ? string.Empty : "L" + stampName.Replace("-", "").ToUpperInvariant());
             using (var process = Process.GetCurrentProcess())
             {
                 this.procID = process.Id;

--- a/src/WebJobs.Extensions.DurableTask/LinuxAppServiceLogger.cs
+++ b/src/WebJobs.Extensions.DurableTask/LinuxAppServiceLogger.cs
@@ -36,6 +36,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         private readonly JToken roleInstance;
         private readonly JToken tenant;
         private readonly JToken procID;
+        private readonly string stamp;
+        private readonly string primaryStamp;
 
         // if true, we write to console (linux consumption), else to a file (linux dedicated).
         private readonly bool writeToConsole;
@@ -57,6 +59,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             this.writeToConsole = writeToConsole;
             this.roleInstance = JToken.FromObject("App-" + containerName);
             this.tenant = JToken.FromObject(tenant);
+            this.stamp = stampName;
+
+            var finalCharIndex = stampName.Length - 1;
+            this.primaryStamp = char.IsLetter(stampName[finalCharIndex]) ? stampName.Remove(finalCharIndex) : stampName;
 
             using (var process = Process.GetCurrentProcess())
             {
@@ -94,6 +100,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             // We pack them into a JSON
             JObject json = new JObject
             {
+                { "EventStampName", this.stamp },
+                { "EventPrimaryStampName", this.primaryStamp },
+                { "ProviderName", eventData.EventSource.Name },
+                { "TaskName", eventData.EventName },
                 { "EventId", eventData.EventId },
                 { "TimeStamp", DateTime.UtcNow },
                 { "RoleInstance", this.roleInstance },
@@ -102,9 +112,21 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 { "Tid", Thread.CurrentThread.ManagedThreadId },
             };
 
+            // Add payload elements
             for (int i = 0; i < values.Count; i++)
             {
                 json.Add(keys[i], JToken.FromObject(values[i]));
+            }
+
+            // Add ActivityId and RelatedActivityId, if non-null
+            if (!eventData.ActivityId.Equals(Guid.Empty))
+            {
+                json.Add("ActivityId", eventData.ActivityId);
+            }
+
+            if (!eventData.RelatedActivityId.Equals(Guid.Empty))
+            {
+                json.Add("RelatedActivityId", eventData.RelatedActivityId);
             }
 
             // Generate string-representation of JSON. Also remove newlines.

--- a/test/Common/DurableTaskEndToEndTests.cs
+++ b/test/Common/DurableTaskEndToEndTests.cs
@@ -465,7 +465,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                     foundActivityId = true;
                 }
 
-                if (keys.Contains("ActivityId"))
+                if (keys.Contains("RelatedActivityId"))
                 {
                     foundRelatedActivityId = true;
                 }

--- a/test/Common/DurableTaskEndToEndTests.cs
+++ b/test/Common/DurableTaskEndToEndTests.cs
@@ -371,9 +371,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         /// this test checks our JSON logs satisfy a minimal set of requirements:
         /// (1) Is JSON parseable
         /// (2) Contains minimal expected fields: EventId, TimeStamp, RoleInstance,
-        ///     Tenant, SourceMoniker, Pid, Tid.
+        ///     Tenant, SourceMoniker, Pid, Tid, etc.
         /// (3) Ensure some Enums are printed correctly.
         /// (4) That we have logs from a variety of EventSource providers.
+        /// (5) Ensure ActivityId and RelatedActivityId are eventually present.
         /// </summary>
         [Fact]
         [Trait("Category", PlatformSpecificHelpers.TestCategory)]
@@ -420,6 +421,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             bool foundEtwEventSourceLog = false;
             bool foundDurableTaskCoreLog = false;
 
+            bool foundActivityId = false;
+            bool foundRelatedActivityId = false;
+
             // Validating JSON outputs
             foreach (string line in lines)
             {
@@ -428,6 +432,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
                 // (2) Contains minimal expected fields
                 List<string> keys = json.Properties().Select(p => p.Name).ToList();
+                Assert.Contains("EventStampName", keys);
+                Assert.Contains("EventPrimaryStampName", keys);
+                Assert.Contains("ProviderName", keys);
+                Assert.Contains("TaskName", keys);
                 Assert.Contains("EventId", keys);
                 Assert.Contains("TimeStamp", keys);
                 Assert.Contains("RoleInstance", keys);
@@ -450,6 +458,18 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                     foundAzureStorageLog = true;
                 }
 
+                // recording if ActivityId and RelatedActivityId are seen
+                // we expect to see them, at some point, in a trivial orchestrator
+                if (keys.Contains("ActivityId"))
+                {
+                    foundActivityId = true;
+                }
+
+                if (keys.Contains("ActivityId"))
+                {
+                    foundRelatedActivityId = true;
+                }
+
                 // (3) Ensure some Enums are printed correctly: as strings
                 string eventType = (string)json.GetValue("EventType");
                 if (!string.IsNullOrEmpty(eventType))
@@ -462,6 +482,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             Assert.True(foundAzureStorageLog);
             Assert.True(foundEtwEventSourceLog);
             Assert.True(foundDurableTaskCoreLog);
+
+            // (5) Ensure ActivityId and RelatedActivityId are present in logs
+            Assert.True(foundActivityId);
+            Assert.True(foundRelatedActivityId);
 
             // To ensure other tests generate the path
             File.Delete(LinuxAppServiceLogger.LoggingPath);

--- a/test/Common/DurableTaskEndToEndTests.cs
+++ b/test/Common/DurableTaskEndToEndTests.cs
@@ -432,7 +432,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 Assert.Contains("TimeStamp", keys);
                 Assert.Contains("RoleInstance", keys);
                 Assert.Contains("Tenant", keys);
-                Assert.Contains("SourceMoniker", keys);
                 Assert.Contains("Pid", keys);
                 Assert.Contains("Tid", keys);
 


### PR DESCRIPTION
_This was originally a small test PR, but now it's grown in scope_

This PR adds missing fields to our LinuxLogger class, providing now a fuller scope of logs and, hopefully, enough to make our telemetry and existing diagnostics tools more effective in debugging linux apps.

The logging validation test has been updated accordingly