### PR TITLE
Improve handling of deleted/disabled/renamed orchestrator and activity functions

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -4,5 +4,6 @@
 
 * Fix message loss bug in ContinueAsNew scenarios ([Azure/durabletask#544](https://github.com/Azure/durabletask/pull/544))
 * Allow custom connection string names when creating a DurableClient in an ASP.NET Core app (external app) (#1895)
+* Improve handling of deleted/disabled/renamed orchestrator and activity functions (#1901)
 
 ## Breaking Changes

--- a/release_notes.md
+++ b/release_notes.md
@@ -4,6 +4,6 @@
 
 * Fix message loss bug in ContinueAsNew scenarios ([Azure/durabletask#544](https://github.com/Azure/durabletask/pull/544))
 * Allow custom connection string names when creating a DurableClient in an ASP.NET Core app (external app) (#1895)
-* Improve handling of deleted/disabled/renamed orchestrator and activity functions (#1901)
+* Instead of endlessly retrying deleted, disabled, or renamed orchestrator and activity functions, we will now fail any in-flight executions if a function with that name no longer exists. (#1901)
 
 ## Breaking Changes

--- a/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
@@ -621,11 +621,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             if (!this.knownActivities.TryGetValue(activityFunction, out info))
             {
                 string message = $"Activity function '{activityFunction}' does not exist.";
-                this.TraceHelper.ExtensionWarningEvent(
-                    this.Options.HubName,
-                    activityFunction.Name,
-                    string.Empty /* TODO: Flow the instance id into this event */,
-                    message);
 
                 return new TaskNonexistentActivityShim(this, name, message);
             }

--- a/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
@@ -22,6 +22,7 @@ using Microsoft.Azure.WebJobs.Description;
 using Microsoft.Azure.WebJobs.Extensions.DurableTask.Correlation;
 using Microsoft.Azure.WebJobs.Host.Scale;
 #endif
+using System.Runtime.ExceptionServices;
 using Microsoft.Azure.WebJobs.Extensions.DurableTask.Listener;
 using Microsoft.Azure.WebJobs.Host;
 using Microsoft.Azure.WebJobs.Host.Config;
@@ -625,7 +626,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     activityFunction.Name,
                     string.Empty /* TODO: Flow the instance id into this event */,
                     message);
-                throw new InvalidOperationException(message);
+
+                return new TaskNonexistentActivityShim(this, name, message);
             }
 
             return new TaskActivityShim(this, info.Executor, this.hostLifetimeService, name);
@@ -684,55 +686,61 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             if (info == null)
             {
                 string message = this.GetInvalidOrchestratorFunctionMessage(context.FunctionName);
+
                 this.TraceHelper.ExtensionWarningEvent(
                     this.Options.HubName,
                     orchestrationRuntimeState.Name,
                     orchestrationRuntimeState.OrchestrationInstance.InstanceId,
                     message);
-                throw new InvalidOperationException(message);
-            }
 
-            // 1. Start the functions invocation pipeline (billing, logging, bindings, and timeout tracking).
-            WrappedFunctionResult result = await FunctionExecutionHelper.ExecuteFunctionInOrchestrationMiddleware(
-                info.Executor,
-                new TriggeredFunctionData
-                {
-                    TriggerValue = context,
+                Func<Task<OrchestrationFailureException>> nonExistentException = () => throw new OrchestrationFailureException(message);
+                shim.SetFunctionInvocationCallback(nonExistentException);
+                await next();
+            }
+            else
+            {
+                // 1. Start the functions invocation pipeline (billing, logging, bindings, and timeout tracking).
+                WrappedFunctionResult result = await FunctionExecutionHelper.ExecuteFunctionInOrchestrationMiddleware(
+                    info.Executor,
+                    new TriggeredFunctionData
+                    {
+                        TriggerValue = context,
 
 #pragma warning disable CS0618 // Approved for use by this extension
-                    InvokeHandler = async userCodeInvoker =>
-                    {
-                        context.ExecutorCalledBack = true;
-
-                        // 2. Configure the shim with the inner invoker to execute the user code.
-                        shim.SetFunctionInvocationCallback(userCodeInvoker);
-
-                        // 3. Move to the next stage of the DTFx pipeline to trigger the orchestrator shim.
-                        await next();
-
-                        // 4. If an activity failed, indicate to the functions Host that this execution failed via an exception
-                        if (context.IsCompleted && context.OrchestrationException != null)
+                        InvokeHandler = async userCodeInvoker =>
                         {
-                            context.OrchestrationException.Throw();
-                        }
-                    },
+                            context.ExecutorCalledBack = true;
+
+                            // 2. Configure the shim with the inner invoker to execute the user code.
+                            shim.SetFunctionInvocationCallback(userCodeInvoker);
+
+                            // 3. Move to the next stage of the DTFx pipeline to trigger the orchestrator shim.
+                            await next();
+
+                            // 4. If an activity failed, indicate to the functions Host that this execution failed via an exception
+                            if (context.IsCompleted && context.OrchestrationException != null)
+                            {
+                                context.OrchestrationException.Throw();
+                            }
+                        },
 #pragma warning restore CS0618
-                },
-                context,
-                this.hostLifetimeService.OnStopping);
+                    },
+                    context,
+                    this.hostLifetimeService.OnStopping);
 
-            if (result.ExecutionStatus == WrappedFunctionResult.FunctionResultStatus.FunctionsRuntimeError)
-            {
-                this.TraceHelper.FunctionAborted(
-                    this.Options.HubName,
-                    context.FunctionName,
-                    context.InstanceId,
-                    $"An internal error occurred while attempting to execute this function. The execution will be aborted and retried. Details: {result.Exception}",
-                    functionType: FunctionType.Orchestrator);
+                if (result.ExecutionStatus == WrappedFunctionResult.FunctionResultStatus.FunctionsRuntimeError)
+                {
+                    this.TraceHelper.FunctionAborted(
+                        this.Options.HubName,
+                        context.FunctionName,
+                        context.InstanceId,
+                        $"An internal error occurred while attempting to execute this function. The execution will be aborted and retried. Details: {result.Exception}",
+                        functionType: FunctionType.Orchestrator);
 
-                // This will abort the execution and cause the message to go back onto the queue for re-processing
-                throw new SessionAbortedException(
-                    $"An internal error occurred while attempting to execute '{context.FunctionName}'.", result.Exception);
+                    // This will abort the execution and cause the message to go back onto the queue for re-processing
+                    throw new SessionAbortedException(
+                        $"An internal error occurred while attempting to execute '{context.FunctionName}'.", result.Exception);
+                }
             }
 
             if (!context.IsCompleted && !context.IsLongRunningTimer)

--- a/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
@@ -22,7 +22,6 @@ using Microsoft.Azure.WebJobs.Description;
 using Microsoft.Azure.WebJobs.Extensions.DurableTask.Correlation;
 using Microsoft.Azure.WebJobs.Host.Scale;
 #endif
-using System.Runtime.ExceptionServices;
 using Microsoft.Azure.WebJobs.Extensions.DurableTask.Listener;
 using Microsoft.Azure.WebJobs.Host;
 using Microsoft.Azure.WebJobs.Host.Config;
@@ -620,9 +619,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             RegisteredFunctionInfo info;
             if (!this.knownActivities.TryGetValue(activityFunction, out info))
             {
-                string message = $"Activity function '{activityFunction}' does not exist.";
-
-                return new TaskNonexistentActivityShim(this, name, message);
+                return new TaskNonexistentActivityShim(this, name);
             }
 
             return new TaskActivityShim(this, info.Executor, this.hostLifetimeService, name);

--- a/src/WebJobs.Extensions.DurableTask/Listener/TaskNonexistentActivityShim.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/TaskNonexistentActivityShim.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Threading.Tasks;
+using DurableTask.Core;
+using DurableTask.Core.Common;
+using DurableTask.Core.Exceptions;
+
+namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Listener
+{
+    internal class TaskNonexistentActivityShim : TaskActivity
+    {
+        private readonly DurableTaskExtension config;
+        private readonly string activityName;
+        private readonly string message;
+
+        public TaskNonexistentActivityShim(
+            DurableTaskExtension config,
+            string activityName,
+            string message)
+        {
+            this.config = config;
+            this.activityName = activityName;
+            this.message = message;
+        }
+
+        public override string Run(TaskContext context, string input)
+        {
+            Exception exceptionToReport = new FunctionFailedException(this.message);
+
+            throw new TaskFailureException(
+                $"Activity function '{this.activityName}' failed: {exceptionToReport.Message}",
+                Utils.SerializeCause(exceptionToReport, this.config.ErrorDataConverter));
+        }
+    }
+}

--- a/src/WebJobs.Extensions.DurableTask/Listener/TaskNonexistentActivityShim.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/TaskNonexistentActivityShim.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
 using System.Threading.Tasks;
 using DurableTask.Core;
 using DurableTask.Core.Common;

--- a/src/WebJobs.Extensions.DurableTask/Listener/TaskNonexistentActivityShim.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/TaskNonexistentActivityShim.cs
@@ -13,21 +13,19 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Listener
     {
         private readonly DurableTaskExtension config;
         private readonly string activityName;
-        private readonly string message;
 
         public TaskNonexistentActivityShim(
             DurableTaskExtension config,
-            string activityName,
-            string message)
+            string activityName)
         {
             this.config = config;
             this.activityName = activityName;
-            this.message = message;
         }
 
         public override string Run(TaskContext context, string input)
         {
-            Exception exceptionToReport = new FunctionFailedException(this.message);
+            string message = $"Activity function '{this.activityName}' does not exist.";
+            Exception exceptionToReport = new FunctionFailedException(message);
 
             throw new TaskFailureException(
                 $"Activity function '{this.activityName}' failed: {exceptionToReport.Message}",

--- a/src/WebJobs.Extensions.DurableTask/Listener/TaskOrchestrationShim.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/TaskOrchestrationShim.cs
@@ -167,7 +167,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             }
             catch (Exception e)
             {
-                if (orchestratorInfo.IsOutOfProc
+                if (orchestratorInfo != null
+                    && orchestratorInfo.IsOutOfProc
                     && OutOfProcExceptionHelpers.TryExtractOutOfProcStateJson(e.InnerException, out string returnValue)
                     && !string.IsNullOrEmpty(returnValue))
                 {

--- a/test/Common/DurableTaskEndToEndTests.cs
+++ b/test/Common/DurableTaskEndToEndTests.cs
@@ -2500,8 +2500,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
                 await host.StopAsync();
 
-                await Task.Delay(30000);
-
                 Dictionary<string, string> taskHubAndStorageAppSetting = new Dictionary<string, string>
                 {
                     { "CustomStorageAccountName", TestHelpers.GetStorageConnectionString() },
@@ -2534,7 +2532,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                         await clientHost.StartAsync();
                         IDurableClientFactory durableClientFactory = clientHost.Services.GetService(typeof(IDurableClientFactory)) as DurableClientFactory;
                         IDurableClient durableClient = durableClientFactory.CreateClient(durableClientOptions);
-                        await Task.Delay(20000);
+                        await Task.Delay(15000);
                         DurableOrchestrationStatus newStatus = await durableClient.GetStatusAsync(instanceId);
 
                         Assert.Equal(OrchestrationRuntimeStatus.Failed, newStatus?.RuntimeStatus);

--- a/test/Common/TestActivities.cs
+++ b/test/Common/TestActivities.cs
@@ -63,6 +63,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             throw new InvalidOperationException(message);
         }
 
+        public static async Task TimeDelayActivity([ActivityTrigger] IDurableActivityContext ctx)
+        {
+            await Task.Delay(TimeSpan.FromSeconds(20));
+        }
+
         public static Task<string> LoadStringFromTextBlob(
             [ActivityTrigger] string blobName)
         {

--- a/test/Common/TestActivities.cs
+++ b/test/Common/TestActivities.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
         public static async Task TimeDelayActivity([ActivityTrigger] IDurableActivityContext ctx)
         {
-            await Task.Delay(TimeSpan.FromSeconds(20));
+            await Task.Delay(TimeSpan.FromSeconds(10));
         }
 
         public static Task<string> LoadStringFromTextBlob(

--- a/test/Common/TestHelpers.cs
+++ b/test/Common/TestHelpers.cs
@@ -64,7 +64,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             bool rollbackEntityOperationsOnExceptions = true,
             int entityMessageReorderWindowInMinutes = 30,
             string exactTaskHubName = null,
-            bool addDurableClientFactory = false)
+            bool addDurableClientFactory = false,
+            Type[] types = null)
         {
             switch (storageProviderType)
             {
@@ -156,6 +157,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 onSend: onSend,
 #if !FUNCTIONS_V1
                 addDurableClientFactory: addDurableClientFactory,
+                types: types,
 #endif
                 durabilityProviderFactoryType: durabilityProviderFactoryType);
         }
@@ -170,7 +172,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             IMessageSerializerSettingsFactory serializerSettings = null,
             Action<ITelemetry> onSend = null,
             Type durabilityProviderFactoryType = null,
-            bool addDurableClientFactory = false)
+            bool addDurableClientFactory = false,
+            Type[] types = null)
         {
             if (serializerSettings == null)
             {
@@ -184,12 +187,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 durableHttpMessageHandler = new DurableHttpMessageHandlerFactory();
             }
 
+            ITypeLocator typeLocator = types == null ? GetTypeLocator() : new ExplicitTypeLocator(types);
+
             return PlatformSpecificHelpers.CreateJobHost(
                 options: optionsWrapper,
                 storageProvider: storageProviderType,
 #if !FUNCTIONS_V1
                 durabilityProviderFactoryType: durabilityProviderFactoryType,
                 addDurableClientFactory: addDurableClientFactory,
+                typeLocator: typeLocator,
 #endif
                 loggerProvider: loggerProvider,
                 nameResolver: testNameResolver,

--- a/test/Common/TestOrchestrations.cs
+++ b/test/Common/TestOrchestrations.cs
@@ -637,6 +637,22 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             return "Done";
         }
 
+        public static async Task<string> FanOutFanInWithDelay(
+           [OrchestrationTrigger] IDurableOrchestrationContext context)
+        {
+            int parallelTasks = context.GetInput<int>();
+            var tasks = new Task[parallelTasks];
+            for (int i = 0; i < tasks.Length; i++)
+            {
+                tasks[i] = context.CallActivityAsync(nameof(TestActivities.TimeDelayActivity), null);
+            }
+
+            await Task.WhenAll(tasks);
+
+            return "Done";
+        }
+
+
         public static async Task<int> WaitForEventAndCallActivity(
             [OrchestrationTrigger] IDurableOrchestrationContext context)
         {

--- a/test/Common/TestOrchestrations.cs
+++ b/test/Common/TestOrchestrations.cs
@@ -637,21 +637,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             return "Done";
         }
 
-        public static async Task<string> FanOutFanInWithDelay(
+        public static async Task<string> CallActivityWithDelay(
            [OrchestrationTrigger] IDurableOrchestrationContext context)
         {
-            int parallelTasks = context.GetInput<int>();
-            var tasks = new Task[parallelTasks];
-            for (int i = 0; i < tasks.Length; i++)
-            {
-                tasks[i] = context.CallActivityAsync(nameof(TestActivities.TimeDelayActivity), null);
-            }
-
-            await Task.WhenAll(tasks);
-
+            await context.CallActivityAsync(nameof(TestActivities.TimeDelayActivity), null);
             return "Done";
         }
-
 
         public static async Task<int> WaitForEventAndCallActivity(
             [OrchestrationTrigger] IDurableOrchestrationContext context)

--- a/test/FunctionsV2/PlatformSpecificHelpers.FunctionsV2.cs
+++ b/test/FunctionsV2/PlatformSpecificHelpers.FunctionsV2.cs
@@ -35,7 +35,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             ILifeCycleNotificationHelper lifeCycleNotificationHelper,
             IMessageSerializerSettingsFactory serializerSettingsFactory,
             Action<ITelemetry> onSend,
-            bool addDurableClientFactory)
+            bool addDurableClientFactory,
+            ITypeLocator typeLocator)
         {
             // Unless otherwise specified, use legacy partition management for tests as it makes the task hubs start up faster.
             // These tests run on a single task hub workers, so they don't test partition management anyways, and that is tested
@@ -68,7 +69,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 .ConfigureServices(
                     serviceCollection =>
                     {
-                        ITypeLocator typeLocator = TestHelpers.GetTypeLocator();
                         serviceCollection.AddSingleton(typeLocator);
                         serviceCollection.AddSingleton(nameResolver);
                         serviceCollection.AddSingleton(durableHttpMessageHandler);


### PR DESCRIPTION
This PR changes the status of orchestration and activity functions that are deleted/disabled/renamed to Failed instead of Running. This clears up queue messages and cleans up nonexistent function instances.

Resolves #1729

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)


