### PR TITLE
Make E2E tests more robust in CI pipeline (#1385)

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net461.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net461.xml
@@ -1781,7 +1781,7 @@
             <summary>
             Initializes a new instance of the <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClientAttribute"/> class.
             </summary>
-            <param name="durableClientOptions">durable client options</param>
+            <param name="durableClientOptions">Options to configure the IDurableClient created.</param>
         </member>
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClientAttribute.TaskHub">
             <summary>

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
@@ -1786,7 +1786,7 @@
             <summary>
             Initializes a new instance of the <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClientAttribute"/> class.
             </summary>
-            <param name="durableClientOptions">durable client options</param>
+            <param name="durableClientOptions">Options to configure the IDurableClient created.</param>
         </member>
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClientAttribute.TaskHub">
             <summary>

--- a/test/Common/DurableTaskEndToEndTests.cs
+++ b/test/Common/DurableTaskEndToEndTests.cs
@@ -4901,7 +4901,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
             Assert.NotNull(argumentException);
             Assert.Equal(
-                $"Task hub name '{taskHubName}' should contain only alphanumeric characters, start with a letter, and have a length between 3 and 45 characters.",
+                $"Task hub name '{taskHubName}' should contain only alphanumeric characters, start with a letter, and have length between 3 and 45.",
                 argumentException.Message);
         }
 

--- a/test/Common/DurableTaskEndToEndTests.cs
+++ b/test/Common/DurableTaskEndToEndTests.cs
@@ -4710,7 +4710,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                         this.loggerProvider,
                         taskHubName,
                         false,
