### PR TITLE
Small documentation update for CodeGeneration for Durable Functions

### DIFF
--- a/src/DurableFunctions.TypedInterfaces/README.md
+++ b/src/DurableFunctions.TypedInterfaces/README.md
@@ -10,7 +10,7 @@ Automatically generates method stubs that correspond to the contracts of Orchest
 
 ## How to use
 
-1. Add the project's nuget package as a dependency. Mark the reference with `OutputItemType="Analyzer"` and `ReferenceOutputAssembly="false"`.
+1. Add the project's nuget package as a dependency.
 
 For example: 
 

--- a/src/DurableFunctions.TypedInterfaces/README.md
+++ b/src/DurableFunctions.TypedInterfaces/README.md
@@ -20,9 +20,10 @@ For example:
 
 *The project should now automatically generate code for Orchestration/Activity functions.*
 
-2. *Optionally*, add the following statement to a property group in your project's csproj in order to see the generated files.
+2. *Optionally*, add the following statements to a property group in your project's csproj in order to see the generated files.
 
 ```xml
+<EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
 <CompilerGeneratedFilesOutputPath>$(BaseIntermediateOutputPath)Generated</CompilerGeneratedFilesOutputPath>
 ```
 


### PR DESCRIPTION
Small update to the documentation for CodeGeneration for Durable Functions

- Remove instruction to mark the reference with specific attributes, as these attributes only make sense when adding a Project Reference, and we're talking about a PackageReference here
- Add `<EmitCompilerGeneratedFiles>` to make sure generated code is actually output somewhere

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)


