### PR TITLE
Fix code-gen intialization in Functions V1

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
@@ -531,6 +531,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             this.MessageDataConverter = new MessagePayloadDataConverter(messageSerializerSettingsFactory.CreateJsonSerializerSettings(), true);
             this.ErrorDataConverter = new MessagePayloadDataConverter(errorSerializerSettingsFactory.CreateJsonSerializerSettings(), true);
             this.HttpApiHandler = new HttpApiHandler(this, logger);
+            this.TypedCodeProvider = new TypedCodeProvider();
+            this.TypedCodeProvider.Initialize();
 #endif
         }
 


### PR DESCRIPTION
TypedCodeProvider was not properly initialized in FunctionsV1, leading to a null reference exception for FunctionsV1 scenarios. This PR properly initializes this type for FunctionsV1.

