### PR TITLE
Adding Name to IDurableActivityContext

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/Bindings/ActivityTriggerAttributeBindingProvider.cs
+++ b/src/WebJobs.Extensions.DurableTask/Bindings/ActivityTriggerAttributeBindingProvider.cs
@@ -126,7 +126,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     // Durable functions expects input as a JArray with one element.
                     serializedInput = $"[{serializedInput}]";
 
-                    activityContext = new DurableActivityContext(this.durableTaskConfig, Guid.NewGuid().ToString(), serializedInput);
+                    activityContext = new DurableActivityContext(this.durableTaskConfig, Guid.NewGuid().ToString(), serializedInput, this.activityName.Name);
                 }
 
                 Type destinationType = this.parameterInfo.ParameterType;

--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableActivityContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableActivityContext.cs
@@ -15,6 +15,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         DurableActivityContextBase // for v1 legacy compatibility.
 #pragma warning restore 618
     {
+        private readonly string functionName;
+
         private readonly string serializedInput;
 
         private readonly string instanceId;
@@ -24,15 +26,19 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         private JToken parsedJsonInput;
         private string serializedOutput;
 
-        internal DurableActivityContext(DurableTaskExtension config, string instanceId, string serializedInput)
+        internal DurableActivityContext(DurableTaskExtension config, string instanceId, string serializedInput, string functionName)
         {
             this.messageDataConverter = config.MessageDataConverter;
             this.instanceId = instanceId;
             this.serializedInput = serializedInput;
+            this.functionName = functionName;
         }
 
         /// <inheritdoc />
         string IDurableActivityContext.InstanceId => this.instanceId;
+
+        /// <inheritdoc />
+        string IDurableActivityContext.Name => this.functionName;
 
         /// <summary>
         /// Returns the input of the task activity in its raw JSON string value.

--- a/src/WebJobs.Extensions.DurableTask/ContextInterfaces/IDurableActivityContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextInterfaces/IDurableActivityContext.cs
@@ -9,6 +9,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
     public interface IDurableActivityContext
     {
         /// <summary>
+        /// Gets the name of the current activity function.
+        /// </summary>
+        string Name { get; }
+
+        /// <summary>
         /// Gets the instance ID of the currently executing orchestration.
         /// </summary>
         /// <remarks>

--- a/src/WebJobs.Extensions.DurableTask/Listener/TaskActivityShim.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/TaskActivityShim.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         public override async Task<string> RunAsync(TaskContext context, string rawInput)
         {
             string instanceId = context.OrchestrationInstance.InstanceId;
-            var inputContext = new DurableActivityContext(this.config, instanceId, rawInput);
+            var inputContext = new DurableActivityContext(this.config, instanceId, rawInput, this.activityName);
 
             // TODO: Wire up the parent ID to improve dashboard logging.
             Guid? parentId = null;

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net461.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net461.xml
@@ -64,6 +64,9 @@
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableActivityContext.Microsoft#Azure#WebJobs#Extensions#DurableTask#IDurableActivityContext#InstanceId">
             <inheritdoc />
         </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableActivityContext.Microsoft#Azure#WebJobs#Extensions#DurableTask#IDurableActivityContext#Name">
+            <inheritdoc />
+        </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableActivityContext.GetRawInput">
             <summary>
             Returns the input of the task activity in its raw JSON string value.
@@ -413,6 +416,11 @@
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableActivityContext">
             <summary>
             Provides functionality available to durable activities.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableActivityContext.Name">
+            <summary>
+            Gets the name of the current activity function.
             </summary>
         </member>
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableActivityContext.InstanceId">

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
@@ -67,6 +67,9 @@
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableActivityContext.Microsoft#Azure#WebJobs#Extensions#DurableTask#IDurableActivityContext#InstanceId">
             <inheritdoc />
         </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableActivityContext.Microsoft#Azure#WebJobs#Extensions#DurableTask#IDurableActivityContext#Name">
+            <inheritdoc />
+        </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableActivityContext.GetRawInput">
             <summary>
             Returns the input of the task activity in its raw JSON string value.
@@ -416,6 +419,11 @@
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableActivityContext">
             <summary>
             Provides functionality available to durable activities.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableActivityContext.Name">
+            <summary>
+            Gets the name of the current activity function.
             </summary>
         </member>
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableActivityContext.InstanceId">


### PR DESCRIPTION
Bringing ```IDurableActivityContext``` in parity with ```IDurableOrchestrationContext``` by adding a ```Name``` property to track the current executing function's name.



