### PR TITLE
Expand long running timer functionality to WaitForExternalEvent

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableOrchestrationContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableOrchestrationContext.cs
@@ -383,26 +383,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             return result;
         }
 
-        internal Task OutOfProcCreateTimer(DurableOrchestrationContext ctx, DateTime fireAt, CancellationToken cancelToken)
-        {
-            if (!this.ValidOutOfProcTimer(fireAt, out string errorMessage))
-            {
-                throw new ArgumentException(errorMessage, nameof(fireAt));
-            }
-
-            return ((IDurableOrchestrationContext)ctx).CreateTimer(fireAt, cancelToken);
-        }
-
-        private bool ValidOutOfProcTimer(DateTime fireAt, out string errorMessage)
+        internal void ValidateOutOfProcTimer(DateTime fireAt)
         {
             this.ThrowIfInvalidAccess();
 
-            if (!this.durabilityProvider.ValidateDelayTime(fireAt.Subtract(this.InnerContext.CurrentUtcDateTime), out errorMessage))
+            if (!this.durabilityProvider.ValidateDelayTime(fireAt.Subtract(this.InnerContext.CurrentUtcDateTime), out string errorMessage))
             {
-                return false;
+                throw new ArgumentException(errorMessage, nameof(fireAt));
             }
-
-            return true;
         }
 
         /// <inheritdoc />
@@ -943,11 +931,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
         private Task<T> WaitForExternalEvent<T>(string name, TimeSpan timeout, Action<TaskCompletionSource<T>> timeoutAction, CancellationToken cancelToken)
         {
-            if (!this.durabilityProvider.ValidateDelayTime(timeout, out string errorMessage))
-            {
-                throw new ArgumentException(errorMessage, nameof(timeout));
-            }
-
             var tcs = new TaskCompletionSource<T>();
             var cts = CancellationTokenSource.CreateLinkedTokenSource(cancelToken);
 

--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableOrchestrationContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableOrchestrationContext.cs
@@ -383,7 +383,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             return result;
         }
 
