### PR TITLE
Start StopWatch to prevent CI timeouts

### DIFF
--- a/test/Common/TestHelpers.cs
+++ b/test/Common/TestHelpers.cs
@@ -333,7 +333,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 retryInterval = TimeSpan.FromMilliseconds(100);
             }
 
-            Stopwatch sw = new Stopwatch();
+            Stopwatch sw = Stopwatch.StartNew();
+
             do
             {
                 if (predicate())


### PR DESCRIPTION
<!-- Start the PR description with some context for the change. -->
Some of our recent CIs have been timing out. I believe this is, in part, due to our relatively new "WaitUnitlTrue" helper function. `WaitUntilTrue` is supposed to time out on a fixed interval, but it's StopWatch had not been "started" so its value of "ElapsedTime" remained fixed at zero. This meant that it would never time out.

This PR "starts" this StopWatch so tests time out as expected 😄 .

<!-- Make sure to delete the markdown comments and the below sections when squash merging -->
### Issue describing the changes in this PR

resolves N/A

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)


