### PR TITLE
fix NullReferenceException in task hub worker shutdown

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
@@ -1134,11 +1134,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         {
             using (await this.taskHubLock.AcquireAsync())
             {
+                bool hasActiveListeners(RegisteredFunctionInfo info) 
+                    => info?.HasActiveListener ?? false; // info can be null if function is disabled via attribute
+
                 // Wait to shut down the task hub worker until all function listeners have been shut down.
                 if (this.isTaskHubWorkerStarted &&
-                    !this.knownOrchestrators.Values.Any(info => info?.HasActiveListener ?? false) &&
-                    !this.knownActivities.Values.Any(info => info?.HasActiveListener ?? false) &&
-                    !this.knownEntities.Values.Any(info => info?.HasActiveListener ?? false))
+                    !this.knownOrchestrators.Values.Any(hasActiveListeners) &&
+                    !this.knownActivities.Values.Any(hasActiveListeners) &&
+                    !this.knownEntities.Values.Any(hasActiveListeners))
                 {
                     bool isGracefulStop = this.Options.UseGracefulShutdown;
 

--- a/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
@@ -1134,14 +1134,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         {
             using (await this.taskHubLock.AcquireAsync())
             {
-                bool hasActiveListeners(RegisteredFunctionInfo info) 
+                bool HasActiveListeners(RegisteredFunctionInfo info)
                     => info?.HasActiveListener ?? false; // info can be null if function is disabled via attribute
 
                 // Wait to shut down the task hub worker until all function listeners have been shut down.
                 if (this.isTaskHubWorkerStarted &&
-                    !this.knownOrchestrators.Values.Any(hasActiveListeners) &&
-                    !this.knownActivities.Values.Any(hasActiveListeners) &&
-                    !this.knownEntities.Values.Any(hasActiveListeners))
+                    !this.knownOrchestrators.Values.Any(HasActiveListeners) &&
+                    !this.knownActivities.Values.Any(HasActiveListeners) &&
+                    !this.knownEntities.Values.Any(HasActiveListeners))
                 {
                     bool isGracefulStop = this.Options.UseGracefulShutdown;
 

--- a/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
@@ -1136,9 +1136,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             {
                 // Wait to shut down the task hub worker until all function listeners have been shut down.
                 if (this.isTaskHubWorkerStarted &&
-                    !this.knownOrchestrators.Values.Any(info => info.HasActiveListener) &&
-                    !this.knownActivities.Values.Any(info => info.HasActiveListener) &&
-                    !this.knownEntities.Values.Any(info => info.HasActiveListener))
+                    !this.knownOrchestrators.Values.Any(info => info?.HasActiveListener ?? false) &&
+                    !this.knownActivities.Values.Any(info => info?.HasActiveListener ?? false) &&
+                    !this.knownEntities.Values.Any(info => info?.HasActiveListener ?? false))
                 {
                     bool isGracefulStop = this.Options.UseGracefulShutdown;
 


### PR DESCRIPTION
I noticed that the task hub worker does not shut down correctly if some functions are disabled with the [Disable] attribute.

The reason is that the `info` variable can be null in the following checks that happen during shutdown:

```csharp
 if (this.isTaskHubWorkerStarted &&
                    !this.knownOrchestrators.Values.Any(info => info.HasActiveListener) &&
                    !this.knownActivities.Values.Any(info => info.HasActiveListener) &&
                    !this.knownEntities.Values.Any(info => info.HasActiveListener))
```

As far as I can see this is easily fixed by ignoring null entries for the purpose of this check.