-        internal void ValidateOutOfProcTimer(DateTime fireAt)
+        // We now have built in long-timer support for C#, but in some scenarios, such as out-of-proc,
+        // we may still need to enforce this limitations until the solution works there as well.
+        internal void ThrowIfInvalidTimerLengthForStorageProvider(DateTime fireAt)
         {
             this.ThrowIfInvalidAccess();
 

--- a/src/WebJobs.Extensions.DurableTask/Listener/OutOfProcOrchestrationShim.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/OutOfProcOrchestrationShim.cs
@@ -115,6 +115,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             foreach (AsyncAction[] actionSet in actions)
             {
                 var tasks = new List<Task>(actions.Length);
+                DurableOrchestrationContext ctx = this.context as DurableOrchestrationContext;
 
                 // An actionSet represents all actions that were scheduled within that execution.
                 foreach (AsyncAction action in actionSet)
@@ -127,16 +128,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                         case AsyncActionType.CreateTimer:
                             using (var cts = new CancellationTokenSource())
                             {
-                                DurableOrchestrationContext ctx = this.context as DurableOrchestrationContext;
-
                                 if (ctx != null)
                                 {
-                                    tasks.Add(ctx.OutOfProcCreateTimer(ctx, action.FireAt, cts.Token));
+                                    ctx.ValidateOutOfProcTimer(action.FireAt);
                                 }
-                                else
-                                {
-                                    tasks.Add(this.context.CreateTimer(action.FireAt, cts.Token));
-                                }
+
+                                tasks.Add(this.context.CreateTimer(action.FireAt, cts.Token));
 
                                 if (action.IsCanceled)
                                 {

--- a/src/WebJobs.Extensions.DurableTask/Listener/OutOfProcOrchestrationShim.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/OutOfProcOrchestrationShim.cs
@@ -130,7 +130,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                             {
                                 if (ctx != null)
                                 {
-                                    ctx.ValidateOutOfProcTimer(action.FireAt);
+                                    ctx.ThrowIfInvalidTimerLengthForStorageProvider(action.FireAt);
                                 }
 
                                 tasks.Add(this.context.CreateTimer(action.FireAt, cts.Token));

--- a/test/Common/DurableTaskEndToEndTests.cs
+++ b/test/Common/DurableTaskEndToEndTests.cs
@@ -1555,34 +1555,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         }
 
         /// <summary>
-        /// End-to-end test which validates correct exceptions for invalid timeout values.
-        /// </summary>
-        [Fact]
-        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
-        public async Task WaitForExternalEventWithTooLargeTimeout()
-        {
-            var orchestratorFunctionNames = new[] { nameof(TestOrchestrations.ApprovalWithTimeout) };
-            var extendedSessions = false;
-            using (ITestHost host = TestHelpers.GetJobHost(
-                this.loggerProvider,
-                nameof(this.WaitForExternalEventWithTooLargeTimeout),
-                extendedSessions))
-            {
-                await host.StartAsync();
-
-                var timeout = TimeSpan.FromDays(7);
-                var client = await host.StartOrchestratorAsync(orchestratorFunctionNames[0], (timeout, "throw"), this.output);
-                await client.WaitForStartupAsync(this.output);
-
-                var status = await client.WaitForCompletionAsync(this.output);
-                Assert.Equal(OrchestrationRuntimeStatus.Completed, status?.RuntimeStatus);
-                Assert.Equal("ArgumentException", status?.Output.ToString());
-
-                await host.StopAsync();
-            }
-        }
-
-        /// <summary>
         /// End-to-end test which validates a CancellationToken-providing overload of WaitForExternalEvent.
         /// </summary>
         [Fact]
@@ -3768,32 +3740,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
                 string output = status.Output.ToString();
                 Assert.Contains("MaxRetryInterval", output);
-            }
-        }
-
-        [Fact]
-        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
-        public async Task AzureStorage_EventTimeoutLimitHit_ThrowsException()
-        {
-            string orchestrationFunctionName = nameof(TestOrchestrations.SimpleEventWithTimeoutSucceeds);
-
-            using (var host = TestHelpers.GetJobHost(
-                this.loggerProvider,
-                nameof(this.AzureStorage_EventTimeoutLimitHit_ThrowsException),
-                false))
-            {
-                await host.StartAsync();
-
-                var timeout = TimeSpan.FromDays(7);
-
-                var client = await host.StartOrchestratorAsync(orchestrationFunctionName, timeout, this.output);
-
-                var status = await client.WaitForCompletionAsync(this.output);
-
-                Assert.Equal(OrchestrationRuntimeStatus.Failed, status.RuntimeStatus);
-
-                string output = status.Output.ToString();
-                Assert.Contains("timeout", output);
             }
         }
 

--- a/test/FunctionsV2/LongTimerTests.cs
+++ b/test/FunctionsV2/LongTimerTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
+using System.Security.Cryptography;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Extensions.DurableTask;
 using Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests;
@@ -11,12 +12,12 @@ using Xunit.Abstractions;
 
 namespace WebJobs.Extensions.DurableTask.Tests.V2
 {
-    public class TimerTests
+    public class LongTimerTests
     {
         private readonly ITestOutputHelper output;
         private readonly TestLoggerProvider loggerProvider;
 
-        public TimerTests(ITestOutputHelper output)
+        public LongTimerTests(ITestOutputHelper output)
         {
             this.output = output;
             this.loggerProvider = new TestLoggerProvider(output);
@@ -100,6 +101,30 @@ namespace WebJobs.Extensions.DurableTask.Tests.V2
                     curstate => curstate.Count == 1 ? null : "expect message");
 
                 Assert.Equal("fire", string.Join(", ", state));
+                await host.StopAsync();
+            }
+        }
+
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public async Task WaitForExternalEventAboveMaxTime()
+        {
+            using (ITestHost host = TestHelpers.GetJobHost(
+                this.loggerProvider,
+                nameof(this.WaitForExternalEventAboveMaxTime),
+                enableExtendedSessions: false,
+                storageProviderType: "azure_storage",
+                durabilityProviderFactoryType: typeof(AzureStorageShortenedTimerDurabilityProviderFactory)))
+            {
+                await host.StartAsync();
+
+                var fireAt = TimeSpan.FromSeconds(90);
+                var client = await host.StartOrchestratorAsync(nameof(TestOrchestrations.ApprovalWithTimeout), (fireAt, "throw"), this.output);
+                var status = await client.WaitForCompletionAsync(this.output, timeout: TimeSpan.FromMinutes(2));
+
+                Assert.Equal(OrchestrationRuntimeStatus.Completed, status?.RuntimeStatus);
+                Assert.Equal("TimeoutException", status?.Output);
+
                 await host.StopAsync();
             }
         }

--- a/test/FunctionsV2/LongTimerTests.cs
+++ b/test/FunctionsV2/LongTimerTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
-using System.Security.Cryptography;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Extensions.DurableTask;
 using Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests;
@@ -55,7 +54,7 @@ namespace WebJobs.Extensions.DurableTask.Tests.V2
         {
             using (ITestHost host = TestHelpers.GetJobHost(
                 this.loggerProvider,
-                nameof(this.LongRunningTimer),
+                nameof(this.TimerLengthLessThanMaxTime),
                 extendedSessions,
                 storageProviderType: "azure_storage",
                 durabilityProviderFactoryType: typeof(AzureStorageShortenedTimerDurabilityProviderFactory)))
@@ -79,7 +78,7 @@ namespace WebJobs.Extensions.DurableTask.Tests.V2
         {
             using (var host = TestHelpers.GetJobHost(
                 this.loggerProvider,
-                nameof(this.LongRunningTimer),
+                nameof(this.EntitySignalWithLongDelay),
                 extendedSessions,
                 storageProviderType: "azure_storage",
                 durabilityProviderFactoryType: typeof(AzureStorageShortenedTimerDurabilityProviderFactory)))
@@ -107,11 +106,11 @@ namespace WebJobs.Extensions.DurableTask.Tests.V2
 
         [Fact]
         [Trait("Category", PlatformSpecificHelpers.TestCategory)]
-        public async Task WaitForExternalEventAboveMaxTime()
+        public async Task WaitForExternalEventAboveMaximumTimerLength()
         {
             using (ITestHost host = TestHelpers.GetJobHost(
                 this.loggerProvider,
-                nameof(this.WaitForExternalEventAboveMaxTime),
+                nameof(this.WaitForExternalEventAboveMaximumTimerLength),
                 enableExtendedSessions: false,
                 storageProviderType: "azure_storage",
                 durabilityProviderFactoryType: typeof(AzureStorageShortenedTimerDurabilityProviderFactory)))


### PR DESCRIPTION
Internally WaitForExternalEvent with a timeout uses a timer. In v2.3.0
we added support for long-running timers, we just didn't remove the
now unecessary validation from the WaitForExternalEvent API. This PR
validates the scenario with a test and removes this validation.

Note that initially this PR attempted to expand this functionality to
RetryOptions in CallActivity/SubOrchestrationWithRetry, but
unfortunately the timer used by that retry is lower level than the
Durable Functions layer, meaning we can't use our long-running support.

Addresses #1538