### PR TITLE
Update NugetToolInstaller for Azure Pipelines v2 tests

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -51,7 +51,7 @@ jobs:
       buildConfiguration: 'Debug'
 
     steps:
-    - task: NuGetToolInstaller@0
+    - task: NuGetToolInstaller@1
 
     - task: DotNetCoreCLI@2
       inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -89,7 +89,7 @@ jobs:
       buildConfiguration: 'Debug'
 
     steps:
-    - task: NuGetToolInstaller@0
+    - task: NuGetToolInstaller@1
 
     - task: DotNetCoreCLI@2
       inputs:
@@ -132,7 +132,7 @@ jobs:
       buildConfiguration: 'Debug'
 
     steps:
-    - task: NuGetToolInstaller@0
+    - task: NuGetToolInstaller@1
 
     - task: DotNetCoreCLI@2
       inputs:


### PR DESCRIPTION
Second attempt to fix the CI nuget tool installer issue. This time I am updating the task for the FunctionsV2Tests job as well.