### PR TITLE
Disable OOProc State Transfer Logging

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/Listener/TaskOrchestrationShim.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/TaskOrchestrationShim.cs
@@ -230,12 +230,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         private async Task TraceAndReplay(object result, Exception ex = null)
         {
             var invocationResult = new OrchestrationInvocationResult(result, ex);
-            /* this.Config.TraceHelper.ProcessingOutOfProcPayload(
-                functionName: this.Context.FunctionName,
-                taskHub: this.Context.HubName,
-                instanceId: this.Context.InstanceId,
-                details: invocationResult.JsonString);
-            */
             await this.outOfProcShim.HandleDurableTaskReplay(invocationResult);
         }
 

--- a/src/WebJobs.Extensions.DurableTask/Listener/TaskOrchestrationShim.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/TaskOrchestrationShim.cs
@@ -230,11 +230,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         private async Task TraceAndReplay(object result, Exception ex = null)
         {
             var invocationResult = new OrchestrationInvocationResult(result, ex);
-            this.Config.TraceHelper.ProcessingOutOfProcPayload(
+            /* this.Config.TraceHelper.ProcessingOutOfProcPayload(
                 functionName: this.Context.FunctionName,
                 taskHub: this.Context.HubName,
                 instanceId: this.Context.InstanceId,
                 details: invocationResult.JsonString);
+            */
             await this.outOfProcShim.HandleDurableTaskReplay(invocationResult);
         }
 


### PR DESCRIPTION
<!-- Start the PR description with some context for the change. -->
Follow-up to: https://github.com/Azure/azure-functions-durable-extension/pull/1836
Disables OOProc state transfer logging until we find a less verbose alternative.



