### PR TITLE
Updates to support Durable Client feature

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableClient.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableClient.cs
@@ -651,6 +651,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             string taskHubName,
             string connectionName)
         {
+            if (this.httpApiHandler == null)
+            {
+                throw new InvalidOperationException("CreateHttpManagementPayload not supported.");
+            }
+
             return this.httpApiHandler.CreateHttpManagementPayload(instanceId, taskHubName, connectionName);
         }
 
@@ -807,6 +812,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             DurableClientAttribute attribute,
             bool returnInternalServerErrorOnFailure = false)
         {
+            if (this.httpApiHandler == null)
+            {
+                throw new InvalidOperationException("CreateCheckStatusResponse not supported.");
+            }
+
             return this.httpApiHandler.CreateCheckStatusResponse(request, instanceId, attribute, returnInternalServerErrorOnFailure);
         }
 

--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableClient.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableClient.cs
@@ -653,7 +653,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         {
             if (this.httpApiHandler == null)
             {
-                throw new InvalidOperationException("CreateHttpManagementPayload not supported.");
+                throw new InvalidOperationException("IDurableClient.CreateHttpManagementPayload is not supported for IDurableClient instances created outside of a Durable Functions application.");
             }
 
             return this.httpApiHandler.CreateHttpManagementPayload(instanceId, taskHubName, connectionName);
@@ -814,7 +814,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         {
             if (this.httpApiHandler == null)
             {
-                throw new InvalidOperationException("CreateCheckStatusResponse not supported.");
+                throw new InvalidOperationException("IDurableClient.CreateCheckStatusResponse is not supported for IDurableClient instances created outside of a Durable Functions application.");
             }
 
             return this.httpApiHandler.CreateCheckStatusResponse(request, instanceId, attribute, returnInternalServerErrorOnFailure);

--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableClientFactory.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableClientFactory.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Concurrent;
 using Microsoft.Azure.WebJobs.Extensions.DurableTask.Options;
+using Microsoft.Azure.WebJobs.Host.Config;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Newtonsoft.Json;
@@ -76,19 +77,21 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.ContextImplementations
 
             DurableClientAttribute attribute = new DurableClientAttribute(durableClientOptions);
 
+            /*
             HttpApiHandler httpApiHandler = this.cachedHttpListeners.GetOrAdd(
                 attribute,
                 attr =>
                 {
-                    return new HttpApiHandler(null, null, this.durableTaskOptions, this.logger);
+                    return new HttpApiHandler(this.TraceHelper, this.MessageDataConverter, this.durableTaskOptions, this.logger);
                 });
+            */
 
             DurableClient client = this.cachedClients.GetOrAdd(
                 attribute,
                 attr =>
                 {
                     DurabilityProvider innerClient = this.durabilityProviderFactory.GetDurabilityProvider(attribute);
-                    return new DurableClient(innerClient, httpApiHandler, attribute, this.MessageDataConverter, this.TraceHelper, this.durableTaskOptions);
+                    return new DurableClient(innerClient, null, attribute, this.MessageDataConverter, this.TraceHelper, this.durableTaskOptions);
                 });
 
             return client;

--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableClientFactory.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableClientFactory.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Concurrent;
 using Microsoft.Azure.WebJobs.Extensions.DurableTask.Options;
-using Microsoft.Azure.WebJobs.Host.Config;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Newtonsoft.Json;
@@ -76,15 +75,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.ContextImplementations
             }
 
             DurableClientAttribute attribute = new DurableClientAttribute(durableClientOptions);
-
-            /*
-            HttpApiHandler httpApiHandler = this.cachedHttpListeners.GetOrAdd(
-                attribute,
-                attr =>
-                {
-                    return new HttpApiHandler(this.TraceHelper, this.MessageDataConverter, this.durableTaskOptions, this.logger);
-                });
-            */
 
             DurableClient client = this.cachedClients.GetOrAdd(
                 attribute,

--- a/src/WebJobs.Extensions.DurableTask/DurableTaskJobHostConfigurationExtensions.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskJobHostConfigurationExtensions.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// </summary>
         /// <param name="serviceCollection">The <see cref="IServiceCollection"/> to configure.</param>
         /// <returns>Returns the provided <see cref="IServiceCollection"/>.</returns>
-        public static IServiceCollection AddDurableTask(this IServiceCollection serviceCollection)
+        public static IServiceCollection AddDurableClientFactory(this IServiceCollection serviceCollection)
         {
             if (serviceCollection == null)
             {
@@ -77,9 +77,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// <param name="serviceCollection">The <see cref="IServiceCollection"/> to configure.</param>
         /// <param name="optionsBuilder">Populate default configurations of <see cref="DurableClientOptions"/> to create Durable Clients.</param>
         /// <returns>Returns the provided <see cref="IServiceCollection"/>.</returns>
-        public static IServiceCollection AddDurableTask(this IServiceCollection serviceCollection, Action<DurableClientOptions> optionsBuilder)
+        public static IServiceCollection AddDurableClientFactory(this IServiceCollection serviceCollection, Action<DurableClientOptions> optionsBuilder)
         {
-            AddDurableTask(serviceCollection);
+            AddDurableClientFactory(serviceCollection);
             serviceCollection.Configure<DurableClientOptions>(optionsBuilder.Invoke);
             return serviceCollection;
         }

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net461.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net461.xml
@@ -1781,7 +1781,7 @@
             <summary>
             Initializes a new instance of the <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClientAttribute"/> class.
             </summary>
-            <param name="durableClientOptions">durable client option.</param>
+            <param name="durableClientOptions">durable client options</param>
         </member>
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClientAttribute.TaskHub">
             <summary>

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net461.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net461.xml
@@ -1781,7 +1781,7 @@
             <summary>
             Initializes a new instance of the <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClientAttribute"/> class.
             </summary>
-            <param name="durableClientOptions">durable client options</param>
+            <param name="durableClientOptions">durable client option.</param>
         </member>
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClientAttribute.TaskHub">
             <summary>

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
@@ -2162,14 +2162,14 @@
             <param name="builder">The <see cref="T:Microsoft.Azure.WebJobs.IWebJobsBuilder"/> to configure.</param>
             <returns>Returns the provided <see cref="T:Microsoft.Azure.WebJobs.IWebJobsBuilder"/>.</returns>
         </member>
-        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskJobHostConfigurationExtensions.AddDurableTask(Microsoft.Extensions.DependencyInjection.IServiceCollection)">
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskJobHostConfigurationExtensions.AddDurableClientFactory(Microsoft.Extensions.DependencyInjection.IServiceCollection)">
             <summary>
             Adds the Durable Task extension to the provided <see cref="T:Microsoft.Extensions.DependencyInjection.IServiceCollection"/>.
             </summary>
             <param name="serviceCollection">The <see cref="T:Microsoft.Extensions.DependencyInjection.IServiceCollection"/> to configure.</param>
             <returns>Returns the provided <see cref="T:Microsoft.Extensions.DependencyInjection.IServiceCollection"/>.</returns>
         </member>
-        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskJobHostConfigurationExtensions.AddDurableTask(Microsoft.Extensions.DependencyInjection.IServiceCollection,System.Action{Microsoft.Azure.WebJobs.Extensions.DurableTask.Options.DurableClientOptions})">
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskJobHostConfigurationExtensions.AddDurableClientFactory(Microsoft.Extensions.DependencyInjection.IServiceCollection,System.Action{Microsoft.Azure.WebJobs.Extensions.DurableTask.Options.DurableClientOptions})">
             <summary>
             Adds the Durable Task extension to the provided <see cref="T:Microsoft.Extensions.DependencyInjection.IServiceCollection"/>.
             </summary>

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
@@ -1786,7 +1786,7 @@
             <summary>
             Initializes a new instance of the <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClientAttribute"/> class.
             </summary>
-            <param name="durableClientOptions">durable client options</param>
+            <param name="durableClientOptions">durable client option.</param>
         </member>
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClientAttribute.TaskHub">
             <summary>

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
@@ -1786,7 +1786,7 @@
             <summary>
             Initializes a new instance of the <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClientAttribute"/> class.
             </summary>
-            <param name="durableClientOptions">durable client option.</param>
+            <param name="durableClientOptions">durable client options</param>
         </member>
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClientAttribute.TaskHub">
             <summary>

--- a/test/Common/DurableClientBaseTests.cs
+++ b/test/Common/DurableClientBaseTests.cs
@@ -146,7 +146,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 #if !FUNCTIONS_V1
         [Fact]
         [Trait("Category", PlatformSpecificHelpers.TestCategory)]
-        public async Task DurableClient_DI_StartNewAsync_ReturnsInstanceId()
+        public async Task DurableClient_ExternalApp_StartNewAsync_ReturnsInstanceId()
         {
             var orchestrationServiceClientMock = new Mock<IOrchestrationServiceClient>();
             orchestrationServiceClientMock.Setup(x => x.GetOrchestrationStateAsync(It.IsAny<string>(), It.IsAny<bool>()))
@@ -160,7 +160,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
         [Fact]
         [Trait("Category", PlatformSpecificHelpers.TestCategory)]
-        public async void DurableClient_DI_GetStatusAsync_ReturnsStatus()
+        public async void DurableClient_ExternalApp_GetStatusAsync_ReturnsStatus()
         {
             var orchestrationServiceClientMock = new Mock<IOrchestrationServiceClient>();
             orchestrationServiceClientMock.Setup(x => x.GetOrchestrationStateAsync(It.IsAny<string>(), It.IsAny<bool>()))
@@ -173,7 +173,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
         [Fact]
         [Trait("Category", PlatformSpecificHelpers.TestCategory)]
-        public async void DurableClient_DI_TerminateAsync_TerminateEventPlaced()
+        public async void DurableClient_ExternalApp_TerminateAsync_TerminateEventPlaced()
         {
             var orchestrationServiceClientMock = new Mock<IOrchestrationServiceClient>();
             orchestrationServiceClientMock.Setup(x => x.GetOrchestrationStateAsync(It.IsAny<string>(), It.IsAny<bool>()))
@@ -186,7 +186,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
         [Fact]
         [Trait("Category", PlatformSpecificHelpers.TestCategory)]
-        public void DurableClient_DI_CreateCheckStatusResponse_ThrowsException()
+        public void DurableClient_ExternalApp_CreateCheckStatusResponse_ThrowsException()
         {
             var instanceId = Guid.NewGuid().ToString();
 
@@ -200,7 +200,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
         [Fact]
         [Trait("Category", PlatformSpecificHelpers.TestCategory)]
-        public void DurableClient_DI_CreateHttpManagementPayload_ThrowsException()
+        public void DurableClient_ExternalApp_CreateHttpManagementPayload_ThrowsException()
         {
             var instanceId = Guid.NewGuid().ToString();
 

--- a/test/Common/DurableClientBaseTests.cs
+++ b/test/Common/DurableClientBaseTests.cs
@@ -179,7 +179,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             orchestrationServiceClientMock.Setup(x => x.GetOrchestrationStateAsync(It.IsAny<string>(), It.IsAny<bool>()))
                 .ReturnsAsync(GetInstanceState(OrchestrationStatus.Running));
 
-            var durableOrchestrationClient = this.GetDurableClient(orchestrationServiceClientMock.Object); 
+            var durableOrchestrationClient = this.GetDurableClient(orchestrationServiceClientMock.Object);
             await durableOrchestrationClient.TerminateAsync("valid_instance_id", "any reason");
             orchestrationServiceClientMock.Verify(x => x.ForceTerminateTaskOrchestrationAsync("valid_instance_id", "any reason"), Times.Once());
         }


### PR DESCRIPTION
These changes are for the new Durable Client feature (#1125). With the new feature, there isn't a way to create the HTTP management payloads from the lack of a webhook URL so exceptions are thrown when a user tries to call `CreateCheckStatusResponse` or `CreateHttpManagementPayload`.