### PR TITLE
Fix the warning message for unsuccessful termination

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableClient.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableClient.cs
@@ -370,8 +370,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     hubName: this.TaskHubName,
                     functionName: state.Name,
                     instanceId: instanceId,
-                    message: $"Cannot terminate orchestration instance in {state.Status} state");
-                throw new InvalidOperationException($"Cannot terminate the orchestration instance {instanceId} because instance is in {state.Status} state");
+                    message: $"Cannot terminate orchestration instance in the {state.OrchestrationStatus} state.");
+                throw new InvalidOperationException($"Cannot terminate the orchestration instance {instanceId} because instance is in the {state.OrchestrationStatus} state.");
             }
         }
 


### PR DESCRIPTION
I found this while investigating an unrelated customer issue. The `Status` message represents custom status, which is not what we intended to log (it's also dangerous to log this since it could include sensitive customer data). We should actually be logging the `OrchestrationStatus` value - i.e. "Running", "Completed", "Failed", etc.