### PR TITLE
Adding Timeout Property to DurableHttpRequest

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableOrchestrationContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableOrchestrationContext.cs
@@ -694,6 +694,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             }
             catch (TaskFailedException e)
             {
+                // Check to see if CallHttpAsync() threw a TimeoutException
+                // In this case, we want to throw a TimeoutException instead of a FunctionFailedException
+                if (functionName.Equals(HttpOptions.HttpTaskActivityReservedName) && e.InnerException is TimeoutException)
+                {
+                    throw e.InnerException;
+                }
+
                 exception = e;
                 string message = string.Format(
                     "The {0} function '{1}' failed: \"{2}\". See the function execution logs for additional details.",

--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableOrchestrationContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableOrchestrationContext.cs
@@ -306,16 +306,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         private async Task<DurableHttpResponse> ScheduleDurableHttpActivityAsync(DurableHttpRequest req)
         {
             DurableHttpResponse durableHttpResponse = await this.CallDurableTaskFunctionAsync<DurableHttpResponse>(
-            functionName: HttpOptions.HttpTaskActivityReservedName,
-            functionType: FunctionType.Activity,
-            oneWay: false,
-            instanceId: null,
-            operation: null,
-            retryOptions: null,
-            input: req,
-            scheduledTimeUtc: null);
+                functionName: HttpOptions.HttpTaskActivityReservedName,
+                functionType: FunctionType.Activity,
+                oneWay: false,
+                instanceId: null,
+                operation: null,
+                retryOptions: null,
+                input: req,
+                scheduledTimeUtc: null);
 
-            return durableHttpResponse; 
+            return durableHttpResponse;
         }
 
         private DurableHttpRequest CreateLocationPollRequest(DurableHttpRequest durableHttpRequest, string locationUri)

--- a/src/WebJobs.Extensions.DurableTask/DurableHttpRequest.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableHttpRequest.cs
@@ -92,13 +92,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         [JsonProperty("timeout")]
         public TimeSpan? Timeout { get; }
 
-        /// <summary>
-        /// The timeout expiration DateTime used to calculate when
-        /// the timeout will expire.
-        /// </summary>
-        [JsonProperty("timeoutExpiration")]
-        internal DateTime TimeoutExpirationDateTime { get; set; }
-
         private class HttpMethodConverter : JsonConverter
         {
             public override bool CanConvert(Type objectType)

--- a/src/WebJobs.Extensions.DurableTask/DurableHttpRequest.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableHttpRequest.cs
@@ -26,13 +26,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// <param name="content">Content added to the body of the HTTP request.</param>
         /// <param name="tokenSource">AAD authentication attached to the HTTP request.</param>
         /// <param name="asynchronousPatternEnabled">Specifies whether the DurableHttpRequest should handle the asynchronous pattern.</param>
+        /// <param name="timeout">TimeSpan used for HTTP request timeout.</param>
         public DurableHttpRequest(
             HttpMethod method,
             Uri uri,
             IDictionary<string, StringValues> headers = null,
             string content = null,
             ITokenSource tokenSource = null,
-            bool asynchronousPatternEnabled = true)
+            bool asynchronousPatternEnabled = true,
+            TimeSpan? timeout = null)
         {
             this.Method = method;
             this.Uri = uri;
@@ -40,6 +42,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             this.Content = content;
             this.TokenSource = tokenSource;
             this.AsynchronousPatternEnabled = asynchronousPatternEnabled;
+            this.Timeout = timeout;
         }
 
         /// <summary>
@@ -81,6 +84,20 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// </summary>
         [JsonProperty("asynchronousPatternEnabled")]
         public bool AsynchronousPatternEnabled { get; }
+
+        /// <summary>
+        /// The total timeout for the original HTTP request and any
+        /// asynchronous polling.
+        /// </summary>
+        [JsonProperty("timeout")]
+        public TimeSpan? Timeout { get; }
+
+        /// <summary>
+        /// The timeout expiration DateTime used to calculate when
+        /// the timeout will expire.
+        /// </summary>
+        [JsonProperty("timeoutExpiration")]
+        internal DateTime TimeoutExpirationDateTime { get; set; }
 
         private class HttpMethodConverter : JsonConverter
         {

--- a/src/WebJobs.Extensions.DurableTask/Listener/TaskHttpActivityShim.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/TaskHttpActivityShim.cs
@@ -10,6 +10,8 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using DurableTask.Core;
+using DurableTask.Core.Common;
+using DurableTask.Core.Exceptions;
 using Microsoft.Extensions.Primitives;
 using Newtonsoft.Json;
 
@@ -60,7 +62,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 }
                 catch (OperationCanceledException ex) // when (cts.Token.IsCancellationRequested)
                 {
-                    throw new TimeoutException(ex.Message + $"Reached user specified timeout: {durableHttpRequest.Timeout.Value}.");
+                    TimeoutException e = new TimeoutException(ex.Message + $" Reached user specified timeout: {durableHttpRequest.Timeout.Value}.");
+
+                    string details = Utils.SerializeCause(e, this.config.ErrorDataConverter);
+                    throw new TaskFailureException(e.Message, e, details);
                 }
             }
         }

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net461.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net461.xml
@@ -1781,7 +1781,7 @@
             <summary>
             Initializes a new instance of the <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClientAttribute"/> class.
             </summary>
