### PR TITLE
Adding Storage Backend Selection in host.json

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -1,1 +1,3 @@
 
+## New Features
+- Added support to select a storage backend provider when multiple are installed (#1702): Select which storage backend to use by setting the `type` field under `durableTask/storageProvider` in host.json. If this field isn't set, then the storage backend will default to using Azure Storage.

--- a/src/WebJobs.Extensions.DurableTask/AzureStorageDurabilityProviderFactory.cs
+++ b/src/WebJobs.Extensions.DurableTask/AzureStorageDurabilityProviderFactory.cs
@@ -41,6 +41,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             this.defaultConnectionName = this.azureStorageOptions.ConnectionStringName ?? ConnectionStringNames.Storage;
         }
 
+        public string Name => "Azure Storage";
+
         internal string GetDefaultStorageConnectionString()
         {
             return this.connectionStringResolver.Resolve(this.defaultConnectionName);

--- a/src/WebJobs.Extensions.DurableTask/AzureStorageDurabilityProviderFactory.cs
+++ b/src/WebJobs.Extensions.DurableTask/AzureStorageDurabilityProviderFactory.cs
@@ -11,6 +11,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 {
     internal class AzureStorageDurabilityProviderFactory : IDurabilityProviderFactory
     {
+        internal const string ProviderName = "AzureStorage";
+
         private readonly DurableTaskOptions options;
         private readonly AzureStorageOptions azureStorageOptions;
         private readonly IConnectionStringResolver connectionStringResolver;
@@ -41,7 +43,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             this.defaultConnectionName = this.azureStorageOptions.ConnectionStringName ?? ConnectionStringNames.Storage;
         }
 
-        public string Name => "AzureStorage";
+        public string Name => ProviderName;
 
         internal string GetDefaultStorageConnectionString()
         {

--- a/src/WebJobs.Extensions.DurableTask/AzureStorageDurabilityProviderFactory.cs
+++ b/src/WebJobs.Extensions.DurableTask/AzureStorageDurabilityProviderFactory.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             this.defaultConnectionName = this.azureStorageOptions.ConnectionStringName ?? ConnectionStringNames.Storage;
         }
 
-        public string Name => "Azure Storage";
+        public string Name => "AzureStorage";
 
         internal string GetDefaultStorageConnectionString()
         {

--- a/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
@@ -187,7 +187,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             IPlatformInformationService platformInformationService)
 #pragma warning restore CS0612 // Type or member is obsolete
 
-            : this(options, loggerFactory, nameResolver, orchestrationServiceFactory, shutdownNotification, durableHttpMessageHandlerFactory)
+            : this(options, loggerFactory, nameResolver, orchestrationServiceFactories, shutdownNotification, durableHttpMessageHandlerFactory)
         {
             this.connectionStringResolver = connectionStringResolver;
             this.platformInformationService = platformInformationService;

--- a/src/WebJobs.Extensions.DurableTask/DurableTaskJobHostConfigurationExtensions.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskJobHostConfigurationExtensions.cs
@@ -80,7 +80,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 .Services.AddSingleton<IConnectionStringResolver, WebJobsConnectionStringProvider>();
 
             serviceCollection.TryAddSingleton<IDurableHttpMessageHandlerFactory, DurableHttpMessageHandlerFactory>();
-            serviceCollection.TryAddSingleton<IDurabilityProviderFactory, AzureStorageDurabilityProviderFactory>();
+            serviceCollection.AddSingleton<IDurabilityProviderFactory, AzureStorageDurabilityProviderFactory>();
             serviceCollection.TryAddSingleton<IMessageSerializerSettingsFactory, MessageSerializerSettingsFactory>();
             serviceCollection.TryAddSingleton<IErrorSerializerSettingsFactory, ErrorSerializerSettingsFactory>();
             serviceCollection.TryAddSingleton<IApplicationLifetimeWrapper, HostLifecycleService>();

--- a/src/WebJobs.Extensions.DurableTask/IDurabilityProviderFactory.cs
+++ b/src/WebJobs.Extensions.DurableTask/IDurabilityProviderFactory.cs
@@ -9,6 +9,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
     public interface IDurabilityProviderFactory
     {
         /// <summary>
+        /// Specifies the Durability Provider Factory name.
+        /// </summary>
+        string Name { get; }
+
+        /// <summary>
         /// Creates or retrieves a durability provider to be used throughout the extension.
         /// </summary>
         /// <returns>An durability provider to be used by the Durable Task Extension.</returns>

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net461.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net461.xml
@@ -2111,14 +2111,14 @@
             Obsolete. Please use an alternate constructor overload.
             </summary>
         </member>
-        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.#ctor(Microsoft.Extensions.Options.IOptions{Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskOptions},Microsoft.Extensions.Logging.ILoggerFactory,Microsoft.Azure.WebJobs.INameResolver,Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurabilityProviderFactory,Microsoft.Azure.WebJobs.Extensions.DurableTask.IApplicationLifetimeWrapper,Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableHttpMessageHandlerFactory,Microsoft.Azure.WebJobs.Extensions.DurableTask.ILifeCycleNotificationHelper,Microsoft.Azure.WebJobs.Extensions.DurableTask.IMessageSerializerSettingsFactory,Microsoft.Azure.WebJobs.Extensions.DurableTask.IErrorSerializerSettingsFactory)">
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.#ctor(Microsoft.Extensions.Options.IOptions{Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskOptions},Microsoft.Extensions.Logging.ILoggerFactory,Microsoft.Azure.WebJobs.INameResolver,System.Collections.Generic.IEnumerable{Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurabilityProviderFactory},Microsoft.Azure.WebJobs.Extensions.DurableTask.IApplicationLifetimeWrapper,Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableHttpMessageHandlerFactory,Microsoft.Azure.WebJobs.Extensions.DurableTask.ILifeCycleNotificationHelper,Microsoft.Azure.WebJobs.Extensions.DurableTask.IMessageSerializerSettingsFactory,Microsoft.Azure.WebJobs.Extensions.DurableTask.IErrorSerializerSettingsFactory)">
             <summary>
             Initializes a new instance of the <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension"/>.
             </summary>
             <param name="options">The configuration options for this extension.</param>
             <param name="loggerFactory">The logger factory used for extension-specific logging and orchestration tracking.</param>
             <param name="nameResolver">The name resolver to use for looking up application settings.</param>
-            <param name="orchestrationServiceFactory">The factory used to create orchestration service based on the configured storage provider.</param>
+            <param name="orchestrationServiceFactories">The factories used to create orchestration service based on the configured storage provider.</param>
             <param name="durableHttpMessageHandlerFactory">The HTTP message handler that handles HTTP requests and HTTP responses.</param>
             <param name="hostLifetimeService">The host shutdown notification service for detecting and reacting to host shutdowns.</param>
             <param name="lifeCycleNotificationHelper">The lifecycle notification helper used for custom orchestration tracking.</param>
@@ -2923,6 +2923,11 @@
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurabilityProviderFactory">
             <summary>
             Interface defining methods to build instances of <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurabilityProvider"/>.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurabilityProviderFactory.Name">
+            <summary>
+            Specifies the Durability Provider Factory name.
             </summary>
         </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurabilityProviderFactory.GetDurabilityProvider">

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
@@ -2313,14 +2313,14 @@
             Configuration for the Durable Functions extension.
             </summary>
         </member>
-        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.#ctor(Microsoft.Extensions.Options.IOptions{Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskOptions},Microsoft.Extensions.Logging.ILoggerFactory,Microsoft.Azure.WebJobs.INameResolver,Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurabilityProviderFactory,Microsoft.Azure.WebJobs.Extensions.DurableTask.IApplicationLifetimeWrapper,Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableHttpMessageHandlerFactory,Microsoft.Azure.WebJobs.Extensions.DurableTask.ILifeCycleNotificationHelper,Microsoft.Azure.WebJobs.Extensions.DurableTask.IMessageSerializerSettingsFactory,Microsoft.Azure.WebJobs.Extensions.DurableTask.IErrorSerializerSettingsFactory,Microsoft.Azure.WebJobs.Extensions.DurableTask.Correlation.ITelemetryActivator)">
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.#ctor(Microsoft.Extensions.Options.IOptions{Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskOptions},Microsoft.Extensions.Logging.ILoggerFactory,Microsoft.Azure.WebJobs.INameResolver,System.Collections.Generic.IEnumerable{Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurabilityProviderFactory},Microsoft.Azure.WebJobs.Extensions.DurableTask.IApplicationLifetimeWrapper,Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableHttpMessageHandlerFactory,Microsoft.Azure.WebJobs.Extensions.DurableTask.ILifeCycleNotificationHelper,Microsoft.Azure.WebJobs.Extensions.DurableTask.IMessageSerializerSettingsFactory,Microsoft.Azure.WebJobs.Extensions.DurableTask.IErrorSerializerSettingsFactory,Microsoft.Azure.WebJobs.Extensions.DurableTask.Correlation.ITelemetryActivator)">
             <summary>
             Initializes a new instance of the <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension"/>.
             </summary>
             <param name="options">The configuration options for this extension.</param>
             <param name="loggerFactory">The logger factory used for extension-specific logging and orchestration tracking.</param>
             <param name="nameResolver">The name resolver to use for looking up application settings.</param>
-            <param name="orchestrationServiceFactory">The factory used to create orchestration service based on the configured storage provider.</param>
+            <param name="orchestrationServiceFactories">The factories used to create orchestration service based on the configured storage provider.</param>
             <param name="durableHttpMessageHandlerFactory">The HTTP message handler that handles HTTP requests and HTTP responses.</param>
             <param name="hostLifetimeService">The host shutdown notification service for detecting and reacting to host shutdowns.</param>
             <param name="lifeCycleNotificationHelper">The lifecycle notification helper used for custom orchestration tracking.</param>
@@ -3136,6 +3136,11 @@
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurabilityProviderFactory">
             <summary>
             Interface defining methods to build instances of <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurabilityProvider"/>.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurabilityProviderFactory.Name">
+            <summary>
+            Specifies the Durability Provider Factory name.
             </summary>
         </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurabilityProviderFactory.GetDurabilityProvider">

--- a/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
+++ b/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
@@ -6,8 +6,8 @@
     <RootNamespace>Microsoft.Azure.WebJobs.Extensions.DurableTask</RootNamespace>
     <MajorVersion>2</MajorVersion>
     <MinorVersion>4</MinorVersion>
-    <PatchVersion>4</PatchVersion>
-    <Version>$(MajorVersion).$(MinorVersion).$(PatchVersion)-test</Version>
+    <PatchVersion>1</PatchVersion>
+    <Version>$(MajorVersion).$(MinorVersion).$(PatchVersion)</Version>
     <FileVersion>$(MajorVersion).$(MinorVersion).$(PatchVersion)</FileVersion>
     <AssemblyVersion>$(MajorVersion).0.0.0</AssemblyVersion>
     <Company>Microsoft Corporation</Company>

--- a/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
+++ b/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
@@ -6,8 +6,8 @@
     <RootNamespace>Microsoft.Azure.WebJobs.Extensions.DurableTask</RootNamespace>
     <MajorVersion>2</MajorVersion>
     <MinorVersion>4</MinorVersion>
-    <PatchVersion>1</PatchVersion>
-    <Version>$(MajorVersion).$(MinorVersion).$(PatchVersion)</Version>
+    <PatchVersion>4</PatchVersion>
+    <Version>$(MajorVersion).$(MinorVersion).$(PatchVersion)-test</Version>
     <FileVersion>$(MajorVersion).$(MinorVersion).$(PatchVersion)</FileVersion>
     <AssemblyVersion>$(MajorVersion).0.0.0</AssemblyVersion>
     <Company>Microsoft Corporation</Company>

--- a/test/Common/DurableClientBaseTests.cs
+++ b/test/Common/DurableClientBaseTests.cs
@@ -335,7 +335,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 wrappedOptions,
                 new LoggerFactory(),
                 nameResolver,
-                serviceFactory,
+                new[] { serviceFactory }.ToList(),
                 new TestHostShutdownNotificationService(),
                 new DurableHttpMessageHandlerFactory());
         }

--- a/test/Common/DurableClientBaseTests.cs
+++ b/test/Common/DurableClientBaseTests.cs
@@ -335,7 +335,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 wrappedOptions,
                 new LoggerFactory(),
                 nameResolver,
-                new[] { serviceFactory }.ToList(),
+                new[] { serviceFactory },
                 new TestHostShutdownNotificationService(),
                 new DurableHttpMessageHandlerFactory());
         }

