### PR TITLE
Added RestartAsync API to rerun existing orchestrator instances

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableClient.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableClient.cs
@@ -72,16 +72,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         string IDurableEntityClient.TaskHubName => this.TaskHubName;
 
         /// <inheritdoc />
-        HttpResponseMessage IDurableOrchestrationClient.CreateCheckStatusResponse(HttpRequestMessage request, string instanceId, bool returnInternalServerErrorOnFailure, bool restartWithNewInstanceId)
+        HttpResponseMessage IDurableOrchestrationClient.CreateCheckStatusResponse(HttpRequestMessage request, string instanceId, bool returnInternalServerErrorOnFailure)
         {
-            return this.CreateCheckStatusResponse(request, instanceId, this.attribute, returnInternalServerErrorOnFailure, restartWithNewInstanceId);
+            return this.CreateCheckStatusResponse(request, instanceId, this.attribute, returnInternalServerErrorOnFailure);
         }
 
         /// <inheritdoc />
-        IActionResult IDurableOrchestrationClient.CreateCheckStatusResponse(HttpRequest request, string instanceId, bool returnInternalServerErrorOnFailure, bool restartWithNewInstanceId)
+        IActionResult IDurableOrchestrationClient.CreateCheckStatusResponse(HttpRequest request, string instanceId, bool returnInternalServerErrorOnFailure)
         {
             HttpRequestMessage requestMessage = ConvertHttpRequestMessage(request);
-            HttpResponseMessage responseMessage = ((IDurableOrchestrationClient)this).CreateCheckStatusResponse(requestMessage, instanceId, returnInternalServerErrorOnFailure, restartWithNewInstanceId);
+            HttpResponseMessage responseMessage = ((IDurableOrchestrationClient)this).CreateCheckStatusResponse(requestMessage, instanceId, returnInternalServerErrorOnFailure);
             return ConvertHttpResponseMessage(responseMessage);
         }
 
@@ -791,10 +791,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             HttpRequestMessage request,
             string instanceId,
             DurableClientAttribute attribute,
-            bool returnInternalServerErrorOnFailure = false,
-            bool restartWithNewInstanceId = true)
+            bool returnInternalServerErrorOnFailure = false)
         {
-            return this.httpApiHandler.CreateCheckStatusResponse(request, instanceId, attribute, returnInternalServerErrorOnFailure, restartWithNewInstanceId);
+            return this.httpApiHandler.CreateCheckStatusResponse(request, instanceId, attribute, returnInternalServerErrorOnFailure);
         }
 
         private static void TrackNameAndScheduledTime(JObject historyItem, EventType eventType, int index, Dictionary<string, EventIndexDateMapping> eventMapper)

--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableClient.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableClient.cs
@@ -875,7 +875,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             return ((IDurableOrchestrationClient)this).StartNewAsync<T>(orchestratorFunctionName, string.Empty, input);
         }
 
-        async Task<string> IDurableOrchestrationClient.RestartAsync(string instanceId, bool startWithNewInstanceId)
+        async Task<string> IDurableOrchestrationClient.RestartAsync(string instanceId, bool restartWithNewInstanceId)
         {
             DurableOrchestrationStatus status = await ((IDurableOrchestrationClient)this).GetStatusAsync(instanceId, showHistory: false, showHistoryOutput: false, showInput: true);
 
@@ -884,7 +884,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 throw new ArgumentException($"An orchestrastion with the instanceId {instanceId} was not found.");
             }
 
-            return startWithNewInstanceId ? await ((IDurableOrchestrationClient)this).StartNewAsync(orchestratorFunctionName: status.Name, status.Input)
+            return restartWithNewInstanceId ? await ((IDurableOrchestrationClient)this).StartNewAsync(orchestratorFunctionName: status.Name, status.Input)
                 : await ((IDurableOrchestrationClient)this).StartNewAsync(orchestratorFunctionName: status.Name, instanceId: status.InstanceId, status.Input);
         }
 

--- a/src/WebJobs.Extensions.DurableTask/ContextInterfaces/IDurableOrchestrationClient.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextInterfaces/IDurableOrchestrationClient.cs
@@ -38,8 +38,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// <param name="returnInternalServerErrorOnFailure">Optional parameter that configures the http response code returned. Defaults to <c>false</c>.
         /// If <c>true</c>, the returned http response code will be a 500 when the orchestrator is in a failed state, when <c>false</c> it will
         /// return 200.</param>
+        /// <param name="restartWithNewInstanceId">Otional parameter that configures if restarting an orchestration will use a new instanceId or if it will
+        /// reuse the old instanceId. Defauls to <c>true</c>.</param>
         /// <returns>An HTTP 202 response with a Location header and a payload containing instance control URLs.</returns>
-        HttpResponseMessage CreateCheckStatusResponse(HttpRequestMessage request, string instanceId, bool returnInternalServerErrorOnFailure = false);
+        HttpResponseMessage CreateCheckStatusResponse(HttpRequestMessage request, string instanceId, bool returnInternalServerErrorOnFailure = false, bool restartWithNewInstanceId = true);
 
         /// <summary>
         /// Creates an HTTP response that is useful for checking the status of the specified instance.
@@ -54,8 +56,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// <param name="returnInternalServerErrorOnFailure">Optional parameter that configures the http response code returned. Defaults to <c>false</c>.
         /// If <c>true</c>, the returned http response code will be a 500 when the orchestrator is in a failed state, when <c>false</c> it will
         /// return 200.</param>
+        /// <param name="restartWithNewInstanceId">Otional parameter that configures if restarting an orchestration will use a new instanceId or if it will
+        /// reuse the old instanceId. Defauls to <c>true</c>.</param>
         /// <returns>An HTTP 202 response with a Location header and a payload containing instance control URLs.</returns>
-        IActionResult CreateCheckStatusResponse(HttpRequest request, string instanceId, bool returnInternalServerErrorOnFailure = false);
+        IActionResult CreateCheckStatusResponse(HttpRequest request, string instanceId, bool returnInternalServerErrorOnFailure = false, bool restartWithNewInstanceId = true);
 
         /// <summary>
         /// Creates a <see cref="HttpManagementPayload"/> object that contains status, terminate and send external event HTTP endpoints.
@@ -280,5 +284,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// <param name="cancellationToken">Cancellation token that can be used to cancel the status query operation.</param>
         /// <returns>Returns each page of orchestration status for all instances and continuation token of next page.</returns>
         Task<OrchestrationStatusQueryResult> ListInstancesAsync(OrchestrationStatusQueryCondition condition, CancellationToken cancellationToken);
+
+        Task<string> RestartAsync(string instanceId, bool startWithNewInstanceId = true);
     }
 }

--- a/src/WebJobs.Extensions.DurableTask/ContextInterfaces/IDurableOrchestrationClient.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextInterfaces/IDurableOrchestrationClient.cs
@@ -76,7 +76,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// If the orchestration instance completes within the specified timeout, then the HTTP response payload will
         /// contain the output of the orchestration instance formatted as JSON. However, if the orchestration does not
         /// complete within the specified timeout, then the HTTP response will be identical to that of the
-        /// <see cref="CreateCheckStatusResponse(HttpRequestMessage, string, bool)"/> API.
+        /// <see cref="CreateCheckStatusResponse(HttpRequestMessage, string, bool, bool)"/> API.
         /// </remarks>
         /// <param name="request">The HTTP request that triggered the current function.</param>
         /// <param name="instanceId">The unique ID of the instance to check.</param>
@@ -97,7 +97,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// If the orchestration instance completes within the specified timeout, then the HTTP response payload will
         /// contain the output of the orchestration instance formatted as JSON. However, if the orchestration does not
         /// complete within the specified timeout, then the HTTP response will be identical to that of the
-        /// <see cref="CreateCheckStatusResponse(HttpRequest, string, bool)"/> API.
+        /// <see cref="CreateCheckStatusResponse(HttpRequest, string, bool, bool)"/> API.
         /// </remarks>
         /// <param name="request">The HTTP request that triggered the current function.</param>
         /// <param name="instanceId">The unique ID of the instance to check.</param>
@@ -285,6 +285,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// <returns>Returns each page of orchestration status for all instances and continuation token of next page.</returns>
         Task<OrchestrationStatusQueryResult> ListInstancesAsync(OrchestrationStatusQueryCondition condition, CancellationToken cancellationToken);
 
-        Task<string> RestartAsync(string instanceId, bool startWithNewInstanceId = true);
+        /// <summary>
+        ///  Restarts an existing orchestrator with the original input.
+        /// </summary>
+        /// <param name="instanceId">InstanceId of a previously run orchestrator to restart.</param>
+        /// <param name="restartWithNewInstanceId">Optional parameter that configures if restarting an orchestration will use a new instanceId or if it will
+        /// reuse the old instanceId. Defauls to <c>true</c>.</param>
+        /// <returns>A task that completes when the orchestration is started. The task contains the instance id of the started
+        /// orchestratation instance.</returns>
+        Task<string> RestartAsync(string instanceId, bool restartWithNewInstanceId = true);
     }
 }

--- a/src/WebJobs.Extensions.DurableTask/ContextInterfaces/IDurableOrchestrationClient.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextInterfaces/IDurableOrchestrationClient.cs
@@ -38,10 +38,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// <param name="returnInternalServerErrorOnFailure">Optional parameter that configures the http response code returned. Defaults to <c>false</c>.
         /// If <c>true</c>, the returned http response code will be a 500 when the orchestrator is in a failed state, when <c>false</c> it will
         /// return 200.</param>
-        /// <param name="restartWithNewInstanceId">Otional parameter that configures if restarting an orchestration will use a new instanceId or if it will
-        /// reuse the old instanceId. Defauls to <c>true</c>.</param>
         /// <returns>An HTTP 202 response with a Location header and a payload containing instance control URLs.</returns>
