### PR TITLE
Fix OOP issue where context API exceptions are getting ignored

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/Listener/OutOfProcOrchestrationShim.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/OutOfProcOrchestrationShim.cs
@@ -115,15 +115,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             foreach (AsyncAction[] actionSet in actions)
             {
                 var tasks = new List<Task>(actions.Length);
-                DurableOrchestrationContext ctx = this.context as DurableOrchestrationContext;
+                var ctx = this.context as DurableOrchestrationContext;
 
                 // An actionSet represents all actions that were scheduled within that execution.
                 foreach (AsyncAction action in actionSet)
                 {
+                    Task newTask = null;
                     switch (action.ActionType)
                     {
                         case AsyncActionType.CallActivity:
-                            tasks.Add(this.context.CallActivityAsync(action.FunctionName, action.Input));
+                            newTask = this.context.CallActivityAsync(action.FunctionName, action.Input);
                             break;
                         case AsyncActionType.CreateTimer:
                             using (var cts = new CancellationTokenSource())
@@ -133,7 +134,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                                     ctx.ThrowIfInvalidTimerLengthForStorageProvider(action.FireAt);
                                 }
 
-                                tasks.Add(this.context.CreateTimer(action.FireAt, cts.Token));
+                                newTask = this.context.CreateTimer(action.FireAt, cts.Token);
 
                                 if (action.IsCanceled)
                                 {
@@ -143,18 +144,18 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
                             break;
                         case AsyncActionType.CallActivityWithRetry:
-                            tasks.Add(this.context.CallActivityWithRetryAsync(action.FunctionName, action.RetryOptions, action.Input));
+                            newTask = this.context.CallActivityWithRetryAsync(action.FunctionName, action.RetryOptions, action.Input);
                             break;
                         case AsyncActionType.CallSubOrchestrator:
-                            tasks.Add(this.context.CallSubOrchestratorAsync(action.FunctionName, action.InstanceId, action.Input));
+                            newTask = this.context.CallSubOrchestratorAsync(action.FunctionName, action.InstanceId, action.Input);
                             break;
                         case AsyncActionType.CallSubOrchestratorWithRetry:
-                            tasks.Add(this.context.CallSubOrchestratorWithRetryAsync(action.FunctionName, action.RetryOptions, action.InstanceId, action.Input));
+                            newTask = this.context.CallSubOrchestratorWithRetryAsync(action.FunctionName, action.RetryOptions, action.InstanceId, action.Input);
                             break;
                         case AsyncActionType.CallEntity:
                             {
                                 var entityId = EntityId.GetEntityIdFromSchedulerId(action.InstanceId);
-                                tasks.Add(this.context.CallEntityAsync(entityId, action.EntityOperation, action.Input));
+                                newTask = this.context.CallEntityAsync(entityId, action.EntityOperation, action.Input);
                                 break;
                             }
 
@@ -178,13 +179,25 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                             this.context.ContinueAsNew(action.Input);
                             break;
                         case AsyncActionType.WaitForExternalEvent:
-                            tasks.Add(this.context.WaitForExternalEvent<object>(action.ExternalEventName));
+                            newTask = this.context.WaitForExternalEvent<object>(action.ExternalEventName);
                             break;
                         case AsyncActionType.CallHttp:
-                            tasks.Add(this.context.CallHttpAsync(action.HttpRequest));
+                            newTask = this.context.CallHttpAsync(action.HttpRequest);
                             break;
                         default:
                             break;
+                    }
+
+                    if (newTask != null)
+                    {
+                        // Check to see if the context API call failed e.g. because the caller tried to schedule a function that doesn't exist.
+                        if (newTask.IsFaulted)
+                        {
+                            // Awaiting a faulted task will cause the exception to be thrown.
+                            await newTask;
+                        }
+
+                        tasks.Add(newTask);
                     }
                 }
 

--- a/src/WebJobs.Extensions.DurableTask/Listener/TaskOrchestrationShim.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/TaskOrchestrationShim.cs
@@ -7,7 +7,6 @@ using System.Threading.Tasks;
 using DurableTask.Core;
 using DurableTask.Core.Common;
 using DurableTask.Core.Exceptions;
-using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 {


### PR DESCRIPTION
### Issue describing the changes in this PR
If an out-of-proc orchestration tries to call an activity that doesn't exist, the call will silently fail in the Durable extension. The result is the orchestration will hang indefinitely waiting for the activity to complete.

The issue is actually more broad than this - any exception thrown by the orchestration context object will be ignored with no tracing or other indication of a failure.

This PR fixes this issue by explicitly checking for exceptions in the out-of-proc shim and making sure the exception gets properly raised. The new result is that the orchestration in my example case will fail with a very clear error message.

```
[2021-02-04T18:26:35.489] Executing 'Functions.DurableFunctionsHttpStart1' (Reason='This function was programmatically called via the host APIs.', Id=26c6be14-9dea-43fa-b9e1-be1a3ef1666e)
[2021-02-04T18:26:35.770] Started orchestration with ID = '2afca7b8df5040e8926811a2e7c79f78'.
[2021-02-04T18:26:35.775] Executed 'Functions.DurableFunctionsHttpStart1' (Succeeded, Id=26c6be14-9dea-43fa-b9e1-be1a3ef1666e, Duration=294ms)
[2021-02-04T18:26:35.804] Executing 'Functions.DurableFunctionsOrchestrator1' (Reason='(null)', Id=ecd4be03-297a-42f7-9633-efe2776cb515)
[2021-02-04T18:26:35.855] 2afca7b8df5040e8926811a2e7c79f78: Function 'DurableFunctionsOrchestrator1 (Orchestrator)' failed with an error. Reason: System.ArgumentException: The function 'Hello' doesn't exist, is disabled, or is not an activity function. Additional info: The following are the known activity functions: 'DurableActivity1'.
[2021-02-04T18:26:35.856]    at Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.ThrowIfFunctionDoesNotExist(String name, FunctionType functionType) in C:\GitHub\azure-functions-durable-extension\src\WebJobs.Extensions.DurableTask\DurableTaskExtension.cs:line 1060
[2021-02-04T18:26:35.857]    at Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableOrchestrationContext.CallDurableTaskFunctionAsync[TResult](String functionName, FunctionType functionType, Boolean oneWay, String instanceId, String operation, RetryOptions retryOptions, Object input, Nullable`1 scheduledTimeUtc) in C:\GitHub\azure-functions-durable-extension\src\WebJobs.Extensions.DurableTask\ContextImplementations\DurableOrchestrationContext.cs:line 522
[2021-02-04T18:26:35.859]    at Microsoft.Azure.WebJobs.Extensions.DurableTask.OutOfProcOrchestrationShim.ProcessAsyncActions(AsyncAction[][] actions) in C:\GitHub\azure-functions-durable-extension\src\WebJobs.Extensions.DurableTask\Listener\OutOfProcOrchestrationShim.cs:line 197
[2021-02-04T18:26:35.860]    at Microsoft.Azure.WebJobs.Extensions.DurableTask.OutOfProcOrchestrationShim.ScheduleDurableTaskEvents(OrchestrationInvocationResult result) in C:\GitHub\azure-functions-durable-extension\src\WebJobs.Extensions.DurableTask\Listener\OutOfProcOrchestrationShim.cs:line 87
[2021-02-04T18:26:35.862]    at Microsoft.Azure.WebJobs.Extensions.DurableTask.OutOfProcOrchestrationShim.HandleDurableTaskReplay(OrchestrationInvocationResult executionJson) in C:\GitHub\azure-functions-durable-extension\src\WebJobs.Extensions.DurableTask\Listener\OutOfProcOrchestrationShim.cs:line 51
[2021-02-04T18:26:35.863]    at Microsoft.Azure.WebJobs.Extensions.DurableTask.TaskOrchestrationShim.InvokeUserCodeAndHandleResults(RegisteredFunctionInfo orchestratorInfo, OrchestrationContext innerContext) in C:\GitHub\azure-functions-durable-extension\src\WebJobs.Extensions.DurableTask\Listener\TaskOrchestrationShim.cs:line 155. IsReplay: False. State: Failed. HubName: SampleHubVS. AppName: Sample-Hub-VS. SlotName: . ExtensionVersion: 2.4.1. SequenceNumber: 8. TaskEventId: -1
[2021-02-04T18:26:35.871] Executed 'Functions.DurableFunctionsOrchestrator1' (Failed, Id=ecd4be03-297a-42f7-9633-efe2776cb515, Duration=66ms)
[2021-02-04T18:26:35.873] System.Private.CoreLib: Exception while executing function: Functions.DurableFunctionsOrchestrator1. System.Private.CoreLib: Orchestrator function 'DurableFunctionsOrchestrator1' failed: The function 'Hello' doesn't exist, is disabled, or is not an activity function. Additional info: The following are the known activity functions: 'DurableActivity1'.
```

Resolves https://github.com/Azure/azure-functions-durable-js/issues/197
Resolves https://github.com/Azure/azure-functions-durable-python/issues/132

### Pull request checklist

* [x] My changes **do not** require documentation changes
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)
