### PR TITLE
Enable Structured Logging in V1

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
@@ -52,6 +52,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         private readonly AsyncLock taskHubLock = new AsyncLock();
 
         private readonly bool isOptionsConfigured;
+        private ILoggerFactory loggerFactory;
 
         private INameResolver nameResolver;
         private AzureStorageOrchestrationService orchestrationService;
@@ -93,6 +94,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             // Options will be null in Functions v1 runtime - populated later.
             this.Options = options?.Value ?? new DurableTaskOptions();
             this.nameResolver = nameResolver ?? throw new ArgumentNullException(nameof(nameResolver));
+            this.loggerFactory = loggerFactory ?? throw new ArgumentNullException(nameof(loggerFactory));
             this.connectionStringResolver = connectionStringResolver ?? throw new ArgumentNullException(nameof(connectionStringResolver));
 
             if (loggerFactory == null)
@@ -199,7 +201,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
             this.orchestrationServiceSettings = this.GetOrchestrationServiceSettings();
             this.orchestrationService = new AzureStorageOrchestrationService(this.orchestrationServiceSettings);
-            this.taskHubWorker = new TaskHubWorker(this.orchestrationService, this, this);
+            this.taskHubWorker = new TaskHubWorker(this.orchestrationService, this, this, this.loggerFactory);
             this.taskHubWorker.AddOrchestrationDispatcherMiddleware(this.OrchestrationMiddleware);
 
 #if !FUNCTIONS_V1

--- a/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
@@ -294,8 +294,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         {
 #if FUNCTIONS_V1
             context.ApplyConfig(this.Options, "DurableTask");
+            this.loggerFactory = context.Config.LoggerFactory;
 
-            ILogger logger = context.Config.LoggerFactory.CreateLogger(LoggerCategoryName);
+            ILogger logger = this.loggerFactory.CreateLogger(LoggerCategoryName);
 
             this.TraceHelper = new EndToEndTraceHelper(logger, this.Options.LogReplayEvents);
             this.HttpApiHandler = new HttpApiHandler(this, logger);


### PR DESCRIPTION
<!-- Start the PR description with some context for the change. -->
Unblocks: https://github.com/Azure/azure-functions-durable-extension/pull/1802

The PR listed above depends on the relatively recent StructuredLogging behavior in DTFx. However, this behavior is only enabled when the DTFx TaskWorker constructor receives LoggerFactory object. It appears we had not ported over that behavior yet. As a result, in the PR listed above, we were missing logs.

This PR enables the StructuredLogging EventSource providers in V1. The change is simple: we now provide the LoggerFactory to the TaskHubWorker ⚡ ⚡ 

<!-- Make sure to delete the markdown comments and the below sections when squash merging -->
### Issue describing the changes in this PR

resolves N/A

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)


