### PR TITLE
Support alternative OOProc replay mechanism

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/Bindings/OrchestrationTriggerAttributeBindingProvider.cs
+++ b/src/WebJobs.Extensions.DurableTask/Bindings/OrchestrationTriggerAttributeBindingProvider.cs
@@ -177,7 +177,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     new JProperty("instanceId", arg.InstanceId),
                     new JProperty("isReplaying", arg.IsReplaying),
                     new JProperty("parentInstanceId", arg.ParentInstanceId),
-                    new JProperty("upperSchemaVersion", SchemaVersion.ReplayPatchV1));
+                    new JProperty("upperSchemaVersion", SchemaVersion.V2));
                 return contextObject.ToString();
             }
         }

--- a/src/WebJobs.Extensions.DurableTask/Bindings/OrchestrationTriggerAttributeBindingProvider.cs
+++ b/src/WebJobs.Extensions.DurableTask/Bindings/OrchestrationTriggerAttributeBindingProvider.cs
@@ -11,6 +11,7 @@ using Microsoft.Azure.WebJobs.Host.Listeners;
 using Microsoft.Azure.WebJobs.Host.Protocols;
 using Microsoft.Azure.WebJobs.Host.Triggers;
 using Newtonsoft.Json.Linq;
+using static Microsoft.Azure.WebJobs.Extensions.DurableTask.OutOfProcOrchestrationShim;
 
 namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 {
@@ -175,7 +176,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     new JProperty("input", input),
                     new JProperty("instanceId", arg.InstanceId),
                     new JProperty("isReplaying", arg.IsReplaying),
-                    new JProperty("parentInstanceId", arg.ParentInstanceId));
+                    new JProperty("parentInstanceId", arg.ParentInstanceId),
+                    new JProperty("upperSchemaVersion", SchemaVersion.ReplayPatchV1));
                 return contextObject.ToString();
             }
         }

--- a/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
@@ -648,6 +648,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 return;
             }
 
+            shim.SetOutOfProcTraceHelper(this.TraceHelper);
             DurableOrchestrationContext context = (DurableOrchestrationContext)shim.Context;
 
             OrchestrationRuntimeState orchestrationRuntimeState = dispatchContext.GetProperty<OrchestrationRuntimeState>();

--- a/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
@@ -648,7 +648,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 return;
             }
 
-            shim.SetOutOfProcTraceHelper(this.TraceHelper);
             DurableOrchestrationContext context = (DurableOrchestrationContext)shim.Context;
 
             OrchestrationRuntimeState orchestrationRuntimeState = dispatchContext.GetProperty<OrchestrationRuntimeState>();

--- a/src/WebJobs.Extensions.DurableTask/EndToEndTraceHelper.cs
+++ b/src/WebJobs.Extensions.DurableTask/EndToEndTraceHelper.cs
@@ -239,6 +239,27 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             }
         }
 
+        public void ProcessingOutOfProcPayload(
+            string taskHub,
+            string instanceId,
+            string details,
+            string functionType,
+            bool isReplay)
+        {
+                EtwEventSource.Instance.ProcessingOutOfProcPayload(
+                    taskHub,
+                    LocalAppName,
+                    LocalSlotName,
+                    details,
+                    instanceId,
+                    functionType.ToString(),
+                    ExtensionVersion,
+                    isReplay);
+
+                this.logger.LogInformation("TBD");
+
+        }
+
         public void FunctionTerminated(
             string hubName,
             string functionName,

--- a/src/WebJobs.Extensions.DurableTask/EndToEndTraceHelper.cs
+++ b/src/WebJobs.Extensions.DurableTask/EndToEndTraceHelper.cs
@@ -242,22 +242,17 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         public void ProcessingOutOfProcPayload(
             string taskHub,
             string instanceId,
-            string details,
-            string functionType,
-            bool isReplay)
+            string details)
         {
                 EtwEventSource.Instance.ProcessingOutOfProcPayload(
                     taskHub,
                     LocalAppName,
                     LocalSlotName,
-                    details,
                     instanceId,
-                    functionType.ToString(),
-                    ExtensionVersion,
-                    isReplay);
+                    details,
+                    ExtensionVersion);
 
                 this.logger.LogInformation("TBD");
-
         }
 
         public void FunctionTerminated(

--- a/src/WebJobs.Extensions.DurableTask/EndToEndTraceHelper.cs
+++ b/src/WebJobs.Extensions.DurableTask/EndToEndTraceHelper.cs
@@ -254,8 +254,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 details,
                 ExtensionVersion);
 
-            this.logger.LogInformation(
-                "{instanceId}: Function '{functionName} ({functionType})' is being replayed. Details: {details}. : {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}. SequenceNumber: {sequenceNumber}.",
+            this.logger.LogDebug(
+                "{instanceId}: Function '{functionName} ({functionType})' returned the following OOProc orchestration state: {details}. : {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}. SequenceNumber: {sequenceNumber}.",
                 instanceId, functionName, FunctionType.Orchestrator, details, taskHub, LocalAppName, LocalSlotName, ExtensionVersion, this.sequenceNumber++);
         }
 

--- a/src/WebJobs.Extensions.DurableTask/EndToEndTraceHelper.cs
+++ b/src/WebJobs.Extensions.DurableTask/EndToEndTraceHelper.cs
@@ -245,18 +245,18 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             string instanceId,
             string details)
         {
-                EtwEventSource.Instance.ProcessingOutOfProcPayload(
-                    functionName,
-                    taskHub,
-                    LocalAppName,
-                    LocalSlotName,
-                    instanceId,
-                    details,
-                    ExtensionVersion);
+            EtwEventSource.Instance.ProcessingOutOfProcPayload(
+                functionName,
+                taskHub,
+                LocalAppName,
+                LocalSlotName,
+                instanceId,
+                details,
+                ExtensionVersion);
 
-                this.logger.LogInformation(
-                    "{instanceId}: Function '{functionName} ({functionType})' is being replayed. Details: {details}. : {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}. SequenceNumber: {sequenceNumber}.",
-                    instanceId, functionName, FunctionType.Orchestrator, details, taskHub, LocalAppName, LocalSlotName, ExtensionVersion, this.sequenceNumber++);
+            this.logger.LogInformation(
+                "{instanceId}: Function '{functionName} ({functionType})' is being replayed. Details: {details}. : {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}. SequenceNumber: {sequenceNumber}.",
+                instanceId, functionName, FunctionType.Orchestrator, details, taskHub, LocalAppName, LocalSlotName, ExtensionVersion, this.sequenceNumber++);
         }
 
         public void FunctionTerminated(

--- a/src/WebJobs.Extensions.DurableTask/EndToEndTraceHelper.cs
+++ b/src/WebJobs.Extensions.DurableTask/EndToEndTraceHelper.cs
@@ -240,11 +240,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         }
 
         public void ProcessingOutOfProcPayload(
+            string functionName,
             string taskHub,
             string instanceId,
             string details)
         {
                 EtwEventSource.Instance.ProcessingOutOfProcPayload(
+                    functionName,
                     taskHub,
                     LocalAppName,
                     LocalSlotName,
@@ -252,7 +254,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     details,
                     ExtensionVersion);
 
-                this.logger.LogInformation("TBD");
+                this.logger.LogInformation(
+                    "{instanceId}: Function '{functionName} ({functionType})' is being replayed. Details: {details}. : {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}. SequenceNumber: {sequenceNumber}.",
+                    instanceId, functionName, FunctionType.Orchestrator, details, taskHub, LocalAppName, LocalSlotName, ExtensionVersion, this.sequenceNumber++);
         }
 
         public void FunctionTerminated(

--- a/src/WebJobs.Extensions.DurableTask/EtwEventSource.cs
+++ b/src/WebJobs.Extensions.DurableTask/EtwEventSource.cs
@@ -401,7 +401,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             this.WriteEvent(224, TaskHub, AppName, SlotName, FunctionName, InstanceId, Reason, FunctionType, ExtensionVersion, IsReplay);
         }
 
