### PR TITLE
Ensure using latest webhook url for HTTP management APIs

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -1,1 +1,2 @@
-
+Bug Fixes:
+- Properly used update management API URLs after a successful slot swap (#1716)

--- a/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
@@ -106,6 +106,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// <param name="hostLifetimeService">The host shutdown notification service for detecting and reacting to host shutdowns.</param>
         /// <param name="lifeCycleNotificationHelper">The lifecycle notification helper used for custom orchestration tracking.</param>
         /// <param name="messageSerializerSettingsFactory">The factory used to create <see cref="JsonSerializerSettings"/> for message settings.</param>
+        /// <param name="webhookProvider">A delegate to fetch the webhook URL.</param>
         /// <param name="errorSerializerSettingsFactory">The factory used to create <see cref="JsonSerializerSettings"/> for error settings.</param>
         /// <param name="telemetryActivator">The activator of DistributedTracing. .netstandard2.0 only.</param>
 #pragma warning restore CS1572
@@ -265,13 +266,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             // Throw if any of the configured options are invalid
             this.Options.Validate(this.nameResolver, this.TraceHelper);
 
-            // For 202 support
-            if (this.Options.NotificationUrl == null)
-            {
 #pragma warning disable CS0618 // Type or member is obsolete
-                this.Options.NotificationUrl = context.GetWebhookHandler();
-#pragma warning restore CS0618 // Type or member is obsolete
+
+            // Invoke webhook handler to make functions runtime register extension endpoints.
+            context.GetWebhookHandler();
+
+            if (this.Options.TestWebhookUri == null)
+            {
+                this.HttpApiHandler.RegisterWebhookProvider(() => context.GetWebhookHandler());
             }
+#pragma warning restore CS0618 // Type or member is obsolete
 
             this.TraceConfigurationSettings();
 

--- a/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
@@ -273,6 +273,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
             if (this.Options.TestWebhookUri == null)
             {
+                // This line ensure every time we need the webhook URI, we get it directly from the
+                // function runtime, which has the most up-to-date knowledge about the site hostname.
                 this.HttpApiHandler.RegisterWebhookProvider(() => context.GetWebhookHandler());
             }
 #pragma warning restore CS0618 // Type or member is obsolete

--- a/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
@@ -319,7 +319,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             // function runtime, which has the most up-to-date knowledge about the site hostname.
             this.HttpApiHandler.RegisterWebhookProvider(
                 this.Options.WebhookUriProviderOverride ??
-                (() => context.GetWebhookHandler()));
+                context.GetWebhookHandler);
 #pragma warning restore CS0618 // Type or member is obsolete
 
             this.TraceConfigurationSettings();

--- a/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
@@ -106,7 +106,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// <param name="hostLifetimeService">The host shutdown notification service for detecting and reacting to host shutdowns.</param>
         /// <param name="lifeCycleNotificationHelper">The lifecycle notification helper used for custom orchestration tracking.</param>
         /// <param name="messageSerializerSettingsFactory">The factory used to create <see cref="JsonSerializerSettings"/> for message settings.</param>
-        /// <param name="webhookProvider">A delegate to fetch the webhook URL.</param>
         /// <param name="errorSerializerSettingsFactory">The factory used to create <see cref="JsonSerializerSettings"/> for error settings.</param>
         /// <param name="telemetryActivator">The activator of DistributedTracing. .netstandard2.0 only.</param>
 #pragma warning restore CS1572
@@ -271,12 +270,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             // Invoke webhook handler to make functions runtime register extension endpoints.
             context.GetWebhookHandler();
 
-            if (this.Options.TestWebhookUri == null)
-            {
-                // This line ensure every time we need the webhook URI, we get it directly from the
-                // function runtime, which has the most up-to-date knowledge about the site hostname.
-                this.HttpApiHandler.RegisterWebhookProvider(() => context.GetWebhookHandler());
-            }
+            // This line ensure every time we need the webhook URI, we get it directly from the
+            // function runtime, which has the most up-to-date knowledge about the site hostname.
+            this.HttpApiHandler.RegisterWebhookProvider(
+                this.Options.WebhookUriProviderOverride ??
+                (() => context.GetWebhookHandler()));
 #pragma warning restore CS0618 // Type or member is obsolete
 
             this.TraceConfigurationSettings();

--- a/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
+++ b/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
@@ -84,9 +84,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             this.durableTaskOptions = durableTaskOptions;
             this.traceHelper = traceHelper;
 
-            if (this.durableTaskOptions.TestWebhookUri != null)
+            if (this.durableTaskOptions.WebhookUriProviderOverride != null)
             {
-                this.webhookUrlProvider = () => this.durableTaskOptions.TestWebhookUri;
+                this.webhookUrlProvider = this.durableTaskOptions.WebhookUriProviderOverride;
             }
 
             // The listen URL must not include the path.

--- a/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
+++ b/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
@@ -277,15 +277,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 }
                 else
                 {
-                    Uri webhookUrl = this.GetWebhookUri();
-                    if (webhookUrl != null)
-                    {
-                        basePath = webhookUrl.AbsolutePath;
-                    }
-                    else
-                    {
-                        throw new InvalidOperationException($"Don't know how to handle request to {request.RequestUri}.");
-                    }
+                    basePath = this.GetWebhookUri().AbsolutePath;
                 }
 
                 string path = "/" + request.RequestUri.AbsolutePath.Substring(basePath.Length).Trim('/');

