### PR TITLE
Fix Local RPC race condition on app startup

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -1,1 +1,2 @@
-
+Bug Fixes:
+- Fix race condition when multiple apps start with local RPC endpoints on the same VM. It should now be incredibly rare to be unable to find a port, and in that scenario, we gracefully fallback to using the public HTTP endpoints. (#1719)

--- a/release_notes.md
+++ b/release_notes.md
@@ -1,2 +1,2 @@
 Bug Fixes:
-- Fix race condition when multiple apps start with local RPC endpoints on the same VM. It should now be incredibly rare to be unable to find a port, and in that scenario, we gracefully fallback to using the public HTTP endpoints. (#1719)
+- Fix race condition when multiple apps start with local RPC endpoints on the same VM in parallel. (#1719)

--- a/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
+++ b/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
@@ -1140,15 +1140,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
         internal bool TryGetRpcBaseUrl(out Uri rpcBaseUrl)
         {
-            if (this.durableTaskOptions.LocalRpcEndpointEnabled != false
-                && this.localHttpListener.IsListening)
+            if (this.durableTaskOptions.LocalRpcEndpointEnabled != false)
             {
                 rpcBaseUrl = this.localHttpListener.InternalRpcUri;
                 return true;
             }
 
-            // The app owner explicitly disabled the local RPC endpoint, or we were unable to
-            // successfully find a port after several tries.
+            // The app owner explicitly disabled the local RPC endpoint
             rpcBaseUrl = null;
             return false;
         }

--- a/test/Common/DurableTaskEndToEndTests.cs
+++ b/test/Common/DurableTaskEndToEndTests.cs
@@ -4803,16 +4803,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         public async Task MultipleHostsOnSameVM(bool enableLocalRpc)
         {
             // This test wants to be sure there are no race conditions while starting up multiple hosts in parallel,
-            // so attempt various times to make sure to hit race condition if it exists.
+            // so attempt various times to increase the likelihood of hitting a race condition if one exists.
             int numAttempts = 5;
             for (int attempt = 0; attempt < numAttempts; attempt++)
             {
-                int numHost = 10;
-                var hosts = new List<ITestHost>(numHost);
+                int numThreads = 10;
+                var hosts = new List<ITestHost>(numThreads);
 
                 try
                 {
-                    Parallel.For(0, numHost, new ParallelOptions() { MaxDegreeOfParallelism = numHost }, (i) =>
+                    Parallel.For(0, numThreads, new ParallelOptions() { MaxDegreeOfParallelism = numThreads }, (i) =>
                         hosts.Add(TestHelpers.GetJobHost(
                                 this.loggerProvider,
                                 nameof(this.MultipleHostsOnSameVM) + i,

--- a/test/Common/DurableTaskEndToEndTests.cs
+++ b/test/Common/DurableTaskEndToEndTests.cs
@@ -4814,12 +4814,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
             try
             {
-                // Schedule the startups in Task.Run to schedule on a separate
-                // TaskPool (see https://stackoverflow.com/a/34375762/9035640)
-                Parallel.ForEach(
-                  hosts,
-                  new ParallelOptions { MaxDegreeOfParallelism = 10 },
-                  async (host) => await host.StartAsync());
+                await Task.WhenAll(hosts.Select(host => host.StartAsync()));
             }
             catch (Exception)
             {

--- a/test/Common/DurableTaskEndToEndTests.cs
+++ b/test/Common/DurableTaskEndToEndTests.cs
@@ -4817,8 +4817,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                                 this.loggerProvider,
                                 nameof(this.MultipleHostsOnSameVM) + i,
                                 false,
-                                localRpcEndpointEnabled: enableLocalRpc))
-                    );
+                                localRpcEndpointEnabled: enableLocalRpc)));
 
                     await Task.WhenAll(hosts.Select(host => host.StartAsync()));
                 }
@@ -4828,7 +4827,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 }
                 finally
                 {
-
                     foreach (var host in hosts)
                     {
                         await host.StopAsync();

--- a/test/Common/TestHelpers.cs
+++ b/test/Common/TestHelpers.cs
@@ -208,9 +208,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         }
 
         /// <summary>
-        /// Helper function to regularly poll for some condition until it is true. If timeout hits, throw timeoutexception
+        /// Helper function to regularly poll for some condition until it is true. If timeout hits, throw timeoutexception.
         /// </summary>
-        /// <param name="predicate">Predicate to wait until it returns true</param>
+        /// <param name="predicate">Predicate to wait until it returns true.<param>
         /// <param name="timeout">Time to wait until predicate is true.</param>
         /// <param name="retryInterval">How frequently to test predicate. Defaults to 100 ms.</param>
         public static async Task WaitUntilTrue(Func<bool> predicate, string conditionDescription, TimeSpan timeout, TimeSpan? retryInterval = null)

--- a/test/FunctionsV2/OutOfProcTests.cs
+++ b/test/FunctionsV2/OutOfProcTests.cs
@@ -348,7 +348,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 // Validate if we opened local RPC endpoint by looking at log statements.
                 var logger = this.loggerProvider.CreatedLoggers.Single(l => l.Category == TestHelpers.LogCategory);
                 var logMessages = logger.LogMessages.ToList();
-                bool enabledRpcEndpoint = logMessages.Any(msg => msg.Level == Microsoft.Extensions.Logging.LogLevel.Information && msg.FormattedMessage.StartsWith("Opening local RPC endpoint:"));
+                bool enabledRpcEndpoint = logMessages.Any(msg => msg.Level == Microsoft.Extensions.Logging.LogLevel.Information && msg.FormattedMessage.StartsWith("Opened local RPC endpoint:"));
 
                 Assert.Equal(enabledExpected, enabledRpcEndpoint);
 


### PR DESCRIPTION
Our previous attempt to dynamically select ports for the local RPC endpoint fixed many issues customers had, but there still exists a race condition when multiple hosts start up at the same time. To completely resolve this issue, this PR makes the following changes:

- Move the code that finds a free port closer to the code that attempts to listen on that port.
- Add a retry layer if the free port has been taken by another worker between when we found the free port and when we tried to listen to that port.
- If we somehow hit this race condition 3 times in a row, even though it should be more rare now, we gracefully fallback to using the public endpoints for out-of-process clients instead of failing to start up the host.

resolves #1273

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [ ] My changes **should not** be added to the release notes for the next release
    * [X] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [X] Otherwise: Backport tracked by issue/PR #1723
* [X] I have added all required tests (Unit tests, E2E tests)


