### PR TITLE
Fix StartCounter C# Performance Test

### DIFF
--- a/test/DFPerfScenarios/Tests/Counter.cs
+++ b/test/DFPerfScenarios/Tests/Counter.cs
@@ -2,6 +2,7 @@ using System;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.WebJobs;
 using Microsoft.Azure.WebJobs.Extensions.DurableTask;
@@ -14,7 +15,7 @@ namespace DFPerfScenarios
     public static class CounterTest
 	{
 		[FunctionName("StartCounter")]
-		public static async Task<IActionResult> Start(
+		public static IActionResult Start(
             [HttpTrigger(AuthorizationLevel.Function, methods: "post", Route = "StartCounter")] HttpRequest req,
             [DurableClient] IDurableClient starter,
             ILogger log)
@@ -37,7 +38,7 @@ namespace DFPerfScenarios
                 starter.SignalEntityAsync(entityId, "add", 1).GetAwaiter().GetResult();
             });
 
-            return req.CreateResponse(HttpStatusCode.Accepted);
+            return new AcceptedResult();
 		}
 
         private class Input


### PR DESCRIPTION
This PR fixes a simple compilation error in the DFPerfScenarios project. It updates StartCounter by adding `using Microsoft.AspNetCore.Http;` and updating the response value.

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)


