### PR TITLE
Allow use of encoded characters in http apis

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -1,1 +1,9 @@
+### NuGet Package 
+  
+https://www.nuget.org/packages/Microsoft.Azure.WebJobs.Extensions.DurableTask/2.4.2
+
+### Improvements
+
+##### Fixed a bug with http uri decoding that disallowed use of encoded special characters as parameter values. (https://github.com/Azure/azure-functions-durable-extension/pull/1726)
+In conjunction with a PR in the durable task repo (https://github.com/Azure/durabletask/pull/481) in the previous release that added a DT-AzureStorage specific encoding system to circumvent the Azure Storage character restrictions, we have loosened restrictions on orchestration instance ids and entity keys. /, \\, #, and ?, and when using HTTP APIs their encoded versions, are now valid inputs.
 

--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableClient.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableClient.cs
@@ -287,10 +287,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         private async Task SignalEntityAsyncInternal(DurableClient durableClient, string hubName, EntityId entityId, DateTime? scheduledTimeUtc, string operationName, object operationInput)
         {
             var entityKey = entityId.EntityKey;
-            if (entityKey.Any(IsInvalidCharacter))
-            {
-                throw new ArgumentException(nameof(entityKey), "Entity keys must not contain /, \\, #, ?, or control characters.");
-            }
 
             if (operationName == null)
             {

--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableClient.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableClient.cs
@@ -145,10 +145,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             {
                 throw new ArgumentException(nameof(instanceId), "Orchestration instance ids must not start with @.");
             }
-            else if (instanceId.Any(IsInvalidCharacter))
-            {
-                throw new ArgumentException(nameof(instanceId), "Orchestration instance ids must not contain /, \\, #, ?, or control characters.");
-            }
 
             if (instanceId.Length > MaxInstanceIdLength)
             {
@@ -185,11 +181,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             }
 
             return new OrchestrationStatus[0];
-        }
-
-        private static bool IsInvalidCharacter(char c)
-        {
-            return c == '/' || c == '\\' || c == '?' || c == '#' || char.IsControl(c);
         }
 
         /// <inheritdoc />

--- a/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
+++ b/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
@@ -279,8 +279,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 var routeValues = new RouteValueDictionary();
                 if (StartOrchestrationRoute.TryMatch(pathString, routeValues))
                 {
-                    string functionName = this.GetDecodedRouteParameter(routeValues, FunctionNameRouteParameter);
-                    string instanceId = this.GetDecodedRouteParameter(routeValues, InstanceIdRouteParameter);
+                    string functionName = GetDecodedRouteParameter(routeValues, FunctionNameRouteParameter);
+                    string instanceId = GetDecodedRouteParameter(routeValues, InstanceIdRouteParameter);
                     if (request.Method == HttpMethod.Post)
                     {
                         return await this.HandleStartOrchestratorRequestAsync(request, functionName, instanceId);
@@ -295,8 +295,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 {
                     try
                     {
-                        string entityName = this.GetDecodedRouteParameter(routeValues, EntityNameRouteParameter);
-                        string entityKey = this.GetDecodedRouteParameter(routeValues, EntityKeyRouteParameter);
+                        string entityName = GetDecodedRouteParameter(routeValues, EntityNameRouteParameter);
+                        string entityKey = GetDecodedRouteParameter(routeValues, EntityKeyRouteParameter);
 
                         if (request.Method == HttpMethod.Get)
                         {
@@ -328,8 +328,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
                 if (InstancesRoute.TryMatch(pathString, routeValues))
                 {
-                    var instanceId = this.GetDecodedRouteParameter(routeValues, InstanceIdRouteParameter);
-                    var operation = this.GetDecodedRouteParameter(routeValues, OperationRouteParameter);
+                    var instanceId = GetDecodedRouteParameter(routeValues, InstanceIdRouteParameter);
+                    var operation = GetDecodedRouteParameter(routeValues, OperationRouteParameter);
 
                     if (instanceId == null)
                     {
@@ -385,8 +385,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
                 if (InstanceRaiseEventRoute.TryMatch(pathString, routeValues))
                 {
-                    string instanceId = this.GetDecodedRouteParameter(routeValues, InstanceIdRouteParameter);
-                    string eventName = this.GetDecodedRouteParameter(routeValues, EventNameRouteParameter);
+                    string instanceId = GetDecodedRouteParameter(routeValues, InstanceIdRouteParameter);
+                    string eventName = GetDecodedRouteParameter(routeValues, EventNameRouteParameter);
                     if (request.Method == HttpMethod.Post)
                     {
                         return await this.HandleRaiseEventRequestAsync(request, instanceId, eventName);
@@ -414,10 +414,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             }
         }
 
-        private string GetDecodedRouteParameter(RouteValueDictionary routeValues, string routeParameter)
+        private static string GetDecodedRouteParameter(RouteValueDictionary routeValues, string routeParameter)
         {
             var parameter = (string)routeValues[routeParameter];
-            return Uri.UnescapeDataString(parameter);
+            return parameter != null ? Uri.UnescapeDataString(parameter) : null;
+        }
+
+        private static string GetDecodedQueryParameter(NameValueCollection queryParameters, string queryParameter)
+        {
+            var parameter = (string)queryParameters[queryParameter];
+            return parameter != null ? Uri.UnescapeDataString(parameter) : null;
         }
 
         private async Task<HttpResponseMessage> HandleGetStatusRequestAsync(
@@ -695,26 +701,26 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
         private static bool TryGetDateTimeQueryParameterValue(NameValueCollection queryStringNameValueCollection, string queryParameterName, out DateTime dateTimeValue)
         {
-            string value = queryStringNameValueCollection[queryParameterName];
+            string value = GetDecodedQueryParameter(queryStringNameValueCollection, queryParameterName);
             return DateTime.TryParse(value, out dateTimeValue);
         }
 
         private static bool TryGetBooleanQueryParameterValue(NameValueCollection queryStringNameValueCollection, string queryParameterName, out bool boolValue)
         {
-            string value = queryStringNameValueCollection[queryParameterName];
+            string value = GetDecodedQueryParameter(queryStringNameValueCollection, queryParameterName);
             return bool.TryParse(value, out boolValue);
         }
 
         private static bool TryGetIntQueryParameterValue(NameValueCollection queryStringNameValueCollection, string queryParameterName, out int intValue)
         {
-            string value = queryStringNameValueCollection[queryParameterName];
+            string value = GetDecodedQueryParameter(queryStringNameValueCollection, queryParameterName);
             return int.TryParse(value, out intValue);
         }
 
         private static bool TryGetTimeSpanQueryParameterValue(NameValueCollection queryStringNameValueCollection, string queryParameterName, out TimeSpan? timeSpanValue)
         {
             timeSpanValue = null;
-            string value = queryStringNameValueCollection[queryParameterName];
+            string value = GetDecodedQueryParameter(queryStringNameValueCollection, queryParameterName);
             if (double.TryParse(value, out double doubleValue))
             {
                 timeSpanValue = TimeSpan.FromSeconds(doubleValue);

--- a/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
+++ b/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
@@ -12,6 +12,7 @@ using System.Net.Http.Headers;
 using System.Threading;
 using System.Threading.Tasks;
 using DurableTask.Core;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.Routing.Template;
 using Microsoft.Extensions.Logging;
@@ -274,11 +275,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 }
 
                 string path = "/" + request.RequestUri.AbsolutePath.Substring(basePath.Length).Trim('/');
+                var pathString = new PathString(path);
                 var routeValues = new RouteValueDictionary();
-                if (StartOrchestrationRoute.TryMatch(path, routeValues))
+                if (StartOrchestrationRoute.TryMatch(pathString, routeValues))
                 {
-                    string functionName = (string)routeValues[FunctionNameRouteParameter];
-                    string instanceId = (string)routeValues[InstanceIdRouteParameter];
+                    string functionName = this.GetDecodedRouteParameter(routeValues, FunctionNameRouteParameter);
+                    string instanceId = this.GetDecodedRouteParameter(routeValues, InstanceIdRouteParameter);
                     if (request.Method == HttpMethod.Post)
                     {
                         return await this.HandleStartOrchestratorRequestAsync(request, functionName, instanceId);
@@ -289,12 +291,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     }
                 }
 
-                if (EntityRoute.TryMatch(path, routeValues))
+                if (EntityRoute.TryMatch(pathString, routeValues))
                 {
                     try
                     {
-                        string entityName = (string)routeValues[EntityNameRouteParameter];
-                        string entityKey = (string)routeValues[EntityKeyRouteParameter];
+                        string entityName = this.GetDecodedRouteParameter(routeValues, EntityNameRouteParameter);
+                        string entityKey = this.GetDecodedRouteParameter(routeValues, EntityKeyRouteParameter);
 
                         if (request.Method == HttpMethod.Get)
                         {
@@ -324,12 +326,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     }
                 }
 
-                if (InstancesRoute.TryMatch(path, routeValues))
+                if (InstancesRoute.TryMatch(pathString, routeValues))
                 {
-                    routeValues.TryGetValue(InstanceIdRouteParameter, out object instanceIdValue);
-                    routeValues.TryGetValue(OperationRouteParameter, out object operationValue);
-                    var instanceId = instanceIdValue as string;
-                    var operation = operationValue as string;
+                    var instanceId = this.GetDecodedRouteParameter(routeValues, InstanceIdRouteParameter);
+                    var operation = this.GetDecodedRouteParameter(routeValues, OperationRouteParameter);
 
                     if (instanceId == null)
                     {
@@ -383,10 +383,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     }
                 }
 
-                if (InstanceRaiseEventRoute.TryMatch(path, routeValues))
+                if (InstanceRaiseEventRoute.TryMatch(pathString, routeValues))
                 {
-                    string instanceId = (string)routeValues[InstanceIdRouteParameter];
-                    string eventName = (string)routeValues[EventNameRouteParameter];
+                    string instanceId = this.GetDecodedRouteParameter(routeValues, InstanceIdRouteParameter);
+                    string eventName = this.GetDecodedRouteParameter(routeValues, EventNameRouteParameter);
                     if (request.Method == HttpMethod.Post)
                     {
                         return await this.HandleRaiseEventRequestAsync(request, instanceId, eventName);
@@ -412,6 +412,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             {
                 return request.CreateErrorResponse(HttpStatusCode.InternalServerError, "Something went wrong while processing your request", e);
             }
+        }
+
+        private string GetDecodedRouteParameter(RouteValueDictionary routeValues, string routeParameter)
+        {
+            var parameter = (string)routeValues[routeParameter];
+            return Uri.UnescapeDataString(parameter);
         }
 
         private async Task<HttpResponseMessage> HandleGetStatusRequestAsync(

--- a/test/Common/DurableClientBaseTests.cs
+++ b/test/Common/DurableClientBaseTests.cs
@@ -26,47 +26,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 {
     public class DurableClientBaseTests
     {
-        [Theory]
-        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
-        [InlineData("@invalid")]
-        [InlineData("/invalid")]
-        [InlineData("invalid\\")]
-        [InlineData("invalid#")]
-        [InlineData("invalid?")]
-        [InlineData("invalid\t")]
-        [InlineData("invalid\n")]
-        public async Task StartNewAsync_InvalidInstanceId_ThrowsException(string instanceId)
-        {
-            var orchestrationServiceClientMock = new Mock<IOrchestrationServiceClient>();
-            orchestrationServiceClientMock.Setup(x => x.GetOrchestrationStateAsync(It.IsAny<string>(), It.IsAny<bool>())).ReturnsAsync(GetInvalidInstanceState());
-            var storageProvider = new DurabilityProvider("test", new Mock<IOrchestrationService>().Object, orchestrationServiceClientMock.Object, "test");
-            var durableExtension = GetDurableTaskConfig();
-            var durableClient = (IDurableOrchestrationClient)new DurableClient(storageProvider, durableExtension, durableExtension.HttpApiHandler, new DurableClientAttribute { });
-
-            await Assert.ThrowsAnyAsync<ArgumentException>(async () => await durableClient.StartNewAsync("anyOrchestratorFunction", instanceId, new { message = "any obj" }));
-        }
-
-        [Theory]
-        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
-        [InlineData("@invalid")]
-        [InlineData("/invalid")]
-        [InlineData("invalid\\")]
-        [InlineData("invalid#")]
-        [InlineData("invalid?")]
-        [InlineData("invalid\t")]
-        [InlineData("invalid\n")]
-        public async Task SignalEntity_InvalidEntityKey_ThrowsException(string entityKey)
-        {
-            var orchestrationServiceClientMock = new Mock<IOrchestrationServiceClient>();
-            orchestrationServiceClientMock.Setup(x => x.GetOrchestrationStateAsync(It.IsAny<string>(), It.IsAny<bool>())).ReturnsAsync(GetInvalidInstanceState());
-            var storageProvider = new DurabilityProvider("test", new Mock<IOrchestrationService>().Object, orchestrationServiceClientMock.Object, "test");
-            var durableExtension = GetDurableTaskConfig();
-            var durableClient = (IDurableEntityClient)new DurableClient(storageProvider, durableExtension, durableExtension.HttpApiHandler, new DurableClientAttribute { });
-
-            var entityId = new EntityId("test", entityKey);
-            await Assert.ThrowsAnyAsync<ArgumentException>(async () => await durableClient.SignalEntityAsync(entityId, "test"));
-        }
-
         [Fact]
         [Trait("Category", PlatformSpecificHelpers.TestCategory)]
         public async Task RaiseEventAsync_InvalidInstanceId_ThrowsException()

--- a/test/Common/HttpApiHandlerTests.cs
+++ b/test/Common/HttpApiHandlerTests.cs
@@ -380,7 +380,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             var encodedInstanceId = Guid.NewGuid().ToString() + encodedParam;
             var decodedInstanceId = Uri.UnescapeDataString(encodedInstanceId);
 
-
             var correctResult = $"Got valid decoded parameters! encoded: {encodedInstanceId} decoded: {decodedInstanceId}";
             var list = (IList<DurableOrchestrationStatus>)new List<DurableOrchestrationStatus>
             {

--- a/test/Common/TestHelpers.cs
+++ b/test/Common/TestHelpers.cs
@@ -208,9 +208,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         }
 
         /// <summary>
-        /// Helper function to regularly poll for some condition until it is true. If timeout hits, throw timeoutexception
+        /// Helper function to regularly poll for some condition until it is true. If timeout hits, throw timeoutexception.
         /// </summary>
-        /// <param name="predicate">Predicate to wait until it returns true</param>
+        /// <param name="predicate">Predicate to wait until it returns true.</param>
         /// <param name="timeout">Time to wait until predicate is true.</param>
         /// <param name="retryInterval">How frequently to test predicate. Defaults to 100 ms.</param>
         public static async Task WaitUntilTrue(Func<bool> predicate, string conditionDescription, TimeSpan timeout, TimeSpan? retryInterval = null)


### PR DESCRIPTION
Work done in this PR https://github.com/Azure/durabletask/pull/481 allows us to use characters that are restricted in Azure Storage for partition keys. This helps us remove these restrictions from the Durable extension side and let each backend focus on handling its own individual restrictions.

This PR adds the ability to use encoded characters in our Http Apis to allow customers to use instance ids with characters that were previously Azure Storage character restrictions, like slash for example. After our http api route is matched, we decode the parameters to ensure the intended representation is stored as the instance id.

This PR also removes the exceptions we added when a customer attempts to use an entity key or instance id with one of these restricted characters.

### Issue describing the changes in this PR

resolves #1124 

### Pull request checklist

* [ ] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)