-            <param name="durableClientOptions">durable client options.</param>
+            <param name="durableClientOptions">durable client options</param>
         </member>
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClientAttribute.TaskHub">
             <summary>
@@ -1873,7 +1873,7 @@
             <param name="content">Content added to the body of the HTTP request.</param>
             <param name="tokenSource">AAD authentication attached to the HTTP request.</param>
             <param name="asynchronousPatternEnabled">Specifies whether the DurableHttpRequest should handle the asynchronous pattern.</param>
-            <param name="timeout">TimeSpan used for HTTP request.</param>
+            <param name="timeout">TimeSpan used for HTTP request timeout.</param>
         </member>
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableHttpRequest.Method">
             <summary>

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net461.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net461.xml
@@ -1912,12 +1912,6 @@
             asynchronous polling.
             </summary>
         </member>
-        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableHttpRequest.TimeoutExpirationDateTime">
-            <summary>
-            The timeout expiration DateTime used to calculate when
-            the timeout will expire.
-            </summary>
-        </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableHttpResponse">
             <summary>
             Response received from the HTTP request made by the Durable Function.

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net461.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net461.xml
@@ -1781,7 +1781,7 @@
             <summary>
             Initializes a new instance of the <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClientAttribute"/> class.
             </summary>
-            <param name="durableClientOptions">durable client options</param>
+            <param name="durableClientOptions">durable client options.</param>
         </member>
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClientAttribute.TaskHub">
             <summary>
@@ -1863,7 +1863,7 @@
             Request used to make an HTTP call through Durable Functions.
             </summary>
         </member>
-        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableHttpRequest.#ctor(System.Net.Http.HttpMethod,System.Uri,System.Collections.Generic.IDictionary{System.String,Microsoft.Extensions.Primitives.StringValues},System.String,Microsoft.Azure.WebJobs.Extensions.DurableTask.ITokenSource,System.Boolean)">
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableHttpRequest.#ctor(System.Net.Http.HttpMethod,System.Uri,System.Collections.Generic.IDictionary{System.String,Microsoft.Extensions.Primitives.StringValues},System.String,Microsoft.Azure.WebJobs.Extensions.DurableTask.ITokenSource,System.Boolean,System.Nullable{System.TimeSpan})">
             <summary>
             Initializes a new instance of the <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableHttpRequest"/> class.
             </summary>
@@ -1873,6 +1873,7 @@
             <param name="content">Content added to the body of the HTTP request.</param>
             <param name="tokenSource">AAD authentication attached to the HTTP request.</param>
             <param name="asynchronousPatternEnabled">Specifies whether the DurableHttpRequest should handle the asynchronous pattern.</param>