-        HttpResponseMessage CreateCheckStatusResponse(HttpRequestMessage request, string instanceId, bool returnInternalServerErrorOnFailure = false, bool restartWithNewInstanceId = true);
+        HttpResponseMessage CreateCheckStatusResponse(HttpRequestMessage request, string instanceId, bool returnInternalServerErrorOnFailure = false);
 
         /// <summary>
         /// Creates an HTTP response that is useful for checking the status of the specified instance.
@@ -56,10 +54,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// <param name="returnInternalServerErrorOnFailure">Optional parameter that configures the http response code returned. Defaults to <c>false</c>.
         /// If <c>true</c>, the returned http response code will be a 500 when the orchestrator is in a failed state, when <c>false</c> it will
         /// return 200.</param>
-        /// <param name="restartWithNewInstanceId">Otional parameter that configures if restarting an orchestration will use a new instanceId or if it will
-        /// reuse the old instanceId. Defauls to <c>true</c>.</param>
         /// <returns>An HTTP 202 response with a Location header and a payload containing instance control URLs.</returns>
-        IActionResult CreateCheckStatusResponse(HttpRequest request, string instanceId, bool returnInternalServerErrorOnFailure = false, bool restartWithNewInstanceId = true);
+        IActionResult CreateCheckStatusResponse(HttpRequest request, string instanceId, bool returnInternalServerErrorOnFailure = false);
 
         /// <summary>
         /// Creates a <see cref="HttpManagementPayload"/> object that contains status, terminate and send external event HTTP endpoints.
@@ -76,7 +72,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// If the orchestration instance completes within the specified timeout, then the HTTP response payload will
         /// contain the output of the orchestration instance formatted as JSON. However, if the orchestration does not
         /// complete within the specified timeout, then the HTTP response will be identical to that of the
-        /// <see cref="CreateCheckStatusResponse(HttpRequestMessage, string, bool, bool)"/> API.
+        /// <see cref="CreateCheckStatusResponse(HttpRequestMessage, string, bool)"/> API.
         /// </remarks>
         /// <param name="request">The HTTP request that triggered the current function.</param>
         /// <param name="instanceId">The unique ID of the instance to check.</param>
@@ -97,7 +93,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// If the orchestration instance completes within the specified timeout, then the HTTP response payload will
         /// contain the output of the orchestration instance formatted as JSON. However, if the orchestration does not
         /// complete within the specified timeout, then the HTTP response will be identical to that of the
-        /// <see cref="CreateCheckStatusResponse(HttpRequest, string, bool, bool)"/> API.
+        /// <see cref="CreateCheckStatusResponse(HttpRequest, string, bool)"/> API.
         /// </remarks>
         /// <param name="request">The HTTP request that triggered the current function.</param>
         /// <param name="instanceId">The unique ID of the instance to check.</param>

--- a/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
+++ b/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
@@ -322,7 +322,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                             return request.CreateResponse(HttpStatusCode.NotFound);
                         }
                     }
-                    else
+                    else if (request.Method == HttpMethod.Post)
                     {
                         if (string.Equals(operation, TerminateOperation, StringComparison.OrdinalIgnoreCase))
                         {
@@ -336,10 +336,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                         {
                             return await this.HandleRestartInstanceRequestAsync(request, instanceId);
                         }
-                        else
-                        {
-                            return request.CreateResponse(HttpStatusCode.NotFound);
-                        }
+                    }
+                    else
+                    {
+                        return request.CreateResponse(HttpStatusCode.NotFound);
                     }
                 }
 

--- a/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
+++ b/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
@@ -91,10 +91,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             HttpRequestMessage request,
             string instanceId,
             DurableClientAttribute attribute,
-            bool returnInternalServerErrorOnFailure = false,
-            bool restartWithNewInstanceId = true)
+            bool returnInternalServerErrorOnFailure = false)
         {
-            HttpManagementPayload httpManagementPayload = this.GetClientResponseLinks(request, instanceId, attribute?.TaskHub, attribute?.ConnectionName, returnInternalServerErrorOnFailure, restartWithNewInstanceId);
+            HttpManagementPayload httpManagementPayload = this.GetClientResponseLinks(request, instanceId, attribute?.TaskHub, attribute?.ConnectionName, returnInternalServerErrorOnFailure);
             return this.CreateCheckStatusResponseMessage(
                 request,
                 httpManagementPayload.Id,
@@ -156,8 +155,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 instanceId,
                 taskHub,
                 connectionName,
-                returnInternalServerErrorOnFailure,
-                restartWithNewInstanceId);
+                returnInternalServerErrorOnFailure);
             return httpManagementPayload;
         }
 
@@ -1006,8 +1004,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
              string instanceId,
              string taskHubName,
              string connectionName,
-             bool returnInternalServerErrorOnFailure = false,
-             bool restartWithNewInstanceId = true)
+             bool returnInternalServerErrorOnFailure = false)
         {
             this.ThrowIfWebhooksNotConfigured();
 
@@ -1044,11 +1041,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             if (returnInternalServerErrorOnFailure)
             {
                 httpManagementPayload.StatusQueryGetUri += "&returnInternalServerErrorOnFailure=true";
-            }
-
-            if (!restartWithNewInstanceId)
-            {
-                httpManagementPayload.RestartUri += "&restartWithNewInstanceId=false";
             }
 
             return httpManagementPayload;

--- a/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
+++ b/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         private const string ReturnInternalServerErrorOnFailure = "returnInternalServerErrorOnFailure";
         private const string LastOperationTimeFrom = "lastOperationTimeFrom";
         private const string LastOperationTimeTo = "lastOperationTimeTo";
-        private const string StartWithNewInstanceId = "startWithNewInstanceId";
+        private const string RestartWithNewInstanceId = "restartWithNewInstanceId";
         private const string TimeoutParameter = "timeout";
         private const string PollingInterval = "pollingInterval";
 
@@ -753,9 +753,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 var queryNameValuePairs = request.GetQueryNameValuePairs();
 
                 string newInstanceId;
-                if (TryGetBooleanQueryParameterValue(queryNameValuePairs, StartWithNewInstanceId, out bool startWithNewInstanceId))
+                if (TryGetBooleanQueryParameterValue(queryNameValuePairs, RestartWithNewInstanceId, out bool restartWithNewInstanceId))
                 {
-                    newInstanceId = await client.RestartAsync(instanceId, startWithNewInstanceId);
+                    newInstanceId = await client.RestartAsync(instanceId, restartWithNewInstanceId);
                 }
                 else
                 {

--- a/src/WebJobs.Extensions.DurableTask/HttpManagementPayload.cs
+++ b/src/WebJobs.Extensions.DurableTask/HttpManagementPayload.cs
@@ -63,5 +63,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// </value>
         [JsonProperty("purgeHistoryDeleteUri")]
         public string PurgeHistoryDeleteUri { get; internal set; }
+
+        /// <summary>
+        /// Gets the HTTP POST instance restart endpoint.
+        /// </summary>
+        /// <value>
+        /// The HTTP URL for restarting an orchestration instance.
+        /// </value>
+        [JsonProperty("restartUri")]
+        public string RestartUri { get; internal set; }
     }
 }

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net461.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net461.xml
@@ -99,10 +99,13 @@
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClient.Microsoft#Azure#WebJobs#Extensions#DurableTask#IDurableOrchestrationClient#TaskHubName">
             <inheritdoc />
         </member>
-        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClient.Microsoft#Azure#WebJobs#Extensions#DurableTask#IDurableOrchestrationClient#CreateCheckStatusResponse(System.Net.Http.HttpRequestMessage,System.String,System.Boolean,System.Boolean)">
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClient.ToString">
+            <inheritdoc/>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClient.Microsoft#Azure#WebJobs#Extensions#DurableTask#IDurableOrchestrationClient#CreateCheckStatusResponse(System.Net.Http.HttpRequestMessage,System.String,System.Boolean)">
             <inheritdoc />
         </member>
-        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClient.Microsoft#Azure#WebJobs#Extensions#DurableTask#IDurableOrchestrationClient#CreateCheckStatusResponse(Microsoft.AspNetCore.Http.HttpRequest,System.String,System.Boolean,System.Boolean)">
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClient.Microsoft#Azure#WebJobs#Extensions#DurableTask#IDurableOrchestrationClient#CreateCheckStatusResponse(Microsoft.AspNetCore.Http.HttpRequest,System.String,System.Boolean)">
             <inheritdoc />
         </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClient.Microsoft#Azure#WebJobs#Extensions#DurableTask#IDurableOrchestrationClient#CreateHttpManagementPayload(System.String)">
@@ -579,6 +582,16 @@
             Whether this entity has a state.
             </summary>
         </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableEntityContext.BatchSize">
+            <summary>
+            The size of the current batch of operations.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableEntityContext.BatchPosition">
+            <summary>
+            The position of the currently executing operation within the current batch of operations.
+            </summary>
+        </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableEntityContext.GetState``1(System.Func{``0})">
             <summary>
             Gets the current state of this entity, for reading and/or updating.
@@ -705,7 +718,7 @@
             The name of the task hub.
             </value>
         </member>
-        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableOrchestrationClient.CreateCheckStatusResponse(System.Net.Http.HttpRequestMessage,System.String,System.Boolean,System.Boolean)">
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableOrchestrationClient.CreateCheckStatusResponse(System.Net.Http.HttpRequestMessage,System.String,System.Boolean)">
             <summary>
             Creates an HTTP response that is useful for checking the status of the specified instance.
             </summary>
@@ -719,11 +732,9 @@
             <param name="returnInternalServerErrorOnFailure">Optional parameter that configures the http response code returned. Defaults to <c>false</c>.
             If <c>true</c>, the returned http response code will be a 500 when the orchestrator is in a failed state, when <c>false</c> it will
             return 200.</param>