-        [Event(225, Level = EventLevel.Informational)]
+        [Event(225, Level = EventLevel.Verbose)]
         public void ProcessingOutOfProcPayload(
             string FunctionName,
             string TaskHub,

--- a/src/WebJobs.Extensions.DurableTask/EtwEventSource.cs
+++ b/src/WebJobs.Extensions.DurableTask/EtwEventSource.cs
@@ -403,6 +403,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
         [Event(225, Level = EventLevel.Informational)]
         public void ProcessingOutOfProcPayload(
+            string FunctionName,
             string TaskHub,
             string AppName,
             string SlotName,
@@ -410,7 +411,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             string Details,
             string ExtensionVersion)
         {
-            this.WriteEvent(225, TaskHub, AppName, SlotName, InstanceId, Details, FunctionType.Orchestrator, ExtensionVersion);
+            this.WriteEvent(225, FunctionName, TaskHub, AppName, SlotName, InstanceId, Details, FunctionType.Orchestrator, ExtensionVersion);
         }
 #pragma warning restore SA1313 // Parameter names should begin with lower-case letter
     }

--- a/src/WebJobs.Extensions.DurableTask/EtwEventSource.cs
+++ b/src/WebJobs.Extensions.DurableTask/EtwEventSource.cs
@@ -400,6 +400,20 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         {
             this.WriteEvent(224, TaskHub, AppName, SlotName, FunctionName, InstanceId, Reason, FunctionType, ExtensionVersion, IsReplay);
         }
+
+        [Event(225, Level = EventLevel.Informational)]
+        public void ProcessingOutOfProcPayload(
+            string TaskHub,
+            string AppName,
+            string SlotName,
+            string InstanceId,
+            string Details,
+            string FunctionType,
+            string ExtensionVersion,
+            bool IsReplay)
+        {
+            this.WriteEvent(225, TaskHub, AppName, SlotName, InstanceId, Details, FunctionType, ExtensionVersion, IsReplay);
+        }
 #pragma warning restore SA1313 // Parameter names should begin with lower-case letter
     }
 }

--- a/src/WebJobs.Extensions.DurableTask/EtwEventSource.cs
+++ b/src/WebJobs.Extensions.DurableTask/EtwEventSource.cs
@@ -408,11 +408,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             string SlotName,
             string InstanceId,
             string Details,
-            string FunctionType,
-            string ExtensionVersion,
-            bool IsReplay)
+            string ExtensionVersion)
         {
-            this.WriteEvent(225, TaskHub, AppName, SlotName, InstanceId, Details, FunctionType, ExtensionVersion, IsReplay);
+            this.WriteEvent(225, TaskHub, AppName, SlotName, InstanceId, Details, FunctionType.Orchestrator, ExtensionVersion);
         }
 #pragma warning restore SA1313 // Parameter names should begin with lower-case letter
     }

--- a/src/WebJobs.Extensions.DurableTask/Listener/OutOfProcOrchestrationShim.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/OutOfProcOrchestrationShim.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
     {
         private readonly IDurableOrchestrationContext context;
 
-        private EndToEndTraceHelper TraceHelper;
+        private EndToEndTraceHelper traceHelper;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="OutOfProcOrchestrationShim"/> class.
@@ -31,11 +31,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         public OutOfProcOrchestrationShim(IDurableOrchestrationContext context)
         {
             this.context = context ?? throw new ArgumentNullException(nameof(context));
-        }
-
-        public void SetTraceHelper(EndToEndTraceHelper tracehelper)
-        {
-            this.TraceHelper = tracehelper;
         }
 
         /// <summary>
@@ -64,6 +59,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             WhenAll = 12,
         }
 
+        public void SetTraceHelper(EndToEndTraceHelper tracehelper)
+        {
+            this.traceHelper = tracehelper;
+        }
+
         // Handles replaying the Durable Task APIs that the out-of-proc function scheduled
         // with user code.
         public async Task HandleDurableTaskReplay(OrchestrationInvocationResult executionJson)