+            <param name="timeout">TimeSpan used for HTTP request.</param>
         </member>
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableHttpRequest.Method">
             <summary>
@@ -1903,6 +1904,18 @@
             <summary>
             Specifies whether the Durable HTTP APIs should automatically
             handle the asynchronous HTTP pattern.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableHttpRequest.Timeout">
+            <summary>
+            The total timeout for the original HTTP request and any
+            asynchronous polling.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableHttpRequest.TimeoutExpirationDateTime">
+            <summary>
+            The timeout expiration DateTime used to calculate when
+            the timeout will expire.
             </summary>
         </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableHttpResponse">

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
@@ -1917,12 +1917,6 @@
             asynchronous polling.
             </summary>
         </member>
-        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableHttpRequest.TimeoutExpirationDateTime">
-            <summary>
-            The timeout expiration DateTime used to calculate when
-            the timeout will expire.
-            </summary>
-        </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableHttpResponse">
             <summary>
             Response received from the HTTP request made by the Durable Function.

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
@@ -1786,7 +1786,7 @@
             <summary>
             Initializes a new instance of the <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClientAttribute"/> class.
             </summary>
-            <param name="durableClientOptions">durable client options</param>
+            <param name="durableClientOptions">durable client options.</param>
         </member>
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClientAttribute.TaskHub">
             <summary>
@@ -1868,7 +1868,7 @@
             Request used to make an HTTP call through Durable Functions.
             </summary>
         </member>
-        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableHttpRequest.#ctor(System.Net.Http.HttpMethod,System.Uri,System.Collections.Generic.IDictionary{System.String,Microsoft.Extensions.Primitives.StringValues},System.String,Microsoft.Azure.WebJobs.Extensions.DurableTask.ITokenSource,System.Boolean)">
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableHttpRequest.#ctor(System.Net.Http.HttpMethod,System.Uri,System.Collections.Generic.IDictionary{System.String,Microsoft.Extensions.Primitives.StringValues},System.String,Microsoft.Azure.WebJobs.Extensions.DurableTask.ITokenSource,System.Boolean,System.Nullable{System.TimeSpan})">
             <summary>
             Initializes a new instance of the <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableHttpRequest"/> class.
             </summary>
@@ -1878,6 +1878,7 @@
             <param name="content">Content added to the body of the HTTP request.</param>
             <param name="tokenSource">AAD authentication attached to the HTTP request.</param>
             <param name="asynchronousPatternEnabled">Specifies whether the DurableHttpRequest should handle the asynchronous pattern.</param>
+            <param name="timeout">TimeSpan used for HTTP request.</param>
         </member>
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableHttpRequest.Method">
             <summary>
@@ -1908,6 +1909,18 @@
             <summary>
             Specifies whether the Durable HTTP APIs should automatically
             handle the asynchronous HTTP pattern.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableHttpRequest.Timeout">
+            <summary>
+            The total timeout for the original HTTP request and any
+            asynchronous polling.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableHttpRequest.TimeoutExpirationDateTime">
+            <summary>
+            The timeout expiration DateTime used to calculate when
+            the timeout will expire.
             </summary>
         </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableHttpResponse">

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
@@ -1786,7 +1786,7 @@
             <summary>
             Initializes a new instance of the <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClientAttribute"/> class.
             </summary>
-            <param name="durableClientOptions">durable client options.</param>
+            <param name="durableClientOptions">durable client options</param>
         </member>
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClientAttribute.TaskHub">
             <summary>
@@ -1878,7 +1878,7 @@
             <param name="content">Content added to the body of the HTTP request.</param>
             <param name="tokenSource">AAD authentication attached to the HTTP request.</param>
             <param name="asynchronousPatternEnabled">Specifies whether the DurableHttpRequest should handle the asynchronous pattern.</param>