-            <param name="restartWithNewInstanceId">Otional parameter that configures if restarting an orchestration will use a new instanceId or if it will
-            reuse the old instanceId. Defauls to <c>true</c>.</param>
             <returns>An HTTP 202 response with a Location header and a payload containing instance control URLs.</returns>
         </member>
-        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableOrchestrationClient.CreateCheckStatusResponse(Microsoft.AspNetCore.Http.HttpRequest,System.String,System.Boolean,System.Boolean)">
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableOrchestrationClient.CreateCheckStatusResponse(Microsoft.AspNetCore.Http.HttpRequest,System.String,System.Boolean)">
             <summary>
             Creates an HTTP response that is useful for checking the status of the specified instance.
             </summary>
@@ -737,8 +748,6 @@
             <param name="returnInternalServerErrorOnFailure">Optional parameter that configures the http response code returned. Defaults to <c>false</c>.
             If <c>true</c>, the returned http response code will be a 500 when the orchestrator is in a failed state, when <c>false</c> it will
             return 200.</param>
-            <param name="restartWithNewInstanceId">Otional parameter that configures if restarting an orchestration will use a new instanceId or if it will
-            reuse the old instanceId. Defauls to <c>true</c>.</param>
             <returns>An HTTP 202 response with a Location header and a payload containing instance control URLs.</returns>
         </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableOrchestrationClient.CreateHttpManagementPayload(System.String)">
@@ -757,7 +766,7 @@
             If the orchestration instance completes within the specified timeout, then the HTTP response payload will
             contain the output of the orchestration instance formatted as JSON. However, if the orchestration does not
             complete within the specified timeout, then the HTTP response will be identical to that of the
-            <see cref="!:CreateCheckStatusResponse(HttpRequestMessage, string, bool)"/> API.
+            <see cref="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableOrchestrationClient.CreateCheckStatusResponse(System.Net.Http.HttpRequestMessage,System.String,System.Boolean)"/> API.
             </remarks>
             <param name="request">The HTTP request that triggered the current function.</param>
             <param name="instanceId">The unique ID of the instance to check.</param>
@@ -774,7 +783,7 @@
             If the orchestration instance completes within the specified timeout, then the HTTP response payload will
             contain the output of the orchestration instance formatted as JSON. However, if the orchestration does not
             complete within the specified timeout, then the HTTP response will be identical to that of the
-            <see cref="!:CreateCheckStatusResponse(HttpRequest, string, bool)"/> API.
+            <see cref="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableOrchestrationClient.CreateCheckStatusResponse(Microsoft.AspNetCore.Http.HttpRequest,System.String,System.Boolean)"/> API.
             </remarks>
             <param name="request">The HTTP request that triggered the current function.</param>
             <param name="instanceId">The unique ID of the instance to check.</param>
@@ -1578,6 +1587,16 @@
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurabilityProvider.SupportsEntities">
             <summary>
             Specifies whether the durability provider supports Durable Entities.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurabilityProvider.SupportsPollFreeWait">
+            <summary>
+            Specifies whether the backend's WaitForOrchestration is implemented without polling.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurabilityProvider.GuaranteesOrderedDelivery">
+            <summary>
+            Specifies whether this backend delivers messages in order.
             </summary>
         </member>
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurabilityProvider.ConfigurationJson">
@@ -3807,6 +3826,34 @@
             Option to only start a new orchestrator instance with an existing instance Id when the existing
             instance is in a terminated, failed, or completed state.
             </summary>
+        </member>
+        <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.ProviderUtils">
+            <summary>
+            Provides access to internal functionality for the purpose of implementing durability providers.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.ProviderUtils.GetSchedulerIdFromEntityId(Microsoft.Azure.WebJobs.Extensions.DurableTask.EntityId)">
+            <summary>
+            Returns the instance id of the entity scheduler for a given entity id.
+            </summary>
+            <param name="entityId">The entity id.</param>
+            <returns>The instance id of the scheduler.</returns>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.ProviderUtils.TryGetEntityStateFromSerializedSchedulerState(DurableTask.Core.OrchestrationState,Newtonsoft.Json.JsonSerializerSettings,System.String@)">
+            <summary>
+            Reads the state of an entity from the serialized entity scheduler state.
+            </summary>
+            <param name="state">The orchestration state of the scheduler.</param>
+            <param name="serializerSettings">The serializer settings.</param>
+            <param name="result">The serialized state of the entity.</param>
+            <returns>true if the entity exists, false otherwise.</returns>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.ProviderUtils.ConvertOrchestrationStateToStatus(DurableTask.Core.OrchestrationState)">
+            <summary>
+            Converts the DTFx representation of the orchestration state into the DF representation.
+            </summary>
+            <param name="orchestrationState">The orchestration state.</param>
+            <returns>The orchestration status.</returns>
         </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.PurgeHistoryResult">
             <summary>

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net461.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net461.xml
@@ -898,6 +898,16 @@
             <param name="cancellationToken">Cancellation token that can be used to cancel the status query operation.</param>
             <returns>Returns each page of orchestration status for all instances and continuation token of next page.</returns>
         </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableOrchestrationClient.RestartAsync(System.String,System.Boolean)">
+            <summary>
+             Restarts an existing orchestrator with the original input.
+            </summary>
+            <param name="instanceId">InstanceId of a previously run orchestrator to restart.</param>
+            <param name="restartWithNewInstanceId">Optional parameter that configures if restarting an orchestration will use a new instanceId or if it will
+            reuse the old instanceId. Defauls to <c>true</c>.</param>
+            <returns>A task that completes when the orchestration is started. The task contains the instance id of the started
+            orchestratation instance.</returns>
+        </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableOrchestrationContext">
             <summary>
             Provides functionality available to orchestration code.

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net461.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net461.xml
@@ -38,6 +38,21 @@
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureStorageDurabilityProvider.GetOrchestrationStateWithPagination(Microsoft.Azure.WebJobs.Extensions.DurableTask.OrchestrationStatusQueryCondition,System.Threading.CancellationToken)">
             <inheritdoc/>
         </member>
+        <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.CleanEntityStorageResult">
+            <summary>
+            The result of a clean entity storage operation.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Azure.WebJobs.Extensions.DurableTask.CleanEntityStorageResult.NumberOfOrphanedLocksRemoved">
+            <summary>
+            The number of orphaned locks that were removed.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Azure.WebJobs.Extensions.DurableTask.CleanEntityStorageResult.NumberOfEmptyEntitiesRemoved">
+            <summary>
+            The number of entities whose metadata was removed from storage.
+            </summary>
+        </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableActivityContext">
             <summary>
             The default parameter type for activity functions.
@@ -84,10 +99,10 @@
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClient.Microsoft#Azure#WebJobs#Extensions#DurableTask#IDurableOrchestrationClient#TaskHubName">
             <inheritdoc />
         </member>
-        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClient.Microsoft#Azure#WebJobs#Extensions#DurableTask#IDurableOrchestrationClient#CreateCheckStatusResponse(System.Net.Http.HttpRequestMessage,System.String,System.Boolean)">
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClient.Microsoft#Azure#WebJobs#Extensions#DurableTask#IDurableOrchestrationClient#CreateCheckStatusResponse(System.Net.Http.HttpRequestMessage,System.String,System.Boolean,System.Boolean)">
             <inheritdoc />
         </member>
-        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClient.Microsoft#Azure#WebJobs#Extensions#DurableTask#IDurableOrchestrationClient#CreateCheckStatusResponse(Microsoft.AspNetCore.Http.HttpRequest,System.String,System.Boolean)">
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClient.Microsoft#Azure#WebJobs#Extensions#DurableTask#IDurableOrchestrationClient#CreateCheckStatusResponse(Microsoft.AspNetCore.Http.HttpRequest,System.String,System.Boolean,System.Boolean)">
             <inheritdoc />
         </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClient.Microsoft#Azure#WebJobs#Extensions#DurableTask#IDurableOrchestrationClient#CreateHttpManagementPayload(System.String)">
@@ -136,6 +151,9 @@
             <inheritdoc />
         </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClient.Microsoft#Azure#WebJobs#Extensions#DurableTask#IDurableEntityClient#ListEntitiesAsync(Microsoft.Azure.WebJobs.Extensions.DurableTask.EntityQuery,System.Threading.CancellationToken)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClient.Microsoft#Azure#WebJobs#Extensions#DurableTask#IDurableEntityClient#CleanEntityStorageAsync(System.Boolean,System.Boolean,System.Threading.CancellationToken)">
             <inheritdoc />
         </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClient.Microsoft#Azure#WebJobs#Extensions#DurableTask#IDurableOrchestrationClient#StartNewAsync(System.String,System.String)">
@@ -464,6 +482,20 @@
             <param name="cancellationToken">Cancellation token that can be used to cancel the query operation.</param>
             <returns>Returns a page of entity instances and a continuation token for fetching the next page.</returns>
         </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableEntityClient.CleanEntityStorageAsync(System.Boolean,System.Boolean,System.Threading.CancellationToken)">
+            <summary>
+            Removes empty entities from storage and releases orphaned locks.
+            </summary>
+            <remarks>An entity is considered empty, and is removed, if it has no state, is not locked, and has
+            been idle for more than <see cref="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskOptions.EntityMessageReorderWindowInMinutes"/> minutes.
+            Locks are considered orphaned, and are released, if the orchestration that holds them is not in state <see cref="F:Microsoft.Azure.WebJobs.Extensions.DurableTask.OrchestrationRuntimeStatus.Running"/>. This
+            should not happen under normal circumstances, but can occur if the orchestration instance holding the lock
+            exhibits replay nondeterminism failures, or if it is explicitly purged.</remarks>
+            <param name="removeEmptyEntities">Whether to remove empty entities.</param>
+            <param name="releaseOrphanedLocks">Whether to release orphaned locks.</param>
+            <param name="cancellationToken">Cancellation token that can be used to cancel the operation.</param>
+            <returns>A task that completes when the operation is finished.</returns>
+        </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableEntityContext">
             <summary>
             Provides functionality for application code implementing an entity operation.
