### PR TITLE
Update Durable Task Framework dependencies

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableActivityContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableActivityContext.cs
@@ -89,6 +89,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             }
 
             JToken jToken = this.GetInputAsJson();
+            if (jToken == null)
+            {
+                return null;
+            }
+
             var value = jToken as JValue;
             if (value != null)
             {

--- a/src/WebJobs.Extensions.DurableTask/MessagePayloadDataConverter.cs
+++ b/src/WebJobs.Extensions.DurableTask/MessagePayloadDataConverter.cs
@@ -40,6 +40,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// </summary>
         public string Serialize(object value, int maxSizeInKB)
         {
+            if (value == null)
+            {
+                return null;
+            }
+
             string serializedJson;
 
             JToken json = value as JToken;

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net461.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net461.xml
@@ -99,6 +99,9 @@
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClient.Microsoft#Azure#WebJobs#Extensions#DurableTask#IDurableOrchestrationClient#TaskHubName">
             <inheritdoc />
         </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClient.ToString">
+            <inheritdoc/>
+        </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClient.Microsoft#Azure#WebJobs#Extensions#DurableTask#IDurableOrchestrationClient#CreateCheckStatusResponse(System.Net.Http.HttpRequestMessage,System.String,System.Boolean)">
             <inheritdoc />
         </member>
@@ -577,6 +580,16 @@
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableEntityContext.HasState">
             <summary>
             Whether this entity has a state.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableEntityContext.BatchSize">
+            <summary>
+            The size of the current batch of operations.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableEntityContext.BatchPosition">
+            <summary>
+            The position of the currently executing operation within the current batch of operations.
             </summary>
         </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableEntityContext.GetState``1(System.Func{``0})">
@@ -1564,6 +1577,16 @@
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurabilityProvider.SupportsEntities">
             <summary>
             Specifies whether the durability provider supports Durable Entities.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurabilityProvider.SupportsPollFreeWait">
+            <summary>
+            Specifies whether the backend's WaitForOrchestration is implemented without polling.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurabilityProvider.GuaranteesOrderedDelivery">
+            <summary>
+            Specifies whether this backend delivers messages in order.
             </summary>
         </member>
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurabilityProvider.ConfigurationJson">
@@ -3785,6 +3808,34 @@
             Option to only start a new orchestrator instance with an existing instance Id when the existing
             instance is in a terminated, failed, or completed state.
             </summary>
+        </member>
+        <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.ProviderUtils">
+            <summary>
+            Provides access to internal functionality for the purpose of implementing durability providers.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.ProviderUtils.GetSchedulerIdFromEntityId(Microsoft.Azure.WebJobs.Extensions.DurableTask.EntityId)">
+            <summary>
+            Returns the instance id of the entity scheduler for a given entity id.
+            </summary>
+            <param name="entityId">The entity id.</param>
+            <returns>The instance id of the scheduler.</returns>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.ProviderUtils.TryGetEntityStateFromSerializedSchedulerState(DurableTask.Core.OrchestrationState,Newtonsoft.Json.JsonSerializerSettings,System.String@)">
+            <summary>
+            Reads the state of an entity from the serialized entity scheduler state.
+            </summary>
+            <param name="state">The orchestration state of the scheduler.</param>
+            <param name="serializerSettings">The serializer settings.</param>
+            <param name="result">The serialized state of the entity.</param>
+            <returns>true if the entity exists, false otherwise.</returns>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.ProviderUtils.ConvertOrchestrationStateToStatus(DurableTask.Core.OrchestrationState)">
+            <summary>
+            Converts the DTFx representation of the orchestration state into the DF representation.
+            </summary>
+            <param name="orchestrationState">The orchestration state.</param>
+            <returns>The orchestration status.</returns>
         </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.PurgeHistoryResult">
             <summary>

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
@@ -99,6 +99,9 @@
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClient.Microsoft#Azure#WebJobs#Extensions#DurableTask#IDurableOrchestrationClient#TaskHubName">
             <inheritdoc />
         </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClient.ToString">
+            <inheritdoc/>
+        </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClient.Microsoft#Azure#WebJobs#Extensions#DurableTask#IDurableOrchestrationClient#CreateCheckStatusResponse(System.Net.Http.HttpRequestMessage,System.String,System.Boolean)">
             <inheritdoc />
         </member>
@@ -582,6 +585,16 @@
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableEntityContext.HasState">
             <summary>
             Whether this entity has a state.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableEntityContext.BatchSize">
+            <summary>
+            The size of the current batch of operations.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableEntityContext.BatchPosition">
+            <summary>
+            The position of the currently executing operation within the current batch of operations.
             </summary>
         </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableEntityContext.GetState``1(System.Func{``0})">
@@ -1569,6 +1582,16 @@
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurabilityProvider.SupportsEntities">
             <summary>
             Specifies whether the durability provider supports Durable Entities.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurabilityProvider.SupportsPollFreeWait">
+            <summary>
+            Specifies whether the backend's WaitForOrchestration is implemented without polling.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurabilityProvider.GuaranteesOrderedDelivery">
+            <summary>
+            Specifies whether this backend delivers messages in order.
             </summary>
         </member>
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurabilityProvider.ConfigurationJson">
@@ -3840,6 +3863,34 @@
             Option to only start a new orchestrator instance with an existing instance Id when the existing
             instance is in a terminated, failed, or completed state.
             </summary>
+        </member>
+        <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.ProviderUtils">
+            <summary>
+            Provides access to internal functionality for the purpose of implementing durability providers.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.ProviderUtils.GetSchedulerIdFromEntityId(Microsoft.Azure.WebJobs.Extensions.DurableTask.EntityId)">
+            <summary>
+            Returns the instance id of the entity scheduler for a given entity id.
+            </summary>
+            <param name="entityId">The entity id.</param>
+            <returns>The instance id of the scheduler.</returns>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.ProviderUtils.TryGetEntityStateFromSerializedSchedulerState(DurableTask.Core.OrchestrationState,Newtonsoft.Json.JsonSerializerSettings,System.String@)">
+            <summary>
+            Reads the state of an entity from the serialized entity scheduler state.
+            </summary>
+            <param name="state">The orchestration state of the scheduler.</param>
+            <param name="serializerSettings">The serializer settings.</param>
+            <param name="result">The serialized state of the entity.</param>
+            <returns>true if the entity exists, false otherwise.</returns>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.ProviderUtils.ConvertOrchestrationStateToStatus(DurableTask.Core.OrchestrationState)">
+            <summary>
+            Converts the DTFx representation of the orchestration state into the DF representation.
+            </summary>
+            <param name="orchestrationState">The orchestration state.</param>
+            <returns>The orchestration status.</returns>
         </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.PurgeHistoryResult">
             <summary>

--- a/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
+++ b/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
@@ -76,7 +76,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage" Version="1.8.1" />
+    <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage" Version="1.8.2" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers" Version="0.3.2" />
     <PackageReference Include="Azure.Identity" Version="1.1.1" />
   </ItemGroup>

--- a/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
+++ b/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
@@ -76,7 +76,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage" Version="1.8.2" />
+    <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage" Version="1.8.3" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers" Version="0.3.2" />
     <PackageReference Include="Azure.Identity" Version="1.1.1" />
   </ItemGroup>

--- a/test/Common/TestHelpers.cs
+++ b/test/Common/TestHelpers.cs
@@ -528,7 +528,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             var list = new List<string>()
             {
                 $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})' scheduled. Reason: NewInstance. IsReplay: False.",
-                $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})' started. IsReplay: False. Input: null",
+                $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})' started. IsReplay: False. Input: (null)",
                 $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})' failed with an error. Reason: System.ArgumentNullException: Value cannot be null.",
             };
 

--- a/test/FunctionsV2/WebJobs.Extensions.DurableTask.Tests.V2.csproj
+++ b/test/FunctionsV2/WebJobs.Extensions.DurableTask.Tests.V2.csproj
@@ -26,8 +26,8 @@
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.*" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.Azure.DurableTask.Emulator" Version="2.2.5" />
-    <PackageReference Include="Microsoft.Azure.DurableTask.Redis" Version="0.1.5-alpha" />
+    <PackageReference Include="Microsoft.Azure.DurableTask.Emulator" Version="2.5.0" />
+    <PackageReference Include="Microsoft.Azure.DurableTask.Redis" Version="0.1.6-alpha" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Update to DurableTask.AzureStorage v1.8.3, which due to DurableTask.Core, has some changes in how `null` is serialized.

This PR required some small changes to our serialization + test logic to reflect this. None of these changes should be breaking.