### PR TITLE
Add process changes based on v2.4.0 team retrospective

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-release-template.md
+++ b/.github/ISSUE_TEMPLATE/new-release-template.md
@@ -3,21 +3,31 @@ name: New release template
 about: Template for creating new releases of Durable Functions
 title: ''
 labels: ''
-assignees: cgillum
+assignees: comcmaho, amdeel, davidmrdavid, bachuv
 
 ---
 
-As part of a release, the following items need to be taken care of. For any items that are not applicable, they should be crossed out using the `~~ ~~` markdown syntax with an explanation.
-
-- [ ] Run private scale tests and ensure no regressions
-- [ ] Publish updated versions of [DurableTask.Core](https://www.nuget.org/packages/Microsoft.Azure.DurableTask.Core/) and [DurableTask.AzureStorage](https://www.nuget.org/packages/Microsoft.Azure.DurableTask.AzureStorage/) to nuget.org
+**Prep Release: (assigned to:)**
+_Due: <two-businessdays-before-release>_
 - [ ] Merge all features and fixes into the `master` branch
-- [ ] Update .NET API docs at https://azure.github.io/azure-functions-durable-extension
-- [ ] Publish signed version of [Microsoft.Azure.WebJobs.Extensions.DurableTask](https://www.nuget.org/packages/Microsoft.Azure.WebJobs.Extensions.DurableTask/) to nuget.org
-- [ ] Update samples to point to the latest nuget packages
+- [ ] Publish updated versions of DurableTask.Core and DurableTask.AzureStorage to app-service MyGet feed
+- [ ] Increment extension version
+- [ ] Publish signed version of Microsoft.Azure.WebJobs.Extensions.DurableTask to app-service MyGet feed
+
+**Validation (assigned to: )**
+_Due: <1-businessdays-before-release>_
+- [ ] Run private performance tests and ensure no regressions
+- [ ] Smoke test Functions V1 and Functions V3 .NET apps
+- [ ] Smoke test JavaScript and Python apps
+
+
+** Release Completion (assigned to: )**:
+_Due: <release-deadline>_
+- [ ] Push staged package on MyGet to Nuget.org (for Durable Task Framework, you may need to manually update them)
 - [ ] Create a PR in the [Azure Functions templates repo](https://github.com/Azure/azure-functions-templates) to update templates to the latest version
 - [ ] Create a PR in the [Azure Functions bundles repo](https://github.com/Azure/azure-functions-extension-bundles) to update bundles to the latest version
 - [ ] Close out or punt remaining GitHub issues for the current milestone
-- [ ] Update official docs under https://docs.microsoft.com/en-us/azure/azure-functions/durable ([private docs repo for Microsoft employees](http://github.com/MicrosoftDocs/azure-docs-pr))
-- [ ] Publish release notes
+- [ ] Merge all pending PR docs, and reset pending_docs.md
+- [ ] Publish release notes and reset release_notes.md
+- [ ] Remerge to master now that pending docs and release notes are cleared?
 - [ ] Post announcement on [App Service Announcements GitHub repo](https://github.com/Azure/app-service-announcements) and Twitter.

--- a/.github/ISSUE_TEMPLATE/new-release-template.md
+++ b/.github/ISSUE_TEMPLATE/new-release-template.md
@@ -9,7 +9,7 @@ assignees: comcmaho, amdeel, davidmrdavid, bachuv
 
 **Prep Release: (assigned to:)**
 _Due: <two-businessdays-before-release>_
-- [ ] Merge all features and fixes into the `master` branch
+- [ ] Merge all features and fixes into the `main` branch
 - [ ] Publish updated versions of DurableTask.Core and DurableTask.AzureStorage to app-service MyGet feed
 - [ ] Increment extension version
 - [ ] Publish signed version of Microsoft.Azure.WebJobs.Extensions.DurableTask to app-service MyGet feed

--- a/.github/ISSUE_TEMPLATE/new-release-template.md
+++ b/.github/ISSUE_TEMPLATE/new-release-template.md
@@ -8,17 +8,20 @@ assignees: comcmaho, amdeel, davidmrdavid, bachuv
 ---
 
 **Prep Release: (assigned to:)**
-_Due: <two-businessdays-before-release>_
-- [ ] Merge all features and fixes into the `main` branch
+_Due: <3-business-days-before-release>_
+- [ ] Merge all features and fixes into the `dev` branch
 - [ ] Publish updated versions of DurableTask.Core and DurableTask.AzureStorage to app-service MyGet feed
-- [ ] Increment extension version
+- [ ] Update dependencies and increment extension version in the `dev` branch.
 - [ ] Publish signed version of Microsoft.Azure.WebJobs.Extensions.DurableTask to app-service MyGet feed
+- [ ] Close out or punt remaining GitHub issues for the current milestone
+
 
 **Validation (assigned to: )**
-_Due: <1-businessdays-before-release>_
+_Due: <2-business-days-before-release>_
 - [ ] Run private performance tests and ensure no regressions
 - [ ] Smoke test Functions V1 and Functions V3 .NET apps
 - [ ] Smoke test JavaScript and Python apps
+- [ ] Check for package size, make sure it's not surprisingly heavier than a previous release
 
 
 ** Release Completion (assigned to: )**:
@@ -26,8 +29,8 @@ _Due: <release-deadline>_
 - [ ] Push staged package on MyGet to Nuget.org (for Durable Task Framework, you may need to manually update them)
 - [ ] Create a PR in the [Azure Functions templates repo](https://github.com/Azure/azure-functions-templates) to update templates to the latest version
 - [ ] Create a PR in the [Azure Functions bundles repo](https://github.com/Azure/azure-functions-extension-bundles) to update bundles to the latest version
-- [ ] Close out or punt remaining GitHub issues for the current milestone
-- [ ] Merge all pending PR docs, and reset pending_docs.md
-- [ ] Publish release notes and reset release_notes.md
-- [ ] Remerge to master now that pending docs and release notes are cleared?
+- [ ] Merge all pending PR docs from `pending_docs.md`
+- [ ] Reset `pending_docs.md` and `release_notes.md` in the `dev` branch. You will want to save `release_notes.md` somewhere for when you publish release notes.
+- [ ] Merge `dev` into `main`
+- [ ] Publish release notes from the pre-reset `release_notes.md`
 - [ ] Post announcement on [App Service Announcements GitHub repo](https://github.com/Azure/app-service-announcements) and Twitter.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,20 @@
+<!-- Please provide all the information below.  -->
+
+### Issue describing the changes in this PR
+
+resolves #issue_for_this_pr
+
+### Pull request checklist
+
+* [ ] My changes **do not** require documentation changes
+    * [ ] Otherwise: Documentation issue linked to PR
+* [ ] My changes **should not** be added to the release notes for the next release
+    * [ ] Otherwise: I've added my notes to `release_notes.md`
+* [ ] My changes **do not** need to be backported to a previous version
+    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
+* [ ] I have added all required tests (Unit tests, E2E tests)
+
+<!-- Optional: delete if not applicable  -->
+### Additional information
+
+Additional PR information

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,7 @@
-<!-- Please provide all the information below.  -->
+<-- Start the PR description with some context for the change. -->
 
+
+<-- Make sure to delete the markdown comments and the below sections when squash merging -->
 ### Issue describing the changes in this PR
 
 resolves #issue_for_this_pr
@@ -7,14 +9,11 @@ resolves #issue_for_this_pr
 ### Pull request checklist
 
 * [ ] My changes **do not** require documentation changes
-    * [ ] Otherwise: Documentation issue linked to PR
+    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
 * [ ] My changes **should not** be added to the release notes for the next release
     * [ ] Otherwise: I've added my notes to `release_notes.md`
 * [ ] My changes **do not** need to be backported to a previous version
     * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
 * [ ] I have added all required tests (Unit tests, E2E tests)
 
-<!-- Optional: delete if not applicable  -->
-### Additional information
 
-Additional PR information

--- a/pending_docs.md
+++ b/pending_docs.md
@@ -1,0 +1,2 @@
+<-- Please include a link to your pending docs PR below. https://docs.microsoft.com/en-us/azure/azure-functions/durable ([private docs repo for Microsoft employees](http://github.com/MicrosoftDocs/azure-docs-pr)). 
+Your code PR should not be merged until your docs PR has been signed off. -->

--- a/release_notes.md
+++ b/release_notes.md
@@ -1,0 +1,10 @@
+<!-- Please put your changes into the appropriate category (or categories) below. -->
+
+## New Features
+
+## Bug fixes
+
+## Breaking changes
+
+## Dependency Changes 
+


### PR DESCRIPTION
This PR attempts to tackle the following issues created as a part of the
v2.4.0 retrospective:

- PR template that requires docs to be completed and release notes to be
  written before merging a PR (fixes #1603)
- Update our release template to be more up to date, and to split the
  tasks into seperate roles (fixes #1604)

Both of these are first efforts, and we may need to tweak them to make
sure that they are providing value.