@@ -624,7 +656,7 @@
             The name of the task hub.
             </value>
         </member>
-        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableOrchestrationClient.CreateCheckStatusResponse(System.Net.Http.HttpRequestMessage,System.String,System.Boolean)">
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableOrchestrationClient.CreateCheckStatusResponse(System.Net.Http.HttpRequestMessage,System.String,System.Boolean,System.Boolean)">
             <summary>
             Creates an HTTP response that is useful for checking the status of the specified instance.
             </summary>
@@ -638,9 +670,11 @@
             <param name="returnInternalServerErrorOnFailure">Optional parameter that configures the http response code returned. Defaults to <c>false</c>.
             If <c>true</c>, the returned http response code will be a 500 when the orchestrator is in a failed state, when <c>false</c> it will
             return 200.</param>
+            <param name="restartWithNewInstanceId">Otional parameter that configures if restarting an orchestration will use a new instanceId or if it will
+            reuse the old instanceId. Defauls to <c>true</c>.</param>
             <returns>An HTTP 202 response with a Location header and a payload containing instance control URLs.</returns>
         </member>
-        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableOrchestrationClient.CreateCheckStatusResponse(Microsoft.AspNetCore.Http.HttpRequest,System.String,System.Boolean)">
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableOrchestrationClient.CreateCheckStatusResponse(Microsoft.AspNetCore.Http.HttpRequest,System.String,System.Boolean,System.Boolean)">
             <summary>
             Creates an HTTP response that is useful for checking the status of the specified instance.
             </summary>
@@ -654,6 +688,8 @@
             <param name="returnInternalServerErrorOnFailure">Optional parameter that configures the http response code returned. Defaults to <c>false</c>.
             If <c>true</c>, the returned http response code will be a 500 when the orchestrator is in a failed state, when <c>false</c> it will
             return 200.</param>
+            <param name="restartWithNewInstanceId">Otional parameter that configures if restarting an orchestration will use a new instanceId or if it will
+            reuse the old instanceId. Defauls to <c>true</c>.</param>
             <returns>An HTTP 202 response with a Location header and a payload containing instance control URLs.</returns>
         </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableOrchestrationClient.CreateHttpManagementPayload(System.String)">
@@ -672,7 +708,7 @@
             If the orchestration instance completes within the specified timeout, then the HTTP response payload will
             contain the output of the orchestration instance formatted as JSON. However, if the orchestration does not
             complete within the specified timeout, then the HTTP response will be identical to that of the
-            <see cref="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableOrchestrationClient.CreateCheckStatusResponse(System.Net.Http.HttpRequestMessage,System.String,System.Boolean)"/> API.
+            <see cref="!:CreateCheckStatusResponse(HttpRequestMessage, string, bool)"/> API.
             </remarks>
             <param name="request">The HTTP request that triggered the current function.</param>
             <param name="instanceId">The unique ID of the instance to check.</param>
@@ -689,7 +725,7 @@
             If the orchestration instance completes within the specified timeout, then the HTTP response payload will
             contain the output of the orchestration instance formatted as JSON. However, if the orchestration does not
             complete within the specified timeout, then the HTTP response will be identical to that of the
-            <see cref="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableOrchestrationClient.CreateCheckStatusResponse(Microsoft.AspNetCore.Http.HttpRequest,System.String,System.Boolean)"/> API.
+            <see cref="!:CreateCheckStatusResponse(HttpRequest, string, bool)"/> API.
             </remarks>
             <param name="request">The HTTP request that triggered the current function.</param>
             <param name="instanceId">The unique ID of the instance to check.</param>
@@ -2676,6 +2712,14 @@
             </summary>
             <value>
             The HTTP URL for purging instance history by instance ID.
+            </value>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.HttpManagementPayload.RestartUri">
+            <summary>
+            Gets the HTTP POST instance restart endpoint.
+            </summary>
+            <value>
+            The HTTP URL for restarting an orchestration instance.
             </value>
         </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.IApplicationLifetimeWrapper">

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
@@ -903,6 +903,16 @@
             <param name="cancellationToken">Cancellation token that can be used to cancel the status query operation.</param>
             <returns>Returns each page of orchestration status for all instances and continuation token of next page.</returns>
         </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableOrchestrationClient.RestartAsync(System.String,System.Boolean)">
+            <summary>
+             Restarts an existing orchestrator with the original input.
+            </summary>
+            <param name="instanceId">InstanceId of a previously run orchestrator to restart.</param>
+            <param name="restartWithNewInstanceId">Optional parameter that configures if restarting an orchestration will use a new instanceId or if it will
+            reuse the old instanceId. Defauls to <c>true</c>.</param>
+            <returns>A task that completes when the orchestration is started. The task contains the instance id of the started
+            orchestratation instance.</returns>
+        </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableOrchestrationContext">
             <summary>
             Provides functionality available to orchestration code.

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
@@ -38,6 +38,21 @@
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureStorageDurabilityProvider.GetOrchestrationStateWithPagination(Microsoft.Azure.WebJobs.Extensions.DurableTask.OrchestrationStatusQueryCondition,System.Threading.CancellationToken)">
             <inheritdoc/>
         </member>
+        <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.CleanEntityStorageResult">
+            <summary>
+            The result of a clean entity storage operation.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Azure.WebJobs.Extensions.DurableTask.CleanEntityStorageResult.NumberOfOrphanedLocksRemoved">
+            <summary>
+            The number of orphaned locks that were removed.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Azure.WebJobs.Extensions.DurableTask.CleanEntityStorageResult.NumberOfEmptyEntitiesRemoved">
+            <summary>
+            The number of entities whose metadata was removed from storage.
+            </summary>
+        </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableActivityContext">
             <summary>
             The default parameter type for activity functions.
@@ -84,10 +99,10 @@
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClient.Microsoft#Azure#WebJobs#Extensions#DurableTask#IDurableOrchestrationClient#TaskHubName">
             <inheritdoc />
         </member>
-        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClient.Microsoft#Azure#WebJobs#Extensions#DurableTask#IDurableOrchestrationClient#CreateCheckStatusResponse(System.Net.Http.HttpRequestMessage,System.String,System.Boolean)">
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClient.Microsoft#Azure#WebJobs#Extensions#DurableTask#IDurableOrchestrationClient#CreateCheckStatusResponse(System.Net.Http.HttpRequestMessage,System.String,System.Boolean,System.Boolean)">
             <inheritdoc />
         </member>
-        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClient.Microsoft#Azure#WebJobs#Extensions#DurableTask#IDurableOrchestrationClient#CreateCheckStatusResponse(Microsoft.AspNetCore.Http.HttpRequest,System.String,System.Boolean)">
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClient.Microsoft#Azure#WebJobs#Extensions#DurableTask#IDurableOrchestrationClient#CreateCheckStatusResponse(Microsoft.AspNetCore.Http.HttpRequest,System.String,System.Boolean,System.Boolean)">
             <inheritdoc />
         </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClient.Microsoft#Azure#WebJobs#Extensions#DurableTask#IDurableOrchestrationClient#CreateHttpManagementPayload(System.String)">
@@ -136,6 +151,9 @@
             <inheritdoc />
         </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClient.Microsoft#Azure#WebJobs#Extensions#DurableTask#IDurableEntityClient#ListEntitiesAsync(Microsoft.Azure.WebJobs.Extensions.DurableTask.EntityQuery,System.Threading.CancellationToken)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClient.Microsoft#Azure#WebJobs#Extensions#DurableTask#IDurableEntityClient#CleanEntityStorageAsync(System.Boolean,System.Boolean,System.Threading.CancellationToken)">
             <inheritdoc />
         </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClient.Microsoft#Azure#WebJobs#Extensions#DurableTask#IDurableOrchestrationClient#StartNewAsync(System.String,System.String)">
@@ -464,6 +482,20 @@
             <param name="cancellationToken">Cancellation token that can be used to cancel the query operation.</param>
             <returns>Returns a page of entity instances and a continuation token for fetching the next page.</returns>
         </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableEntityClient.CleanEntityStorageAsync(System.Boolean,System.Boolean,System.Threading.CancellationToken)">
+            <summary>
+            Removes empty entities from storage and releases orphaned locks.
+            </summary>
+            <remarks>An entity is considered empty, and is removed, if it has no state, is not locked, and has
+            been idle for more than <see cref="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskOptions.EntityMessageReorderWindowInMinutes"/> minutes.
+            Locks are considered orphaned, and are released, if the orchestration that holds them is not in state <see cref="F:Microsoft.Azure.WebJobs.Extensions.DurableTask.OrchestrationRuntimeStatus.Running"/>. This
+            should not happen under normal circumstances, but can occur if the orchestration instance holding the lock
+            exhibits replay nondeterminism failures, or if it is explicitly purged.</remarks>
+            <param name="removeEmptyEntities">Whether to remove empty entities.</param>
+            <param name="releaseOrphanedLocks">Whether to release orphaned locks.</param>
+            <param name="cancellationToken">Cancellation token that can be used to cancel the operation.</param>
+            <returns>A task that completes when the operation is finished.</returns>
+        </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableEntityContext">
             <summary>
             Provides functionality for application code implementing an entity operation.
@@ -629,7 +661,7 @@
             The name of the task hub.
             </value>
         </member>
-        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableOrchestrationClient.CreateCheckStatusResponse(System.Net.Http.HttpRequestMessage,System.String,System.Boolean)">
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableOrchestrationClient.CreateCheckStatusResponse(System.Net.Http.HttpRequestMessage,System.String,System.Boolean,System.Boolean)">
             <summary>
             Creates an HTTP response that is useful for checking the status of the specified instance.
             </summary>
