### PR TITLE
Increase ControlQueueBufferThreshold defaults in Consumption

### DIFF
--- a/pending_docs.md
+++ b/pending_docs.md
@@ -1,2 +1,3 @@
 <!-- Please include a link to your pending docs PR below. https://docs.microsoft.com/en-us/azure/azure-functions/durable ([private docs repo for Microsoft employees](http://github.com/MicrosoftDocs/azure-docs-pr)). 
 Your code PR should not be merged until your docs PR has been approved. Wait to #sign-off until release. -->
+https://github.com/MicrosoftDocs/azure-docs-pr/pull/159828

--- a/release_notes.md
+++ b/release_notes.md
@@ -1,5 +1,6 @@
 ## New Features
 - Improved supportability logs on Linux Dedicated plans (https://github.com/Azure/azure-functions-durable-extension/pull/1721)
+- Improved concurrency defaults in Consumption plans for C# and JS (https://github.com/Azure/azure-functions-durable-extension/pull/1846)
 
 ## Bug fixes
 - Fix issue with local RPC endpoint used by non-.NET languages on Windows apps (#1800)

--- a/release_notes.md
+++ b/release_notes.md
@@ -1,6 +1,7 @@
 ## New Features
 - Improved supportability logs on Linux Dedicated plans (https://github.com/Azure/azure-functions-durable-extension/pull/1721)
 - Improved concurrency defaults in Consumption plans for C# and JS (https://github.com/Azure/azure-functions-durable-extension/pull/1846)
+- Initial work to simplify out-of-process execution model (https://github.com/Azure/azure-functions-durable-extension/pull/1836)
 
 ## Bug fixes
 - Fix issue with local RPC endpoint used by non-.NET languages on Windows apps (#1800)

--- a/src/WebJobs.Extensions.DurableTask/AzureStorageDurabilityProviderFactory.cs
+++ b/src/WebJobs.Extensions.DurableTask/AzureStorageDurabilityProviderFactory.cs
@@ -53,8 +53,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 {
                     this.azureStorageOptions.ControlQueueBufferThreshold = 32;
                 }
-
-                this.azureStorageOptions.ControlQueueBufferThreshold = 128;
+                else
+                {
+                    this.azureStorageOptions.ControlQueueBufferThreshold = 128;
+                }
             }
 
             // The following defaults are only applied if the customer did not explicitely set them on `host.json`

--- a/src/WebJobs.Extensions.DurableTask/AzureStorageDurabilityProviderFactory.cs
+++ b/src/WebJobs.Extensions.DurableTask/AzureStorageDurabilityProviderFactory.cs
@@ -46,7 +46,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             // different defaults for key configuration values.
             int maxConcurrentOrchestratorsDefault = this.inConsumption ? 5 : 10 * Environment.ProcessorCount;
             int maxConcurrentActivitiesDefault = this.inConsumption ? 10 : 10 * Environment.ProcessorCount;
-            this.azureStorageOptions.ControlQueueBufferThreshold = this.inConsumption ? 32 : this.azureStorageOptions.ControlQueueBufferThreshold;
+
+            if (this.inConsumption)
+            {
+                if (platformInfo.IsPython())
+                {
+                    this.azureStorageOptions.ControlQueueBufferThreshold = 32;
+                }
+
+                this.azureStorageOptions.ControlQueueBufferThreshold = 128;
+            }
 
             // The following defaults are only applied if the customer did not explicitely set them on `host.json`
             this.options.MaxConcurrentOrchestratorFunctions = this.options.MaxConcurrentOrchestratorFunctions ?? maxConcurrentOrchestratorsDefault;

--- a/src/WebJobs.Extensions.DurableTask/DefaultPlatformInformationProvider.cs
+++ b/src/WebJobs.Extensions.DurableTask/DefaultPlatformInformationProvider.cs
@@ -63,5 +63,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         {
             return this.nameResolver.Resolve("CONTAINER_NAME");
         }
+
+        public bool IsPython()
+        {
+            return this.nameResolver.Resolve("FUNCTIONS_WORKER_RUNTIME") == "python";
+        }
     }
 }

--- a/src/WebJobs.Extensions.DurableTask/IPlatformInformationService.cs
+++ b/src/WebJobs.Extensions.DurableTask/IPlatformInformationService.cs
@@ -35,6 +35,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         bool InWindowsConsumption();
 
         /// <summary>
+        /// Determines is the language worker is for Python.
+        /// </summary>
+        /// <returns>True if the language worker is for Python. Otherwise, False.</returns>
+        bool IsPython();
+
+        /// <summary>
         /// Determines if the application is running in a Linux AppService plan.
         /// </summary>
         /// <returns>True if running in Linux AppService. Otherwise, False.</returns>

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net461.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net461.xml
@@ -3065,6 +3065,12 @@
             </summary>
             <returns>True if running in Linux Consumption. Otherwise, False.</returns>
         </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.IPlatformInformationService.IsPython">
+            <summary>
+            Determines is the language worker is for Python.
+            </summary>
+            <returns>True if the language worker is for Python. Otherwise, False.</returns>
+        </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.IPlatformInformationService.InLinuxAppService">
             <summary>
             Determines if the application is running in a Linux AppService plan.

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
@@ -3316,6 +3316,12 @@
             </summary>
             <returns>True if running in Linux Consumption. Otherwise, False.</returns>
         </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.IPlatformInformationService.IsPython">
+            <summary>
+            Determines is the language worker is for Python.
+            </summary>
+            <returns>True if the language worker is for Python. Otherwise, False.</returns>
+        </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.IPlatformInformationService.InLinuxAppService">
             <summary>
             Determines if the application is running in a Linux AppService plan.

--- a/test/Common/TestHelpers.cs
+++ b/test/Common/TestHelpers.cs
@@ -232,6 +232,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             bool inLinuxConsumption = false,
             bool inWindowsConsumption = false,
             bool inLinuxAppsService = false,
+            bool isPython = false,
             string getLinuxStampName = "",
             string getContainerName = "")
 #pragma warning restore CS0612 // Type or member is obsolete
@@ -245,6 +246,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             mockPlatformProvider.Setup(x => x.InLinuxAppService()).Returns(inLinuxAppsService);
             mockPlatformProvider.Setup(x => x.GetLinuxStampName()).Returns(getLinuxStampName);
             mockPlatformProvider.Setup(x => x.GetContainerName()).Returns(getContainerName);
+            mockPlatformProvider.Setup(x => x.IsPython()).Returns(isPython);
             return mockPlatformProvider.Object;
         }
 

