### PR TITLE
Fix build warnings from code-gen PR

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net461.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net461.xml
@@ -2230,27 +2230,6 @@
             <param name="attribute">The attribute containing the client configuration parameters.</param>
             <returns>Returns a <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableClient"/> instance. The returned instance may be a cached instance.</returns>
         </member>
-        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.GetGeneratedClient``1(Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClientAttribute)">
-            <summary>
-            Gets a <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableClient"/> using configuration from a <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClientAttribute"/> instance.
-            </summary>
-            <param name="attribute">The attribute containing the client configuration parameters.</param>
-            <returns>Returns a <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableClient"/> instance. The returned instance may be a cached instance.</returns>
-        </member>
-        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.GetDurableClient(Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClientAttribute)">
-            <summary>
-            Gets a <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableClient"/> using configuration from a <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClientAttribute"/> instance.
-            </summary>
-            <param name="attribute">The attribute containing the client configuration parameters.</param>
-            <returns>Returns a <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableClient"/> instance. The returned instance may be a cached instance.</returns>
-        </member>
-        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.GetGeneratedDurableClient``1(Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClientAttribute)">
-            <summary>
-            Gets a <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableClient"/> using configuration from a <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClientAttribute"/> instance.
-            </summary>
-            <param name="attribute">The attribute containing the client configuration parameters.</param>
-            <returns>Returns a <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableClient"/> instance. The returned instance may be a cached instance.</returns>
-        </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.Microsoft#Azure#WebJobs#IAsyncConverter{System#Net#Http#HttpRequestMessage,System#Net#Http#HttpResponseMessage}#ConvertAsync(System.Net.Http.HttpRequestMessage,System.Threading.CancellationToken)">
             <inheritdoc/>
         </member>
@@ -4226,6 +4205,12 @@
             <value>
             The name of the orchestrator function or <c>null</c> to use the function name.
             </value>
+        </member>
+        <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.TypedDurableClientBindingProvider">
+            <summary>
+            Provides an input binding for the typed client experience that
+            is generated via the source-generator nuget package.
+            </summary>
         </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.WebJobsConnectionStringProvider">
             <summary>

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
@@ -2437,27 +2437,6 @@
             <param name="attribute">The attribute containing the client configuration parameters.</param>
             <returns>Returns a <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableClient"/> instance. The returned instance may be a cached instance.</returns>
         </member>
-        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.GetGeneratedClient``1(Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClientAttribute)">
-            <summary>
-            Gets a <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableClient"/> using configuration from a <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClientAttribute"/> instance.
-            </summary>
-            <param name="attribute">The attribute containing the client configuration parameters.</param>
-            <returns>Returns a <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableClient"/> instance. The returned instance may be a cached instance.</returns>
-        </member>
-        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.GetDurableClient(Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClientAttribute)">
-            <summary>
-            Gets a <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableClient"/> using configuration from a <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClientAttribute"/> instance.
-            </summary>
-            <param name="attribute">The attribute containing the client configuration parameters.</param>
-            <returns>Returns a <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableClient"/> instance. The returned instance may be a cached instance.</returns>
-        </member>
-        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.GetGeneratedDurableClient``1(Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClientAttribute)">
-            <summary>
-            Gets a <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableClient"/> using configuration from a <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClientAttribute"/> instance.
-            </summary>
-            <param name="attribute">The attribute containing the client configuration parameters.</param>
-            <returns>Returns a <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableClient"/> instance. The returned instance may be a cached instance.</returns>
-        </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskExtension.Microsoft#Azure#WebJobs#IAsyncConverter{System#Net#Http#HttpRequestMessage,System#Net#Http#HttpResponseMessage}#ConvertAsync(System.Net.Http.HttpRequestMessage,System.Threading.CancellationToken)">
             <inheritdoc/>
         </member>
@@ -4521,6 +4500,12 @@
             <value>
             The name of the orchestrator function or <c>null</c> to use the function name.
             </value>
+        </member>
+        <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.TypedDurableClientBindingProvider">
+            <summary>
+            Provides an input binding for the typed client experience that
+            is generated via the source-generator nuget package.
+            </summary>
         </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.WebJobsConnectionStringProvider">
             <summary>

--- a/src/WebJobs.Extensions.DurableTask/TypedCodeProvider.cs
+++ b/src/WebJobs.Extensions.DurableTask/TypedCodeProvider.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;

--- a/src/WebJobs.Extensions.DurableTask/TypedDurableClientBindingProvider.cs
+++ b/src/WebJobs.Extensions.DurableTask/TypedDurableClientBindingProvider.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
 using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Host.Bindings;
@@ -6,7 +9,11 @@ using Microsoft.Azure.WebJobs.Host.Protocols;
 
 namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 {
-    public class TypedDurableClientBindingProvider : IBindingProvider
+    /// <summary>
+    /// Provides an input binding for the typed client experience that
+    /// is generated via the source-generator nuget package.
+    /// </summary>
+    internal class TypedDurableClientBindingProvider : IBindingProvider
     {
         private readonly Func<DurableClientAttribute, IDurableClient> clientGenerator;
         private readonly TypedCodeProvider typedCodeProvider;


### PR DESCRIPTION
Previous PR #1813 missed the CI runs because it was from an external contributor, so some build warnings that broke our build slipped in. This PR fixes those.