@@ -643,9 +675,11 @@
             <param name="returnInternalServerErrorOnFailure">Optional parameter that configures the http response code returned. Defaults to <c>false</c>.
             If <c>true</c>, the returned http response code will be a 500 when the orchestrator is in a failed state, when <c>false</c> it will
             return 200.</param>
+            <param name="restartWithNewInstanceId">Otional parameter that configures if restarting an orchestration will use a new instanceId or if it will
+            reuse the old instanceId. Defauls to <c>true</c>.</param>
             <returns>An HTTP 202 response with a Location header and a payload containing instance control URLs.</returns>
         </member>
-        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableOrchestrationClient.CreateCheckStatusResponse(Microsoft.AspNetCore.Http.HttpRequest,System.String,System.Boolean)">
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableOrchestrationClient.CreateCheckStatusResponse(Microsoft.AspNetCore.Http.HttpRequest,System.String,System.Boolean,System.Boolean)">
             <summary>
             Creates an HTTP response that is useful for checking the status of the specified instance.
             </summary>
@@ -659,6 +693,8 @@
             <param name="returnInternalServerErrorOnFailure">Optional parameter that configures the http response code returned. Defaults to <c>false</c>.
             If <c>true</c>, the returned http response code will be a 500 when the orchestrator is in a failed state, when <c>false</c> it will
             return 200.</param>
+            <param name="restartWithNewInstanceId">Otional parameter that configures if restarting an orchestration will use a new instanceId or if it will
+            reuse the old instanceId. Defauls to <c>true</c>.</param>
             <returns>An HTTP 202 response with a Location header and a payload containing instance control URLs.</returns>
         </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableOrchestrationClient.CreateHttpManagementPayload(System.String)">
@@ -677,7 +713,7 @@
             If the orchestration instance completes within the specified timeout, then the HTTP response payload will
             contain the output of the orchestration instance formatted as JSON. However, if the orchestration does not
             complete within the specified timeout, then the HTTP response will be identical to that of the
-            <see cref="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableOrchestrationClient.CreateCheckStatusResponse(System.Net.Http.HttpRequestMessage,System.String,System.Boolean)"/> API.
+            <see cref="!:CreateCheckStatusResponse(HttpRequestMessage, string, bool)"/> API.
             </remarks>
             <param name="request">The HTTP request that triggered the current function.</param>
             <param name="instanceId">The unique ID of the instance to check.</param>
@@ -694,7 +730,7 @@
             If the orchestration instance completes within the specified timeout, then the HTTP response payload will
             contain the output of the orchestration instance formatted as JSON. However, if the orchestration does not
             complete within the specified timeout, then the HTTP response will be identical to that of the
-            <see cref="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableOrchestrationClient.CreateCheckStatusResponse(Microsoft.AspNetCore.Http.HttpRequest,System.String,System.Boolean)"/> API.
+            <see cref="!:CreateCheckStatusResponse(HttpRequest, string, bool)"/> API.
             </remarks>
             <param name="request">The HTTP request that triggered the current function.</param>
             <param name="instanceId">The unique ID of the instance to check.</param>
@@ -2687,6 +2723,14 @@
             </summary>
             <value>
             The HTTP URL for purging instance history by instance ID.
+            </value>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.HttpManagementPayload.RestartUri">
+            <summary>
+            Gets the HTTP POST instance restart endpoint.
+            </summary>
+            <value>
+            The HTTP URL for restarting an orchestration instance.
             </value>
         </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.IApplicationLifetimeWrapper">

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
@@ -99,10 +99,13 @@
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClient.Microsoft#Azure#WebJobs#Extensions#DurableTask#IDurableOrchestrationClient#TaskHubName">
             <inheritdoc />
         </member>
-        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClient.Microsoft#Azure#WebJobs#Extensions#DurableTask#IDurableOrchestrationClient#CreateCheckStatusResponse(System.Net.Http.HttpRequestMessage,System.String,System.Boolean,System.Boolean)">
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClient.ToString">
+            <inheritdoc/>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClient.Microsoft#Azure#WebJobs#Extensions#DurableTask#IDurableOrchestrationClient#CreateCheckStatusResponse(System.Net.Http.HttpRequestMessage,System.String,System.Boolean)">
             <inheritdoc />
         </member>
-        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClient.Microsoft#Azure#WebJobs#Extensions#DurableTask#IDurableOrchestrationClient#CreateCheckStatusResponse(Microsoft.AspNetCore.Http.HttpRequest,System.String,System.Boolean,System.Boolean)">
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClient.Microsoft#Azure#WebJobs#Extensions#DurableTask#IDurableOrchestrationClient#CreateCheckStatusResponse(Microsoft.AspNetCore.Http.HttpRequest,System.String,System.Boolean)">
             <inheritdoc />
         </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClient.Microsoft#Azure#WebJobs#Extensions#DurableTask#IDurableOrchestrationClient#CreateHttpManagementPayload(System.String)">
@@ -584,6 +587,16 @@
             Whether this entity has a state.
             </summary>
         </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableEntityContext.BatchSize">
+            <summary>
+            The size of the current batch of operations.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableEntityContext.BatchPosition">
+            <summary>
+            The position of the currently executing operation within the current batch of operations.
+            </summary>
+        </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableEntityContext.GetState``1(System.Func{``0})">
             <summary>
             Gets the current state of this entity, for reading and/or updating.
@@ -710,7 +723,7 @@
             The name of the task hub.
             </value>
         </member>
-        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableOrchestrationClient.CreateCheckStatusResponse(System.Net.Http.HttpRequestMessage,System.String,System.Boolean,System.Boolean)">
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableOrchestrationClient.CreateCheckStatusResponse(System.Net.Http.HttpRequestMessage,System.String,System.Boolean)">
             <summary>
             Creates an HTTP response that is useful for checking the status of the specified instance.
             </summary>
@@ -724,11 +737,9 @@
             <param name="returnInternalServerErrorOnFailure">Optional parameter that configures the http response code returned. Defaults to <c>false</c>.
             If <c>true</c>, the returned http response code will be a 500 when the orchestrator is in a failed state, when <c>false</c> it will
             return 200.</param>
-            <param name="restartWithNewInstanceId">Otional parameter that configures if restarting an orchestration will use a new instanceId or if it will
-            reuse the old instanceId. Defauls to <c>true</c>.</param>
             <returns>An HTTP 202 response with a Location header and a payload containing instance control URLs.</returns>
         </member>
-        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableOrchestrationClient.CreateCheckStatusResponse(Microsoft.AspNetCore.Http.HttpRequest,System.String,System.Boolean,System.Boolean)">
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableOrchestrationClient.CreateCheckStatusResponse(Microsoft.AspNetCore.Http.HttpRequest,System.String,System.Boolean)">
             <summary>
             Creates an HTTP response that is useful for checking the status of the specified instance.
             </summary>
@@ -742,8 +753,6 @@
             <param name="returnInternalServerErrorOnFailure">Optional parameter that configures the http response code returned. Defaults to <c>false</c>.
             If <c>true</c>, the returned http response code will be a 500 when the orchestrator is in a failed state, when <c>false</c> it will
             return 200.</param>
-            <param name="restartWithNewInstanceId">Otional parameter that configures if restarting an orchestration will use a new instanceId or if it will
-            reuse the old instanceId. Defauls to <c>true</c>.</param>
             <returns>An HTTP 202 response with a Location header and a payload containing instance control URLs.</returns>
         </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableOrchestrationClient.CreateHttpManagementPayload(System.String)">
@@ -762,7 +771,7 @@
             If the orchestration instance completes within the specified timeout, then the HTTP response payload will
             contain the output of the orchestration instance formatted as JSON. However, if the orchestration does not
             complete within the specified timeout, then the HTTP response will be identical to that of the
-            <see cref="!:CreateCheckStatusResponse(HttpRequestMessage, string, bool)"/> API.
+            <see cref="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableOrchestrationClient.CreateCheckStatusResponse(System.Net.Http.HttpRequestMessage,System.String,System.Boolean)"/> API.
             </remarks>
             <param name="request">The HTTP request that triggered the current function.</param>
             <param name="instanceId">The unique ID of the instance to check.</param>
@@ -779,7 +788,7 @@
             If the orchestration instance completes within the specified timeout, then the HTTP response payload will
             contain the output of the orchestration instance formatted as JSON. However, if the orchestration does not
             complete within the specified timeout, then the HTTP response will be identical to that of the
-            <see cref="!:CreateCheckStatusResponse(HttpRequest, string, bool)"/> API.
+            <see cref="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableOrchestrationClient.CreateCheckStatusResponse(Microsoft.AspNetCore.Http.HttpRequest,System.String,System.Boolean)"/> API.
             </remarks>
             <param name="request">The HTTP request that triggered the current function.</param>
             <param name="instanceId">The unique ID of the instance to check.</param>
@@ -1583,6 +1592,16 @@
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurabilityProvider.SupportsEntities">
             <summary>
             Specifies whether the durability provider supports Durable Entities.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurabilityProvider.SupportsPollFreeWait">
+            <summary>
+            Specifies whether the backend's WaitForOrchestration is implemented without polling.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurabilityProvider.GuaranteesOrderedDelivery">
+            <summary>
+            Specifies whether this backend delivers messages in order.
             </summary>
         </member>
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurabilityProvider.ConfigurationJson">
@@ -3862,6 +3881,34 @@
             Option to only start a new orchestrator instance with an existing instance Id when the existing
             instance is in a terminated, failed, or completed state.
             </summary>