--- a/test/FunctionsV2/AzureStorageDurabilityProviderFactoryTests.cs
+++ b/test/FunctionsV2/AzureStorageDurabilityProviderFactoryTests.cs
@@ -50,6 +50,28 @@ namespace WebJobs.Extensions.DurableTask.Tests.V2
 
             var settings = factory.GetAzureStorageOrchestrationServiceSettings();
 
+            Assert.Equal(128, settings.ControlQueueBufferThreshold);
+            Assert.Equal(5, settings.MaxConcurrentTaskOrchestrationWorkItems);
+            Assert.Equal(10, settings.MaxConcurrentTaskActivityWorkItems);
+            Assert.Equal(25, settings.MaxStorageOperationConcurrency);
+        }
+
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public void ConsumptionDefaultsForPythonAreApplied()
+        {
+            var connectionStringResolver = new TestConnectionStringResolver();
+            var mockOptions = new OptionsWrapper<DurableTaskOptions>(new DurableTaskOptions());
+            var nameResolver = new Mock<INameResolver>().Object;
+            var factory = new AzureStorageDurabilityProviderFactory(
+                mockOptions,
+                connectionStringResolver,
+                nameResolver,
+                NullLoggerFactory.Instance,
+                TestHelpers.GetMockPlatformInformationService(inConsumption: true, isPython: true));
+
+            var settings = factory.GetAzureStorageOrchestrationServiceSettings();
+
             Assert.Equal(32, settings.ControlQueueBufferThreshold);
             Assert.Equal(5, settings.MaxConcurrentTaskOrchestrationWorkItems);
             Assert.Equal(10, settings.MaxConcurrentTaskActivityWorkItems);


### PR DESCRIPTION
<!-- Start the PR description with some context for the change. -->
We recently learned that some customers are experiencing increased latency in their orchestration completion times in the Consumption plan. This is because we recently (https://github.com/Azure/azure-functions-durable-extension/pull/1706) changed our concurrency defaults in the Consumption plan to accommodate its resource constraints and scaling behavior.

In that process, we decreased the value of `ControlQueueBufferThreshold` from 256 to just 32. That decrease appears to blame for the increased latency.

This PR increases the default for JS and C# to be 128, a less dramatic decrease from 256. For Python, we keep the default as 32 as we theorize that the Python language worker would benefit from a small  `ControlQueueBufferThreshold` value.

This PR comes as a bit of a hot-patch and is subject to change in the future. In particular, we have a pending work item (https://github.com/Azure/azure-functions-durable-extension/issues/1700) to come up with PL-aware concurrency defaults, as well as improving the design of the `IPlatformInformationService` interface. _Those changes are still pending._

<!-- Make sure to delete the markdown comments and the below sections when squash merging -->
### Issue describing the changes in this PR

Relates to https://github.com/Azure/azure-functions-durable-extension/issues/1842

### Pull request checklist

* [ ] My changes **do not** require documentation changes
    * [x] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)