-            <param name="timeout">TimeSpan used for HTTP request.</param>
+            <param name="timeout">TimeSpan used for HTTP request timeout.</param>
         </member>
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableHttpRequest.Method">
             <summary>

--- a/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
+++ b/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
@@ -6,7 +6,7 @@
     <RootNamespace>Microsoft.Azure.WebJobs.Extensions.DurableTask</RootNamespace>
     <MajorVersion>2</MajorVersion>
     <MinorVersion>3</MinorVersion>
-    <PatchVersion>1</PatchVersion>
+    <PatchVersion>2</PatchVersion>
     <Version>$(MajorVersion).$(MinorVersion).$(PatchVersion)</Version>
     <FileVersion>$(MajorVersion).$(MinorVersion).$(PatchVersion)</FileVersion>
     <AssemblyVersion>$(MajorVersion).0.0.0</AssemblyVersion>
@@ -77,7 +77,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage" Version="1.8.1" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers" Version="0.3.2" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers" Version="0.3.0" />
     <PackageReference Include="Azure.Identity" Version="1.1.1" />
   </ItemGroup>
 

--- a/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
+++ b/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
@@ -6,7 +6,7 @@
     <RootNamespace>Microsoft.Azure.WebJobs.Extensions.DurableTask</RootNamespace>
     <MajorVersion>2</MajorVersion>
     <MinorVersion>3</MinorVersion>
-    <PatchVersion>2</PatchVersion>
+    <PatchVersion>1</PatchVersion>
     <Version>$(MajorVersion).$(MinorVersion).$(PatchVersion)</Version>
     <FileVersion>$(MajorVersion).$(MinorVersion).$(PatchVersion)</FileVersion>
     <AssemblyVersion>$(MajorVersion).0.0.0</AssemblyVersion>
@@ -77,7 +77,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage" Version="1.8.1" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers" Version="0.3.0" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers" Version="0.3.2" />
     <PackageReference Include="Azure.Identity" Version="1.1.1" />
   </ItemGroup>
 

--- a/test/Common/DurableHttpTests.cs
+++ b/test/Common/DurableHttpTests.cs
@@ -145,7 +145,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
       ""tenantid"": ""tenant_id""
     }
   },
-  ""AsynchronousPatternEnabled"": true
+  ""AsynchronousPatternEnabled"": true,
+  ""Timeout"": null
 }";
 
             Dictionary<string, string> headers = new Dictionary<string, string>();
@@ -183,7 +184,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
       ""tenantid"": ""tenant_id""
     }
    },
-  ""asynchronousPatternEnabled"": true
+  ""asynchronousPatternEnabled"": true,
+  ""timeout"": null
 }";
             ManagedIdentityTokenSource managedIdentityTokenSource = new ManagedIdentityTokenSource("dummy url", options);
             TestDurableHttpRequest testDurableHttpRequest = new TestDurableHttpRequest(
@@ -213,7 +215,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
     ""kind"": ""AzureManagedIdentity"",
     ""resource"": ""dummy url""
   },
-  ""asynchronousPatternEnabled"": true
+  ""asynchronousPatternEnabled"": true,
+  ""timeout"": null
 }";
 
             Dictionary<string, string> headers = new Dictionary<string, string>();

--- a/test/Common/DurableHttpTests.cs
+++ b/test/Common/DurableHttpTests.cs
@@ -312,7 +312,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         }
 
         /// <summary>
-        /// End-to-end test which checks if the CallHttpAsync Orchestrator returns an OK (200) status code.
+        /// End-to-end test which checks if the CallHttpAsync Orchestrator returns an OK (200) status code
+        /// when a DurableHttpRequest timeout value is set.
         /// </summary>
         [Theory]
         [Trait("Category", PlatformSpecificHelpers.TestCategory)]
@@ -351,7 +352,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         }
 
         /// <summary>
