### PR TITLE
Change local RPC port selection logic

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -1,5 +1,6 @@
 ## New Features
 
 ## Bug fixes
+- Fix issue with local RPC endpoint used by non-.NET languages on Windows apps (#1800)
 
 ## Breaking Changes

--- a/src/WebJobs.Extensions.DurableTask/LocalHttpListener.cs
+++ b/src/WebJobs.Extensions.DurableTask/LocalHttpListener.cs
@@ -49,6 +49,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             this.InternalRpcUri = new Uri($"http://uninitialized");
             this.localWebHost = new NoOpWebHost();
             this.portGenerator = new Random();
+            this.attemptedPorts = new HashSet<int>();
         }
 
         public Uri InternalRpcUri { get; private set; }


### PR DESCRIPTION
Current RPC port selection logic favors ephemeral ports. This leads to
issues with the web apps sandbox.

Instead, we now use randomized port selection from an approved range of
ports.

<!-- Start the PR description with some context for the change. -->


<!-- Make sure to delete the markdown comments and the below sections when squash merging -->
### Issue describing the changes in this PR

resolves #1798

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [x] Otherwise: Backport tracked by issue/PR #1801
* [x] I have added all required tests (Unit tests, E2E tests)


