### PR TITLE
Expose AddDurableTaskFactory methodss to .NET Framework release

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -1,7 +1,7 @@
 <!-- Please put your changes into the appropriate category (or categories) below. -->
 
 ## New Features
-- Exposed IServiceCollection extension methods AddDurableTaskFactory() for net461 releases so classic .NET Framework apps using the .NET Core model of dependency injection can create their own Durable Clients.
+- Exposed IServiceCollection extension methods AddDurableTaskFactory() for net461 releases so classic .NET Framework apps using the .NET Core model of dependency injection can create their own Durable Clients. (#1653)
 
 ## Bug fixes
 - Remove incorrect information from C# docs summary for IDurableEntityClient.ReadEntityStateAsync() regarding states large than 16KB (#1637)

--- a/release_notes.md
+++ b/release_notes.md
@@ -1,11 +1,11 @@
 <!-- Please put your changes into the appropriate category (or categories) below. -->
 
 ## New Features
+- Exposed IServiceCollection extension methods AddDurableTaskFactory() for net461 releases so classic .NET Framework apps using the .NET Core model of dependency injection can create their own Durable Clients.
 
 ## Bug fixes
 - Remove incorrect information from C# docs summary for IDurableEntityClient.ReadEntityStateAsync() regarding states large than 16KB (#1637)
 - Fix a NullReferenceException in IDurableClient.SignalClient() for IDurableClient objects created by the new DurabilityClientFactory (#1644)
-
 
 ## Breaking changes
 

--- a/src/WebJobs.Extensions.DurableTask/DurableTaskJobHostConfigurationExtensions.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskJobHostConfigurationExtensions.cs
@@ -13,8 +13,12 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 #else
+using Microsoft.Azure.WebJobs.Extensions.DurableTask.ContextImplementations;
+using Microsoft.Azure.WebJobs.Extensions.DurableTask.Options;
 using Microsoft.Azure.WebJobs.Host;
 using Microsoft.Azure.WebJobs.Host.Config;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 #endif
 
 namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
@@ -24,36 +28,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
     /// </summary>
     public static class DurableTaskJobHostConfigurationExtensions
     {
-#if !FUNCTIONS_V1
-        /// <summary>
-        /// Adds the Durable Task extension to the provided <see cref="IWebJobsBuilder"/>.
-        /// </summary>
-        /// <param name="builder">The <see cref="IWebJobsBuilder"/> to configure.</param>
-        /// <returns>Returns the provided <see cref="IWebJobsBuilder"/>.</returns>
-        public static IWebJobsBuilder AddDurableTask(this IWebJobsBuilder builder)
-        {
-            if (builder == null)
-            {
-                throw new ArgumentNullException(nameof(builder));
-            }
-
-            var serviceCollection = builder.AddExtension<DurableTaskExtension>()
-                .BindOptions<DurableTaskOptions>()
-                .Services.AddSingleton<IConnectionStringResolver, WebJobsConnectionStringProvider>();
-
-            serviceCollection.TryAddSingleton<IDurableHttpMessageHandlerFactory, DurableHttpMessageHandlerFactory>();
-            serviceCollection.TryAddSingleton<IDurabilityProviderFactory, AzureStorageDurabilityProviderFactory>();
-            serviceCollection.TryAddSingleton<IMessageSerializerSettingsFactory, MessageSerializerSettingsFactory>();
-            serviceCollection.TryAddSingleton<IErrorSerializerSettingsFactory, ErrorSerializerSettingsFactory>();
-            serviceCollection.TryAddSingleton<IApplicationLifetimeWrapper, HostLifecycleService>();
-#if !FUNCTIONS_V1
-            serviceCollection.AddSingleton<ITelemetryActivator, TelemetryActivator>();
-#endif
-            serviceCollection.TryAddSingleton<IDurableClientFactory, DurableClientFactory>();
-
-            return builder;
-        }
-
         /// <summary>
         /// Adds the Durable Task extension to the provided <see cref="IServiceCollection"/>.
         /// </summary>
@@ -86,6 +60,34 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             AddDurableClientFactory(serviceCollection);
             serviceCollection.Configure<DurableClientOptions>(optionsBuilder.Invoke);
             return serviceCollection;
+        }
+
+#if !FUNCTIONS_V1
+        /// <summary>
+        /// Adds the Durable Task extension to the provided <see cref="IWebJobsBuilder"/>.
+        /// </summary>
+        /// <param name="builder">The <see cref="IWebJobsBuilder"/> to configure.</param>
+        /// <returns>Returns the provided <see cref="IWebJobsBuilder"/>.</returns>
+        public static IWebJobsBuilder AddDurableTask(this IWebJobsBuilder builder)
+        {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            var serviceCollection = builder.AddExtension<DurableTaskExtension>()
+                .BindOptions<DurableTaskOptions>()
+                .Services.AddSingleton<IConnectionStringResolver, WebJobsConnectionStringProvider>();
+
+            serviceCollection.TryAddSingleton<IDurableHttpMessageHandlerFactory, DurableHttpMessageHandlerFactory>();
+            serviceCollection.TryAddSingleton<IDurabilityProviderFactory, AzureStorageDurabilityProviderFactory>();
+            serviceCollection.TryAddSingleton<IMessageSerializerSettingsFactory, MessageSerializerSettingsFactory>();
+            serviceCollection.TryAddSingleton<IErrorSerializerSettingsFactory, ErrorSerializerSettingsFactory>();
+            serviceCollection.TryAddSingleton<IApplicationLifetimeWrapper, HostLifecycleService>();
+            serviceCollection.AddSingleton<ITelemetryActivator, TelemetryActivator>();
+            serviceCollection.TryAddSingleton<IDurableClientFactory, DurableClientFactory>();
+
+            return builder;
         }
 
         /// <summary>

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
@@ -517,8 +517,7 @@
         </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableEntityClient.ReadEntityStateAsync``1(Microsoft.Azure.WebJobs.Extensions.DurableTask.EntityId,System.String,System.String)">
             <summary>
-            Tries to read the current state of an entity. Returns default(<typeparamref name="T"/>) if the entity does not
-            exist, or if the JSON-serialized state of the entity is larger than 16KB.
+            Tries to read the current state of an entity. Returns default(<typeparamref name="T"/>) if the entity does not exist.
             </summary>
             <typeparam name="T">The JSON-serializable type of the entity.</typeparam>
             <param name="entityId">The target entity.</param>
@@ -699,7 +698,7 @@
         </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableEntityContext.StartNewOrchestration(System.String,System.Object,System.String)">
             <summary>
-            Schedules a orchestration function named <paramref name="functionName"/> for execution./>.
+            Schedules an orchestration function named <paramref name="functionName"/> for execution./>.
             Any result or exception is ignored (fire and forget).
             </summary>
             <param name="functionName">The name of the orchestrator function to call.</param>
@@ -2071,7 +2070,7 @@
         </member>
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClientAttribute.ExternalClient">
             <summary>
-                Indicate if the client is External from the azure function where orchestrator functions are hosted.
+            Indicate if the client is External from the azure function where orchestrator functions are hosted.
             </summary>
         </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClientAttribute.GetHashCode">
@@ -2423,13 +2422,6 @@
             Extension for registering a Durable Functions configuration with <c>JobHostConfiguration</c>.
             </summary>
         </member>
-        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskJobHostConfigurationExtensions.AddDurableTask(Microsoft.Azure.WebJobs.IWebJobsBuilder)">
-            <summary>
-            Adds the Durable Task extension to the provided <see cref="T:Microsoft.Azure.WebJobs.IWebJobsBuilder"/>.
-            </summary>
-            <param name="builder">The <see cref="T:Microsoft.Azure.WebJobs.IWebJobsBuilder"/> to configure.</param>
-            <returns>Returns the provided <see cref="T:Microsoft.Azure.WebJobs.IWebJobsBuilder"/>.</returns>
-        </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskJobHostConfigurationExtensions.AddDurableClientFactory(Microsoft.Extensions.DependencyInjection.IServiceCollection)">
             <summary>
             Adds the Durable Task extension to the provided <see cref="T:Microsoft.Extensions.DependencyInjection.IServiceCollection"/>.
@@ -2444,6 +2436,13 @@
             <param name="serviceCollection">The <see cref="T:Microsoft.Extensions.DependencyInjection.IServiceCollection"/> to configure.</param>
             <param name="optionsBuilder">Populate default configurations of <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.Options.DurableClientOptions"/> to create Durable Clients.</param>
             <returns>Returns the provided <see cref="T:Microsoft.Extensions.DependencyInjection.IServiceCollection"/>.</returns>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskJobHostConfigurationExtensions.AddDurableTask(Microsoft.Azure.WebJobs.IWebJobsBuilder)">
+            <summary>
+            Adds the Durable Task extension to the provided <see cref="T:Microsoft.Azure.WebJobs.IWebJobsBuilder"/>.
+            </summary>
+            <param name="builder">The <see cref="T:Microsoft.Azure.WebJobs.IWebJobsBuilder"/> to configure.</param>
+            <returns>Returns the provided <see cref="T:Microsoft.Azure.WebJobs.IWebJobsBuilder"/>.</returns>
         </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskJobHostConfigurationExtensions.AddDurableTask(Microsoft.Azure.WebJobs.IWebJobsBuilder,Microsoft.Extensions.Options.IOptions{Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskOptions})">
             <summary>
@@ -2886,13 +2885,14 @@
             that we use to capture their data and log it in Linux App Service plans.
             </summary>
         </member>
-        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.EventSourceListener.#ctor(Microsoft.Azure.WebJobs.Extensions.DurableTask.LinuxAppServiceLogger,System.Boolean)">
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.EventSourceListener.#ctor(Microsoft.Azure.WebJobs.Extensions.DurableTask.LinuxAppServiceLogger,System.Boolean,Microsoft.Azure.WebJobs.Extensions.DurableTask.EndToEndTraceHelper)">
             <summary>
             Create an EventSourceListener to capture and log Durable EventSource
             data in Linux.
             </summary>
             <param name="logger">A LinuxAppService logger configured for the current linux host.</param>
             <param name="enableVerbose">If true, durableTask.Core verbose logs are enabled. The opposite if false.</param>
+            <param name="traceHelper">A tracing client to log exceptions.</param>
         </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.EventSourceListener.OnEventSourceCreated(System.Diagnostics.Tracing.EventSource)">
             <summary>

--- a/test/Common/InterfaceOverloadTests.cs
+++ b/test/Common/InterfaceOverloadTests.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
     /// Tests to make sure that calls to interface methods with closely related overloads
     /// do not change as we add/tweak methods on the interfaces.
     ///
-    /// TODO: Add more tests: https://github.com/Azure/azure-functions-durable-extension/issues/1500
+    /// TODO: Add more tests: https://github.com/Azure/azure-functions-durable-extension/issues/1500.
     /// </summary>
     public class InterfaceOverloadTests
     {


### PR DESCRIPTION
Some customers with .NET Framework apps may be using the
IServiceCollection dependency injection model for their applications, so
these extension methods should be exposed for that scenario.

For a future release, we should expose a simple static method to create
an instance of IDurableClientFactory so .NET Framework apps using other
dependency injection methods can still take advantage of the new
external client work.

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] ~I have added all required tests (Unit tests, E2E tests)~


