### PR TITLE
Replace the impl of Syscall.rename and remove Mono.Posix.NETStandard

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/LinuxAppServiceFileLogger.cs
+++ b/src/WebJobs.Extensions.DurableTask/LinuxAppServiceFileLogger.cs
@@ -6,12 +6,9 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
-
-#if !FUNCTIONS_V1
-using Mono.Unix.Native;
-#endif
 
 namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 {
@@ -173,9 +170,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             // Rename current file to older file.
 
 #if !FUNCTIONS_V1
-            Syscall.rename(this.logFilePath, this.archiveFilePath);
+            rename(this.logFilePath, this.archiveFilePath);
 #endif
 
         }
+
+#if !FUNCTIONS_V1
+        [DllImport("libc", SetLastError = true)]
+        private static extern int rename(string oldPath, string newPath);
+#endif
     }
 }

--- a/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
+++ b/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
@@ -70,7 +70,6 @@
     <PackageReference Include="Microsoft.Extensions.Http" Version="2.2.0" />
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.12.2" />
     <PackageReference Include="Microsoft.ApplicationInsights.DependencyCollector" Version="2.12.2" />
-    <PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Mono.Posix.NETStandard was included since Durable Functions v2.3.1, which increased the size of the deployment package by nearly three times.

This is a contribution by @shibayan :) 

And I have verified that this implementation still raises the correct `inotify` signal, so our telemetry pipeline should continue to work with it

### Issue describing the changes in this PR
https://github.com/Azure/azure-functions-durable-extension/issues/1597

resolves #1597 

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [ ] My changes **should not** be added to the release notes for the next release
* [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)


