### PR TITLE
Register IPlatformInformationService in AddDurableClientFactory()

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/DurableTaskJobHostConfigurationExtensions.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskJobHostConfigurationExtensions.cs
@@ -45,6 +45,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             serviceCollection.TryAddSingleton<IDurabilityProviderFactory, AzureStorageDurabilityProviderFactory>();
             serviceCollection.TryAddSingleton<IDurableClientFactory, DurableClientFactory>();
             serviceCollection.TryAddSingleton<IMessageSerializerSettingsFactory, MessageSerializerSettingsFactory>();
+#pragma warning disable CS0612 // Type or member is obsolete
+            serviceCollection.TryAddSingleton<IPlatformInformationService, DefaultPlatformInformationProvider>();
+#pragma warning restore CS0612 // Type or member is obsolete
 
             return serviceCollection;
         }

--- a/test/Common/DurableClientBaseTests.cs
+++ b/test/Common/DurableClientBaseTests.cs
@@ -7,8 +7,6 @@ using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
 using DurableTask.Core;
-using FluentAssertions;
-using Microsoft.Azure.WebJobs.Host.TestCommon;
 #if !FUNCTIONS_V1
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -28,14 +26,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 {
     public class DurableClientBaseTests
     {
-        private readonly ITestOutputHelper output;
-        private readonly TestLoggerProvider loggerProvider;
-
-        public DurableClientBaseTests(ITestOutputHelper output)
-        {
-            this.output = output;
-            this.loggerProvider = new TestLoggerProvider(output);
-        }
+        public DurableClientBaseTests() { }
 
         [Theory]
         [Trait("Category", PlatformSpecificHelpers.TestCategory)]
@@ -221,30 +212,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
             var durableOrchestrationClient = this.GetDurableClient(orchestrationServiceClientMock.Object);
             Assert.ThrowsAny<InvalidOperationException>(() => durableOrchestrationClient.CreateHttpManagementPayload("testInstanceId"));
-        }
-
-        /// <summary>
-        /// End to end test that ensures that DurableClientFactory is set up correctly
-        /// (i.e. the correct services are injected through dependency injection
-        /// and AzureStorageDurabilityProvider is created).
-        /// </summary>
-        [Fact]
-        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
-        public async Task DurableClient_AzureStorage_SuccessfulSetup()
-        {
-            string orchestratorName = nameof(TestOrchestrations.SayHelloInline);
-            using (ITestHost host = TestHelpers.GetJobHost(
-                loggerProvider: this.loggerProvider,
-                testName: nameof(this.DurableClient_AzureStorage_SuccessfulSetup),
-                enableExtendedSessions: false,
-                storageProviderType: "azure_storage",
-                addDurableClientFactory: true))
-            {
-                await host.StartAsync();
-                var client = await host.StartOrchestratorAsync(orchestratorName, input: "World", this.output);
-                var status = await client.WaitForCompletionAsync(this.output);
-                await host.StopAsync();
-            }
         }
 
         private IDurableOrchestrationClient GetDurableClient(IOrchestrationServiceClient orchestrationServiceClientMockObject)

--- a/test/Common/DurableClientBaseTests.cs
+++ b/test/Common/DurableClientBaseTests.cs
@@ -26,8 +26,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 {
     public class DurableClientBaseTests
     {
-        public DurableClientBaseTests() { }
-
         [Theory]
         [Trait("Category", PlatformSpecificHelpers.TestCategory)]
         [InlineData("@invalid")]

--- a/test/Common/DurableClientBaseTests.cs
+++ b/test/Common/DurableClientBaseTests.cs
@@ -8,11 +8,11 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using DurableTask.Core;
 using FluentAssertions;
+using Microsoft.Azure.WebJobs.Host.TestCommon;
 #if !FUNCTIONS_V1
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.WebJobs.Extensions.DurableTask.Options;
-using Microsoft.Azure.WebJobs.Host.TestCommon;
 #endif
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -29,17 +29,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
     public class DurableClientBaseTests
     {
         private readonly ITestOutputHelper output;
-
-#if !FUNCTIONS_V1
         private readonly TestLoggerProvider loggerProvider;
-#endif
 
         public DurableClientBaseTests(ITestOutputHelper output)
         {
             this.output = output;
-#if !FUNCTIONS_V1
             this.loggerProvider = new TestLoggerProvider(output);
-#endif
         }
 
         [Theory]

--- a/test/Common/DurableTaskEndToEndTests.cs
+++ b/test/Common/DurableTaskEndToEndTests.cs
@@ -195,6 +195,30 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         }
 
         /// <summary>
+        /// End to end test that ensures that DurableClientFactory is set up correctly
+        /// (i.e. the correct services are injected through dependency injection
+        /// and AzureStorageDurabilityProvider is created).
+        /// </summary>
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public async Task DurableClient_AzureStorage_SuccessfulSetup()
+        {
+            string orchestratorName = nameof(TestOrchestrations.SayHelloInline);
+            using (ITestHost host = TestHelpers.GetJobHost(
+                loggerProvider: this.loggerProvider,
+                testName: nameof(this.DurableClient_AzureStorage_SuccessfulSetup),
+                enableExtendedSessions: false,
+                storageProviderType: "azure_storage",
+                addDurableClientFactory: true))
+            {
+                await host.StartAsync();
+                var client = await host.StartOrchestratorAsync(orchestratorName, input: "World", this.output);
+                var status = await client.WaitForCompletionAsync(this.output);
+                await host.StopAsync();
+            }
+        }
+
+        /// <summary>
         /// End-to-end test which validates a simple orchestrator function does not have assigned value for <see cref="DurableOrchestrationContext.ParentInstanceId"/>.
         /// </summary>
         [Theory]

--- a/test/Common/TestHelpers.cs
+++ b/test/Common/TestHelpers.cs
@@ -145,30 +145,19 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 options.StorageProvider["maxQueuePollingInterval"] = maxQueuePollingInterval.Value;
             }
 
-#if !FUNCTIONS_V1
-            if (addDurableClientFactory)
-            {
-                return GetJobHostWithOptionsForDurableClient(
-                    loggerProvider,
-                    options,
-                    nameResolver,
-                    durableHttpMessageHandler,
-                    lifeCycleNotificationHelper,
-                    serializerSettings,
-                    onSend);
-            }
-#endif
-
             return GetJobHostWithOptions(
-                loggerProvider,
-                options,
-                storageProviderType,
-                nameResolver,
-                durableHttpMessageHandler,
-                lifeCycleNotificationHelper,
-                serializerSettings,
-                onSend,
-                durabilityProviderFactoryType);
+                loggerProvider: loggerProvider,
+                durableTaskOptions: options,
+                storageProviderType: storageProviderType,
+                nameResolver: nameResolver,
+                durableHttpMessageHandler: durableHttpMessageHandler,
+                lifeCycleNotificationHelper: lifeCycleNotificationHelper,
+                serializerSettings: serializerSettings,
+                onSend: onSend,
+#if !FUNCTIONS_V1
+                addDurableClientFactory: addDurableClientFactory,
+#endif
+                durabilityProviderFactoryType: durabilityProviderFactoryType);
         }
 
         public static ITestHost GetJobHostWithOptions(
@@ -180,7 +169,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             ILifeCycleNotificationHelper lifeCycleNotificationHelper = null,
             IMessageSerializerSettingsFactory serializerSettings = null,
             Action<ITelemetry> onSend = null,
-            Type durabilityProviderFactoryType = null)
+            Type durabilityProviderFactoryType = null,
+            bool addDurableClientFactory = false)
         {
             if (serializerSettings == null)
             {
@@ -199,6 +189,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 storageProvider: storageProviderType,
 #if !FUNCTIONS_V1
                 durabilityProviderFactoryType: durabilityProviderFactoryType,
+                addDurableClientFactory: addDurableClientFactory,
 #endif
                 loggerProvider: loggerProvider,
                 nameResolver: testNameResolver,
@@ -232,37 +223,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             return PlatformSpecificHelpers.CreateJobHostWithMultipleDurabilityProviders(
                 optionsWrapper,
                 durabilityProviderFactories);
-        }
-
-        public static ITestHost GetJobHostWithOptionsForDurableClient(
-            ILoggerProvider loggerProvider,
-            DurableTaskOptions durableTaskOptions,
-            INameResolver nameResolver = null,
-            IDurableHttpMessageHandlerFactory durableHttpMessageHandler = null,
-            ILifeCycleNotificationHelper lifeCycleNotificationHelper = null,
-            IMessageSerializerSettingsFactory serializerSettings = null,
-            Action<ITelemetry> onSend = null)
-        {
-            if (serializerSettings == null)
-            {
-                serializerSettings = new MessageSerializerSettingsFactory();
-            }
-
-            var optionsWrapper = new OptionsWrapper<DurableTaskOptions>(durableTaskOptions);
-            var testNameResolver = new TestNameResolver(nameResolver);
-            if (durableHttpMessageHandler == null)
-            {
-                durableHttpMessageHandler = new DurableHttpMessageHandlerFactory();
-            }
-
-            return PlatformSpecificHelpers.CreateJobHostForDurableClient(
-                options: optionsWrapper,
-                loggerProvider: loggerProvider,
-                nameResolver: testNameResolver,
-                durableHttpMessageHandler: durableHttpMessageHandler,
-                lifeCycleNotificationHelper: lifeCycleNotificationHelper,
-                serializerSettingsFactory: serializerSettings,
-                onSend: onSend);
         }
 #endif
 

--- a/test/FunctionsV2/PlatformSpecificHelpers.FunctionsV2.cs
+++ b/test/FunctionsV2/PlatformSpecificHelpers.FunctionsV2.cs
@@ -219,7 +219,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         /// Registers the services needed for DurableClientFactory and calls AddDurableClientFactory()
         /// which adds the Durable Task extension that uses Azure Storage.
         /// </summary>
-        private static IWebJobsBuilder AddDurableClientFactoryDurableTask(this IWebJobsBuilder builder, IOptions<DurableTaskOptions> options, IEnumerable<IDurabilityProviderFactory> durabilityProviderFactories = null)
+        private static IWebJobsBuilder AddDurableClientFactoryDurableTask(this IWebJobsBuilder builder, IOptions<DurableTaskOptions> options)
         {
             builder.Services.AddDurableClientFactory();
 

--- a/test/FunctionsV2/PlatformSpecificHelpers.FunctionsV2.cs
+++ b/test/FunctionsV2/PlatformSpecificHelpers.FunctionsV2.cs
@@ -215,6 +215,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             return builder;
         }
 
+        /// <summary>
+        /// Registers the services needed for DurableClientFactory and calls AddDurableClientFactory()
+        /// which adds the Durable Task extension that uses Azure Storage.
+        /// </summary>
         private static IWebJobsBuilder AddDurableClientFactoryDurableTask(this IWebJobsBuilder builder, IOptions<DurableTaskOptions> options, IEnumerable<IDurabilityProviderFactory> durabilityProviderFactories = null)
         {
             builder.Services.AddDurableClientFactory();


### PR DESCRIPTION
These changes incorporate the changes from #1706 and register `IPlatformInformationService` in `AddDurableClientFactory()`. Without registering `IPlatformInformationService` , creating a DurableClient with Azure Storage fails because it can't find an implementation of `IPlatformInformationService` in `AzureStorageDurabilityProviderFactory`. This PR also includes a test in DurableClientBaseTests to help us catch if any new services need to be registered in `AddDurableClientFactory()` in the future.

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)


