### PR TITLE
Handling HttpRequestException in CallHttpAsync()

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -1,2 +1,5 @@
 ## Bug fixes
 - Fix CallHttpAsync() to throw an HttpRequestException instead of a serialization exception if the target endpoint doesn't exist (#1718)
+
+## Breaking changes
+- Fix CallHttpAsync() to throw an HttpRequestException instead of a serialization exception if the target endpoint doesn't exist (#1718). This is a breaking change if you were handling `HttpRequestException`s by catching `FunctionFailedException`s

--- a/release_notes.md
+++ b/release_notes.md
@@ -1,1 +1,2 @@
-
+## Bug fixes
+- Fix CallHttpAsync() to throw an HttpRequestException instead of a serialization exception if the target endpoint doesn't exist (#1718)

--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableOrchestrationContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableOrchestrationContext.cs
@@ -690,8 +690,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             {
                 // Check to see if CallHttpAsync() threw a TimeoutException
                 // In this case, we want to throw a TimeoutException instead of a FunctionFailedException
-                if (functionName.Equals(HttpOptions.HttpTaskActivityReservedName) && e.InnerException is TimeoutException)
+                if (functionName.Equals(HttpOptions.HttpTaskActivityReservedName) &&
+                    (e.InnerException is TimeoutException || e.InnerException is HttpRequestException))
                 {
+                    if (e.InnerException is HttpRequestException)
+                    {
+                        throw new HttpRequestException(e.Message);
+                    }
+
                     throw e.InnerException;
                 }
 

--- a/test/Common/DurableHttpTests.cs
+++ b/test/Common/DurableHttpTests.cs
@@ -1549,7 +1549,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
         private static HttpMessageHandler MockSynchronousHttpMessageHandlerWithHttpRequestException()
         {
-            HttpResponseMessage httpResponseMessage = CreateTestHttpResponseMessage(HttpStatusCode.OK);
+            HttpResponseMessage httpResponseMessage = CreateTestHttpResponseMessage(HttpStatusCode.NotFound);
 
             httpResponseMessage.Content = new ExceptionThrowingContent(new HttpRequestException("No such host is known."));
 

--- a/test/Common/DurableHttpTests.cs
+++ b/test/Common/DurableHttpTests.cs
@@ -363,6 +363,44 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         }
 
         /// <summary>
+        /// End-to-end test which checks if the CallHttpAsync Orchestrator fails  when the
+        /// target url doesn't exist and throws an HttpRequestException.
+        /// </summary>
+        [Theory]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        [MemberData(nameof(TestDataGenerator.GetFullFeaturedStorageProviderOptions), MemberType = typeof(TestDataGenerator))]
+        public async Task DurableHttpAsync_Synchronous_HttpRequestException(string storageProvider)
+        {
+            HttpMessageHandler httpMessageHandler = MockSynchronousHttpMessageHandlerWithHttpRequestException();
+
+            using (ITestHost host = TestHelpers.GetJobHost(
+                this.loggerProvider,
+                nameof(this.DurableHttpAsync_Synchronous_HttpRequestException),
+                enableExtendedSessions: false,
+                storageProviderType: storageProvider,
+                durableHttpMessageHandler: new DurableHttpMessageHandlerFactory(httpMessageHandler)))
+            {
+                await host.StartAsync();
+
+                Dictionary<string, string> headers = new Dictionary<string, string>();
+                headers.Add("Accept", "application/json");
+                TestDurableHttpRequest testRequest = new TestDurableHttpRequest(
+                    httpMethod: HttpMethod.Get,
+                    headers: headers);
+
+                string functionName = nameof(TestOrchestrations.CallHttpAsyncOrchestrator);
+                var client = await host.StartOrchestratorAsync(functionName, testRequest, this.output);
+                var status = await client.WaitForCompletionAsync(this.output);
+
+                var output = status?.Output;
+                Assert.Contains("No such host is known.", output.ToString());
+                Assert.Equal(OrchestrationRuntimeStatus.Failed, status?.RuntimeStatus);
+
+                await host.StopAsync();
+            }
+        }
+
+        /// <summary>
         /// End-to-end test which checks if the UserAgent header is set in the HttpResponseMessage.
         /// </summary>
         [Theory]
@@ -1505,6 +1543,21 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                    await Task.Delay(timeoutTimespan);
                    return httpResponseMessage;
                });
+
+            return handlerMock.Object;
+        }
+
+        private static HttpMessageHandler MockSynchronousHttpMessageHandlerWithHttpRequestException()
+        {
+            HttpResponseMessage httpResponseMessage = CreateTestHttpResponseMessage(HttpStatusCode.OK);
+
+            httpResponseMessage.Content = new ExceptionThrowingContent(new HttpRequestException("No such host is known."));
+
+            var handlerMock = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+            handlerMock
+               .Protected()
+               .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+               .ReturnsAsync(httpResponseMessage);
 
             return handlerMock.Object;
         }


### PR DESCRIPTION
These changes add a way to handle when  `this.httpClient.SendAsync()` throws an `HttpRequestException` and propagate the exception to customer code. Before this change, the extension would throw an exception about serialization instead of `HttpRequestException`. By handling the `HttpRequestException` in `TaskHttpActivityShim`, an `HttpRequestException` is thrown with a descriptive message.

Resolves #1669

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)