+        </member>
+        <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.ProviderUtils">
+            <summary>
+            Provides access to internal functionality for the purpose of implementing durability providers.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.ProviderUtils.GetSchedulerIdFromEntityId(Microsoft.Azure.WebJobs.Extensions.DurableTask.EntityId)">
+            <summary>
+            Returns the instance id of the entity scheduler for a given entity id.
+            </summary>
+            <param name="entityId">The entity id.</param>
+            <returns>The instance id of the scheduler.</returns>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.ProviderUtils.TryGetEntityStateFromSerializedSchedulerState(DurableTask.Core.OrchestrationState,Newtonsoft.Json.JsonSerializerSettings,System.String@)">
+            <summary>
+            Reads the state of an entity from the serialized entity scheduler state.
+            </summary>
+            <param name="state">The orchestration state of the scheduler.</param>
+            <param name="serializerSettings">The serializer settings.</param>
+            <param name="result">The serialized state of the entity.</param>
+            <returns>true if the entity exists, false otherwise.</returns>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.ProviderUtils.ConvertOrchestrationStateToStatus(DurableTask.Core.OrchestrationState)">
+            <summary>
+            Converts the DTFx representation of the orchestration state into the DF representation.
+            </summary>
+            <param name="orchestrationState">The orchestration state.</param>
+            <returns>The orchestration status.</returns>
         </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.PurgeHistoryResult">
             <summary>

--- a/test/Common/DurableTaskEndToEndTests.cs
+++ b/test/Common/DurableTaskEndToEndTests.cs
@@ -4773,6 +4773,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             Assert.Equal(
                 $"{notificationUrl}/instances/{instanceId}/terminate?reason={{text}}&taskHub={taskHubName}&connection=AzureWebJobsStorage&code=mykey",
                 httpManagementPayload.TerminatePostUri);
+            Assert.Equal(
+                $"{notificationUrl}/instances/{instanceId}/restart?taskHub={taskHubName}&connection=AzureWebJobsStorage&code=mykey",
+                httpManagementPayload.RestartUri);
         }
 
         [DataContract]

--- a/test/Common/DurableTaskEndToEndTests.cs
+++ b/test/Common/DurableTaskEndToEndTests.cs
@@ -3790,7 +3790,79 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             }
         }
 
-        [Theory(Skip = "Azure Storage fails due to container deletion")]
+        [Theory]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task RestartOrchestator_IsSuccess(bool restartWithNewInstanceId)
+        {
+            string[] orchestratorFunctionNames =
+            {
+                nameof(TestOrchestrations.SayHelloInline),
+            };
+            using (var host = TestHelpers.GetJobHost(
+                this.loggerProvider,
+                nameof(this.HelloWorldOrchestration_Inline),
+                false))
+            {
+                await host.StartAsync();
+
+                var instanceId = Guid.NewGuid().ToString();
+
+                var client = await host.StartOrchestratorAsync(orchestratorFunctionNames[0], "RestartAsyncTest", this.output, instanceId: instanceId);
+                await client.WaitForCompletionAsync(this.output);
+
+                var newInstanceId = await client.InnerClient.RestartAsync(instanceId, restartWithNewInstanceId: restartWithNewInstanceId);
+                var status = await client.WaitForCompletionAsync(this.output);
+
+                if (restartWithNewInstanceId)
+                {
+                    Assert.NotEqual(instanceId, newInstanceId);
+                }
+                else
+                {
+                    Assert.Equal(instanceId, newInstanceId);
+                }
+
+                Assert.Equal(OrchestrationRuntimeStatus.Completed, status?.RuntimeStatus);
+                Assert.Equal("RestartAsyncTest", status?.Input);
+
+                await host.StopAsync();
+            }
+        }
+
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public async Task RestartOrchestrator_ThrowsException()
+        {
+            string[] orchestratorFunctionNames =
+            {
+                nameof(TestOrchestrations.SayHelloInline),
+            };
+            using (var host = TestHelpers.GetJobHost(
+                this.loggerProvider,
+                nameof(this.HelloWorldOrchestration_Inline),
+                false))
+            {
+                await host.StartAsync();
+
+                var nonExistentId = Guid.NewGuid().ToString();
+
+                var client = await host.StartOrchestratorAsync(orchestratorFunctionNames[0], "World", this.output);
+
+                ArgumentException exception =
+                    await Assert.ThrowsAsync<ArgumentException>(async () =>
+                    {
+                        await client.InnerClient.RestartAsync(nonExistentId);
+                    });
+
+                Assert.Equal(
+                    $"An orchestrastion with the instanceId {nonExistentId} was not found.",
+                    exception.Message);
+            }
+        }
+
+        [Theory]
         [Trait("Category", PlatformSpecificHelpers.TestCategory)]
         [MemberData(nameof(TestDataGenerator.GetBooleanAndFullFeaturedStorageProviderOptions), MemberType = typeof(TestDataGenerator))]
         public async Task GetStatus_WithCondition(bool extendedSessions, string storageProvider)

--- a/test/Common/HttpApiHandlerTests.cs
+++ b/test/Common/HttpApiHandlerTests.cs
@@ -196,7 +196,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 $"{TestConstants.NotificationUrlBase}/instances/7b59154ae666471993659902ed0ba742?taskHub=SampleHubVS&connection=TestConnection&code=mykey",
                 httpManagementPayload.PurgeHistoryDeleteUri);
             Assert.Equal(
-                $"{TestConstants.NotificationUrlBase}/instances/7b59154ae666471993659902ed0ba742/restart?taskHub=SampleHubVS&connection=TestConnection&code=mykey&restartWithNewInstanceId=false",
+                $"{TestConstants.NotificationUrlBase}/instances/7b59154ae666471993659902ed0ba742/restart?taskHub=SampleHubVS&connection=TestConnection&code=mykey",
                 httpManagementPayload.RestartUri);
         }
 
@@ -763,7 +763,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 .Returns(Task.FromResult(restartedInstanceId));
 
             clientMock
-                .Setup(x => x.CreateCheckStatusResponse(It.IsAny<HttpRequestMessage>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>()))
+                .Setup(x => x.CreateCheckStatusResponse(It.IsAny<HttpRequestMessage>(), It.IsAny<string>(), It.IsAny<bool>()))
                 .Returns(testResponse);
 
             var httpApiHandler = new ExtendedHttpApiHandler(clientMock.Object);
@@ -914,7 +914,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 .Returns(Task.FromResult(testInstanceId));
 
             clientMock
-                .Setup(x => x.CreateCheckStatusResponse(It.IsAny<HttpRequestMessage>(), It.IsAny<string>(), false, true))
+                .Setup(x => x.CreateCheckStatusResponse(It.IsAny<HttpRequestMessage>(), It.IsAny<string>(), false))
                 .Returns(testResponse);
 
             var httpApiHandler = new ExtendedHttpApiHandler(clientMock.Object);
@@ -1018,7 +1018,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 .Returns(Task.FromResult(testInstanceId));
 
             clientMock
-                .Setup(x => x.CreateCheckStatusResponse(It.IsAny<HttpRequestMessage>(), It.IsAny<string>(), false, true))
+                .Setup(x => x.CreateCheckStatusResponse(It.IsAny<HttpRequestMessage>(), It.IsAny<string>(), false))
                 .Throws(new JsonReaderException());
 
             var httpApiHandler = new ExtendedHttpApiHandler(clientMock.Object);

--- a/test/Common/HttpApiHandlerTests.cs
+++ b/test/Common/HttpApiHandlerTests.cs
@@ -95,6 +95,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             Assert.Equal(
                 $"{TestConstants.NotificationUrlBase}/instances/7b59154ae666471993659902ed0ba742?taskHub=SampleHubVS&connection=Storage&code=mykey",
                 (string)status["purgeHistoryDeleteUri"]);
+            Assert.Equal(
+                $"{TestConstants.NotificationUrlBase}/instances/7b59154ae666471993659902ed0ba742/restart?taskHub=SampleHubVS&connection=Storage&code=mykey",
+                (string)status["restartUri"]);
         }
 
         [Fact]
@@ -117,6 +120,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             Assert.Equal(
                 $"{TestConstants.NotificationUrlBase}/instances/7b59154ae666471993659902ed0ba742?taskHub=DurableFunctionsHub&connection=Storage&code=mykey",
                 httpManagementPayload.PurgeHistoryDeleteUri);
+            Assert.Equal(
+               $"{TestConstants.NotificationUrlBase}/instances/7b59154ae666471993659902ed0ba742/restart?taskHub=DurableFunctionsHub&connection=Storage&code=mykey",
+               httpManagementPayload.RestartUri);
         }
 
         [Fact]
@@ -139,6 +145,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             Assert.Equal(
                 $"{TestConstants.NotificationUrlBase}/instances/7b59154ae666471993659902ed0ba742?taskHub=SampleHubVS&connection=Storage&code=mykey",
                 httpManagementPayload.PurgeHistoryDeleteUri);
+            Assert.Equal(
+                $"{TestConstants.NotificationUrlBase}/instances/7b59154ae666471993659902ed0ba742/restart?taskHub=SampleHubVS&connection=Storage&code=mykey",
+                httpManagementPayload.RestartUri);
         }
 
         [Fact]
@@ -161,6 +170,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             Assert.Equal(
                 $"{TestConstants.NotificationUrlBase}/instances/7b59154ae666471993659902ed0ba742?taskHub=DurableFunctionsHub&connection=TestConnection&code=mykey",
                 httpManagementPayload.PurgeHistoryDeleteUri);
+            Assert.Equal(
+                $"{TestConstants.NotificationUrlBase}/instances/7b59154ae666471993659902ed0ba742/restart?taskHub=DurableFunctionsHub&connection=TestConnection&code=mykey",
+                httpManagementPayload.RestartUri);
         }
 
         [Fact]