--- a/test/Common/DurableTaskLifeCycleNotificationTest.cs
+++ b/test/Common/DurableTaskLifeCycleNotificationTest.cs
@@ -1243,15 +1243,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
             var wrappedOptions = new OptionsWrapper<DurableTaskOptions>(options);
             var connectionStringResolver = new TestConnectionStringResolver();
+            var serviceFactory = new AzureStorageDurabilityProviderFactory(
+                    wrappedOptions,
+                    connectionStringResolver,
+                    mockNameResolver.Object,
+                    NullLoggerFactory.Instance);
             var extension = new DurableTaskExtension(
                 wrappedOptions,
                 new LoggerFactory(),
                 mockNameResolver.Object,
-                new AzureStorageDurabilityProviderFactory(
-                    wrappedOptions,
-                    connectionStringResolver,
-                    mockNameResolver.Object,
-                    NullLoggerFactory.Instance),
+                new[] { serviceFactory }.ToList(),
                 new TestHostShutdownNotificationService());
 
             var eventGridLifeCycleNotification = (EventGridLifeCycleNotificationHelper)extension.LifeCycleNotificationHelper;
@@ -1289,15 +1290,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
             var wrappedOptions = new OptionsWrapper<DurableTaskOptions>(options);
             var nameResolver = new SimpleNameResolver();