@@ -85,7 +85,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             {
                 try
                 {
-                    this.TraceHelper.ProcessingOutOfProcPayload("", "", jsonText, "", this.context.IsReplaying);
+                    this.traceHelper.ProcessingOutOfProcPayload(
+                        taskHub: "TBD",
+                        instanceId: this.context.InstanceId,
+                        details: jsonText);
+
                     jObj = JObject.Parse(jsonText);
                 }
                 catch
@@ -133,7 +137,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// <returns>If the API returns a task, the DF task corresponding to the input action. Else, null.</returns>
         private Task InvokeAPIFromAction(AsyncAction action)
         {
-
             Task fireAndForgetTask = Task.CompletedTask;
             Task task = null;
             switch (action.ActionType)

--- a/src/WebJobs.Extensions.DurableTask/Listener/OutOfProcOrchestrationShim.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/OutOfProcOrchestrationShim.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         internal enum SchemaVersion
         {
             Original = 0,
-            ReplayPatchV1 = 1,
+            V2 = 1,
         }
 
         private enum AsyncActionType
@@ -125,7 +125,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
         /// <summary>
         /// Invokes a DF API based on the input action object.
-        /// Most APIs will return a Task to be awaited, but others such as SignalEntity do not.
         /// </summary>
         /// <param name="action">An OOProc action object representing a DF task.</param>
         /// <returns>If the API returns a task, the DF task corresponding to the input action. Else, null.</returns>
@@ -215,7 +214,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
         /// <summary>
         /// Replays the orchestration execution from an OOProc SDK in .NET.
-        /// This is the V2 implementation of that replay procedure.
         /// </summary>
         /// <param name="actions">The OOProc actions payload.</param>
         /// <returns>An awaitable Task that completes once replay completes.</returns>
@@ -238,7 +236,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         {
             switch (schema)
             {
-                case SchemaVersion.ReplayPatchV1:
+                case SchemaVersion.V2:
                     // In this schema, action arrays should be 1 dimensional (1 action per yield), but due to legacy behavior they're nested within a 2-dimensional array.
                     if (actions.Length != 1)
                     {
@@ -248,12 +246,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     await this.ProcessAsyncActionsV2(actions[0]);
                     break;
                 default: // same as: case SchemaVersion.Original
-                    await this.ProcessAsyncActions(actions);
+                    await this.ProcessAsyncActionsV1(actions);
                     break;
             }
         }
 
-        private async Task ProcessAsyncActions(AsyncAction[][] actions)
+        private async Task ProcessAsyncActionsV1(AsyncAction[][] actions)
         {
             if (actions == null)
             {

--- a/src/WebJobs.Extensions.DurableTask/Listener/OutOfProcOrchestrationShim.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/OutOfProcOrchestrationShim.cs
@@ -71,33 +71,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             }
         }
 
-        internal JObject ParseOOProcResult(OrchestrationInvocationResult result)
-        {
-            JObject jObj = result.ReturnValue as JObject;
-            if (jObj == null && result.ReturnValue is string jsonText)
-            {
-                try
-                {
-                    jObj = JObject.Parse(jsonText);
-                }
-                catch
-                {
-                    throw new ArgumentException("Out of proc orchestrators must return a valid JSON schema");
-                }
-            }
-
-            if (jObj == null)
-            {
-                throw new ArgumentException("The data returned by the out-of-process function execution was not valid json.");
-            }
-
-            return jObj;
-        }
-
         internal async Task<bool> ScheduleDurableTaskEvents(OrchestrationInvocationResult result)
         {
-            JObject jObj = this.ParseOOProcResult(result);
-            var execution = JsonConvert.DeserializeObject<OutOfProcOrchestratorState>(jObj.ToString());
+            var execution = JsonConvert.DeserializeObject<OutOfProcOrchestratorState>(result.JsonString);
             if (execution.CustomStatus != null)
             {
                 this.context.SetCustomStatus(execution.CustomStatus);

--- a/src/WebJobs.Extensions.DurableTask/Listener/OutOfProcOrchestrationShim.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/OutOfProcOrchestrationShim.cs
@@ -22,6 +22,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
     {
         private readonly IDurableOrchestrationContext context;
 
+        private EndToEndTraceHelper TraceHelper;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="OutOfProcOrchestrationShim"/> class.
         /// </summary>
@@ -29,6 +31,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         public OutOfProcOrchestrationShim(IDurableOrchestrationContext context)
         {
             this.context = context ?? throw new ArgumentNullException(nameof(context));
+        }
+
+        public void SetTraceHelper(EndToEndTraceHelper tracehelper)
+        {
+            this.TraceHelper = tracehelper;
         }
 
         /// <summary>
@@ -78,6 +85,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             {
                 try
                 {
+                    this.TraceHelper.ProcessingOutOfProcPayload("", "", jsonText, "", this.context.IsReplaying);
                     jObj = JObject.Parse(jsonText);
                 }
                 catch

--- a/src/WebJobs.Extensions.DurableTask/Listener/OutOfProcOrchestrationShim.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/OutOfProcOrchestrationShim.cs
@@ -221,9 +221,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
                     await this.ProcessAsyncActionsV2(actions[0]);
                     break;
-                default: // same as: case SchemaVersion.Original
+                case SchemaVersion.Original:
                     await this.ProcessAsyncActionsV1(actions);
                     break;
+                default:
+                    throw new ArgumentException($"The OOProc schema of of version \"{schema}\" is unsupported by this durable-extension version.");
             }
         }
 

--- a/src/WebJobs.Extensions.DurableTask/Listener/OutOfProcOrchestrationShim.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/OutOfProcOrchestrationShim.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// <summary>
         /// Identifiers for each OOProc Schema Version.
         /// </summary>
-        private enum SchemaVersion
+        internal enum SchemaVersion
         {
             Original = 0,
             ReplayPatchV1 = 1,

--- a/src/WebJobs.Extensions.DurableTask/Listener/TaskOrchestrationShim.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/TaskOrchestrationShim.cs
@@ -250,13 +250,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 this.JsonString = resultJSONString;
             }
 
-            public object ReturnValue { get; private set; }
+            public object ReturnValue { get; }
 
-            public Exception Exception { get; private set; }
+            public Exception Exception { get; }
 
-            public JObject Json { get; private set; }
+            public JObject Json { get; }
 
-            public string JsonString { get; private set; }
+            public string JsonString { get; }
 
             private (JObject, string) ParseOOProcResult(object result)
             {

--- a/src/WebJobs.Extensions.DurableTask/Listener/TaskOrchestrationShim.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/TaskOrchestrationShim.cs
@@ -19,7 +19,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         private readonly DurableOrchestrationContext context;
         private readonly OutOfProcOrchestrationShim outOfProcShim;
         private readonly DurableTaskExtension config;
-        private EndToEndTraceHelper traceHelper;
 
         public TaskOrchestrationShim(DurableTaskExtension config, DurabilityProvider durabilityProvider, string name)
             : base(config)
@@ -29,12 +28,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             this.outOfProcShim = new OutOfProcOrchestrationShim(this.context);
         }
 
+        public override DurableCommonContext Context => this.context;
+
         public void SetOutOfProcTraceHelper(EndToEndTraceHelper traceHelper)
         {
             this.outOfProcShim.SetTraceHelper(traceHelper);
         }
-
-        public override DurableCommonContext Context => this.context;
 
         public override RegisteredFunctionInfo GetFunctionInfo()
         {

--- a/src/WebJobs.Extensions.DurableTask/Listener/TaskOrchestrationShim.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/TaskOrchestrationShim.cs
@@ -25,15 +25,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         {
             this.config = config;
             this.context = new DurableOrchestrationContext(config, durabilityProvider, name);
-            this.outOfProcShim = new OutOfProcOrchestrationShim(this.context);
+            this.outOfProcShim = new OutOfProcOrchestrationShim(this.context, this.Context, this.Config.TraceHelper);
         }
 
         public override DurableCommonContext Context => this.context;
-
-        public void SetOutOfProcTraceHelper(EndToEndTraceHelper traceHelper)
-        {
-            this.outOfProcShim.SetTraceHelper(traceHelper);
-        }
 
         public override RegisteredFunctionInfo GetFunctionInfo()
         {

--- a/src/WebJobs.Extensions.DurableTask/Listener/TaskOrchestrationShim.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/TaskOrchestrationShim.cs
@@ -19,6 +19,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         private readonly DurableOrchestrationContext context;
         private readonly OutOfProcOrchestrationShim outOfProcShim;
         private readonly DurableTaskExtension config;
+        private EndToEndTraceHelper traceHelper;
 
         public TaskOrchestrationShim(DurableTaskExtension config, DurabilityProvider durabilityProvider, string name)
             : base(config)
@@ -26,6 +27,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             this.config = config;
             this.context = new DurableOrchestrationContext(config, durabilityProvider, name);
             this.outOfProcShim = new OutOfProcOrchestrationShim(this.context);
+        }
+
+        public void SetOutOfProcTraceHelper(EndToEndTraceHelper traceHelper)
+        {
+            this.outOfProcShim.SetTraceHelper(traceHelper);
         }
 
         public override DurableCommonContext Context => this.context;

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net461.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net461.xml
@@ -3176,36 +3176,27 @@
             Identifiers for each OOProc Schema Version.
             </summary>
         </member>
-        <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.OutOfProcOrchestrationShim.TaskGroupingType">
+        <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.OutOfProcOrchestrationShim.OperationType">
             <summary>
             Identifiers for each kind of action object.
             </summary>
         </member>
-        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.OutOfProcOrchestrationShim.InvokeAPIFromAction(Microsoft.Azure.WebJobs.Extensions.DurableTask.OutOfProcOrchestrationShim.AsyncAction)">
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.OutOfProcOrchestrationShim.InvokeAPIFromAction(Microsoft.Azure.WebJobs.Extensions.DurableTask.OutOfProcOrchestrationShim.AsyncAction,System.Boolean)">
             <summary>
             Invokes a DF API based on the input action object.
             Most APIs will return a Task to be awaited, but others such as SignalEntity do not.
             </summary>
             <param name="action">An OOProc action object representing a DF task.</param>
+            <param name="returnfireAndForgetTask">Whether to return a `CompletedTask` to represent fire-and-forget APIs. Defaults to `true`.</param>
             <returns>If the API returns a task, the DF task corresponding to the input action. Else, null.</returns>
         </member>
-        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.OutOfProcOrchestrationShim.ProcessAsyncActionsV2(Microsoft.Azure.WebJobs.Extensions.DurableTask.OutOfProcOrchestrationShim.AsyncAction[][])">
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.OutOfProcOrchestrationShim.ProcessAsyncActionsV2(Microsoft.Azure.WebJobs.Extensions.DurableTask.OutOfProcOrchestrationShim.AsyncAction[])">
             <summary>
             Replays the orchestration execution from an OOProc SDK in .NET.
             This is the V2 implementation of that replay procedure.
             </summary>
-            <param name="actionSet">The OOProc actions payload.</param>
-            <returns>An awaitable Task that completes once replay completes.</returns>
-        </member>
-        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.OutOfProcOrchestrationShim.GetCompoundTaskFromActions(Microsoft.Azure.WebJobs.Extensions.DurableTask.OutOfProcOrchestrationShim.AsyncAction[],System.Int32,System.Int32,Microsoft.Azure.WebJobs.Extensions.DurableTask.OutOfProcOrchestrationShim.TaskGroupingType)">
-            <summary>
-            Recursively construct a compound Task (a task of tasks) from a list of actions.
-            </summary>
             <param name="actions">The OOProc actions payload.</param>
-            <param name="index">The index at which to start processing the actions.</param>
-            <param name="depth">The current task depth, equal to the number of outer / parent tasks.</param>
-            <param name="kind">The kind of parent task: WhenAll or WhenAny.</param>
-            <returns>A compound task, either: WhenAll or WhenAny.</returns>
+            <returns>An awaitable Task that completes once replay completes.</returns>
         </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.OutOfProcOrchestrationShim.ReplayOOProcOrchestration(Microsoft.Azure.WebJobs.Extensions.DurableTask.OutOfProcOrchestrationShim.AsyncAction[][],Microsoft.Azure.WebJobs.Extensions.DurableTask.OutOfProcOrchestrationShim.SchemaVersion)">
             <summary>

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net461.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net461.xml
@@ -3179,7 +3179,6 @@
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.OutOfProcOrchestrationShim.InvokeAPIFromAction(Microsoft.Azure.WebJobs.Extensions.DurableTask.OutOfProcOrchestrationShim.AsyncAction)">
             <summary>
             Invokes a DF API based on the input action object.
-            Most APIs will return a Task to be awaited, but others such as SignalEntity do not.
             </summary>
             <param name="action">An OOProc action object representing a DF task.</param>
             <returns>If the API returns a task, the DF task corresponding to the input action. Else, null.</returns>
@@ -3187,7 +3186,6 @@
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.OutOfProcOrchestrationShim.ProcessAsyncActionsV2(Microsoft.Azure.WebJobs.Extensions.DurableTask.OutOfProcOrchestrationShim.AsyncAction[])">
             <summary>
             Replays the orchestration execution from an OOProc SDK in .NET.
-            This is the V2 implementation of that replay procedure.
             </summary>
             <param name="actions">The OOProc actions payload.</param>
             <returns>An awaitable Task that completes once replay completes.</returns>

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net461.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net461.xml
@@ -3176,18 +3176,12 @@
             Identifiers for each OOProc Schema Version.
             </summary>
         </member>
-        <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.OutOfProcOrchestrationShim.OperationType">
-            <summary>
-            Identifiers for each kind of action object.
-            </summary>
-        </member>
-        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.OutOfProcOrchestrationShim.InvokeAPIFromAction(Microsoft.Azure.WebJobs.Extensions.DurableTask.OutOfProcOrchestrationShim.AsyncAction,System.Boolean)">
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.OutOfProcOrchestrationShim.InvokeAPIFromAction(Microsoft.Azure.WebJobs.Extensions.DurableTask.OutOfProcOrchestrationShim.AsyncAction)">
             <summary>
             Invokes a DF API based on the input action object.
             Most APIs will return a Task to be awaited, but others such as SignalEntity do not.
             </summary>
             <param name="action">An OOProc action object representing a DF task.</param>
-            <param name="returnfireAndForgetTask">Whether to return a `CompletedTask` to represent fire-and-forget APIs. Defaults to `true`.</param>
             <returns>If the API returns a task, the DF task corresponding to the input action. Else, null.</returns>
         </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.OutOfProcOrchestrationShim.ProcessAsyncActionsV2(Microsoft.Azure.WebJobs.Extensions.DurableTask.OutOfProcOrchestrationShim.AsyncAction[])">

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net461.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net461.xml
@@ -3165,13 +3165,11 @@
             Not intended for public consumption.
             </summary>
         </member>
-        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.OutOfProcOrchestrationShim.#ctor(Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableOrchestrationContext,Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableCommonContext,Microsoft.Azure.WebJobs.Extensions.DurableTask.EndToEndTraceHelper)">
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.OutOfProcOrchestrationShim.#ctor(Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableOrchestrationContext)">
             <summary>
             Initializes a new instance of the <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.OutOfProcOrchestrationShim"/> class.
             </summary>
             <param name="context">The orchestration execution context.</param>
-            <param name="durablecommonContext">The durable app shared context.</param>
-            <param name="traceHelper">The traceHelper for OOProc-specific telemetry.</param>
         </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.OutOfProcOrchestrationShim.SchemaVersion">
             <summary>

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net461.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net461.xml
@@ -3171,6 +3171,51 @@
             </summary>
             <param name="context">The orchestration execution context.</param>
         </member>
+        <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.OutOfProcOrchestrationShim.SchemaVersion">
+            <summary>
+            Identifiers for each OOProc Schema Version.
+            </summary>
+        </member>
+        <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.OutOfProcOrchestrationShim.TaskGroupingType">
+            <summary>
+            Identifiers for each kind of action object.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.OutOfProcOrchestrationShim.InvokeAPIFromAction(Microsoft.Azure.WebJobs.Extensions.DurableTask.OutOfProcOrchestrationShim.AsyncAction)">
+            <summary>
+            Invokes a DF API based on the input action object.
+            Most APIs will return a Task to be awaited, but others such as SignalEntity do not.
+            </summary>
+            <param name="action">An OOProc action object representing a DF task.</param>
+            <returns>If the API returns a task, the DF task corresponding to the input action. Else, null.</returns>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.OutOfProcOrchestrationShim.ProcessAsyncActionsV2(Microsoft.Azure.WebJobs.Extensions.DurableTask.OutOfProcOrchestrationShim.AsyncAction[][])">
+            <summary>
+            Replays the orchestration execution from an OOProc SDK in .NET.
+            This is the V2 implementation of that replay procedure.
+            </summary>
+            <param name="actionSet">The OOProc actions payload.</param>
+            <returns>An awaitable Task that completes once replay completes.</returns>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.OutOfProcOrchestrationShim.GetCompoundTaskFromActions(Microsoft.Azure.WebJobs.Extensions.DurableTask.OutOfProcOrchestrationShim.AsyncAction[],System.Int32,System.Int32,Microsoft.Azure.WebJobs.Extensions.DurableTask.OutOfProcOrchestrationShim.TaskGroupingType)">
+            <summary>
+            Recursively construct a compound Task (a task of tasks) from a list of actions.
+            </summary>
+            <param name="actions">The OOProc actions payload.</param>
+            <param name="index">The index at which to start processing the actions.</param>
+            <param name="depth">The current task depth, equal to the number of outer / parent tasks.</param>
+            <param name="kind">The kind of parent task: WhenAll or WhenAny.</param>
+            <returns>A compound task, either: WhenAll or WhenAny.</returns>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.OutOfProcOrchestrationShim.ReplayOOProcOrchestration(Microsoft.Azure.WebJobs.Extensions.DurableTask.OutOfProcOrchestrationShim.AsyncAction[][],Microsoft.Azure.WebJobs.Extensions.DurableTask.OutOfProcOrchestrationShim.SchemaVersion)">
+            <summary>
+            Replays the OOProc orchestration based on the actions array. It uses the schema enum to
+            determine which replay implementation is most appropiate.
+            </summary>
+            <param name="actions">The OOProc actions payload.</param>
+            <param name="schema">The OOProc protocol schema version.</param>
+            <returns>An awaitable Task that completes once replay completes.</returns>
+        </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.TaskActivityShim">
             <summary>
             Task activity implementation which delegates the implementation to a function.
@@ -3909,6 +3954,34 @@
             Option to only start a new orchestrator instance with an existing instance Id when the existing
             instance is in a terminated, failed, or completed state.
             </summary>
+        </member>
+        <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.ProviderUtils">
+            <summary>
+            Provides access to internal functionality for the purpose of implementing durability providers.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.ProviderUtils.GetSchedulerIdFromEntityId(Microsoft.Azure.WebJobs.Extensions.DurableTask.EntityId)">
+            <summary>
+            Returns the instance id of the entity scheduler for a given entity id.
+            </summary>
+            <param name="entityId">The entity id.</param>
+            <returns>The instance id of the scheduler.</returns>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.ProviderUtils.TryGetEntityStateFromSerializedSchedulerState(DurableTask.Core.OrchestrationState,Newtonsoft.Json.JsonSerializerSettings,System.String@)">
+            <summary>
+            Reads the state of an entity from the serialized entity scheduler state.
+            </summary>
+            <param name="state">The orchestration state of the scheduler.</param>
+            <param name="serializerSettings">The serializer settings.</param>
+            <param name="result">The serialized state of the entity.</param>
+            <returns>true if the entity exists, false otherwise.</returns>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.ProviderUtils.ConvertOrchestrationStateToStatus(DurableTask.Core.OrchestrationState)">
+            <summary>
+            Converts the DTFx representation of the orchestration state into the DF representation.
+            </summary>
+            <param name="orchestrationState">The orchestration state.</param>
+            <returns>The orchestration status.</returns>
         </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.PurgeHistoryResult">
             <summary>

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net461.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net461.xml
@@ -3165,11 +3165,13 @@
             Not intended for public consumption.
             </summary>
         </member>
-        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.OutOfProcOrchestrationShim.#ctor(Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableOrchestrationContext)">
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.OutOfProcOrchestrationShim.#ctor(Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableOrchestrationContext,Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableCommonContext,Microsoft.Azure.WebJobs.Extensions.DurableTask.EndToEndTraceHelper)">
             <summary>
             Initializes a new instance of the <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.OutOfProcOrchestrationShim"/> class.
             </summary>
             <param name="context">The orchestration execution context.</param>
+            <param name="durablecommonContext">The durable app shared context.</param>
+            <param name="traceHelper">The traceHelper for OOProc-specific telemetry.</param>
         </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.OutOfProcOrchestrationShim.SchemaVersion">
             <summary>

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
@@ -3445,11 +3445,13 @@
             Not intended for public consumption.
             </summary>
         </member>
-        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.OutOfProcOrchestrationShim.#ctor(Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableOrchestrationContext)">
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.OutOfProcOrchestrationShim.#ctor(Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableOrchestrationContext,Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableCommonContext,Microsoft.Azure.WebJobs.Extensions.DurableTask.EndToEndTraceHelper)">
             <summary>
             Initializes a new instance of the <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.OutOfProcOrchestrationShim"/> class.
             </summary>
             <param name="context">The orchestration execution context.</param>
+            <param name="durablecommonContext">The durable app shared context.</param>
+            <param name="traceHelper">The traceHelper for OOProc-specific telemetry.</param>
         </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.OutOfProcOrchestrationShim.SchemaVersion">
             <summary>

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
@@ -3456,18 +3456,12 @@
             Identifiers for each OOProc Schema Version.
             </summary>
         </member>
-        <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.OutOfProcOrchestrationShim.OperationType">
-            <summary>
-            Identifiers for each kind of action object.
-            </summary>
-        </member>
-        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.OutOfProcOrchestrationShim.InvokeAPIFromAction(Microsoft.Azure.WebJobs.Extensions.DurableTask.OutOfProcOrchestrationShim.AsyncAction,System.Boolean)">
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.OutOfProcOrchestrationShim.InvokeAPIFromAction(Microsoft.Azure.WebJobs.Extensions.DurableTask.OutOfProcOrchestrationShim.AsyncAction)">
             <summary>
             Invokes a DF API based on the input action object.
             Most APIs will return a Task to be awaited, but others such as SignalEntity do not.
             </summary>
             <param name="action">An OOProc action object representing a DF task.</param>
-            <param name="returnfireAndForgetTask">Whether to return a `CompletedTask` to represent fire-and-forget APIs. Defaults to `true`.</param>
             <returns>If the API returns a task, the DF task corresponding to the input action. Else, null.</returns>
         </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.OutOfProcOrchestrationShim.ProcessAsyncActionsV2(Microsoft.Azure.WebJobs.Extensions.DurableTask.OutOfProcOrchestrationShim.AsyncAction[])">

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
@@ -3445,13 +3445,11 @@
             Not intended for public consumption.
             </summary>
         </member>
-        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.OutOfProcOrchestrationShim.#ctor(Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableOrchestrationContext,Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableCommonContext,Microsoft.Azure.WebJobs.Extensions.DurableTask.EndToEndTraceHelper)">
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.OutOfProcOrchestrationShim.#ctor(Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableOrchestrationContext)">
             <summary>
             Initializes a new instance of the <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.OutOfProcOrchestrationShim"/> class.
             </summary>
             <param name="context">The orchestration execution context.</param>
-            <param name="durablecommonContext">The durable app shared context.</param>
-            <param name="traceHelper">The traceHelper for OOProc-specific telemetry.</param>
         </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.OutOfProcOrchestrationShim.SchemaVersion">
             <summary>

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
@@ -3451,6 +3451,51 @@
             </summary>
             <param name="context">The orchestration execution context.</param>
         </member>
+        <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.OutOfProcOrchestrationShim.SchemaVersion">
+            <summary>
+            Identifiers for each OOProc Schema Version.
+            </summary>
+        </member>
+        <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.OutOfProcOrchestrationShim.TaskGroupingType">
+            <summary>
+            Identifiers for each kind of action object.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.OutOfProcOrchestrationShim.InvokeAPIFromAction(Microsoft.Azure.WebJobs.Extensions.DurableTask.OutOfProcOrchestrationShim.AsyncAction)">
+            <summary>
+            Invokes a DF API based on the input action object.
+            Most APIs will return a Task to be awaited, but others such as SignalEntity do not.
+            </summary>
+            <param name="action">An OOProc action object representing a DF task.</param>
+            <returns>If the API returns a task, the DF task corresponding to the input action. Else, null.</returns>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.OutOfProcOrchestrationShim.ProcessAsyncActionsV2(Microsoft.Azure.WebJobs.Extensions.DurableTask.OutOfProcOrchestrationShim.AsyncAction[][])">
+            <summary>
+            Replays the orchestration execution from an OOProc SDK in .NET.
+            This is the V2 implementation of that replay procedure.
+            </summary>
+            <param name="actionSet">The OOProc actions payload.</param>
+            <returns>An awaitable Task that completes once replay completes.</returns>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.OutOfProcOrchestrationShim.GetCompoundTaskFromActions(Microsoft.Azure.WebJobs.Extensions.DurableTask.OutOfProcOrchestrationShim.AsyncAction[],System.Int32,System.Int32,Microsoft.Azure.WebJobs.Extensions.DurableTask.OutOfProcOrchestrationShim.TaskGroupingType)">
+            <summary>
+            Recursively construct a compound Task (a task of tasks) from a list of actions.
+            </summary>
+            <param name="actions">The OOProc actions payload.</param>
+            <param name="index">The index at which to start processing the actions.</param>
+            <param name="depth">The current task depth, equal to the number of outer / parent tasks.</param>
+            <param name="kind">The kind of parent task: WhenAll or WhenAny.</param>
+            <returns>A compound task, either: WhenAll or WhenAny.</returns>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.OutOfProcOrchestrationShim.ReplayOOProcOrchestration(Microsoft.Azure.WebJobs.Extensions.DurableTask.OutOfProcOrchestrationShim.AsyncAction[][],Microsoft.Azure.WebJobs.Extensions.DurableTask.OutOfProcOrchestrationShim.SchemaVersion)">
+            <summary>
+            Replays the OOProc orchestration based on the actions array. It uses the schema enum to
+            determine which replay implementation is most appropiate.
+            </summary>
+            <param name="actions">The OOProc actions payload.</param>
+            <param name="schema">The OOProc protocol schema version.</param>
+            <returns>An awaitable Task that completes once replay completes.</returns>
+        </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.TaskActivityShim">
             <summary>
             Task activity implementation which delegates the implementation to a function.
@@ -4202,6 +4247,34 @@
             Option to only start a new orchestrator instance with an existing instance Id when the existing
             instance is in a terminated, failed, or completed state.
             </summary>
+        </member>
+        <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.ProviderUtils">
+            <summary>
+            Provides access to internal functionality for the purpose of implementing durability providers.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.ProviderUtils.GetSchedulerIdFromEntityId(Microsoft.Azure.WebJobs.Extensions.DurableTask.EntityId)">
+            <summary>
+            Returns the instance id of the entity scheduler for a given entity id.
+            </summary>
+            <param name="entityId">The entity id.</param>
+            <returns>The instance id of the scheduler.</returns>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.ProviderUtils.TryGetEntityStateFromSerializedSchedulerState(DurableTask.Core.OrchestrationState,Newtonsoft.Json.JsonSerializerSettings,System.String@)">
+            <summary>
+            Reads the state of an entity from the serialized entity scheduler state.
+            </summary>
+            <param name="state">The orchestration state of the scheduler.</param>
+            <param name="serializerSettings">The serializer settings.</param>
+            <param name="result">The serialized state of the entity.</param>
+            <returns>true if the entity exists, false otherwise.</returns>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.ProviderUtils.ConvertOrchestrationStateToStatus(DurableTask.Core.OrchestrationState)">
+            <summary>
+            Converts the DTFx representation of the orchestration state into the DF representation.
+            </summary>
+            <param name="orchestrationState">The orchestration state.</param>
+            <returns>The orchestration status.</returns>
         </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.PurgeHistoryResult">
             <summary>

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
@@ -3459,7 +3459,6 @@
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.OutOfProcOrchestrationShim.InvokeAPIFromAction(Microsoft.Azure.WebJobs.Extensions.DurableTask.OutOfProcOrchestrationShim.AsyncAction)">
             <summary>
             Invokes a DF API based on the input action object.
-            Most APIs will return a Task to be awaited, but others such as SignalEntity do not.
             </summary>
             <param name="action">An OOProc action object representing a DF task.</param>
             <returns>If the API returns a task, the DF task corresponding to the input action. Else, null.</returns>
@@ -3467,7 +3466,6 @@
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.OutOfProcOrchestrationShim.ProcessAsyncActionsV2(Microsoft.Azure.WebJobs.Extensions.DurableTask.OutOfProcOrchestrationShim.AsyncAction[])">
             <summary>
             Replays the orchestration execution from an OOProc SDK in .NET.
-            This is the V2 implementation of that replay procedure.
             </summary>
             <param name="actions">The OOProc actions payload.</param>
             <returns>An awaitable Task that completes once replay completes.</returns>

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
@@ -3456,36 +3456,27 @@
             Identifiers for each OOProc Schema Version.
             </summary>
         </member>
-        <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.OutOfProcOrchestrationShim.TaskGroupingType">
+        <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.OutOfProcOrchestrationShim.OperationType">
             <summary>
             Identifiers for each kind of action object.
             </summary>
         </member>
-        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.OutOfProcOrchestrationShim.InvokeAPIFromAction(Microsoft.Azure.WebJobs.Extensions.DurableTask.OutOfProcOrchestrationShim.AsyncAction)">
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.OutOfProcOrchestrationShim.InvokeAPIFromAction(Microsoft.Azure.WebJobs.Extensions.DurableTask.OutOfProcOrchestrationShim.AsyncAction,System.Boolean)">
             <summary>
             Invokes a DF API based on the input action object.
             Most APIs will return a Task to be awaited, but others such as SignalEntity do not.
             </summary>
             <param name="action">An OOProc action object representing a DF task.</param>
+            <param name="returnfireAndForgetTask">Whether to return a `CompletedTask` to represent fire-and-forget APIs. Defaults to `true`.</param>
             <returns>If the API returns a task, the DF task corresponding to the input action. Else, null.</returns>
         </member>
-        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.OutOfProcOrchestrationShim.ProcessAsyncActionsV2(Microsoft.Azure.WebJobs.Extensions.DurableTask.OutOfProcOrchestrationShim.AsyncAction[][])">
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.OutOfProcOrchestrationShim.ProcessAsyncActionsV2(Microsoft.Azure.WebJobs.Extensions.DurableTask.OutOfProcOrchestrationShim.AsyncAction[])">
             <summary>
             Replays the orchestration execution from an OOProc SDK in .NET.
             This is the V2 implementation of that replay procedure.
             </summary>
-            <param name="actionSet">The OOProc actions payload.</param>
-            <returns>An awaitable Task that completes once replay completes.</returns>
-        </member>
-        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.OutOfProcOrchestrationShim.GetCompoundTaskFromActions(Microsoft.Azure.WebJobs.Extensions.DurableTask.OutOfProcOrchestrationShim.AsyncAction[],System.Int32,System.Int32,Microsoft.Azure.WebJobs.Extensions.DurableTask.OutOfProcOrchestrationShim.TaskGroupingType)">
-            <summary>
-            Recursively construct a compound Task (a task of tasks) from a list of actions.
-            </summary>
             <param name="actions">The OOProc actions payload.</param>
-            <param name="index">The index at which to start processing the actions.</param>
-            <param name="depth">The current task depth, equal to the number of outer / parent tasks.</param>
-            <param name="kind">The kind of parent task: WhenAll or WhenAny.</param>
-            <returns>A compound task, either: WhenAll or WhenAny.</returns>
+            <returns>An awaitable Task that completes once replay completes.</returns>
         </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.OutOfProcOrchestrationShim.ReplayOOProcOrchestration(Microsoft.Azure.WebJobs.Extensions.DurableTask.OutOfProcOrchestrationShim.AsyncAction[][],Microsoft.Azure.WebJobs.Extensions.DurableTask.OutOfProcOrchestrationShim.SchemaVersion)">
             <summary>

--- a/test/FunctionsV2/OutOfProcTests.cs
+++ b/test/FunctionsV2/OutOfProcTests.cs
@@ -69,12 +69,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
             // Feed the out-of-proc execution result JSON to the out-of-proc shim.
             var jsonObject = JObject.Parse(executionJson);
-            OrchestrationInvocationResult result = new OrchestrationInvocationResult()
-            {
-                ReturnValue = jsonObject,
-                Json = jsonObject,
-                JsonString = executionJson,
-            };
+            OrchestrationInvocationResult result = new OrchestrationInvocationResult(jsonObject);
             bool moreWork = await shim.ScheduleDurableTaskEvents(result);
 
             // The request should not have completed because one additional replay is needed
@@ -135,12 +130,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
             // Feed the out-of-proc execution result JSON to the out-of-proc shim.
             var jsonObject = JObject.Parse(executionJson);
-            OrchestrationInvocationResult result = new OrchestrationInvocationResult()
-            {
-                ReturnValue = jsonObject,
-                Json = jsonObject,
-                JsonString = executionJson,
-            };
+            OrchestrationInvocationResult result = new OrchestrationInvocationResult(jsonObject);
             bool moreWork = await shim.ScheduleDurableTaskEvents(result);
 
             Assert.NotNull(request);
@@ -192,12 +182,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
             // Feed the out-of-proc execution result JSON to the out-of-proc shim.
             var jsonObject = JObject.Parse(executionJson);
-            OrchestrationInvocationResult result = new OrchestrationInvocationResult()
-            {
-                ReturnValue = jsonObject,
-                Json = jsonObject,
-                JsonString = executionJson,
-            };
+            OrchestrationInvocationResult result = new OrchestrationInvocationResult(jsonObject);
             bool moreWork = await shim.ScheduleDurableTaskEvents(result);
 
             Assert.NotNull(request);

--- a/test/FunctionsV2/OutOfProcTests.cs
+++ b/test/FunctionsV2/OutOfProcTests.cs
@@ -44,7 +44,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 .Callback<DurableHttpRequest>(req => request = req)
                 .Returns(Task.FromResult(new DurableHttpResponse(System.Net.HttpStatusCode.OK)));
 
-            var shim = new OutOfProcOrchestrationShim(contextMock.Object);
+            var durableCommonContextMock = new Mock<DurableCommonContext>();
+            var traceHelperMock = new Mock<EndToEndTraceHelper>();
+
+            var shim = new OutOfProcOrchestrationShim(contextMock.Object, durableCommonContextMock.Object, traceHelperMock.Object);
 
             var executionJson = @"
 {
@@ -111,7 +114,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 .Callback<DurableHttpRequest>(req => request = req)
                 .Returns(Task.FromResult(new DurableHttpResponse(System.Net.HttpStatusCode.OK)));
 
-            var shim = new OutOfProcOrchestrationShim(contextMock.Object);
+            var durableCommonContextMock = new Mock<DurableCommonContext>();
+            var traceHelperMock = new Mock<EndToEndTraceHelper>();
+
+            var shim = new OutOfProcOrchestrationShim(contextMock.Object, durableCommonContextMock.Object, traceHelperMock.Object);
 
             var executionJson = @"
 {
@@ -162,7 +168,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 .Callback<DurableHttpRequest>(req => request = req)
                 .Returns(Task.FromResult(new DurableHttpResponse(System.Net.HttpStatusCode.OK)));
 
-            var shim = new OutOfProcOrchestrationShim(contextMock.Object);
+            var durableCommonContextMock = new Mock<DurableCommonContext>();
+            var traceHelperMock = new Mock<EndToEndTraceHelper>();
+
+            var shim = new OutOfProcOrchestrationShim(contextMock.Object, durableCommonContextMock.Object, traceHelperMock.Object);
 
             var executionJson = @"
 {

--- a/test/FunctionsV2/OutOfProcTests.cs
+++ b/test/FunctionsV2/OutOfProcTests.cs
@@ -44,10 +44,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 .Callback<DurableHttpRequest>(req => request = req)
                 .Returns(Task.FromResult(new DurableHttpResponse(System.Net.HttpStatusCode.OK)));
 
-            var durableCommonContextMock = new Mock<DurableCommonContext>();
-            var traceHelperMock = new Mock<EndToEndTraceHelper>();
-
-            var shim = new OutOfProcOrchestrationShim(contextMock.Object, durableCommonContextMock.Object, traceHelperMock.Object);
+            var shim = new OutOfProcOrchestrationShim(contextMock.Object);
 
             var executionJson = @"
 {
@@ -114,10 +111,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 .Callback<DurableHttpRequest>(req => request = req)
                 .Returns(Task.FromResult(new DurableHttpResponse(System.Net.HttpStatusCode.OK)));
 
-            var durableCommonContextMock = new Mock<DurableCommonContext>();
-            var traceHelperMock = new Mock<EndToEndTraceHelper>();
-
-            var shim = new OutOfProcOrchestrationShim(contextMock.Object, durableCommonContextMock.Object, traceHelperMock.Object);
+            var shim = new OutOfProcOrchestrationShim(contextMock.Object);
 
             var executionJson = @"
 {
@@ -168,10 +162,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 .Callback<DurableHttpRequest>(req => request = req)
                 .Returns(Task.FromResult(new DurableHttpResponse(System.Net.HttpStatusCode.OK)));
 
-            var durableCommonContextMock = new Mock<DurableCommonContext>();
-            var traceHelperMock = new Mock<EndToEndTraceHelper>();
-
-            var shim = new OutOfProcOrchestrationShim(contextMock.Object, durableCommonContextMock.Object, traceHelperMock.Object);
+            var shim = new OutOfProcOrchestrationShim(contextMock.Object);
 
             var executionJson = @"
 {

--- a/test/FunctionsV2/OutOfProcTests.cs
+++ b/test/FunctionsV2/OutOfProcTests.cs
@@ -72,6 +72,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             OrchestrationInvocationResult result = new OrchestrationInvocationResult()
             {
                 ReturnValue = jsonObject,
+                Json = jsonObject,
+                JsonString = executionJson,
             };
             bool moreWork = await shim.ScheduleDurableTaskEvents(result);
 
@@ -136,6 +138,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             OrchestrationInvocationResult result = new OrchestrationInvocationResult()
             {
                 ReturnValue = jsonObject,
+                Json = jsonObject,
+                JsonString = executionJson,
             };
             bool moreWork = await shim.ScheduleDurableTaskEvents(result);
 
@@ -191,6 +195,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             OrchestrationInvocationResult result = new OrchestrationInvocationResult()
             {
                 ReturnValue = jsonObject,
+                Json = jsonObject,
+                JsonString = executionJson,
             };
             bool moreWork = await shim.ScheduleDurableTaskEvents(result);
 


### PR DESCRIPTION
<!-- Start the PR description with some context for the change. -->
We recently discovered a handful of telemetry mishaps that occur only to OOProc SDKs. It was determined that these were due to our existing replay logic, which can be imprecise in a few cases. Furthermore, there's evidence suggesting that our replay logic _might_ be the cause for runtime errors as well, which motivates the need to mitigate this issue further.

This PR aims to mitigate these replay imprecisions in a backwards compatible way.

First, some definitions:

- **Compound task**: A task of tasks, either: Task.WhenAll and Task.WhenAny.
- **Atomic task:** A singleton task,  i.e a Task that does not contain other tasks. For example: callActivityAsync.
- **Deep compound tasks**: A compound task containing at least 1 task that is also **compound**,  potentially  **deep** as well. For example: Task.WhenAll( [ Task.WhenAny( TaskA, TaskB), TaskC ] )

With that, here are the changes.

First, this PR introduces a `SchemaVersion` enum to track OOProc return payload schemas versions. We use this to determine whether or not to use the legacy (current) replay mechanism or if to use the one developed in this PR.

Second, this PR introduces a new method `ProcessAsyncActionsV2` (name open to change) which represents a more accurate replay procedure than `ProcessAsyncActions`. The key difference between these two methods is that `ProcessAsyncActionsV2` properly replays **deep compound tasks**. We can do this because we augment the existing OOProc output payload to include extra fields that allow us to determine
(1) if an atomic task is part of a compound task  [tracked by the Depth field]
(2) If the surrounding compound task is a WhenAny or WhenAll [tracked by the TaskGrouping field]
(3) how many parent compound tasks deep we are from the top-level compound task [tracked by the Depth field]

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)