@@ -168,11 +180,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         public void CreateCheckStatus_Returns_Correct_HttpManagementPayload_based_on_custom_values()
         {
             var httpApiHandler = new HttpApiHandler(GetTestExtension(), null);
-            HttpManagementPayload httpManagementPayload = httpApiHandler.CreateHttpManagementPayload(TestConstants.InstanceId, TestConstants.TaskHub, TestConstants.CustomConnectionName);
+            HttpManagementPayload httpManagementPayload = httpApiHandler.CreateHttpManagementPayload(TestConstants.InstanceId, TestConstants.TaskHub, TestConstants.CustomConnectionName, returnInternalServerErrorOnFailure: true, restartWithNewInstanceId: false);
             Assert.NotNull(httpManagementPayload);
             Assert.Equal(httpManagementPayload.Id, TestConstants.InstanceId);
             Assert.Equal(
-                $"{TestConstants.NotificationUrlBase}/instances/7b59154ae666471993659902ed0ba742?taskHub=SampleHubVS&connection=TestConnection&code=mykey",
+                $"{TestConstants.NotificationUrlBase}/instances/7b59154ae666471993659902ed0ba742?taskHub=SampleHubVS&connection=TestConnection&code=mykey&returnInternalServerErrorOnFailure=true",
                 httpManagementPayload.StatusQueryGetUri);
             Assert.Equal(
                 $"{TestConstants.NotificationUrlBase}/instances/7b59154ae666471993659902ed0ba742/raiseEvent/{{eventName}}?taskHub=SampleHubVS&connection=TestConnection&code=mykey",
@@ -183,6 +195,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             Assert.Equal(
                 $"{TestConstants.NotificationUrlBase}/instances/7b59154ae666471993659902ed0ba742?taskHub=SampleHubVS&connection=TestConnection&code=mykey",
                 httpManagementPayload.PurgeHistoryDeleteUri);
+            Assert.Equal(
+                $"{TestConstants.NotificationUrlBase}/instances/7b59154ae666471993659902ed0ba742/restart?taskHub=SampleHubVS&connection=TestConnection&code=mykey&restartWithNewInstanceId=false",
+                httpManagementPayload.RestartUri);
         }
 
         [Fact]
@@ -221,6 +236,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             Assert.Equal(
                 $"{TestConstants.NotificationUrlBase}/instances/9b59154ae666471993659902ed0ba749?taskHub=SampleHubVS&connection=Storage&code=mykey",
                 (string)status["purgeHistoryDeleteUri"]);
+            Assert.Equal(
+                $"{TestConstants.NotificationUrlBase}/instances/9b59154ae666471993659902ed0ba749/restart?taskHub=SampleHubVS&connection=Storage&code=mykey",
+                (string)status["restartUri"]);
             Assert.True(stopWatch.Elapsed > TimeSpan.FromSeconds(30));
         }
 
@@ -704,6 +722,153 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         }
 
         [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public async Task RestartInstance_Is_Success(bool restartWithNewInstanceId)
+        {
+            string testInstanceId = Guid.NewGuid().ToString();
+            string restartedInstanceId = restartWithNewInstanceId ? Guid.NewGuid().ToString() : testInstanceId;
+
+            var restartUriBuilder = new UriBuilder(TestConstants.NotificationUrl);
+            restartUriBuilder.Path += $"/Instances/{testInstanceId}/restart";
+            restartUriBuilder.Query = $"restartWithNewInstanceId={restartWithNewInstanceId}&{restartUriBuilder.Query.TrimStart('?')}";
+
+            var testRequest = new HttpRequestMessage
+            {
+                Method = HttpMethod.Post,
+                RequestUri = restartUriBuilder.Uri,
+            };
+
+            var testStatusQueryGetUri = $"{TestConstants.NotificationUrlBase}/instances/{restartedInstanceId}?taskhub=SampleHubVS&connection=Storage&code=mykey";
+            var testSendEventPostUri = $"{TestConstants.NotificationUrlBase}/instances/{restartedInstanceId}/raiseEvent/{{eventName}}?taskHub=SampleHubVS&connection=Storage&code=mykey";
+            var testTerminatePostUri = $"{TestConstants.NotificationUrlBase}/instances/{restartedInstanceId}/terminate?reason={{text}}&taskHub=SampleHubVS&connection=Storage&code=mykey";
+            var testRewindPostUri = $"{TestConstants.NotificationUrlBase}/instances/{restartedInstanceId}/rewind?reason={{text}}&taskHub=SampleHubVS&connection=Storage&code=mykey";
+            var testRestartPostUri = $"{TestConstants.NotificationUrlBase}/instances/{restartedInstanceId}/restart?taskHub=SampleHubVS&connection=Storage&code=mykey&startWithNewInstanceId={restartWithNewInstanceId}";
+            var testResponse = testRequest.CreateResponse(
+                HttpStatusCode.Accepted,
+                new
+                {
+                    id = restartedInstanceId,
+                    statusQueryGetUri = testStatusQueryGetUri,
+                    sendEventPostUri = testSendEventPostUri,
+                    terminatePostUri = testTerminatePostUri,
+                    rewindPostUri = testRewindPostUri,
+                    restartPostUri = testRestartPostUri,
+                });
+
+            var clientMock = new Mock<IDurableClient>();
+            clientMock
+                .Setup(x => x.RestartAsync(testInstanceId, restartWithNewInstanceId))
+                .Returns(Task.FromResult(restartedInstanceId));
+
+            clientMock
+                .Setup(x => x.CreateCheckStatusResponse(It.IsAny<HttpRequestMessage>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>()))
+                .Returns(testResponse);
+
+            var httpApiHandler = new ExtendedHttpApiHandler(clientMock.Object);
+            var actualResponse = await httpApiHandler.HandleRequestAsync(testRequest);
+
+            Assert.Equal(HttpStatusCode.Accepted, actualResponse.StatusCode);
+            var content = await actualResponse.Content.ReadAsStringAsync();
+            var status = JsonConvert.DeserializeObject<JObject>(content);
+            Assert.Equal(status["id"], restartedInstanceId);
+            Assert.Equal(status["statusQueryGetUri"], testStatusQueryGetUri);
+            Assert.Equal(status["sendEventPostUri"], testSendEventPostUri);
+            Assert.Equal(status["terminatePostUri"], testTerminatePostUri);
+            Assert.Equal(status["rewindPostUri"], testRewindPostUri);
+            Assert.Equal(status["restartPostUri"], testRestartPostUri);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public async Task RestartInstanceAndWaitToComplete_Is_Success(bool restartWithNewInstanceId)
+        {
+            string testInstanceId = Guid.NewGuid().ToString();
+            string restartedInstanceId = restartWithNewInstanceId ? Guid.NewGuid().ToString() : testInstanceId;
+
+            var restartUriBuilder = new UriBuilder(TestConstants.NotificationUrl);
+            restartUriBuilder.Path += $"/Instances/{testInstanceId}/restart";
+            restartUriBuilder.Query = $"timeout=90&pollingInterval=10&restartWithNewInstanceId={restartWithNewInstanceId}&{restartUriBuilder.Query.TrimStart('?')}";
+
+            var testRequest = new HttpRequestMessage
+            {
+                Method = HttpMethod.Post,
+                RequestUri = restartUriBuilder.Uri,
+            };
+
+            var testStatusQueryGetUri = $"{TestConstants.NotificationUrlBase}/instances/{restartedInstanceId}?taskhub=SampleHubVS&connection=Storage&code=mykey";
+            var testSendEventPostUri = $"{TestConstants.NotificationUrlBase}/instances/{restartedInstanceId}/raiseEvent/{{eventName}}?taskHub=SampleHubVS&connection=Storage&code=mykey";
+            var testTerminatePostUri = $"{TestConstants.NotificationUrlBase}/instances/{restartedInstanceId}/terminate?reason={{text}}&taskHub=SampleHubVS&connection=Storage&code=mykey";
+            var testRewindPostUri = $"{TestConstants.NotificationUrlBase}/instances/{restartedInstanceId}/rewind?reason={{text}}&taskHub=SampleHubVS&connection=Storage&code=mykey";
+            var testRestartPostUri = $"{TestConstants.NotificationUrlBase}/instances/{restartedInstanceId}/restart?taskHub=SampleHubVS&connection=Storage&code=mykey&startWithNewInstanceId={restartWithNewInstanceId}";
+            var testResponse = testRequest.CreateResponse(
+                HttpStatusCode.Accepted,
+                new
+                {
+                    id = restartedInstanceId,
+                    statusQueryGetUri = testStatusQueryGetUri,
+                    sendEventPostUri = testSendEventPostUri,
+                    terminatePostUri = testTerminatePostUri,
+                    rewindPostUri = testRewindPostUri,
+                    restartPostUri = testRestartPostUri,
+                });
+
+            var clientMock = new Mock<IDurableClient>();
+            clientMock
+                .Setup(x => x.RestartAsync(testInstanceId, restartWithNewInstanceId))
+                .Returns(Task.FromResult(restartedInstanceId));
+
+            clientMock
+                .Setup(x => x.WaitForCompletionOrCreateCheckStatusResponseAsync(It.IsAny<HttpRequestMessage>(), It.IsAny<string>(), It.IsAny<TimeSpan>(), It.IsAny<TimeSpan>()))
+                .Returns(Task.FromResult(testResponse));
+
+            var httpApiHandler = new ExtendedHttpApiHandler(clientMock.Object);
+            var actualResponse = await httpApiHandler.HandleRequestAsync(testRequest);
+
+            Assert.Equal(HttpStatusCode.Accepted, actualResponse.StatusCode);
+            var content = await actualResponse.Content.ReadAsStringAsync();
+            var status = JsonConvert.DeserializeObject<JObject>(content);
+            Assert.Equal(status["id"], restartedInstanceId);
+            Assert.Equal(status["statusQueryGetUri"], testStatusQueryGetUri);
+            Assert.Equal(status["sendEventPostUri"], testSendEventPostUri);
+            Assert.Equal(status["terminatePostUri"], testTerminatePostUri);
+            Assert.Equal(status["rewindPostUri"], testRewindPostUri);
+            Assert.Equal(status["restartPostUri"], testRestartPostUri);
+        }
+
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public async Task RestartInstance_Returns_HTTP_400_On_Invalid_InstanceId()
+        {
+            string testBadInstanceId = Guid.NewGuid().ToString("N");
+
+            var startRequestUriBuilder = new UriBuilder(TestConstants.NotificationUrl);
+            startRequestUriBuilder.Path += $"/Instances/{testBadInstanceId}/restart";
+
+            var testRequest = new HttpRequestMessage
+            {
+                Method = HttpMethod.Post,
+                RequestUri = startRequestUriBuilder.Uri,
+            };
+
+            var clientMock = new Mock<IDurableClient>();
+            clientMock
+                .Setup(x => x.RestartAsync(It.IsAny<string>(), It.IsAny<bool>()))
+                .Throws(new ArgumentException());
+
+            var httpApiHandler = new ExtendedHttpApiHandler(clientMock.Object);
+            var actualResponse = await httpApiHandler.HandleRequestAsync(testRequest);
+
+            Assert.Equal(HttpStatusCode.BadRequest, actualResponse.StatusCode);
+            var content = await actualResponse.Content.ReadAsStringAsync();
+            var error = JsonConvert.DeserializeObject<JObject>(content);
+            Assert.Equal("InstanceId does not match a valid orchestration instance.", error["Message"].ToString());
+        }
+
+        [Theory]
         [InlineData(null, false)]
         [InlineData(null, true)]
         [InlineData(TestConstants.RandomInstanceId, false)]
@@ -726,10 +891,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                     : new StringContent("\"TestContent\""),
             };
 
-            var testStatusQueryGetUri = $"{TestConstants.NotificationUrlBase}/instances/{testInstanceId}?taskhub=SampleHubVS&connection=Storage&code=mykey&returnInternalServerErrorOnFailure=False";
+            var testStatusQueryGetUri = $"{TestConstants.NotificationUrlBase}/instances/{testInstanceId}?taskhub=SampleHubVS&connection=Storage&code=mykey";
             var testSendEventPostUri = $"{TestConstants.NotificationUrlBase}/instances/{testInstanceId}/raiseEvent/{{eventName}}?taskHub=SampleHubVS&connection=Storage&code=mykey";
             var testTerminatePostUri = $"{TestConstants.NotificationUrlBase}/instances/{testInstanceId}/terminate?reason={{text}}&taskHub=SampleHubVS&connection=Storage&code=mykey";
             var testRewindPostUri = $"{TestConstants.NotificationUrlBase}/instances/{testInstanceId}/rewind?reason={{text}}&taskHub=SampleHubVS&connection=Storage&code=mykey";
+            var testRestartPostUri = $"{TestConstants.NotificationUrlBase}/instances/{testInstanceId}/restart?taskHub=SampleHubVS&connection=Storage&code=mykey";
             var testResponse = testRequest.CreateResponse(
                 HttpStatusCode.Accepted,
                 new
@@ -739,6 +905,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                     sendEventPostUri = testSendEventPostUri,
                     terminatePostUri = testTerminatePostUri,
                     rewindPostUri = testRewindPostUri,
+                    restartPostUri = testRestartPostUri,
                 });
 
             var clientMock = new Mock<IDurableClient>();
