### PR TITLE
Remove documentation warning so CI can pass

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/DurableClientAttribute.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableClientAttribute.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// <summary>
         /// Initializes a new instance of the <see cref="DurableClientAttribute"/> class.
         /// </summary>
-        /// <param name="durableClientOptions">durable client options</param>
+        /// <param name="durableClientOptions">Options to configure the IDurableClient created.</param>
         public DurableClientAttribute(DurableClientOptions durableClientOptions)
         {
             this.TaskHub = durableClientOptions.TaskHub;


### PR DESCRIPTION
Our CI fails on warnings, and a warning was being generated because
documentation didn't end in a period.