### PR TITLE
Fix custom backend provider logging on Linux

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -7,5 +7,6 @@
 - Fix issue with local RPC endpoint used by non-.NET languages on Windows apps (#1800)
 - Emit warning instead of blocking startup if Distributed Tracing is enabled, but `APPINSIGHTS_INSTRUMENTATIONKEY` isn't set (#1787),
 - Assign cloud_RoleName and operation_Name fields to RequestTelemetry to populate Activity Function's Invocations List when Distributed Tracing is enabled (#1808)
+- Fix Linux telemetry for new durablity providers (#1848)
 
 ## Breaking Changes

--- a/src/WebJobs.Extensions.DurableTask/AzureStorageDurabilityProviderFactory.cs
+++ b/src/WebJobs.Extensions.DurableTask/AzureStorageDurabilityProviderFactory.cs
@@ -73,7 +73,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             this.defaultConnectionName = this.azureStorageOptions.ConnectionStringName ?? ConnectionStringNames.Storage;
         }
 
-        public string Name => ProviderName;
+        public virtual string Name => ProviderName;
 
         internal string GetDefaultStorageConnectionString()
         {

--- a/src/WebJobs.Extensions.DurableTask/EventSourceListener.cs
+++ b/src/WebJobs.Extensions.DurableTask/EventSourceListener.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             this.durabilityProviderEventSourceName = durabilityProviderEventSourceName;
 
             // Check to see if any event sources were created before we knew the event source
-            //// name for the durability provider and enable that provider.
+            // name for the durability provider and enable that provider.
             var eventSourcesToEnable = this.pendingEventSources.Where(eventSource => eventSource.Name == this.durabilityProviderEventSourceName);
             foreach (var eventSource in eventSourcesToEnable)
             {

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
@@ -1742,11 +1742,12 @@
             TraceContextBase extension methods.
             </summary>
         </member>
-        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.Correlation.TraceContextBaseExtensions.CreateRequestTelemetry(DurableTask.Core.TraceContextBase)">
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.Correlation.TraceContextBaseExtensions.CreateRequestTelemetry(DurableTask.Core.TraceContextBase,System.String)">
             <summary>
             Create RequestTelemetry from the TraceContext.
             </summary>
             <param name="context">TraceContext.</param>
+            <param name="siteName">Site name.</param>
             <returns>RequestTelemetry.</returns>
         </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.Correlation.TraceContextBaseExtensions.CreateDependencyTelemetry(DurableTask.Core.TraceContextBase)">

--- a/test/Common/DurableTaskEndToEndTests.cs
+++ b/test/Common/DurableTaskEndToEndTests.cs
@@ -302,7 +302,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
         /// <summary>
         /// By simulating the appropiate environment variables for Linux Consumption,
-        /// this test checks that we are emitting logs from DurableTask.AzureStorage
+        /// this test checks that we are emitting logs from DurableTask-CustomSource
         /// and reading the DurabilityProvider's EventSourceName property correctly.
         /// </summary>
         [Fact]
@@ -344,8 +344,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
                 // Validate that the JSON has DurableTask-AzureStorage fields
                 string[] lines = consoleOutput.Split('\n');
-                var azureStorageLogLines = lines.Where(l => l.Contains("DurableTask-CustomSource") && l.StartsWith(prefix));
-                Assert.NotEmpty(azureStorageLogLines);
+                var customeEtwLogs = lines.Where(l => l.Contains("DurableTask-CustomSource") && l.StartsWith(prefix));
+                Assert.NotEmpty(customeEtwLogs);
             }
         }
 

--- a/test/FunctionsV2/AzureStorageShortenedTimerDurabilityProviderFactory.cs
+++ b/test/FunctionsV2/AzureStorageShortenedTimerDurabilityProviderFactory.cs
@@ -21,6 +21,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         {
         }
 
+        public override string Name => typeof(AzureStorageShortenedTimerDurabilityProviderFactory).Name;
+
         public override DurabilityProvider GetDurabilityProvider(DurableClientAttribute attribute)
         {
             AzureStorageDurabilityProvider provider = base.GetDurabilityProvider(attribute) as AzureStorageDurabilityProvider;

--- a/test/FunctionsV2/CustomEtwDurabilityProviderFactory.cs
+++ b/test/FunctionsV2/CustomEtwDurabilityProviderFactory.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+using System.Diagnostics.Tracing;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
+{
+    internal class CustomEtwDurabilityProviderFactory : EmulatorDurabilityProviderFactory
+    {
+        public CustomEtwDurabilityProviderFactory()
+            : base()
+        {
+        }
+
+        public override string Name => typeof(CustomEtwDurabilityProviderFactory).Name;
+
+        public override DurabilityProvider GetDurabilityProvider(DurableClientAttribute attribute)
+        {
+            DurabilityProvider provider = base.GetDurabilityProvider(attribute);
+            provider.EventSourceName = "DurableTask-CustomSource";
+            EtwSource.Current.Information("Created durability provider.");
+            return provider;
+        }
+
+        public override DurabilityProvider GetDurabilityProvider()
+        {
+            DurabilityProvider provider = base.GetDurabilityProvider();
+            provider.EventSourceName = "DurableTask-CustomSource";
+            EtwSource.Current.Information("Created durability provider.");
+            return provider;
+        }
+    }
+
+    [EventSource(Name = "DurableTask-CustomSource")]
+#pragma warning disable SA1402 // File may only contain a single type
+    internal sealed class EtwSource : EventSource
+#pragma warning restore SA1402 // File may only contain a single type
+    {
+        public static readonly EtwSource Current = new EtwSource();
+
+        [Event(1)]
+        public void Information(string summary)
+        {
+            this.WriteEvent(1, summary);
+        }
+    }
+}

--- a/test/FunctionsV2/CustomEtwDurabilityProviderFactory.cs
+++ b/test/FunctionsV2/CustomEtwDurabilityProviderFactory.cs
@@ -19,10 +19,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
         public override DurabilityProvider GetDurabilityProvider(DurableClientAttribute attribute)
         {
-            DurabilityProvider provider = base.GetDurabilityProvider(attribute);
-            provider.EventSourceName = "DurableTask-CustomSource";
-            EtwSource.Current.Information("Created durability provider.");
-            return provider;
+            return this.GetDurabilityProvider();
         }
 
         public override DurabilityProvider GetDurabilityProvider()

--- a/test/FunctionsV2/EmulatorDurabilityProviderFactory.cs
+++ b/test/FunctionsV2/EmulatorDurabilityProviderFactory.cs
@@ -18,14 +18,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
         public bool SupportsEntities => false;
 
-        public string Name => "Emulator";
+        public virtual string Name => "Emulator";
 
-        public DurabilityProvider GetDurabilityProvider(DurableClientAttribute attribute)
+        public virtual DurabilityProvider GetDurabilityProvider(DurableClientAttribute attribute)
         {
             return this.provider;
         }
 
-        public DurabilityProvider GetDurabilityProvider()
+        public virtual DurabilityProvider GetDurabilityProvider()
         {
             return this.provider;
         }

--- a/test/FunctionsV2/PlatformSpecificHelpers.FunctionsV2.cs
+++ b/test/FunctionsV2/PlatformSpecificHelpers.FunctionsV2.cs
@@ -121,7 +121,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         {
             if (durabilityProviderFactoryType != null)
             {
-                builder.Services.AddSingleton(typeof(IDurabilityProviderFactory), typeof(AzureStorageShortenedTimerDurabilityProviderFactory));
+                builder.Services.AddSingleton(typeof(IDurabilityProviderFactory), durabilityProviderFactoryType);
+                options.Value.StorageProvider.Add("type", durabilityProviderFactoryType.Name);
                 builder.AddDurableTask(options);
                 return builder;
             }


### PR DESCRIPTION
If a custom durability provider uses its ETW event source before we
instantiate the Linux logging architecture (like Netherite's ETW event
for instantiating its orchestration service), then the
OnEventSourceCreated method will call before our constructor finishes
instantiating the event source name for the custom provider. This
happens due to the ordering of constructor calls in .NET.

To work around this, we temporarily store all event sources before our
constructor establishes the durability provider event source name so
that we can enable the correct provider when we do establish the provider name.

resolves #1796

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)