@@ -747,7 +914,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 .Returns(Task.FromResult(testInstanceId));
 
             clientMock
-                .Setup(x => x.CreateCheckStatusResponse(It.IsAny<HttpRequestMessage>(), It.IsAny<string>(), false))
+                .Setup(x => x.CreateCheckStatusResponse(It.IsAny<HttpRequestMessage>(), It.IsAny<string>(), false, true))
                 .Returns(testResponse);
 
             var httpApiHandler = new ExtendedHttpApiHandler(clientMock.Object);
@@ -761,6 +928,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             Assert.Equal(status["sendEventPostUri"], testSendEventPostUri);
             Assert.Equal(status["terminatePostUri"], testTerminatePostUri);
             Assert.Equal(status["rewindPostUri"], testRewindPostUri);
+            Assert.Equal(status["restartPostUri"], testRestartPostUri);
         }
 
         [Theory]
@@ -787,10 +955,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                     : new StringContent("\"TestContent\""),
             };
 
-            var testStatusQueryGetUri = $"{TestConstants.NotificationUrlBase}/instances/{testInstanceId}?taskhub=SampleHubVS&connection=Storage&code=mykey&returnInternalServerErrorOnFailure=False";
+            var testStatusQueryGetUri = $"{TestConstants.NotificationUrlBase}/instances/{testInstanceId}?taskhub=SampleHubVS&connection=Storage&code=mykey";
             var testSendEventPostUri = $"{TestConstants.NotificationUrlBase}/instances/{testInstanceId}/raiseEvent/{{eventName}}?taskHub=SampleHubVS&connection=Storage&code=mykey";
             var testTerminatePostUri = $"{TestConstants.NotificationUrlBase}/instances/{testInstanceId}/terminate?reason={{text}}&taskHub=SampleHubVS&connection=Storage&code=mykey";
             var testRewindPostUri = $"{TestConstants.NotificationUrlBase}/instances/{testInstanceId}/rewind?reason={{text}}&taskHub=SampleHubVS&connection=Storage&code=mykey";
+            var testRestartPostUri = $"{TestConstants.NotificationUrlBase}/instances/{testInstanceId}/restart?taskHub=SampleHubVS&connection=Storage&code=mykey";
             var testResponse = testRequest.CreateResponse(
                 HttpStatusCode.Accepted,
                 new
@@ -800,6 +969,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                     sendEventPostUri = testSendEventPostUri,
                     terminatePostUri = testTerminatePostUri,
                     rewindPostUri = testRewindPostUri,
+                    restartPostUri = testRestartPostUri,
                 });
 
             var clientMock = new Mock<IDurableClient>();
@@ -822,6 +992,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             Assert.Equal(status["sendEventPostUri"], testSendEventPostUri);
             Assert.Equal(status["terminatePostUri"], testTerminatePostUri);
             Assert.Equal(status["rewindPostUri"], testRewindPostUri);
+            Assert.Equal(status["restartPostUri"], testRestartPostUri);
         }
 
         [Fact]
@@ -847,7 +1018,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 .Returns(Task.FromResult(testInstanceId));
 
             clientMock
-                .Setup(x => x.CreateCheckStatusResponse(It.IsAny<HttpRequestMessage>(), It.IsAny<string>(), false))
+                .Setup(x => x.CreateCheckStatusResponse(It.IsAny<HttpRequestMessage>(), It.IsAny<string>(), false, true))
                 .Throws(new JsonReaderException());
 
             var httpApiHandler = new ExtendedHttpApiHandler(clientMock.Object);

--- a/test/Common/HttpApiHandlerTests.cs
+++ b/test/Common/HttpApiHandlerTests.cs
@@ -744,7 +744,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             var testSendEventPostUri = $"{TestConstants.NotificationUrlBase}/instances/{restartedInstanceId}/raiseEvent/{{eventName}}?taskHub=SampleHubVS&connection=Storage&code=mykey";
             var testTerminatePostUri = $"{TestConstants.NotificationUrlBase}/instances/{restartedInstanceId}/terminate?reason={{text}}&taskHub=SampleHubVS&connection=Storage&code=mykey";
             var testRewindPostUri = $"{TestConstants.NotificationUrlBase}/instances/{restartedInstanceId}/rewind?reason={{text}}&taskHub=SampleHubVS&connection=Storage&code=mykey";
-            var testRestartPostUri = $"{TestConstants.NotificationUrlBase}/instances/{restartedInstanceId}/restart?taskHub=SampleHubVS&connection=Storage&code=mykey&startWithNewInstanceId={restartWithNewInstanceId}";
+            var testRestartPostUri = $"{TestConstants.NotificationUrlBase}/instances/{restartedInstanceId}/restart?taskHub=SampleHubVS&connection=Storage&code=mykey&restartWithNewInstanceId={restartWithNewInstanceId}";
             var testResponse = testRequest.CreateResponse(
                 HttpStatusCode.Accepted,
                 new
@@ -803,7 +803,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             var testSendEventPostUri = $"{TestConstants.NotificationUrlBase}/instances/{restartedInstanceId}/raiseEvent/{{eventName}}?taskHub=SampleHubVS&connection=Storage&code=mykey";
             var testTerminatePostUri = $"{TestConstants.NotificationUrlBase}/instances/{restartedInstanceId}/terminate?reason={{text}}&taskHub=SampleHubVS&connection=Storage&code=mykey";
             var testRewindPostUri = $"{TestConstants.NotificationUrlBase}/instances/{restartedInstanceId}/rewind?reason={{text}}&taskHub=SampleHubVS&connection=Storage&code=mykey";
-            var testRestartPostUri = $"{TestConstants.NotificationUrlBase}/instances/{restartedInstanceId}/restart?taskHub=SampleHubVS&connection=Storage&code=mykey&startWithNewInstanceId={restartWithNewInstanceId}";
+            var testRestartPostUri = $"{TestConstants.NotificationUrlBase}/instances/{restartedInstanceId}/restart?taskHub=SampleHubVS&connection=Storage&code=mykey&restartWithNewInstanceId={restartWithNewInstanceId}";
             var testResponse = testRequest.CreateResponse(
                 HttpStatusCode.Accepted,
                 new


### PR DESCRIPTION
Added RestartAsync(string instanceId, bool restartWithNewInstanceId = true) API to rerun orchestrators. Given a valid instance Id of an existing orchestrator, a new orchestrator will be started reusing the same input.

restartWithNewInstanceId is an optional input determining if the started orchestrator instance should reuse the same instance Id or be started with a new instance Id.

resolves #1243 