### PR TITLE
Add tracing for entity state creation and deletion

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/EndToEndTraceHelper.cs
+++ b/src/WebJobs.Extensions.DurableTask/EndToEndTraceHelper.cs
@@ -559,6 +559,68 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             }
         }
 
+        public void EntityStateCreated(
+            string hubName,
+            string functionName,
+            string instanceId,
+            string operationName,
+            string operationId,
+            bool isReplay)
+        {
+            if (this.ShouldLogEvent(isReplay))
+            {
+                FunctionType functionType = FunctionType.Entity;
+
+                EtwEventSource.Instance.EntityStateCreated(
+                    hubName,
+                    LocalAppName,
+                    LocalSlotName,
+                    functionName,
+                    instanceId,
+                    operationName,
+                    operationId,
+                    FunctionType.Entity.ToString(),
+                    ExtensionVersion,
+                    isReplay);
+
+                this.logger.LogInformation(
+                    "{instanceId}: Function '{functionName} ({functionType})' created entity state in '{operationName}' operation {operationId}. State: {state}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}. SequenceNumber: {sequenceNumber}.",
+                    instanceId, functionName, functionType, operationName, operationId, FunctionState.EntityStateCreated, hubName,
+                    LocalAppName, LocalSlotName, ExtensionVersion, this.sequenceNumber++);
+            }
+        }
+
+        public void EntityStateDeleted(
+            string hubName,
+            string functionName,
+            string instanceId,
+            string operationName,
+            string operationId,
+            bool isReplay)
+        {
+            if (this.ShouldLogEvent(isReplay))
+            {
+                FunctionType functionType = FunctionType.Entity;
+
+                EtwEventSource.Instance.EntityStateDeleted(
+                    hubName,
+                    LocalAppName,
+                    LocalSlotName,
+                    functionName,
+                    instanceId,
+                    operationName,
+                    operationId,
+                    FunctionType.Entity.ToString(),
+                    ExtensionVersion,
+                    isReplay);
+
+                this.logger.LogInformation(
+                    "{instanceId}: Function '{functionName} ({functionType})' deleted entity state in '{operationName}' operation {operationId}. State: {state}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}. SequenceNumber: {sequenceNumber}.",
+                    instanceId, functionName, functionType, operationName, operationId, FunctionState.EntityStateDeleted, hubName,
+                    LocalAppName, LocalSlotName, ExtensionVersion, this.sequenceNumber++);
+            }
+        }
+
         public void EntityLockAcquired(
             string hubName,
             string functionName,

--- a/src/WebJobs.Extensions.DurableTask/EtwEventSource.cs
+++ b/src/WebJobs.Extensions.DurableTask/EtwEventSource.cs
@@ -400,6 +400,39 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         {
             this.WriteEvent(224, TaskHub, AppName, SlotName, FunctionName, InstanceId, Reason, FunctionType, ExtensionVersion, IsReplay);
         }
+
+        [Event(225, Level = EventLevel.Informational)]
+        public void EntityStateCreated(
+            string TaskHub,
+            string AppName,
+            string SlotName,
+            string FunctionName,
+            string InstanceId,
+            string OperationName,
+            string OperationId,
+            string FunctionType,
+            string ExtensionVersion,
+            bool IsReplay)
+        {
+            this.WriteEvent(225, TaskHub, AppName, SlotName, FunctionName, InstanceId, OperationName, OperationId, FunctionType, ExtensionVersion, IsReplay);
+        }
+
+        [Event(226, Level = EventLevel.Informational)]
+        public void EntityStateDeleted(
+            string TaskHub,
+            string AppName,
+            string SlotName,
+            string FunctionName,
+            string InstanceId,
+            string OperationName,
+            string OperationId,
+            string FunctionType,
+            string ExtensionVersion,
+            bool IsReplay)
+        {
+            this.WriteEvent(226, TaskHub, AppName, SlotName, FunctionName, InstanceId, OperationName, OperationId, FunctionType, ExtensionVersion, IsReplay);
+        }
+
 #pragma warning restore SA1313 // Parameter names should begin with lower-case letter
     }
 }

--- a/src/WebJobs.Extensions.DurableTask/FunctionState.cs
+++ b/src/WebJobs.Extensions.DurableTask/FunctionState.cs
@@ -18,5 +18,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         LockReleased,
         TimerExpired,
         Rewound,
+        EntityStateCreated,
+        EntityStateDeleted,
     }
 }


### PR DESCRIPTION
Prior to this PR, there were no trace events related specifically to the creation and deletion of entity states.

I have added two trace events to clarify when entity states are created and deleted:
- EntityStateCreated
- EntityStateDeleted

Example:
```
 2021-01-11T09:21:43.3166496-08:00: @functionbasedfaultyentity@8d8ddab5-9934-4509-abe0-631dca054839: Function 'functionbasedfaultyentity (Entity)' deleted entity state in 'Delete' operation 6a73c51f-1b25-57f9-ac44-84e957eba3d6. State: EntityStateDeleted. HubName: DurableEntityCallFaultyEntityV2f23e. AppName: . SlotName: . ExtensionVersion: 2.4.0. SequenceNumber: 558.
```

These events include the name and id of the operation if that information is applicable, i.e. if the creation or deletion can be attributed to an individual operation. If batch processing is used (e.g. for out-of-process execution), then the operation name and id are blank.
 
### Issue describing the changes in this PR

resolves #1108

### Pull request checklist

* [ ] My changes **do not** require documentation changes
* [ ] I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
* [ ] No unit tests are required for tracing


