### PR TITLE
Fix typed interfaces readme namespaces and simplify setup

### DIFF
--- a/src/DurableFunctions.TypedInterfaces/README.md
+++ b/src/DurableFunctions.TypedInterfaces/README.md
@@ -203,9 +203,9 @@ public async Task<int> Multiply(
 
 ### 1. Manually Adding Namespace
 
-For the moment, generated code will not show up intellisense unless the namespace containing the code is added to the file you are trying to use them in. Generated code is placed in the namespace ```Microsoft.Azure.Webjobs.Extensions.DurableTask.Generated```. 
+For the moment, generated code will not show up intellisense unless the namespace containing the code is added to the file you are trying to use them in. Generated code is placed in the namespace ```Microsoft.Azure.Webjobs.Extensions.DurableTask.TypedInterfaces```. 
 
-To use the generated interfaces, and have intellisense available for the generated types, you must manually include the using statement:
+In order to use the new typed interfaces, you must manually include the using statement:
 ```csharp
 using Microsoft.Azure.WebJobs.Extensions.DurableTask.TypedInterfaces;
 ```

--- a/src/DurableFunctions.TypedInterfaces/README.md
+++ b/src/DurableFunctions.TypedInterfaces/README.md
@@ -15,7 +15,7 @@ Automatically generates method stubs that correspond to the contracts of Orchest
 For example: 
 
 ```xml
-<ProjectReference Include="..\WebJobs.Extensions.DurableTask.CodeGen.SourceGenerator\WebJobs.Extensions.DurableTask.CodeGen.SourceGenerator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+<PackageReference Include="DurableFunctions.TypedInterfaces" Version="0.1.0-preview" />
 ```
 
 *The project should now automatically generate code for Orchestration/Activity functions.*
@@ -42,7 +42,7 @@ public static string SayHello([ActivityTrigger] IDurableActivityContext context,
 4. Manually add using statement to reference the generated code.
 
 ```
-using DurableFunctions.TypedInterfaces;
+using Microsoft.Azure.WebJobs.Extensions.DurableTask.TypedInterfaces;
 ```
 
 5. Replace ```IDurableClient``` / ```IDurableOrchestrationContext``` usage for their generated counterparts ```ITypedDurableClient``` / ```ITypedDurableOrchestrationContext```. The generated interfaces can perform all operations exposed by standard interfaces, in additional to performing typed calls to Orchestration/Activity Function.
@@ -207,7 +207,7 @@ For the moment, generated code will not show up intellisense unless the namespac
 
 To use the generated interfaces, and have intellisense available for the generated types, you must manually include the using statement:
 ```csharp
-using using DurableFunctions.TypedInterfaces;
+using Microsoft.Azure.WebJobs.Extensions.DurableTask.TypedInterfaces;
 ```
 
 ### 2. Scoped Code Generation


### PR DESCRIPTION
Previous attempt to fix namespace was incorrect, and now instruct people to install nuget package instead of package reference.