-        /// End-to-end test which checks if the CallHttpAsync Orchestrator returns an OK (200) status code.
+        /// End-to-end test which checks if the CallHttpAsync Orchestrator fails  when the
+        /// HTTP request times out and the CallHttpAsync API throws a TimeoutException.
         /// </summary>
         [Theory]
         [Trait("Category", PlatformSpecificHelpers.TestCategory)]

--- a/test/Common/TestDurableHttpRequest.cs
+++ b/test/Common/TestDurableHttpRequest.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Runtime.Serialization;
@@ -17,13 +18,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
     [DataContract]
     public class TestDurableHttpRequest
     {
-        public TestDurableHttpRequest(HttpMethod httpMethod, string uri = "https://www.dummy-url.com", IDictionary<string, string> headers = null, string content = null, ITokenSource tokenSource = null)
+        public TestDurableHttpRequest(HttpMethod httpMethod, string uri = "https://www.dummy-url.com", IDictionary<string, string> headers = null, string content = null, ITokenSource tokenSource = null, TimeSpan? timeout = null)
         {
             this.HttpMethod = httpMethod;
             this.Uri = uri;
             this.Headers = headers;
             this.Content = content;
             this.TokenSource = tokenSource;
+            this.Timeout = timeout;
         }
 
         [DataMember]
@@ -46,5 +48,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
         [DataMember]
         public bool AsynchronousPatternEnabled { get; set; } = true;
+
+        [DataMember]
+        public TimeSpan? Timeout { get; set; }
     }
 }

--- a/test/Common/TestOrchestrations.cs
+++ b/test/Common/TestOrchestrations.cs
@@ -498,15 +498,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         {
             TestDurableHttpRequest testRequest = ctx.GetInput<TestDurableHttpRequest>();
             DurableHttpRequest durableHttpRequest = ConvertTestRequestToDurableHttpRequest(testRequest);
-            try
-            {
-                DurableHttpResponse response = await ctx.CallHttpAsync(durableHttpRequest);
-                return response;
-            }
-            catch (Exception)
-            {
-                throw;
-            }
+            DurableHttpResponse response = await ctx.CallHttpAsync(durableHttpRequest);
+            return response;
         }
 
         public static DurableHttpRequest ConvertTestRequestToDurableHttpRequest(TestDurableHttpRequest testRequest)

--- a/test/Common/TestOrchestrations.cs
+++ b/test/Common/TestOrchestrations.cs
@@ -498,8 +498,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         {
             TestDurableHttpRequest testRequest = ctx.GetInput<TestDurableHttpRequest>();
             DurableHttpRequest durableHttpRequest = ConvertTestRequestToDurableHttpRequest(testRequest);
-            DurableHttpResponse response = await ctx.CallHttpAsync(durableHttpRequest);
-            return response;
+            try
+            {
+                DurableHttpResponse response = await ctx.CallHttpAsync(durableHttpRequest);
+                return response;
+            }
+            catch (Exception e)
+            {
+                throw;
+            }
         }
 
         public static DurableHttpRequest ConvertTestRequestToDurableHttpRequest(TestDurableHttpRequest testRequest)
@@ -529,7 +536,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 headers: testHeaders,
                 content: testRequest.Content,
                 tokenSource: testRequest.TokenSource,
-                asynchronousPatternEnabled: testRequest.AsynchronousPatternEnabled);
+                asynchronousPatternEnabled: testRequest.AsynchronousPatternEnabled,
+                timeout: testRequest.Timeout);
 
             return durableHttpRequest;
         }

--- a/test/Common/TestOrchestrations.cs
+++ b/test/Common/TestOrchestrations.cs
@@ -503,7 +503,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 DurableHttpResponse response = await ctx.CallHttpAsync(durableHttpRequest);
                 return response;
             }
-            catch (Exception e)
+            catch (Exception)
             {
                 throw;
             }


### PR DESCRIPTION
These changes resolve #1278 by adding a `Timeout` property to `DurableHttpRequest`. This property defines the timeout for each individual HTTP request. This timeout applies to each asynchronous polling request too.