### PR TITLE
Backport linux loggging capabilities to V1 extension release

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
@@ -247,11 +247,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// <param name="context">Extension context provided by WebJobs.</param>
         void IExtensionConfigProvider.Initialize(ExtensionConfigContext context)
         {
-#if !FUNCTIONS_V1
-            // .NET461 is not supported in linux, so this is conditionally compiled
             // We initialize linux logging early on in case any initialization steps below were to trigger a log event.
             this.InitializeLinuxLogging();
-#endif
 
             ConfigureLoaderHooks();
 

--- a/src/WebJobs.Extensions.DurableTask/EventSourceListener.cs
+++ b/src/WebJobs.Extensions.DurableTask/EventSourceListener.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Diagnostics.Tracing;
-using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 {

--- a/src/WebJobs.Extensions.DurableTask/LinuxAppServiceFileLogger.cs
+++ b/src/WebJobs.Extensions.DurableTask/LinuxAppServiceFileLogger.cs
@@ -168,17 +168,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         private void RollFiles()
         {
             // Rename current file to older file.
-#if !FUNCTIONS_V1
             rename(this.logFilePath, this.archiveFilePath);
-#endif
-
         }
 
-#if !FUNCTIONS_V1
         [DllImport("libc", SetLastError = true)]
 #pragma warning disable SA1300 // Element should begin with upper-case letter
         private static extern int rename(string oldPath, string newPath);
 #pragma warning restore SA1300 // Element should begin with upper-case letter
-#endif
     }
 }

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net461.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net461.xml
@@ -517,8 +517,7 @@
         </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableEntityClient.ReadEntityStateAsync``1(Microsoft.Azure.WebJobs.Extensions.DurableTask.EntityId,System.String,System.String)">
             <summary>
-            Tries to read the current state of an entity. Returns default(<typeparamref name="T"/>) if the entity does not
-            exist, or if the JSON-serialized state of the entity is larger than 16KB.
+            Tries to read the current state of an entity. Returns default(<typeparamref name="T"/>) if the entity does not exist.
             </summary>
             <typeparam name="T">The JSON-serializable type of the entity.</typeparam>
             <param name="entityId">The target entity.</param>
@@ -694,7 +693,7 @@
         </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableEntityContext.StartNewOrchestration(System.String,System.Object,System.String)">
             <summary>
-            Schedules a orchestration function named <paramref name="functionName"/> for execution./>.
+            Schedules an orchestration function named <paramref name="functionName"/> for execution./>.
             Any result or exception is ignored (fire and forget).
             </summary>
             <param name="functionName">The name of the orchestrator function to call.</param>
@@ -1864,7 +1863,7 @@
         </member>
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClientAttribute.ExternalClient">
             <summary>
-                Indicate if the client is External from the azure function where orchestrator functions are hosted.
+            Indicate if the client is External from the azure function where orchestrator functions are hosted.
             </summary>
         </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClientAttribute.GetHashCode">
@@ -2225,6 +2224,21 @@
             <summary>
             Extension for registering a Durable Functions configuration with <c>JobHostConfiguration</c>.
             </summary>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskJobHostConfigurationExtensions.AddDurableClientFactory(Microsoft.Extensions.DependencyInjection.IServiceCollection)">
+            <summary>
+            Adds the Durable Task extension to the provided <see cref="T:Microsoft.Extensions.DependencyInjection.IServiceCollection"/>.
+            </summary>
+            <param name="serviceCollection">The <see cref="T:Microsoft.Extensions.DependencyInjection.IServiceCollection"/> to configure.</param>
+            <returns>Returns the provided <see cref="T:Microsoft.Extensions.DependencyInjection.IServiceCollection"/>.</returns>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskJobHostConfigurationExtensions.AddDurableClientFactory(Microsoft.Extensions.DependencyInjection.IServiceCollection,System.Action{Microsoft.Azure.WebJobs.Extensions.DurableTask.Options.DurableClientOptions})">
+            <summary>
+            Adds the Durable Task extension to the provided <see cref="T:Microsoft.Extensions.DependencyInjection.IServiceCollection"/>.
+            </summary>
+            <param name="serviceCollection">The <see cref="T:Microsoft.Extensions.DependencyInjection.IServiceCollection"/> to configure.</param>
+            <param name="optionsBuilder">Populate default configurations of <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.Options.DurableClientOptions"/> to create Durable Clients.</param>
+            <returns>Returns the provided <see cref="T:Microsoft.Extensions.DependencyInjection.IServiceCollection"/>.</returns>
         </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskJobHostConfigurationExtensions.UseDurableTask(Microsoft.Azure.WebJobs.JobHostConfiguration,Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension)">
             <summary>
@@ -2658,13 +2672,14 @@
             that we use to capture their data and log it in Linux App Service plans.
             </summary>
         </member>
-        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.EventSourceListener.#ctor(Microsoft.Azure.WebJobs.Extensions.DurableTask.LinuxAppServiceLogger,System.Boolean)">
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.EventSourceListener.#ctor(Microsoft.Azure.WebJobs.Extensions.DurableTask.LinuxAppServiceLogger,System.Boolean,Microsoft.Azure.WebJobs.Extensions.DurableTask.EndToEndTraceHelper)">
             <summary>
             Create an EventSourceListener to capture and log Durable EventSource
             data in Linux.
             </summary>
             <param name="logger">A LinuxAppService logger configured for the current linux host.</param>
             <param name="enableVerbose">If true, durableTask.Core verbose logs are enabled. The opposite if false.</param>
+            <param name="traceHelper">A tracing client to log exceptions.</param>
         </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.EventSourceListener.OnEventSourceCreated(System.Diagnostics.Tracing.EventSource)">
             <summary>

--- a/test/Common/DurableTaskEndToEndTests.cs
+++ b/test/Common/DurableTaskEndToEndTests.cs
@@ -223,7 +223,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             }
         }
 
-#if !FUNCTIONS_V1
         /// <summary>
         /// By simulating the appropiate enviorment variables for Linux Consumption,
         /// this test checks that we are writing our JSON logs to the console. It does not
@@ -687,7 +686,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             // To ensure other tests generate the path
             File.Delete(LinuxAppServiceLogger.LoggingPath);
         }*/
-#endif
 
         /// <summary>
         /// End-to-end test which runs a simple orchestrator function that calls a single activity function.


### PR DESCRIPTION
Adds linux logging to V1 release

### Pull request checklist

* [ ] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)


