### PR TITLE
Upgrade AzureStorage to 1.8.5 in V1

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/DurableActivityContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableActivityContext.cs
@@ -82,6 +82,11 @@ namespace Microsoft.Azure.WebJobs
             }
 
             JToken jToken = this.GetInputAsJson();
+            if (jToken == null)
+            {
+                return null;
+            }
+
             var value = jToken as JValue;
             if (value != null)
             {

--- a/src/WebJobs.Extensions.DurableTask/MessagePayloadDataConverter.cs
+++ b/src/WebJobs.Extensions.DurableTask/MessagePayloadDataConverter.cs
@@ -50,6 +50,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// </summary>
         public string Serialize(object value, int maxSizeInKB)
         {
+            if (value == null)
+            {
+                return null;
+            }
+
             string serializedJson;
 
             JToken json = value as JToken;

--- a/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
+++ b/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
@@ -52,7 +52,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage" Version="1.8.1" />
+    <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage" Version="1.8.5" />
   </ItemGroup>
 
   <!-- NuGet Publishing Metadata -->

--- a/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
+++ b/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
@@ -52,7 +52,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage" Version="1.7.7" />
+    <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage" Version="1.8.1" />
   </ItemGroup>
 
   <!-- NuGet Publishing Metadata -->

--- a/test/Common/TestHelpers.cs
+++ b/test/Common/TestHelpers.cs
@@ -454,7 +454,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             var list = new List<string>()
             {
                 $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})' scheduled. Reason: NewInstance. IsReplay: False.",
-                $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})' started. IsReplay: False. Input: null",
+                $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})' started. IsReplay: False. Input: (null)",
                 $"{messageId}: Function '{orchestratorFunctionNames[0]} ({FunctionType.Orchestrator})' failed with an error. Reason: System.ArgumentNullException: Value cannot be null.",
             };
 

--- a/test/FunctionsV1/WebJobs.Extensions.DurableTask.Tests.V1.csproj
+++ b/test/FunctionsV1/WebJobs.Extensions.DurableTask.Tests.V1.csproj
@@ -10,7 +10,6 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="4.19.4" />
-    <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage" Version="1.7.7" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="2.2.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" Version="2.2.0" />
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.33" />

--- a/test/FunctionsV2/WebJobs.Extensions.DurableTask.Tests.V2.csproj
+++ b/test/FunctionsV2/WebJobs.Extensions.DurableTask.Tests.V2.csproj
@@ -10,7 +10,6 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="4.19.4" />
-    <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage" Version="1.7.7" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.14" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="3.0.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" Version="3.0.0" />


### PR DESCRIPTION
<!-- Start the PR description with some context for the change. -->
Unblocks: https://github.com/Azure/azure-functions-durable-extension/pull/1802

This PR simply upgrades the V1 dependency on AzureStorage from 1.7.7 to 1.8.1.
I decided against upgrading to version 1.8.5 because, starting from version 1.8.2, there are serialization changes in azureStorage that make some of our unit tests to fail. Upgrading to version 1.8.5 will require more careful cherry-picking of commits, as well as expertise in the serialization changes that took place.

<!-- Make sure to delete the markdown comments and the below sections when squash merging -->
### Issue describing the changes in this PR: N/A

resolves N/A

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)


