### PR TITLE
Edit issue creation flow to accomodate Discussions

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Ask a question about Durable Functions
+    url: https://github.com/Azure/azure-functions-durable-extension/discussions/new?category=q-a
+    about: Get advice/answers to questions from the community and the development team
+  - name: Suggest a feature idea
+    url: https://github.com/Azure/azure-functions-durable-extension/discussions/new?category=ideas
+    about: Have a loose idea for a feature without a concrete proposal? Start a discussion about the problem you are trying to solve and potential features that could fix those issues.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,6 +1,6 @@
 ---
-name: Feature request
-about: Suggest an idea for this project
+name: Feature Proposal
+about: Fleshed out proposal for a new feature. For brainstorming feature ideas, go to https://github.com/Azure/azure-functions-durable-extension/discussions/categories/ideas
 title: ''
 labels: ''
 assignees: ''
@@ -9,6 +9,9 @@ assignees: ''
 
 **Is your feature request related to a problem? Please describe.**
 A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Are there any existing GitHub discussions or issues filed that help give some context to this proposal?**
+Links to any previous discussions or issues providing context for the proposal.
 
 **Describe the solution you'd like**
 A clear and concise description of what you want to happen.


### PR DESCRIPTION
Reconfigure the issue creation flow to point people to using the new Discussions GitHub functionality when asking features or proposing feature ideas without concrete proposals.

