### PR TITLE
Fix message loss bug in ContinueAsNew scenarios (update DT.AzureStorage dependency)

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -2,4 +2,6 @@
 
 ## Bug fixes
 
+* Fix message loss bug in ContinueAsNew scenarios ([Azure/durabletask#544](https://github.com/Azure/durabletask/pull/544))
+
 ## Breaking Changes

--- a/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
+++ b/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
@@ -85,7 +85,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage" Version="1.8.6" />
+    <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage" Version="1.8.7" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers" Version="0.4.0" />
     <PackageReference Include="Azure.Identity" Version="1.1.1" />
 


### PR DESCRIPTION
This PR is increments the dependency of DurableTask.AzureStorage to v1.8.**7**. The main fix being pulled in is https://github.com/Azure/durabletask/pull/544.

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)


