### PR TITLE
Fix incorrect documentation for ReadEntityStateAsync()

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -3,6 +3,7 @@
 ## New Features
 
 ## Bug fixes
+- Remove incorrect information from C# docs summary for IDurableEntityClient.ReadEntityStateAsync() regarding states large than 16KB (#1637)
 
 ## Breaking changes
 

--- a/src/WebJobs.Extensions.DurableTask/ContextInterfaces/IDurableEntityClient.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextInterfaces/IDurableEntityClient.cs
@@ -82,8 +82,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         Task SignalEntityAsync<TEntityInterface>(EntityId entityId, DateTime scheduledTimeUtc, Action<TEntityInterface> operation);
 
         /// <summary>
-        /// Tries to read the current state of an entity. Returns default(<typeparamref name="T"/>) if the entity does not
-        /// exist, or if the JSON-serialized state of the entity is larger than 16KB.
+        /// Tries to read the current state of an entity. Returns default(<typeparamref name="T"/>) if the entity does not exist.
         /// </summary>
         /// <typeparam name="T">The JSON-serializable type of the entity.</typeparam>
         /// <param name="entityId">The target entity.</param>


### PR DESCRIPTION
Remove the section about state above 16KB returning default(T), which
has never been true after entities went GA.

Resolves #1631

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)