+            var serviceFactory = new AzureStorageDurabilityProviderFactory(
+                    wrappedOptions,
+                    new TestConnectionStringResolver(),
+                    nameResolver,
+                    NullLoggerFactory.Instance);
             var extension = new DurableTaskExtension(
                 wrappedOptions,
                 new LoggerFactory(),
                 nameResolver,
-                new AzureStorageDurabilityProviderFactory(
-                    wrappedOptions,
-                    new TestConnectionStringResolver(),
-                    nameResolver,
-                    NullLoggerFactory.Instance),
+                new[] { serviceFactory }.ToList(),
                 new TestHostShutdownNotificationService());
 
             var lifeCycleNotificationHelper = extension.LifeCycleNotificationHelper;
@@ -1317,15 +1319,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
             var wrappedOptions = new OptionsWrapper<DurableTaskOptions>(options);
             var nameResolver = new SimpleNameResolver();
+            var serviceFactory = new AzureStorageDurabilityProviderFactory(
+                    wrappedOptions,
+                    new TestConnectionStringResolver(),
+                    nameResolver,
+                    NullLoggerFactory.Instance);
             var extension = new DurableTaskExtension(
                 wrappedOptions,
                 new LoggerFactory(),
                 nameResolver,
-                new AzureStorageDurabilityProviderFactory(
-                    wrappedOptions,
-                    new TestConnectionStringResolver(),
-                    nameResolver,
-                    NullLoggerFactory.Instance),
+                new[] { serviceFactory }.ToList(),
                 new TestHostShutdownNotificationService());
 
             int callCount = 0;

--- a/test/Common/DurableTaskLifeCycleNotificationTest.cs
+++ b/test/Common/DurableTaskLifeCycleNotificationTest.cs
@@ -1252,7 +1252,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 wrappedOptions,
                 new LoggerFactory(),
                 mockNameResolver.Object,
-                new[] { serviceFactory }.ToList(),
+                new[] { serviceFactory },
                 new TestHostShutdownNotificationService());
 
             var eventGridLifeCycleNotification = (EventGridLifeCycleNotificationHelper)extension.LifeCycleNotificationHelper;
@@ -1291,15 +1291,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             var wrappedOptions = new OptionsWrapper<DurableTaskOptions>(options);
             var nameResolver = new SimpleNameResolver();
             var serviceFactory = new AzureStorageDurabilityProviderFactory(
-                    wrappedOptions,
-                    new TestConnectionStringResolver(),
-                    nameResolver,
-                    NullLoggerFactory.Instance);
+                wrappedOptions,
+                new TestConnectionStringResolver(),
+                nameResolver,
+                NullLoggerFactory.Instance);
             var extension = new DurableTaskExtension(
                 wrappedOptions,
                 new LoggerFactory(),
                 nameResolver,
-                new[] { serviceFactory }.ToList(),
+                new[] { serviceFactory },
                 new TestHostShutdownNotificationService());
 
             var lifeCycleNotificationHelper = extension.LifeCycleNotificationHelper;
