### PR TITLE
Convert scheduledTimeUtc to UTC in SignalEntityAsync

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableClient.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableClient.cs
@@ -297,6 +297,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 throw new ArgumentNullException(nameof(operationName));
             }
 
+            if (scheduledTimeUtc.HasValue)
+            {
+                scheduledTimeUtc = scheduledTimeUtc.Value.ToUniversalTime();
+            }
+
             if (this.ClientReferencesCurrentApp(durableClient))
             {
                 this.config.ThrowIfFunctionDoesNotExist(entityId.EntityName, FunctionType.Entity);

--- a/test/Common/DurableTaskEndToEndTests.cs
+++ b/test/Common/DurableTaskEndToEndTests.cs
@@ -3442,9 +3442,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         /// </summary>
         [Theory]
         [Trait("Category", PlatformSpecificHelpers.TestCategory)]
-        [InlineData(true)]
-        [InlineData(false)]
-        public async Task DurableEntity_ScheduledSignal(bool extendedSessions)
+        [InlineData(true, true)]
+        [InlineData(false, true)]
+        [InlineData(true, false)]
+        [InlineData(false, false)]
+        public async Task DurableEntity_ScheduledSignal(bool extendedSessions, bool useUtc)
         {
             using (var host = TestHelpers.GetJobHost(
                 this.loggerProvider,
@@ -3459,7 +3461,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 // Wait 8 seconds to account for time to grab ownership lease.
                 await Task.Delay(8000);
 
-                var now = DateTime.UtcNow;
+                var now = useUtc ? DateTime.UtcNow : DateTime.Now;
 
                 await client.SignalEntity(this.output, now + TimeSpan.FromSeconds(4), "delayed", null);
                 await client.SignalEntity(this.output, "immediate", null);


### PR DESCRIPTION
Previously, passing a non-UTC time instead of the expected UTC caused problems in the backend.
To fix this, we call `ToUniversalTime()` which is a no-op if the time is already in UTC, or converts it to UTC if not.

### Issue describing the changes in this PR

resolves #1689

### Pull request checklist

* [x] My changes **do not** require documentation changes
* [x] My changes **should not** be added to the release notes for the next release
* [x] My changes **do not** need to be backported to a previous version
* [x] I have added all required tests