-                        exactTaskHubName: taskHubName))
+                        exactTaskHubName: taskHubName + PlatformSpecificHelpers.VersionSuffix))
                     {
                         await host.StartAsync();
                         await host.StopAsync();

--- a/test/Common/DurableTaskLifeCycleNotificationTest.cs
+++ b/test/Common/DurableTaskLifeCycleNotificationTest.cs
@@ -50,9 +50,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             Func<HttpRequestMessage, HttpResponseMessage> responseGenerator =
                 (HttpRequestMessage req) => req.CreateResponse(HttpStatusCode.OK, "{\"message\":\"OK!\"}");
 
+            string taskHub = TestHelpers.GetTaskHubNameFromTestName(testName, extendedSessionsEnabled);
             int callCount = 0;
             HttpMessageHandler httpMessageHandler = this.ConfigureEventGridMockHandler(
-                TestHelpers.GetTaskHubNameFromTestName(testName, extendedSessionsEnabled),
+                taskHub,
                 functionName,
                 createdInstanceId,
                 eventGridKeyValue,
@@ -89,7 +90,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 eventGridKeySettingName,
                 mockNameResolver.Object,
                 eventGridEndpoint,
-                eventGridNotificationHandler: httpMessageHandler))
+                eventGridNotificationHandler: httpMessageHandler,
+                exactTaskHubName: taskHub))
             {
                 await host.StartAsync();
 
@@ -126,6 +128,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         {
             var testName = nameof(this.OrchestrationFailed);
             var functionName = nameof(TestOrchestrations.ThrowOrchestrator);
+            var taskHub = TestHelpers.GetTaskHubNameFromTestName(testName, extendedSessionsEnabled);
             var eventGridKeyValue = "testEventGridKey";
             var eventGridKeySettingName = "eventGridKeySettingName";
             var eventGridEndpoint = "http://dymmy.com/";
@@ -138,7 +141,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
             int callCount = 0;
             HttpMessageHandler httpMessageHandler = this.ConfigureEventGridMockHandler(
-                TestHelpers.GetTaskHubNameFromTestName(testName, extendedSessionsEnabled),
+                taskHub,
                 functionName,
                 createdInstanceId,
                 eventGridKeyValue,
@@ -175,6 +178,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 eventGridKeySettingName,
                 mockNameResolver.Object,
                 eventGridEndpoint,
+                exactTaskHubName: taskHub,
                 eventGridNotificationHandler: httpMessageHandler))
             {
                 await host.StartAsync();
@@ -210,6 +214,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         public async Task OrchestrationTerminate(bool extendedSessionsEnabled)
         {
             var testName = nameof(this.OrchestrationTerminate);
+            var taskHub = TestHelpers.GetTaskHubNameFromTestName(testName, extendedSessionsEnabled);
 
             // Using the counter orchestration because it will wait indefinitely for input.
             var functionName = nameof(TestOrchestrations.Counter);
@@ -225,7 +230,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
             int callCount = 0;
             HttpMessageHandler httpMessageHandler = this.ConfigureEventGridMockHandler(
-                TestHelpers.GetTaskHubNameFromTestName(testName, extendedSessionsEnabled),
+                taskHub,
                 functionName,
                 createdInstanceId,
                 eventGridKeyValue,
@@ -262,6 +267,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 eventGridKeySettingName,
                 mockNameResolver.Object,
                 eventGridEndpoint,
+                exactTaskHubName: taskHub,
                 eventGridNotificationHandler: httpMessageHandler))
             {
                 await host.StartAsync();
@@ -313,8 +319,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             Func<HttpRequestMessage, HttpResponseMessage> responseGenerator =
                 (HttpRequestMessage req) => req.CreateResponse(HttpStatusCode.OK, "{\"message\":\"OK!\"}");
 
+            var taskHub = TestHelpers.GetTaskHubNameFromTestName(testName, extendedSessionsEnabled);
             HttpMessageHandler httpMessageHandler = this.ConfigureEventGridMockHandler(
-                TestHelpers.GetTaskHubNameFromTestName(testName, extendedSessionsEnabled),
+                taskHub,
                 functionName,
                 createdInstanceId,
                 eventGridKeyValue,
@@ -335,6 +342,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 eventGridKeySettingName,
                 mockNameResolver.Object,
                 eventGridEndpoint,
+                exactTaskHubName: taskHub,
                 eventGridNotificationHandler: httpMessageHandler,
                 eventGridPublishEventTypes: new[] { "Completed", "Failed" }))
             {
@@ -361,6 +369,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         {
             var testName = nameof(this.OrchestrationCompletedOptOutOfEvent);
             var functionName = nameof(TestOrchestrations.SayHelloInline);
+            var taskHub = TestHelpers.GetTaskHubNameFromTestName(testName, extendedSessionsEnabled);
             var eventGridKeyValue = "testEventGridKey";
             var eventGridKeySettingName = "eventGridKeySettingName";
             var eventGridEndpoint = "http://dymmy.com/";
@@ -372,7 +381,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 (HttpRequestMessage req) => req.CreateResponse(HttpStatusCode.OK, "{\"message\":\"OK!\"}");
 
             HttpMessageHandler httpMessageHandler = this.ConfigureEventGridMockHandler(
-                TestHelpers.GetTaskHubNameFromTestName(testName, extendedSessionsEnabled),
+                taskHub,
                 functionName,
                 createdInstanceId,
                 eventGridKeyValue,
@@ -393,6 +402,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 eventGridKeySettingName,
                 mockNameResolver.Object,
                 eventGridEndpoint,
+                exactTaskHubName: taskHub,
                 eventGridNotificationHandler: httpMessageHandler,
                 eventGridPublishEventTypes: new[] { "Started", "Failed" }))
             {
@@ -418,6 +428,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         public async Task OrchestrationFailedOptOutOfEvent(bool extendedSessionsEnabled)
         {
             var testName = nameof(this.OrchestrationFailedOptOutOfEvent);
+            var taskHub = TestHelpers.GetTaskHubNameFromTestName(testName, extendedSessionsEnabled);
             var functionName = nameof(TestOrchestrations.ThrowOrchestrator);
             var eventGridKeyValue = "testEventGridKey";
             var eventGridKeySettingName = "eventGridKeySettingName";
@@ -430,7 +441,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 (HttpRequestMessage req) => req.CreateResponse(HttpStatusCode.OK, "{\"message\":\"OK!\"}");
 
             HttpMessageHandler httpMessageHandler = this.ConfigureEventGridMockHandler(
-                TestHelpers.GetTaskHubNameFromTestName(testName, extendedSessionsEnabled),
+                taskHub,
                 functionName,
                 createdInstanceId,
                 eventGridKeyValue,
@@ -451,6 +462,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 eventGridKeySettingName,
                 mockNameResolver.Object,
                 eventGridEndpoint,
+                exactTaskHubName: taskHub,
                 eventGridNotificationHandler: httpMessageHandler,
                 eventGridPublishEventTypes: new[] { "Started", "Completed" }))
             {
@@ -477,6 +489,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         public async Task OrchestrationTerminatedOptOutOfEvent(bool extendedSessionsEnabled)
         {
             var testName = nameof(this.OrchestrationTerminate);
+            var taskHub = TestHelpers.GetTaskHubNameFromTestName(testName, extendedSessionsEnabled);
 
             // Using the counter orchestration because it will wait indefinitely for input.
             var functionName = nameof(TestOrchestrations.Counter);
@@ -491,7 +504,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 (HttpRequestMessage req) => req.CreateResponse(HttpStatusCode.OK, "{\"message\":\"OK!\"}");
 
             HttpMessageHandler httpMessageHandler = this.ConfigureEventGridMockHandler(
-                TestHelpers.GetTaskHubNameFromTestName(testName, extendedSessionsEnabled),
+                taskHub,
                 functionName,
                 createdInstanceId,
                 eventGridKeyValue,
@@ -512,6 +525,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 eventGridKeySettingName,
                 mockNameResolver.Object,
                 eventGridEndpoint,
+                exactTaskHubName: taskHub,
                 eventGridNotificationHandler: httpMessageHandler,
                 eventGridPublishEventTypes: new[] { "Started", "Failed", "Completed" }))
             {
@@ -552,10 +566,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                     HttpStatusCode.InternalServerError,
                     new { message = "Exception has been thrown" });
 
+            string taskHubName = TestHelpers.GetTaskHubNameFromTestName(testName, extendedSessionsEnabled);
             string createdInstanceId = Guid.NewGuid().ToString("N");
             int callCount = 0;
             HttpMessageHandler httpMessageHandler = this.ConfigureEventGridMockHandler(
-                TestHelpers.GetTaskHubNameFromTestName(testName, extendedSessionsEnabled),
+                taskHubName,
                 functionName,
                 createdInstanceId,
                 eventGridKeyValue,
@@ -592,6 +607,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 eventGridKeySettingName,
                 mockNameResolver.Object,
                 eventGridEndpoint,
+                exactTaskHubName: taskHubName,
                 eventGridNotificationHandler: httpMessageHandler))
             {
                 await host.StartAsync();

--- a/test/Common/TestHelpers.cs
+++ b/test/Common/TestHelpers.cs
@@ -212,39 +212,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             return truncatedTestName + testPropertiesSuffix + randomSuffix;
         }
 
-        internal static async Task DeleteAllElementsInStorageTaskHubAsync(string connectionString, string taskHub, int partitionCount)
-        {
-            var deletionTasks = new List<Task>();
-            CloudStorageAccount storageAccount = CloudStorageAccount.Parse(connectionString);
-
-            // Delete blobs
-            CloudBlobClient blobClient = storageAccount.CreateCloudBlobClient();
-            CloudBlobContainer leases = blobClient.GetContainerReference($"{taskHub}-leases");
-            deletionTasks.Add(leases.DeleteIfExistsAsync());
-            CloudBlobContainer largeContainers = blobClient.GetContainerReference($"{taskHub}-largemessages");
-            deletionTasks.Add(largeContainers.DeleteIfExistsAsync());
-
-            // Delete queues
-            CloudQueueClient queueClient = storageAccount.CreateCloudQueueClient();
-            CloudQueue workItemQueue = queueClient.GetQueueReference($"{taskHub}-workitems");
-            deletionTasks.Add(workItemQueue.DeleteIfExistsAsync());
-            for (int i = 0; i < partitionCount; i++)
-            {
-                string controlQueueName = $"{taskHub}-control-{i.ToString("00")}";
-                CloudQueue controlQueue = queueClient.GetQueueReference(controlQueueName);
-                deletionTasks.Add(controlQueue.DeleteIfExistsAsync());
-            }
-
-            // Delete tables
-            CloudTableClient tableClient = storageAccount.CreateCloudTableClient();
-            CloudTable historyTable = tableClient.GetTableReference($"{taskHub}History");
-            CloudTable instancesTable = tableClient.GetTableReference($"{taskHub}Instances");
-            deletionTasks.Add(historyTable.DeleteIfExistsAsync());
-            deletionTasks.Add(instancesTable.DeleteIfExistsAsync());
-
-            await Task.WhenAll(deletionTasks);
-        }
-
         public static ITypeLocator GetTypeLocator()
         {
             var types = new Type[]

--- a/test/Common/TestHelpers.cs
+++ b/test/Common/TestHelpers.cs
@@ -79,6 +79,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 options = new DurableTaskOptions();
             }
 
+            // Some tests require knowing the task hub that the provider uses. Because of that, they will instantiate the exact
+            // task hub name and require the usage of that task hub. Otherwise, generate a partially random task hub from the
+            // test name and properties of the test.
             options.HubName = exactTaskHubName ?? GetTaskHubNameFromTestName(testName, enableExtendedSessions);
             options.Tracing = new TraceOptions()
             {

--- a/test/Common/TestHelpers.cs
+++ b/test/Common/TestHelpers.cs
@@ -11,7 +11,6 @@ using Microsoft.Azure.WebJobs.Host.TestCommon;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.WindowsAzure.Storage;
-using Newtonsoft.Json.Linq;
 using Microsoft.WindowsAzure.Storage.Blob;
 using Microsoft.WindowsAzure.Storage.Queue;
 using Microsoft.WindowsAzure.Storage.Table;
@@ -206,7 +205,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         // Create a valid task hub from the test name, and add a random suffix to avoid conflicts
         public static string GetTaskHubNameFromTestName(string testName, bool enableExtendedSessions)
         {
-
             string strippedTestName = testName.Replace("_", "");
             string truncatedTestName = strippedTestName.Substring(0, Math.Min(35, strippedTestName.Length));
             string deterministicSuffix = (enableExtendedSessions ? "EX" : "") + PlatformSpecificHelpers.VersionSuffix;

--- a/test/Common/TestHelpers.cs
+++ b/test/Common/TestHelpers.cs
@@ -207,9 +207,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         {
             string strippedTestName = testName.Replace("_", "");
             string truncatedTestName = strippedTestName.Substring(0, Math.Min(35, strippedTestName.Length));
-            string deterministicSuffix = (enableExtendedSessions ? "EX" : "") + PlatformSpecificHelpers.VersionSuffix;
+            string testPropertiesSuffix = (enableExtendedSessions ? "EX" : "") + PlatformSpecificHelpers.VersionSuffix;
             string randomSuffix = Guid.NewGuid().ToString().Substring(0, 4);
-            return truncatedTestName + deterministicSuffix + randomSuffix;
+            return truncatedTestName + testPropertiesSuffix + randomSuffix;
         }
 
         internal static async Task DeleteAllElementsInStorageTaskHubAsync(string connectionString, string taskHub, int partitionCount)

--- a/test/FunctionsV1/PlatformSpecificHelpers.FunctionsV1.cs
+++ b/test/FunctionsV1/PlatformSpecificHelpers.FunctionsV1.cs
@@ -69,16 +69,23 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             config.LoggerFactory = loggerFactory;
 
             var host = new JobHost(config);
-            return new FunctionsV1HostWrapper(host);
+            return new FunctionsV1HostWrapper(host, options, connectionResolver);
         }
 
         private class FunctionsV1HostWrapper : ITestHost
         {
             private readonly JobHost innerHost;
+            private readonly DurableTaskOptions options;
+            private readonly IConnectionStringResolver connectionResolver;
 
-            public FunctionsV1HostWrapper(JobHost innerHost)
+            public FunctionsV1HostWrapper(
+                JobHost innerHost, 
+                IOptions<DurableTaskOptions> options,
+                IConnectionStringResolver connectionResolver)
             {
                 this.innerHost = innerHost ?? throw new ArgumentNullException(nameof(innerHost));
+                this.options = options.Value;
+                this.connectionResolver = connectionResolver;
             }
 
             public Task CallAsync(string methodName, IDictionary<string, object> args)
@@ -87,7 +94,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             public Task CallAsync(MethodInfo method, IDictionary<string, object> args)
                 => this.innerHost.CallAsync(method, args);
 
-            public void Dispose() => this.innerHost.Dispose();
+            public void Dispose()
+            {
+                this.innerHost.Dispose();
+#if !DEBUG
+                string connectionString = this.connectionResolver.Resolve(this.options.AzureStorageConnectionStringName ?? "AzureWebJobsStorage");
+                int partitionCount = this.options.PartitionCount;
+                string taskHub = this.options.HubName.ToLowerInvariant();
+                Task.Run(() => TestHelpers.DeleteAllElementsInStorageTaskHubAsync(connectionString, taskHub, partitionCount)).GetAwaiter().GetResult();
+#endif
+            }
 
             public Task StartAsync() => this.innerHost.StartAsync();
 

--- a/test/FunctionsV1/PlatformSpecificHelpers.FunctionsV1.cs
+++ b/test/FunctionsV1/PlatformSpecificHelpers.FunctionsV1.cs
@@ -97,12 +97,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             public void Dispose()
             {
                 this.innerHost.Dispose();
-#if !DEBUG
-                string connectionString = this.connectionResolver.Resolve(this.options.AzureStorageConnectionStringName ?? "AzureWebJobsStorage");
-                int partitionCount = this.options.PartitionCount;
-                string taskHub = this.options.HubName.ToLowerInvariant();
-                Task.Run(() => TestHelpers.DeleteAllElementsInStorageTaskHubAsync(connectionString, taskHub, partitionCount)).GetAwaiter().GetResult();
-#endif
             }
 
             public Task StartAsync() => this.innerHost.StartAsync();

--- a/test/FunctionsV1/PlatformSpecificHelpers.FunctionsV1.cs
+++ b/test/FunctionsV1/PlatformSpecificHelpers.FunctionsV1.cs
@@ -79,7 +79,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             private readonly IConnectionStringResolver connectionResolver;
 
             public FunctionsV1HostWrapper(
-                JobHost innerHost, 
+                JobHost innerHost,
                 IOptions<DurableTaskOptions> options,
                 IConnectionStringResolver connectionResolver)
             {

--- a/test/FunctionsV2/PlatformSpecificHelpers.FunctionsV2.cs
+++ b/test/FunctionsV2/PlatformSpecificHelpers.FunctionsV2.cs
@@ -133,12 +133,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             public void Dispose()
             {
                 this.innerHost.Dispose();
-#if !DEBUG
-                string connectionString = this.nameResolver.Resolve(this.options.AzureStorageConnectionStringName ?? "AzureWebJobsStorage");
-                int partitionCount = this.options.PartitionCount;
-                string taskHub = this.options.HubName.ToLowerInvariant();
-                Task.Run(() => TestHelpers.DeleteAllElementsInStorageTaskHubAsync(connectionString, taskHub, partitionCount)).GetAwaiter().GetResult();
-#endif
             }
 
             public Task StartAsync() => this.innerHost.StartAsync();

--- a/test/FunctionsV2/PlatformSpecificHelpers.FunctionsV2.cs
+++ b/test/FunctionsV2/PlatformSpecificHelpers.FunctionsV2.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                     })
                 .Build();
 
-            return new FunctionsV2HostWrapper(host);
+            return new FunctionsV2HostWrapper(host, options, nameResolver);
         }
 
         private static IWebJobsBuilder AddDurableTask(this IWebJobsBuilder builder, IOptions<DurableTaskOptions> options, string storageProvider, Type durabilityProviderFactoryType = null)
@@ -110,11 +110,18 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         {
             private readonly IHost innerHost;
             private readonly JobHost innerWebJobsHost;
+            private readonly DurableTaskOptions options;
+            private readonly INameResolver nameResolver;
 
-            public FunctionsV2HostWrapper(IHost innerHost)
+            public FunctionsV2HostWrapper(
+                IHost innerHost,
+                IOptions<DurableTaskOptions> options,
+                INameResolver nameResolver)
             {
                 this.innerHost = innerHost ?? throw new ArgumentNullException(nameof(innerHost));
                 this.innerWebJobsHost = (JobHost)this.innerHost.Services.GetService<IJobHost>();
+                this.options = options.Value;
+                this.nameResolver = nameResolver;
             }
 
             public Task CallAsync(string methodName, IDictionary<string, object> args)
@@ -123,7 +130,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             public Task CallAsync(MethodInfo method, IDictionary<string, object> args)
                 => this.innerWebJobsHost.CallAsync(method, args);
 
-            public void Dispose() => this.innerHost.Dispose();
+            public void Dispose()
+            {
+                this.innerHost.Dispose();
+#if !DEBUG
+                string connectionString = this.nameResolver.Resolve(this.options.AzureStorageConnectionStringName ?? "AzureWebJobsStorage");
+                int partitionCount = this.options.PartitionCount;
+                string taskHub = this.options.HubName.ToLowerInvariant();
+                Task.Run(() => TestHelpers.DeleteAllElementsInStorageTaskHubAsync(connectionString, taskHub, partitionCount)).GetAwaiter().GetResult();
+#endif
+            }
 
             public Task StartAsync() => this.innerHost.StartAsync();
 

--- a/test/FunctionsV2/TestCleanup.cs
+++ b/test/FunctionsV2/TestCleanup.cs
@@ -88,7 +88,15 @@ namespace WebJobs.Extensions.DurableTask.Tests.V2
             var service = new AzureStorageOrchestrationService(settings);
             await service.StartAsync();
             this.output.WriteLine($"Deleting task hub : {taskHub}");
-            await service.DeleteAsync();
+            try
+            {
+                await service.DeleteAsync();
+            }
+            catch (Exception ex)
+            {
+                // Log error, but don't fail the test, as it can be cleaned up later.
+                this.output.WriteLine($"Encountered exception deleting task hub: : {ex.ToString()}");
+            }
         }
     }
 }

--- a/test/FunctionsV2/TestCleanup.cs
+++ b/test/FunctionsV2/TestCleanup.cs
@@ -1,14 +1,16 @@
-﻿using DurableTask.AzureStorage;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using DurableTask.AzureStorage;
 using FluentAssertions.Common;
 using Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests;
 using Microsoft.Azure.WebJobs.Host.TestCommon;
 using Microsoft.WindowsAzure.Storage;
 using Microsoft.WindowsAzure.Storage.Blob;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -32,6 +34,7 @@ namespace WebJobs.Extensions.DurableTask.Tests.V2
         public async Task CleanupOldAzureStorageTaskHubs()
         {
             TimeSpan oldTaskHubDeletionThreshold = TimeSpan.FromMinutes(5);
+
             // An approximate limit to the number of taskhubs to delete to prevent test from taking to long.
             // Future test runs will clean up more.
             const int maxDeletedTaskHubs = 2000;
@@ -67,7 +70,8 @@ namespace WebJobs.Extensions.DurableTask.Tests.V2
                         }
                     }
                 }
