### PR TITLE
Tweak C# docs for CreateTimer APIs

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -4,5 +4,6 @@
 
 * Fix message loss bug in ContinueAsNew scenarios ([Azure/durabletask#544](https://github.com/Azure/durabletask/pull/544))
 * Allow custom connection string names when creating a DurableClient in an ASP.NET Core app (external app) (#1895)
+* Improve API documentation regarding uncancelled timers (#1903)
 
 ## Breaking Changes

--- a/src/WebJobs.Extensions.DurableTask/ContextInterfaces/IDurableOrchestrationContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextInterfaces/IDurableOrchestrationContext.cs
@@ -328,7 +328,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// <remarks>
         /// All durable timers created using this method must either expire or be cancelled
         /// using the <paramref name="cancelToken"/> before the orchestrator function completes.
-        /// Otherwise the underlying framework will keep the instance alive until the timer expires.
+        ///  Otherwise the underlying framework will keep the instance in the "Running" state
+        ///  even after the orchestrator function has completed.
         /// </remarks>
         /// <typeparam name="T">The type of <paramref name="state"/>.</typeparam>
         /// <param name="fireAt">The time at which the timer should expire.</param>
@@ -343,7 +344,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// <remarks>
         /// All durable timers created using this method must either expire or be cancelled
         /// using the <paramref name="cancelToken"/> before the orchestrator function completes.
-        /// Otherwise the underlying framework will keep the instance alive until the timer expires.
+        ///  Otherwise the underlying framework will keep the instance in the "Running" state
+        ///  even after the orchestrator function has completed.
         /// </remarks>
         /// <param name="fireAt">The time at which the timer should expire.</param>
         /// <param name="cancelToken">The <c>CancellationToken</c> to use for cancelling the timer.</param>

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net461.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net461.xml
@@ -1322,7 +1322,8 @@
             <remarks>
             All durable timers created using this method must either expire or be cancelled
             using the <paramref name="cancelToken"/> before the orchestrator function completes.
-            Otherwise the underlying framework will keep the instance alive until the timer expires.
+             Otherwise the underlying framework will keep the instance in the "Running" state
+             even after the orchestrator function has completed.
             </remarks>
             <typeparam name="T">The type of <paramref name="state"/>.</typeparam>
             <param name="fireAt">The time at which the timer should expire.</param>
@@ -1337,7 +1338,8 @@
             <remarks>
             All durable timers created using this method must either expire or be cancelled
             using the <paramref name="cancelToken"/> before the orchestrator function completes.
-            Otherwise the underlying framework will keep the instance alive until the timer expires.
+             Otherwise the underlying framework will keep the instance in the "Running" state
+             even after the orchestrator function has completed.
             </remarks>
             <param name="fireAt">The time at which the timer should expire.</param>
             <param name="cancelToken">The <c>CancellationToken</c> to use for cancelling the timer.</param>

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
@@ -1330,7 +1330,8 @@
             <remarks>
             All durable timers created using this method must either expire or be cancelled
             using the <paramref name="cancelToken"/> before the orchestrator function completes.
-            Otherwise the underlying framework will keep the instance alive until the timer expires.
+             Otherwise the underlying framework will keep the instance in the "Running" state
+             even after the orchestrator function has completed.
             </remarks>
             <typeparam name="T">The type of <paramref name="state"/>.</typeparam>
             <param name="fireAt">The time at which the timer should expire.</param>
@@ -1345,7 +1346,8 @@
             <remarks>
             All durable timers created using this method must either expire or be cancelled
             using the <paramref name="cancelToken"/> before the orchestrator function completes.
-            Otherwise the underlying framework will keep the instance alive until the timer expires.
+             Otherwise the underlying framework will keep the instance in the "Running" state
+             even after the orchestrator function has completed.
             </remarks>
             <param name="fireAt">The time at which the timer should expire.</param>
             <param name="cancelToken">The <c>CancellationToken</c> to use for cancelling the timer.</param>
@@ -2506,14 +2508,6 @@
             </summary>
             <param name="serviceCollection">The <see cref="T:Microsoft.Extensions.DependencyInjection.IServiceCollection"/> to configure.</param>
             <param name="optionsBuilder">Populate default configurations of <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.Options.DurableClientOptions"/> to create Durable Clients.</param>
-            <returns>Returns the provided <see cref="T:Microsoft.Extensions.DependencyInjection.IServiceCollection"/>.</returns>
-        </member>
-        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskJobHostConfigurationExtensions.AddDurableClientFactory(Microsoft.Extensions.DependencyInjection.IServiceCollection,Microsoft.Extensions.Options.IOptions{Microsoft.Azure.WebJobs.Extensions.DurableTask.Options.DurableClientOptions})">
-            <summary>
-            Adds the Durable Task extension to the provided <see cref="T:Microsoft.Extensions.DependencyInjection.IServiceCollection"/>.
-            </summary>
-            <param name="serviceCollection">The <see cref="T:Microsoft.Extensions.DependencyInjection.IServiceCollection"/> to configure.</param>
-            <param name="durableClientOptions">Populate configurations of <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.Options.DurableClientOptions"/> to create Durable Clients.</param>
             <returns>Returns the provided <see cref="T:Microsoft.Extensions.DependencyInjection.IServiceCollection"/>.</returns>
         </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskJobHostConfigurationExtensions.AddDurableTask(Microsoft.Azure.WebJobs.IWebJobsBuilder)">


### PR DESCRIPTION
Resolves #1893

* [X] My changes **do not** require documentation changes
    * [X] ~Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`~
* [X] ~My changes **should not** be added to the release notes for the next release~
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [X] My changes **do not** need to be backported to a previous version
    * [X] ~Otherwise: Backport tracked by issue/PR #issue_or_pr~
* [X] ~I have added all required tests (Unit tests, E2E tests)~


