### PR TITLE
Update DurableTask.AzureStorage dependency

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -1,7 +1,8 @@
 ## New Features
-- Improved supportability logs on Linux Dedicated plans (https://github.com/Azure/azure-functions-durable-extension/pull/1721)
-- Improved concurrency defaults in Consumption plans for C# and JS (https://github.com/Azure/azure-functions-durable-extension/pull/1846)
-- Initial work to simplify out-of-process execution model (https://github.com/Azure/azure-functions-durable-extension/pull/1836)
+- Improved supportability logs on Linux Dedicated plans (#1721)
+- Improved concurrency defaults in Consumption plans for C# and JS (#1846)
+- Initial work to simplify out-of-process execution model (#1836)
+- Mutliple concurrent start requests to a singleton orchestration instance should now only start a single instance ((#528)[https://github.com/Azure/durabletask/pull/528])
 
 ## Bug fixes
 - Fix issue with local RPC endpoint used by non-.NET languages on Windows apps (#1800)

--- a/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
+++ b/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
@@ -82,7 +82,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage" Version="1.8.5" />
+    <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage" Version="1.8.6" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers" Version="0.4.0" />
     <PackageReference Include="Azure.Identity" Version="1.1.1" />
   </ItemGroup>

--- a/test/FunctionsV2/WebJobs.Extensions.DurableTask.Tests.V2.csproj
+++ b/test/FunctionsV2/WebJobs.Extensions.DurableTask.Tests.V2.csproj
@@ -26,8 +26,8 @@
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.*" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.Azure.DurableTask.Emulator" Version="2.5.2" />
-    <PackageReference Include="Microsoft.Azure.DurableTask.Redis" Version="0.1.8-alpha" />
+    <PackageReference Include="Microsoft.Azure.DurableTask.Emulator" Version="2.5.4" />
+    <PackageReference Include="Microsoft.Azure.DurableTask.Redis" Version="0.1.9-alpha" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Upgrade from 1.8.5 to 1.8.6.

The main two improvements in this upgrade is improved support for
concurrent requests to start a singleton orchestration, along with the
required enhancements for the new steal app lease APIs.


### Pull request checklist

* [X] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [X] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [X] I have added all required tests (Unit tests, E2E tests)


