### PR TITLE
Fix AD0001 warning in Durable Analyzer

### DIFF
--- a/src/WebJobs.Extensions.DurableTask.Analyzers/SyntaxNodeUtils.cs
+++ b/src/WebJobs.Extensions.DurableTask.Analyzers/SyntaxNodeUtils.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
         {
             if (node != null && TryGetSemanticModelForSyntaxTree(semanticModel, node, out SemanticModel newModel))
             {
-                symbol = semanticModel.GetSymbolInfo(node).Symbol;
+                symbol = newModel.GetSymbolInfo(node).Symbol;
                 return symbol != null;
             }
 

--- a/src/WebJobs.Extensions.DurableTask.Analyzers/WebJobs.Extensions.DurableTask.Analyzers.csproj
+++ b/src/WebJobs.Extensions.DurableTask.Analyzers/WebJobs.Extensions.DurableTask.Analyzers.csproj
@@ -8,7 +8,7 @@
 
   <PropertyGroup>
     <PackageId>Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers</PackageId>
-    <PackageVersion>0.3.2-prerelease1</PackageVersion>
+    <PackageVersion>0.3.2</PackageVersion>
     <Authors>Microsoft</Authors>
     <PackageLicenseUrl>https://go.microsoft.com/fwlink/?linkid=2028464</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/Azure/azure-functions-durable-extension</PackageProjectUrl>

--- a/src/WebJobs.Extensions.DurableTask.Analyzers/WebJobs.Extensions.DurableTask.Analyzers.csproj
+++ b/src/WebJobs.Extensions.DurableTask.Analyzers/WebJobs.Extensions.DurableTask.Analyzers.csproj
@@ -8,7 +8,7 @@
 
   <PropertyGroup>
     <PackageId>Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers</PackageId>
-    <PackageVersion>0.3.1</PackageVersion>
+    <PackageVersion>0.3.2-prerelease1</PackageVersion>
     <Authors>Microsoft</Authors>
     <PackageLicenseUrl>https://go.microsoft.com/fwlink/?linkid=2028464</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/Azure/azure-functions-durable-extension</PackageProjectUrl>


### PR DESCRIPTION
A small typo in PR #1494 resulted in the analyzer failing to load due to
an argument exception. Fixing this typo fixes the problem.

A future PR should be add a test to make sure this doesn't regress in the
future.