### PR TITLE
Turn directions in PR template into comments

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,7 @@
-<-- Start the PR description with some context for the change. -->
+<!-- Start the PR description with some context for the change. -->
 
 
-<-- Make sure to delete the markdown comments and the below sections when squash merging -->
+<!-- Make sure to delete the markdown comments and the below sections when squash merging -->
 ### Issue describing the changes in this PR
 
 resolves #issue_for_this_pr


### PR DESCRIPTION
<-- Start the PR description with some context for the change. -->
Currently, the directions in the PR template aren't proper markdown comments, so they need to either be removed from every PR, or manually turned into comments so they won't render. 

As an example, see above 👀^

This PR simply turns those directions into comments so that the instructions can be preserved while editing the text without the need to modify them further.

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)