--- a/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
+++ b/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
@@ -84,10 +84,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             this.durableTaskOptions = durableTaskOptions;
             this.traceHelper = traceHelper;
 
-            if (this.durableTaskOptions.WebhookUriProviderOverride != null)
-            {
-                this.webhookUrlProvider = this.durableTaskOptions.WebhookUriProviderOverride;
-            }
+            this.webhookUrlProvider = this.durableTaskOptions.WebhookUriProviderOverride;
 
             // The listen URL must not include the path.
             this.localHttpListener = new LocalHttpListener(

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net461.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net461.xml
@@ -2123,6 +2123,7 @@
             <param name="hostLifetimeService">The host shutdown notification service for detecting and reacting to host shutdowns.</param>
             <param name="lifeCycleNotificationHelper">The lifecycle notification helper used for custom orchestration tracking.</param>
             <param name="messageSerializerSettingsFactory">The factory used to create <see cref="T:Newtonsoft.Json.JsonSerializerSettings"/> for message settings.</param>
+            <param name="webhookProvider">A delegate to fetch the webhook URL.</param>
             <param name="errorSerializerSettingsFactory">The factory used to create <see cref="T:Newtonsoft.Json.JsonSerializerSettings"/> for error settings.</param>
             <param name="telemetryActivator">The activator of DistributedTracing. .netstandard2.0 only.</param>
         </member>
@@ -3472,17 +3473,6 @@
             </summary>
             <value>
             A positive integer configured by the host. The default value is 10X the number of processors on the current machine.
-            </value>
-        </member>
-        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskOptions.NotificationUrl">
-            <summary>
-            Gets or sets the base URL for the HTTP APIs managed by this extension.
-            </summary>
-            <remarks>
-            This property is intended for use only by runtime hosts.
-            </remarks>
-            <value>
-            A URL pointing to the hosted function app that responds to status polling requests.
             </value>
         </member>
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskOptions.LocalRpcEndpointEnabled">

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
@@ -2325,6 +2325,7 @@
             <param name="hostLifetimeService">The host shutdown notification service for detecting and reacting to host shutdowns.</param>
             <param name="lifeCycleNotificationHelper">The lifecycle notification helper used for custom orchestration tracking.</param>
             <param name="messageSerializerSettingsFactory">The factory used to create <see cref="T:Newtonsoft.Json.JsonSerializerSettings"/> for message settings.</param>
+            <param name="webhookProvider">A delegate to fetch the webhook URL.</param>
             <param name="errorSerializerSettingsFactory">The factory used to create <see cref="T:Newtonsoft.Json.JsonSerializerSettings"/> for error settings.</param>
             <param name="telemetryActivator">The activator of DistributedTracing. .netstandard2.0 only.</param>
         </member>
@@ -3714,17 +3715,6 @@
             </summary>
             <value>
             A positive integer configured by the host. The default value is 10X the number of processors on the current machine.
-            </value>
-        </member>
-        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskOptions.NotificationUrl">
-            <summary>
-            Gets or sets the base URL for the HTTP APIs managed by this extension.
-            </summary>
-            <remarks>
-            This property is intended for use only by runtime hosts.
-            </remarks>
-            <value>
-            A URL pointing to the hosted function app that responds to status polling requests.
             </value>
         </member>
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskOptions.LocalRpcEndpointEnabled">

--- a/src/WebJobs.Extensions.DurableTask/Options/DurableTaskOptions.cs
+++ b/src/WebJobs.Extensions.DurableTask/Options/DurableTaskOptions.cs
@@ -201,7 +201,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
         // This is just a way for tests to overwrite the webhook url, since there is no easy way
         // to mock the value from ExtensionConfigContext. It should not be used in production code paths.
-        internal Uri TestWebhookUri { get; set; }
+        internal Func<Uri> WebhookUriProviderOverride { get; set; }
 
         /// <summary>
         /// Sets HubName to a value that is considered a default value.

--- a/src/WebJobs.Extensions.DurableTask/Options/DurableTaskOptions.cs
+++ b/src/WebJobs.Extensions.DurableTask/Options/DurableTaskOptions.cs
@@ -99,17 +99,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         public int MaxConcurrentOrchestratorFunctions { get; set; } = 10 * Environment.ProcessorCount;
 
         /// <summary>
-        /// Gets or sets the base URL for the HTTP APIs managed by this extension.
-        /// </summary>
-        /// <remarks>
-        /// This property is intended for use only by runtime hosts.
-        /// </remarks>
-        /// <value>
-        /// A URL pointing to the hosted function app that responds to status polling requests.
-        /// </value>
-        public Uri NotificationUrl { get; set; }
-
-        /// <summary>
         /// Gets or sets a value indicating whether to enable the local RPC endpoint managed by this extension.
         /// </summary>
         /// <remarks>
@@ -210,6 +199,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         // Used for mocking the lifecycle notification helper.
         internal HttpMessageHandler NotificationHandler { get; set; }
 
+        // This is purely a way for tests to overwrite the webhook url, since there is no easyway
+        // to mock the value from ExtensionConfigContext.
+        internal Uri TestWebhookUri { get; set; }
+
         /// <summary>
         /// Sets HubName to a value that is considered a default value.
         /// </summary>
@@ -225,14 +218,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             // Clone the options to avoid making changes to the original.
             // We make updates to the clone rather than to JSON to ensure we're updating what we think we're updating.
             DurableTaskOptions clone = JObject.FromObject(this).ToObject<DurableTaskOptions>();
-
-            // Don't trace the notification URL query string since it may contain secrets.
-            // This is the only property which we expect to contain secrets. Everything else should be *names*
-            // of secrets that are resolved later from environment variables, etc.
-            if (clone.NotificationUrl != null)
-            {
-                clone.NotificationUrl = new Uri(clone.NotificationUrl.GetLeftPart(UriPartial.Path));
-            }
 
             // At this stage the task hub name is expected to have been resolved. However, we want to know
             // what the original value was in addition to the resolved value, so we're updating the JSON

--- a/src/WebJobs.Extensions.DurableTask/Options/DurableTaskOptions.cs
+++ b/src/WebJobs.Extensions.DurableTask/Options/DurableTaskOptions.cs
@@ -199,8 +199,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         // Used for mocking the lifecycle notification helper.
         internal HttpMessageHandler NotificationHandler { get; set; }
 
-        // This is purely a way for tests to overwrite the webhook url, since there is no easyway
-        // to mock the value from ExtensionConfigContext.
+        // This is just a way for tests to overwrite the webhook url, since there is no easy way
+        // to mock the value from ExtensionConfigContext. It should not be used in production code paths.
         internal Uri TestWebhookUri { get; set; }
 
         /// <summary>

--- a/test/Common/DurableClientBaseTests.cs
+++ b/test/Common/DurableClientBaseTests.cs
@@ -322,7 +322,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         {
             var options = new DurableTaskOptions();
             options.HubName = "DurableTaskHub";
-            options.TestWebhookUri = new Uri("https://sampleurl.net");
+            options.WebhookUriProviderOverride = () => new Uri("https://sampleurl.net");
             var wrappedOptions = new OptionsWrapper<DurableTaskOptions>(options);
             var nameResolver = TestHelpers.GetTestNameResolver();
             var connectionStringResolver = new TestConnectionStringResolver();

--- a/test/Common/DurableClientBaseTests.cs
+++ b/test/Common/DurableClientBaseTests.cs
@@ -322,7 +322,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         {
             var options = new DurableTaskOptions();
             options.HubName = "DurableTaskHub";
-            options.NotificationUrl = new Uri("https://sampleurl.net");
+            options.TestWebhookUri = new Uri("https://sampleurl.net");
             var wrappedOptions = new OptionsWrapper<DurableTaskOptions>(options);
             var nameResolver = TestHelpers.GetTestNameResolver();
             var connectionStringResolver = new TestConnectionStringResolver();

--- a/test/Common/HttpApiHandlerTests.cs
+++ b/test/Common/HttpApiHandlerTests.cs
@@ -33,7 +33,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             {
                 Notifications = new NotificationOptions(),
             };
-            options.TestWebhookUri = null;
+
+            // With a null override, and the production code path returning null webhook path,
+            // this simulates a non-configured webhook url.
+            options.WebhookUriProviderOverride = null;
             options.HubName = "DurableTaskHub";
 
             var httpApiHandler = new HttpApiHandler(GetTestExtension(options), null);
@@ -1393,7 +1396,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         private static DurableTaskExtension GetTestExtension()
         {
             var options = new DurableTaskOptions();
-            options.TestWebhookUri = new Uri(TestConstants.NotificationUrl);
+            options.WebhookUriProviderOverride = () => new Uri(TestConstants.NotificationUrl);
             options.HubName = "DurableFunctionsHub";
 
             return GetTestExtension(options);

--- a/test/Common/HttpApiHandlerTests.cs
+++ b/test/Common/HttpApiHandlerTests.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
         [Fact]
         [Trait("Category", PlatformSpecificHelpers.TestCategory)]
-        public void OutOfProcEndpoints_UpdateWithUpdatedWebhookUri()
+        public void OutOfProcEndpoints_UpdateWithNewWebhookUri()
         {
             var httpApiHandler = new HttpApiHandler(GetTestExtension(), null);
             var webhookProvider = new ChangingWebhookProvider() { WebhookUri = new Uri(TestConstants.NotificationUrl) };

--- a/test/Common/TestHelpers.cs
+++ b/test/Common/TestHelpers.cs
@@ -103,7 +103,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             {
                 DefaultAsyncRequestSleepTimeMilliseconds = httpAsyncSleepTime,
             };
-            options.NotificationUrl = notificationUrl;
+            options.TestWebhookUri = notificationUrl;
             options.ExtendedSessionsEnabled = enableExtendedSessions;
             options.MaxConcurrentOrchestratorFunctions = 200;
             options.MaxConcurrentActivityFunctions = 200;

--- a/test/Common/TestHelpers.cs
+++ b/test/Common/TestHelpers.cs
@@ -103,7 +103,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             {
                 DefaultAsyncRequestSleepTimeMilliseconds = httpAsyncSleepTime,
             };
-            options.TestWebhookUri = notificationUrl;
+            options.WebhookUriProviderOverride = () => notificationUrl;
             options.ExtendedSessionsEnabled = enableExtendedSessions;
             options.MaxConcurrentOrchestratorFunctions = 200;
             options.MaxConcurrentActivityFunctions = 200;

--- a/test/FunctionsV2/DurableTaskListenerTests.cs
+++ b/test/FunctionsV2/DurableTaskListenerTests.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         {
             var options = new DurableTaskOptions();
             options.HubName = "DurableTaskHub";
-            options.NotificationUrl = new Uri("https://sampleurl.net");
+            options.TestWebhookUri = new Uri("https://sampleurl.net");
             var wrappedOptions = new OptionsWrapper<DurableTaskOptions>(options);
             var nameResolver = TestHelpers.GetTestNameResolver();
             var connectionStringResolver = new TestConnectionStringResolver();

--- a/test/FunctionsV2/DurableTaskListenerTests.cs
+++ b/test/FunctionsV2/DurableTaskListenerTests.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         {
             var options = new DurableTaskOptions();
             options.HubName = "DurableTaskHub";
-            options.TestWebhookUri = new Uri("https://sampleurl.net");
+            options.WebhookUriProviderOverride = () => new Uri("https://sampleurl.net");
             var wrappedOptions = new OptionsWrapper<DurableTaskOptions>(options);
             var nameResolver = TestHelpers.GetTestNameResolver();
             var connectionStringResolver = new TestConnectionStringResolver();


### PR DESCRIPTION
### Issue describing the changes in this PR

Previously, we store the value of the webhook URL during extension
initialization with the assumption that this webhook URL never changes
after startup. This stored value is used for various IDurableClient
methods, along with the out-of-proc clients when local RPC endpoints are
disabled.

However, it turns out that in the case of slot-swap operations,
WEBSITE_HOSTNAME uses the staging slot hostname at site startup, and
only after the slot swap does the hostname change. The function host
listens for a new header value sent as a part of some ping, updating the
source of ExtensionConfigContext.GetWebhookUrl() with the new value once
the slot swap is complete. This PR makes sure we always fetch the value
from the ExtensionConfigContext instead of caching it to ensure we have
the most up-to-date value.

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [x] Otherwise: Backport tracked by issue/PR #1717
* [x] I have added all required tests (Unit tests, E2E tests)