-            } while (continuationToken != null && taskHubsToDelete.Count < maxDeletedTaskHubs);
+            }
+            while (continuationToken != null && taskHubsToDelete.Count < maxDeletedTaskHubs);
 
             await Task.WhenAll(taskHubsToDelete.Select(taskHub => this.DeleteTaskHub(taskHub, connectionString)));
         }

--- a/test/FunctionsV2/TestCleanup.cs
+++ b/test/FunctionsV2/TestCleanup.cs
@@ -31,6 +31,7 @@ namespace WebJobs.Extensions.DurableTask.Tests.V2
         // This test should never fail. The sole purpose is to cleanup old taskhubs in the CI
         // storage account to prevent clutter now that TaskHub names are non-deterministic.
         [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
         public async Task CleanupOldAzureStorageTaskHubs()
         {
             TimeSpan oldTaskHubDeletionThreshold = TimeSpan.FromMinutes(5);

--- a/test/FunctionsV2/TestCleanup.cs
+++ b/test/FunctionsV2/TestCleanup.cs
@@ -1,0 +1,89 @@
+﻿using DurableTask.AzureStorage;
+using FluentAssertions.Common;
+using Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests;
+using Microsoft.Azure.WebJobs.Host.TestCommon;
+using Microsoft.WindowsAzure.Storage;
+using Microsoft.WindowsAzure.Storage.Blob;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace WebJobs.Extensions.DurableTask.Tests.V2
+{
+    public class TestCleanup
+    {
+        private readonly ITestOutputHelper output;
+
+        private readonly TestLoggerProvider loggerProvider;
+
+        public TestCleanup(ITestOutputHelper output)
+        {
+            this.output = output;
+            this.loggerProvider = new TestLoggerProvider(output);
+        }
+
+        // This test should never fail. The sole purpose is to cleanup old taskhubs in the CI
+        // storage account to prevent clutter now that TaskHub names are non-deterministic.
+        [Fact]
+        public async Task CleanupOldAzureStorageTaskHubs()
+        {
+            TimeSpan oldTaskHubDeletionThreshold = TimeSpan.FromMinutes(5);
+            // An approximate limit to the number of taskhubs to delete to prevent test from taking to long.
+            // Future test runs will clean up more.
+            const int maxDeletedTaskHubs = 2000;
+            string connectionString = TestHelpers.GetStorageConnectionString();
+            CloudStorageAccount account = CloudStorageAccount.Parse(connectionString);
+
+            this.output.WriteLine($"Using storage account: {account.Credentials.AccountName}");
+
+            CloudBlobClient blobClient = account.CreateCloudBlobClient();
+            BlobContinuationToken continuationToken = null;
+            List<string> taskHubsToDelete = new List<string>();
+            do
+            {
+                var containersSegmentResult = await blobClient.ListContainersSegmentedAsync(
+                    prefix: string.Empty,
+                    ContainerListingDetails.Metadata,
+                    maxResults: 500,
+                    continuationToken,
+                    new BlobRequestOptions(),
+                    new OperationContext());
+                continuationToken = containersSegmentResult.ContinuationToken;
+
+                foreach (var blobContainer in containersSegmentResult.Results)
+                {
+                    int suffixIndex = blobContainer.Name.IndexOf("-leases");
+                    if (suffixIndex > 0)
+                    {
+                        if (blobContainer.Properties.LastModified.HasValue
+                            && DateTime.UtcNow.ToDateTimeOffset().Subtract(blobContainer.Properties.LastModified.Value) > oldTaskHubDeletionThreshold)
+                        {
+                            string taskHub = blobContainer.Name.Substring(0, suffixIndex);
+                            taskHubsToDelete.Add(taskHub);
+                        }
+                    }
+                }
+            } while (continuationToken != null && taskHubsToDelete.Count < maxDeletedTaskHubs);
+
+            await Task.WhenAll(taskHubsToDelete.Select(taskHub => this.DeleteTaskHub(taskHub, connectionString)));
+        }
+
+        private async Task DeleteTaskHub(string taskHub, string connectionString)
+        {
+            var settings = new AzureStorageOrchestrationServiceSettings()
+            {
+                TaskHubName = taskHub,
+                StorageConnectionString = connectionString,
+            };
+
+            var service = new AzureStorageOrchestrationService(settings);
+            await service.StartAsync();
+            this.output.WriteLine($"Deleting task hub : {taskHub}");
+            await service.DeleteAsync();
+        }
+    }
+}


### PR DESCRIPTION
Our end-to-end tests currently rely on having unique taskhub names so
that tests can be run safely in parallel. This has been proven to be
hard to catch/maintain this restriction, so we add a random 4
alphanumeric suffix to each task hub to make sure that there are never
duplicate taskhub names.

The other benefit of creating non-deterministic taskhubs for each test
run is that we should no longer end up with the corrupted state problem,
where a previous test run somehow corrupted a task hub and the test now
fails until we use a new storage account or preform manual intervention.

Finally, this test adds a dummy test that deletes up to 2000 taskhubs
older than 3 days, to ensure that we don't collect to many entities in
our storage account over time.