### PR TITLE
Remove ApplicationInsights.DependencyCollector package

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
+++ b/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
@@ -69,7 +69,6 @@
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="2.2.0" />
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.12.2" />
-    <PackageReference Include="Microsoft.ApplicationInsights.DependencyCollector" Version="2.12.2" />
     <PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION
The `Microsoft.ApplicationInsights.DependencyCollector` package is not used, but it will be included in the artifacts and unnecessarily increases the artifacts size

The tests were run locally. cc @TsuyoshiUshio @cgillum 