@@ -1328,7 +1328,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 wrappedOptions,
                 new LoggerFactory(),
                 nameResolver,
-                new[] { serviceFactory }.ToList(),
+                new[] { serviceFactory },
                 new TestHostShutdownNotificationService());
 
             int callCount = 0;

--- a/test/Common/HttpApiHandlerTests.cs
+++ b/test/Common/HttpApiHandlerTests.cs
@@ -1396,7 +1396,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                         new TestConnectionStringResolver(),
                         TestHelpers.GetTestNameResolver(),
                         NullLoggerFactory.Instance),
-                    }.ToList(),
+                    },
                     new TestHostShutdownNotificationService(),
                     new DurableHttpMessageHandlerFactory())
             {

--- a/test/Common/HttpApiHandlerTests.cs
+++ b/test/Common/HttpApiHandlerTests.cs
@@ -1389,11 +1389,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                     new OptionsWrapper<DurableTaskOptions>(options),
                     new LoggerFactory(),
                     TestHelpers.GetTestNameResolver(),
-                    new AzureStorageDurabilityProviderFactory(
+                    new[]
+                    {
+                        new AzureStorageDurabilityProviderFactory(
                         new OptionsWrapper<DurableTaskOptions>(options),
                         new TestConnectionStringResolver(),
                         TestHelpers.GetTestNameResolver(),
                         NullLoggerFactory.Instance),
+                    }.ToList(),
                     new TestHostShutdownNotificationService(),
                     new DurableHttpMessageHandlerFactory())
             {

--- a/test/Common/TestHelpers.cs
+++ b/test/Common/TestHelpers.cs
@@ -20,7 +20,6 @@ using Microsoft.WindowsAzure.Storage.Queue;
 using Microsoft.WindowsAzure.Storage.Table;
 using Xunit;
 using Xunit.Abstractions;
-using static Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests.PlatformSpecificHelpers;
 
 namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 {
@@ -197,8 +196,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
 #if !FUNCTIONS_V1
         public static ITestHost GetJobHostWithMultipleDurabilityProviders(
-        DurableTaskOptions options = null,
-        IEnumerable<IDurabilityProviderFactory> durabilityProviderFactories = null)
+            DurableTaskOptions options = null,
+            IEnumerable<IDurabilityProviderFactory> durabilityProviderFactories = null)
         {
             if (options == null)
             {
@@ -216,7 +215,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         {
             var optionsWrapper = new OptionsWrapper<DurableTaskOptions>(durableTaskOptions);
 
-            return CreateJobHostWithMultipleDurabilityProviders(
+            return PlatformSpecificHelpers.CreateJobHostWithMultipleDurabilityProviders(
                 optionsWrapper,
                 durabilityProviderFactories);
         }

--- a/test/Common/TestHelpers.cs
+++ b/test/Common/TestHelpers.cs
@@ -20,6 +20,7 @@ using Microsoft.WindowsAzure.Storage.Queue;
 using Microsoft.WindowsAzure.Storage.Table;
 using Xunit;
 using Xunit.Abstractions;
+using static Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests.PlatformSpecificHelpers;
 
 namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 {
@@ -193,6 +194,33 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 serializerSettingsFactory: serializerSettings,
                 onSend: onSend);
         }
+
+#if !FUNCTIONS_V1
+        public static ITestHost GetJobHostWithMultipleDurabilityProviders(
+        DurableTaskOptions options = null,
+        IEnumerable<IDurabilityProviderFactory> durabilityProviderFactories = null)
+        {
+            if (options == null)
+            {
+                options = new DurableTaskOptions();
+            }
+
+            return GetJobHostWithOptionsWithMultipleDurabilityProviders(
+                options,
+                durabilityProviderFactories);
+        }
+
+        public static ITestHost GetJobHostWithOptionsWithMultipleDurabilityProviders(
+            DurableTaskOptions durableTaskOptions,
+            IEnumerable<IDurabilityProviderFactory> durabilityProviderFactories = null)
+        {
+            var optionsWrapper = new OptionsWrapper<DurableTaskOptions>(durableTaskOptions);
+
+            return CreateJobHostWithMultipleDurabilityProviders(
+                optionsWrapper,
+                durabilityProviderFactories);
+        }
+#endif
 
         public static DurableTaskOptions GetDurableTaskOptionsForStorageProvider(string storageProvider)
         {

--- a/test/FunctionsV1/PlatformSpecificHelpers.FunctionsV1.cs
+++ b/test/FunctionsV1/PlatformSpecificHelpers.FunctionsV1.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 options,
                 loggerFactory,
                 nameResolver,
-                new[] { orchestrationServiceFactory }.ToList(),
+                new[] { orchestrationServiceFactory },
                 shutdownNotificationService ?? new TestHostShutdownNotificationService(),
                 durableHttpMessageHandler,
                 lifeCycleNotificationHelper,

--- a/test/FunctionsV1/PlatformSpecificHelpers.FunctionsV1.cs
+++ b/test/FunctionsV1/PlatformSpecificHelpers.FunctionsV1.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.ApplicationInsights.Channel;
@@ -50,7 +51,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 options,
                 loggerFactory,
                 nameResolver,
-                orchestrationServiceFactory,
+                new[] { orchestrationServiceFactory }.ToList(),
                 shutdownNotificationService ?? new TestHostShutdownNotificationService(),
                 durableHttpMessageHandler,
                 lifeCycleNotificationHelper,

--- a/test/FunctionsV2/DurableTaskListenerTests.cs
+++ b/test/FunctionsV2/DurableTaskListenerTests.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 wrappedOptions,
                 new LoggerFactory(),
                 nameResolver,
-                new[] { serviceFactory }.ToList(),
+                new[] { serviceFactory },
                 new TestHostShutdownNotificationService(),
                 new DurableHttpMessageHandlerFactory());
         }

--- a/test/FunctionsV2/DurableTaskListenerTests.cs
+++ b/test/FunctionsV2/DurableTaskListenerTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
+using System.Linq;
 using Microsoft.Azure.WebJobs.Host.Executors;
 using Microsoft.Azure.WebJobs.Host.Scale;
 using Microsoft.Extensions.Logging;
@@ -66,7 +67,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 wrappedOptions,
                 new LoggerFactory(),
                 nameResolver,
-                serviceFactory,
+                new[] { serviceFactory }.ToList(),
                 new TestHostShutdownNotificationService(),
                 new DurableHttpMessageHandlerFactory());
         }

--- a/test/FunctionsV2/EmulatorDurabilityProviderFactory.cs
+++ b/test/FunctionsV2/EmulatorDurabilityProviderFactory.cs
@@ -18,6 +18,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
         public bool SupportsEntities => false;
 
+        public string Name => "Emulator";
+
         public DurabilityProvider GetDurabilityProvider(DurableClientAttribute attribute)
         {
             return this.provider;

--- a/test/FunctionsV2/PlatformSpecificHelpers.FunctionsV2.cs
+++ b/test/FunctionsV2/PlatformSpecificHelpers.FunctionsV2.cs
@@ -150,6 +150,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 .Services.AddSingleton<IConnectionStringResolver, WebJobsConnectionStringProvider>();
 
             serviceCollection.TryAddSingleton<IApplicationLifetimeWrapper, HostLifecycleService>();
+#pragma warning disable CS0612 // Type or member is obsolete
+            serviceCollection.TryAddSingleton<IPlatformInformationService, DefaultPlatformInformationProvider>();
+#pragma warning restore CS0612 // Type or member is obsolete
 
             return builder;
         }

--- a/test/FunctionsV2/RedisDurabilityProviderFactory.cs
+++ b/test/FunctionsV2/RedisDurabilityProviderFactory.cs
@@ -31,6 +31,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
         public bool SupportsEntities => false;
 
+        public string Name => "Redis";
+
         public DurabilityProvider GetDurabilityProvider(DurableClientAttribute attribute)
         {
             if (string.IsNullOrEmpty(attribute.TaskHub) && string.IsNullOrEmpty(attribute.ConnectionName))

--- a/test/FunctionsV2/StorageProviderSelectionTests.cs
+++ b/test/FunctionsV2/StorageProviderSelectionTests.cs
@@ -1,0 +1,76 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Azure.WebJobs.Extensions.DurableTask;
+using Microsoft.Azure.WebJobs.Host.TestCommon;
+using Moq;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace WebJobs.Extensions.DurableTask.Tests.V2
+{
+    public class StorageProviderSelectionTests
+    {
+        static StorageProviderSelectionTests()
+        {
+            AzureStorageDurabilityProviderFactoryMock = new Mock<IDurabilityProviderFactory>();
+            AzureStorageDurabilityProviderFactoryMock.Setup(f => f.Name).Returns("AzureStorage");
+
+            MicrosoftSQLDurabilityProviderFactoryMock = new Mock<IDurabilityProviderFactory>();
+            MicrosoftSQLDurabilityProviderFactoryMock.Setup(f => f.Name).Returns("MicrosoftSQL");
+
+            NetheriteProviderDurabilityProviderFactoryMock = new Mock<IDurabilityProviderFactory>();
+            NetheriteProviderDurabilityProviderFactoryMock.Setup(f => f.Name).Returns("Netherite");
+
+            AllDurabilityProviderFactories = new[] { AzureStorageDurabilityProviderFactoryMock.Object, MicrosoftSQLDurabilityProviderFactoryMock.Object, NetheriteProviderDurabilityProviderFactoryMock.Object };
+            EmptyDurabilityProviderFactoriesList = Enumerable.Empty<IDurabilityProviderFactory>();
+
+            ValidStorageProviderTypesData = new List<object[]>
+            {
+                new object[] { "AzureStorage", AzureStorageDurabilityProviderFactoryMock.Object },
+                new object[] { "MicrosoftSQL", MicrosoftSQLDurabilityProviderFactoryMock.Object },
+                new object[] { "Netherite", NetheriteProviderDurabilityProviderFactoryMock.Object },
+            };
+        }
+
+        public StorageProviderSelectionTests() { }
+
+        private static Mock<IDurabilityProviderFactory> AzureStorageDurabilityProviderFactoryMock { get; }
+
+        private static Mock<IDurabilityProviderFactory> MicrosoftSQLDurabilityProviderFactoryMock { get; }
+
+        private static Mock<IDurabilityProviderFactory> NetheriteProviderDurabilityProviderFactoryMock { get; }
+
+        private static IEnumerable<IDurabilityProviderFactory> AllDurabilityProviderFactories { get; }
+
+        private static IEnumerable<IDurabilityProviderFactory> EmptyDurabilityProviderFactoriesList { get; }
+
+        public static IEnumerable<object[]> ValidStorageProviderTypesData { get; }
+
+        [Theory]
+        [MemberData(nameof(ValidStorageProviderTypesData))]
+        public void SelectingAvailableStorageProvider(string storageProvider, IDurabilityProviderFactory expectedFactory)
+        {
+            IDurabilityProviderFactory defaultFactory = AllDurabilityProviderFactories.First(f => f.Name.Equals(storageProvider));
+
+            Assert.Equal(expectedFactory, defaultFactory);
+        }
+
+        [Theory]
+        [InlineData("AzureStorage")]
+        public void SelectingFromEmptyFactoryListThrowsException(string storageProvider)
+        {
+            Assert.Throws<InvalidOperationException>(() => EmptyDurabilityProviderFactoriesList.First(f => f.Name.Equals(storageProvider)));
+        }
+
+        [Theory]
+        [InlineData("storage")]
+        public void SelectingUnavailableStorageProviderThrowsException(string storageProvider)
+        {
+            Assert.Throws<InvalidOperationException>(() => AllDurabilityProviderFactories.First(f => f.Name.Equals(storageProvider)));
+        }
+    }
+}

--- a/test/FunctionsV2/StorageProviderSelectionTests.cs
+++ b/test/FunctionsV2/StorageProviderSelectionTests.cs
@@ -4,69 +4,104 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using DurableTask.Core;
 using Microsoft.Azure.WebJobs.Extensions.DurableTask;
 using Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests;
-using Microsoft.Azure.WebJobs.Host.TestCommon;
 using Moq;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace WebJobs.Extensions.DurableTask.Tests.V2
 {
     public class StorageProviderSelectionTests
     {
-        static StorageProviderSelectionTests()
-        {
-            AzureStorageDurabilityProviderFactoryMock = new Mock<IDurabilityProviderFactory>();
-            AzureStorageDurabilityProviderFactoryMock.Setup(f => f.Name).Returns("AzureStorage");
-
-            MicrosoftSQLDurabilityProviderFactoryMock = new Mock<IDurabilityProviderFactory>();
-            MicrosoftSQLDurabilityProviderFactoryMock.Setup(f => f.Name).Returns("MicrosoftSQL");
-
-            NetheriteProviderDurabilityProviderFactoryMock = new Mock<IDurabilityProviderFactory>();
-            NetheriteProviderDurabilityProviderFactoryMock.Setup(f => f.Name).Returns("Netherite");
-
-            AllDurabilityProviderFactories = new[] { AzureStorageDurabilityProviderFactoryMock.Object, MicrosoftSQLDurabilityProviderFactoryMock.Object, NetheriteProviderDurabilityProviderFactoryMock.Object };
-            EmptyDurabilityProviderFactoriesList = Enumerable.Empty<IDurabilityProviderFactory>();
-
-            ValidStorageProviderTypesData = new List<object[]>
-            {
-                new object[] { "AzureStorage", AzureStorageDurabilityProviderFactoryMock.Object },
-                new object[] { "MicrosoftSQL", MicrosoftSQLDurabilityProviderFactoryMock.Object },
-                new object[] { "Netherite", NetheriteProviderDurabilityProviderFactoryMock.Object },
-            };
-        }
-
         public StorageProviderSelectionTests() { }
-
-        private static Mock<IDurabilityProviderFactory> AzureStorageDurabilityProviderFactoryMock { get; }
-
-        private static Mock<IDurabilityProviderFactory> MicrosoftSQLDurabilityProviderFactoryMock { get; }
-
-        private static Mock<IDurabilityProviderFactory> NetheriteProviderDurabilityProviderFactoryMock { get; }
-
-        private static IEnumerable<IDurabilityProviderFactory> AllDurabilityProviderFactories { get; }
-
-        private static IEnumerable<IDurabilityProviderFactory> EmptyDurabilityProviderFactoriesList { get; }
-
-        public static IEnumerable<object[]> ValidStorageProviderTypesData { get; }
-
-        [Theory]
-        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
-        [MemberData(nameof(ValidStorageProviderTypesData))]
-        public void SelectingAvailableStorageProvider(string storageProvider, IDurabilityProviderFactory expectedFactory)
-        {
-            IDurabilityProviderFactory defaultFactory = AllDurabilityProviderFactories.First(f => f.Name.Equals(storageProvider));
-
-            Assert.Equal(expectedFactory, defaultFactory);
-        }
 
         [Theory]
         [Trait("Category", PlatformSpecificHelpers.TestCategory)]
         [InlineData("AzureStorage")]
-        public void SelectingFromEmptyFactoryListThrowsException(string storageProvider)
+        public void SelectingAzureStorageStorageProvider(string storageProvider)
         {
-            Assert.Throws<InvalidOperationException>(() => EmptyDurabilityProviderFactoriesList.First(f => f.Name.Equals(storageProvider)));
+            var orchestrationServiceClientMock = new Mock<IOrchestrationServiceClient>();
+            Mock<IDurabilityProviderFactory> azureStorageMock = GetAzureStorageStorageProviderMock(orchestrationServiceClientMock);
+            Mock<IDurabilityProviderFactory> microsoftSQLMock = GetMicrosoftSQLStorageProviderMock(orchestrationServiceClientMock);
+            Mock<IDurabilityProviderFactory> netheriteMock = GetNetheriteStorageProviderMock(orchestrationServiceClientMock);
+
+            IEnumerable<IDurabilityProviderFactory> durabilityProviderFactories = new[] { azureStorageMock.Object, microsoftSQLMock.Object, netheriteMock.Object };
+
+            DurableTaskOptions options = new DurableTaskOptions();
+            options.StorageProvider["type"] = storageProvider;
+
+            using (ITestHost host = TestHelpers.GetJobHostWithMultipleDurabilityProviders(
+                options: options,
+                durabilityProviderFactories: durabilityProviderFactories))
+            {
+                azureStorageMock.Verify(a => a.GetDurabilityProvider(), Times.Once());
+                netheriteMock.Verify(n => n.GetDurabilityProvider(), Times.Never());
+                microsoftSQLMock.Verify(m => m.GetDurabilityProvider(), Times.Never());
+            }
+        }
+
+        [Theory]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        [InlineData("Netherite")]
+        public void SelectingNetheriteStorageProvider(string storageProvider)
+        {
+            var orchestrationServiceClientMock = new Mock<IOrchestrationServiceClient>();
+            Mock<IDurabilityProviderFactory> azureStorageMock = GetAzureStorageStorageProviderMock(orchestrationServiceClientMock);
+            Mock<IDurabilityProviderFactory> microsoftSQLMock = GetMicrosoftSQLStorageProviderMock(orchestrationServiceClientMock);
+            Mock<IDurabilityProviderFactory> netheriteMock = GetNetheriteStorageProviderMock(orchestrationServiceClientMock);
+
+            IEnumerable<IDurabilityProviderFactory> durabilityProviderFactories = new[] { azureStorageMock.Object, microsoftSQLMock.Object, netheriteMock.Object };
+
+            DurableTaskOptions options = new DurableTaskOptions();
+            options.StorageProvider["type"] = storageProvider;
+
+            using (ITestHost host = TestHelpers.GetJobHostWithMultipleDurabilityProviders(
+                options: options,
+                durabilityProviderFactories: durabilityProviderFactories))
+            {
+                azureStorageMock.Verify(a => a.GetDurabilityProvider(), Times.Never());
+                netheriteMock.Verify(n => n.GetDurabilityProvider(), Times.Once());
+                microsoftSQLMock.Verify(m => m.GetDurabilityProvider(), Times.Never());
+            }
+        }
+
+        [Theory]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        [InlineData("MicrosoftSQL")]
+        public void SelectingMicrosoftSQLStorageProvider(string storageProvider)
+        {
+            var orchestrationServiceClientMock = new Mock<IOrchestrationServiceClient>();
+            Mock<IDurabilityProviderFactory> azureStorageMock = GetAzureStorageStorageProviderMock(orchestrationServiceClientMock);
+            Mock<IDurabilityProviderFactory> microsoftSQLMock = GetMicrosoftSQLStorageProviderMock(orchestrationServiceClientMock);
+            Mock<IDurabilityProviderFactory> netheriteMock = GetNetheriteStorageProviderMock(orchestrationServiceClientMock);
+
+            IEnumerable<IDurabilityProviderFactory> durabilityProviderFactories = new[] { azureStorageMock.Object, microsoftSQLMock.Object, netheriteMock.Object };
+
+            DurableTaskOptions options = new DurableTaskOptions();
+            options.StorageProvider["type"] = storageProvider;
+
+            using (ITestHost host = TestHelpers.GetJobHostWithMultipleDurabilityProviders(
+                options: options,
+                durabilityProviderFactories: durabilityProviderFactories))
+            {
+                azureStorageMock.Verify(a => a.GetDurabilityProvider(), Times.Never());
+                netheriteMock.Verify(n => n.GetDurabilityProvider(), Times.Never());
+                microsoftSQLMock.Verify(m => m.GetDurabilityProvider(), Times.Once());
+            }
+        }
+
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public void SelectingFromEmptyFactoryListThrowsException()
+        {
+            IEnumerable<IDurabilityProviderFactory> emptyDurabilityProviderFactoriesList = Enumerable.Empty<IDurabilityProviderFactory>();
+
+            var ex = Assert.Throws<InvalidOperationException>(() =>
+                TestHelpers.GetJobHostWithMultipleDurabilityProviders(
+                    durabilityProviderFactories: emptyDurabilityProviderFactoriesList));
+
+            Assert.Equal($"Couldn't find the default storage provider: AzureStorage.", ex.Message);
         }
 
         [Theory]
@@ -74,7 +109,69 @@ namespace WebJobs.Extensions.DurableTask.Tests.V2
         [InlineData("storage")]
         public void SelectingUnavailableStorageProviderThrowsException(string storageProvider)
         {
-            Assert.Throws<InvalidOperationException>(() => AllDurabilityProviderFactories.First(f => f.Name.Equals(storageProvider)));
+            var orchestrationServiceClientMock = new Mock<IOrchestrationServiceClient>();
+            Mock<IDurabilityProviderFactory> azureStorageMock = GetAzureStorageStorageProviderMock(orchestrationServiceClientMock);
+            Mock<IDurabilityProviderFactory> microsoftSQLMock = GetMicrosoftSQLStorageProviderMock(orchestrationServiceClientMock);
+            Mock<IDurabilityProviderFactory> netheriteMock = GetNetheriteStorageProviderMock(orchestrationServiceClientMock);
+
+            IEnumerable<IDurabilityProviderFactory> durabilityProviderFactories = new[] { azureStorageMock.Object, microsoftSQLMock.Object, netheriteMock.Object };
+
+            DurableTaskOptions options = new DurableTaskOptions();
+            options.StorageProvider["type"] = storageProvider;
+
+            var ex = Assert.Throws<InvalidOperationException>(() =>
+                TestHelpers.GetJobHostWithMultipleDurabilityProviders(
+                    options: options,
+                    durabilityProviderFactories: durabilityProviderFactories));
+
+            IList<string> factoryNames = durabilityProviderFactories.Select(f => f.Name).ToList();
+
+            Assert.Equal($"Storage provider type ({storageProvider}) was not found. Available storage providers: {string.Join(", ", factoryNames)}.", ex.Message);
+        }
+
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public void SelectingDefaultStorageProviderWhenNoTypeIsProvided()
+        {
+            var orchestrationServiceClientMock = new Mock<IOrchestrationServiceClient>();
+            Mock<IDurabilityProviderFactory> azureStorageMock = GetAzureStorageStorageProviderMock(orchestrationServiceClientMock);
+            Mock<IDurabilityProviderFactory> microsoftSQLMock = GetMicrosoftSQLStorageProviderMock(orchestrationServiceClientMock);
+            Mock<IDurabilityProviderFactory> netheriteMock = GetNetheriteStorageProviderMock(orchestrationServiceClientMock);
+
+            IEnumerable<IDurabilityProviderFactory> durabilityProviderFactories = new[] { azureStorageMock.Object, microsoftSQLMock.Object, netheriteMock.Object };
+
+            using (ITestHost host = TestHelpers.GetJobHostWithMultipleDurabilityProviders(
+                durabilityProviderFactories: durabilityProviderFactories))
+            {
+                netheriteMock.Verify(n => n.GetDurabilityProvider(), Times.Never());
+                azureStorageMock.Verify(a => a.GetDurabilityProvider(), Times.Once());
+                microsoftSQLMock.Verify(m => m.GetDurabilityProvider(), Times.Never());
+            }
+        }
+
+        private static Mock<IDurabilityProviderFactory> GetAzureStorageStorageProviderMock(Mock<IOrchestrationServiceClient> orchestrationServiceClientMock)
+        {
+            Mock<IDurabilityProviderFactory> azureStorageMock = new Mock<IDurabilityProviderFactory>();
+            azureStorageMock.Setup(f => f.Name).Returns("AzureStorage");
+            azureStorageMock.Setup(f => f.GetDurabilityProvider()).Returns(new DurabilityProvider("AzureStorage", new Mock<IOrchestrationService>().Object, orchestrationServiceClientMock.Object, "test"));
+
+            return azureStorageMock;
+        }
+
+        private static Mock<IDurabilityProviderFactory> GetMicrosoftSQLStorageProviderMock(Mock<IOrchestrationServiceClient> orchestrationServiceClientMock)
+        {
+            Mock<IDurabilityProviderFactory> microsoftSQLMock = new Mock<IDurabilityProviderFactory>();
+            microsoftSQLMock.Setup(f => f.Name).Returns("MicrosoftSQL");
+            microsoftSQLMock.Setup(f => f.GetDurabilityProvider()).Returns(new DurabilityProvider("MicrosoftSQL", new Mock<IOrchestrationService>().Object, orchestrationServiceClientMock.Object, "test"));
+            return microsoftSQLMock;
+        }
+
+        private static Mock<IDurabilityProviderFactory> GetNetheriteStorageProviderMock(Mock<IOrchestrationServiceClient> orchestrationServiceClientMock)
+        {
+            Mock<IDurabilityProviderFactory> netheriteMock = new Mock<IDurabilityProviderFactory>();
+            netheriteMock.Setup(f => f.Name).Returns("Netherite");
+            netheriteMock.Setup(f => f.GetDurabilityProvider()).Returns(new DurabilityProvider("Netherite", new Mock<IOrchestrationService>().Object, orchestrationServiceClientMock.Object, "test"));
+            return netheriteMock;
         }
     }
 }

--- a/test/FunctionsV2/StorageProviderSelectionTests.cs
+++ b/test/FunctionsV2/StorageProviderSelectionTests.cs
@@ -62,7 +62,6 @@ namespace WebJobs.Extensions.DurableTask.Tests.V2
         [MemberData(nameof(DurabilityProviderFactoriesListsWithoutAzureStorage))]
         public void NoProviderSpecified_AzureStorageFactoryNotRegistered(IEnumerable<IDurabilityProviderFactory> durabilityProviderFactories)
         {
-
             var ex = Assert.Throws<InvalidOperationException>(() =>
                 TestHelpers.GetJobHostWithMultipleDurabilityProviders(
                     durabilityProviderFactories: durabilityProviderFactories));

--- a/test/FunctionsV2/StorageProviderSelectionTests.cs
+++ b/test/FunctionsV2/StorageProviderSelectionTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Azure.WebJobs.Extensions.DurableTask;
+using Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests;
 using Microsoft.Azure.WebJobs.Host.TestCommon;
 using Moq;
 using Xunit;
@@ -51,6 +52,7 @@ namespace WebJobs.Extensions.DurableTask.Tests.V2
         public static IEnumerable<object[]> ValidStorageProviderTypesData { get; }
 
         [Theory]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
         [MemberData(nameof(ValidStorageProviderTypesData))]
         public void SelectingAvailableStorageProvider(string storageProvider, IDurabilityProviderFactory expectedFactory)
         {
@@ -60,6 +62,7 @@ namespace WebJobs.Extensions.DurableTask.Tests.V2
         }
 
         [Theory]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
         [InlineData("AzureStorage")]
         public void SelectingFromEmptyFactoryListThrowsException(string storageProvider)
         {
@@ -67,6 +70,7 @@ namespace WebJobs.Extensions.DurableTask.Tests.V2
         }
 
         [Theory]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
         [InlineData("storage")]
         public void SelectingUnavailableStorageProviderThrowsException(string storageProvider)
         {


### PR DESCRIPTION
These changes allow customers to configure which storage backend they want their app to use (e.g. Azure Storage, MicrosoftSQL, or Netherite) with a new `type` attribute under `durableTask/storageProvider` in host.json (example below). The extension will register all storage backend services and then choose which one to use in the `DurableTaskExtension` constructor. Adding the ability to register all backends and then choose a storage backend allows us to deploy all storage backend packages through extension bundles.

The main changes in this PR are allowing the extension to register a collection of services through dependency injection, adding a `Name` property in `IDurabilityProviderFactory`, and choosing the `DurabilityProvider` by comparing a customers configured `type` with the `Name` property in the available `IDurabilityProviderFactory` implementations.

```
{
  "version": "2.0",
  "extensions": {
    "durableTask": {
      "storageProvider": {
        "type": "MicrosoftSQL",
        "connectionStringName": "SQLDB_Connection"
      }
    }
  }
}
```

Resolves #1666 

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)