### PR TITLE
Update release template with learnings from v2.5.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-release-template.md
+++ b/.github/ISSUE_TEMPLATE/new-release-template.md
@@ -13,7 +13,7 @@ _Due: <2-3-business-days-before-release>_
 - [ ] Delete DTFx test packages from staging myget.
 - [ ] Update OneBranch durabletask repo, run signing pipeline (using these notes:  [Durable Task Framework Build Pipeline] (https://microsoft.sharepoint.com/teams/AzureWebjobs/_layouts/OneNote.aspx?id=%2Fteams%2FAzureWebjobs%2FSiteAssets%2FAzureWebjobs%20Notebook&wd=target%28Planning%2FFunctions%20Post-GA.one%7CA43CF112-7272-481A-B23E-9AA5CA8EEE06%2FDurable%20Task%20Framework%20Build%20Pipeline%7CD0946823-6FB0-44E3-A57F-E252617B69CD%2F%29
 onenote:https://microsoft.sharepoint.com/teams/AzureWebjobs/SiteAssets/AzureWebjobs%20Notebook/Planning/Functions%20Post-GA.one#Durable%20Task%20Framework%20Build%20Pipeline&section-id={A43CF112-7272-481A-B23E-9AA5CA8EEE06}&page-id={D0946823-6FB0-44E3-A57F-E252617B69CD}&end) ).
-- [ ] Publish DTFx packages to staging myget for testing. (either DT-AzureStorage only or if there were Core changes DT-AzureStorage, DT-Core, DT-Redis, and DT-Emulator)
+- [ ] Publish DTFx packages to staging myget for testing. (either DT-AzureStorage only or if there were Core changes DT-AzureStorage and DT-Core)
 
 **Prep Release (assigned to: )**
 _Due: <2-business-days-before-release>_
@@ -43,7 +43,6 @@ _Due: <release-deadline>_
 - [ ] Create a PR in the [Azure Functions bundles repo](https://github.com/Azure/azure-functions-extension-bundles) to update bundles to the latest version.
 - [ ] Merge all pending PR docs from `pending_docs.md.`
 - [ ] Reset `pending_docs.md` and `release_notes.md` in the `dev` branch. You will want to save `release_notes.md` somewhere for when you publish release notes.
-- [ ] Merge `dev` into `main.`
 - [ ] Publish release notes from the pre-reset `release_notes.md.`
 - [ ] Post announcement on [App Service Announcements GitHub repo](https://github.com/Azure/app-service-announcements) and Twitter (Chris).
 - [ ] Increment Durable Functions patch version.


### PR DESCRIPTION
In the v2.5.0 release, we discovered that releasing new versions of
DTFx.Redis and DTFx.Emulator is unnecessary, and leads to potential
customer confusion.

In addition, the second merge from dev into main after resetting the
release notes and the pending docs felt unecessary, as having the
release tag with those files as they were is acceptable and reduces
unnecessary work.


