### PR TITLE
Reduce number of entity deserializations

### DIFF
--- a/test/Common/TestOrchestrations.cs
+++ b/test/Common/TestOrchestrations.cs
@@ -917,11 +917,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 ctx.SignalEntity(entityId, "Set", 56);
                 ctx.SignalEntity(entityId, "SetToUnDeserializable");
                 ctx.SignalEntity(entityId, "Set", 12);
-                ctx.SignalEntity(entityId, "SetAndThrow", 999);
+                ctx.SignalEntity(entityId, "SetThenThrow", 999);
 
                 if (rollbackOnException)
                 {
+                    // we rolled back to an un-deserializable state
                     await Assert.ThrowsAsync<EntitySchedulerException>(() => entity.Get());
+                }
+                else
+                {
+                    Assert.Equal(999, await entity.Get());
                 }
 
                 await ctx.CallEntityAsync<bool>(entityId, "deletewithoutreading");


### PR DESCRIPTION
The current implementation re-constructs the entity state (i.e. constructs the object and populates the fields by deserializing the json) prior to processing each operation (if RollbackEntityOperationsOnExceptions=true, default) or each operation batch (if RollbackEntityOperationsOnExceptions=false). This happens even if that entity state is still in memory.

This seems wasteful; in this PR I modified the state management slightly so it can reuse the already existing object.