### PR TITLE
Refactor PlatformInformationProvider

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/AzureStorageDurabilityProviderFactory.cs
+++ b/src/WebJobs.Extensions.DurableTask/AzureStorageDurabilityProviderFactory.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             this.nameResolver = nameResolver;
             this.loggerFactory = loggerFactory;
             this.azureStorageOptions = new AzureStorageOptions();
-            this.inConsumption = platformInfo.InConsumption();
+            this.inConsumption = platformInfo.GetAppSevicePlan() == AppServicePlan.Consumption;
 
             // The consumption plan has different performance characteristics so we provide
             // different defaults for key configuration values.
@@ -49,7 +49,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
             if (this.inConsumption)
             {
-                if (platformInfo.IsPython())
+                ProgLanguage language = platformInfo.GetProgLanguage();
+                if (language == ProgLanguage.Python)
                 {
                     this.azureStorageOptions.ControlQueueBufferThreshold = 32;
                 }

--- a/src/WebJobs.Extensions.DurableTask/IPlatformInformationService.cs
+++ b/src/WebJobs.Extensions.DurableTask/IPlatformInformationService.cs
@@ -6,6 +6,64 @@ using System;
 namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 {
     /// <summary>
+    /// Representation of the Consumption and the AppService (Dedicated or Premium) plans.
+    /// </summary>
+    public enum AppServicePlan
+    {
+        /// <summary>
+        /// Consumption App Service plan.
+        /// </summary>
+        Consumption,
+
+        /// <summary>
+        /// Non-consumption App Service plans: Dedicated, EP, etc.
+        /// </summary>
+        AppService,
+    }
+
+    /// <summary>
+    /// Representation of the supported Operating Systems.
+    /// </summary>
+    public enum OperatingSystem
+    {
+        /// <summary>
+        /// Linux OS.
+        /// </summary>
+        Linux,
+
+        /// <summary>
+        /// Windows OS
+        /// </summary>
+        Windows,
+    }
+
+    /// <summary>
+    /// Representation of supported Programming Languages.
+    /// </summary>
+    public enum ProgLanguage
+    {
+        /// <summary>
+        /// C-Sharp.
+        /// </summary>
+        Csharp,
+
+        /// <summary>
+        /// Python.
+        /// </summary>
+        Python,
+
+        /// <summary>
+        /// JavaScript.
+        /// </summary>
+        JavaScript,
+
+        /// <summary>
+        /// PowerShell.
+        /// </summary>
+        PowerShell,
+    }
+
+    /// <summary>
     /// Interface for accessing the AppService plan information,
     /// the OS, and user-facing PL.
     ///
@@ -16,35 +74,28 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
     public interface IPlatformInformationService
     {
         /// <summary>
-        /// Determines if the application is running on a Consumption plan,
-        /// irrespective of OS.
+        /// Determine the App Service Plan of this application.
         /// </summary>
-        /// <returns>True if running in Consumption. Otherwise, False.</returns>
-        bool InConsumption();
+        /// <returns>An AppServicePlan enum.</returns>
+        AppServicePlan GetAppSevicePlan();
 
         /// <summary>
-        /// Determines if the application is running in a Linux Consumption plan.
+        /// Determine the underlying operating system.
         /// </summary>
-        /// <returns>True if running in Linux Consumption. Otherwise, False.</returns>
-        bool InLinuxConsumption();
+        /// <returns>An OperatingSystem enum.</returns>
+        OperatingSystem GetOperatingSystem();
 
         /// <summary>
-        /// Determines if the application is running in a Windows Consumption plan.
+        /// Determine the underlying programming language.
         /// </summary>
-        /// <returns>True if running in Linux Consumption. Otherwise, False.</returns>
-        bool InWindowsConsumption();
+        /// <returns>A ProgLanguage enum.</returns>
+        ProgLanguage GetProgLanguage();
 
         /// <summary>
-        /// Determines is the language worker is for Python.
+        /// Determines is the language worker is OOProc.
         /// </summary>
         /// <returns>True if the language worker is for Python. Otherwise, False.</returns>
-        bool IsPython();
-
-        /// <summary>
-        /// Determines if the application is running in a Linux AppService plan.
-        /// </summary>
-        /// <returns>True if running in Linux AppService. Otherwise, False.</returns>
-        bool InLinuxAppService();
+        bool IsOutOfProc();
 
         /// <summary>
         /// Returns the application tenant when running on linux.

--- a/test/Common/DurableTaskEndToEndTests.cs
+++ b/test/Common/DurableTaskEndToEndTests.cs
@@ -227,7 +227,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
 #if !FUNCTIONS_V1
         /// <summary>
-        /// End to end test that ensures that customers can configure custom connection string names 
+        /// End to end test that ensures that customers can configure custom connection string names
         /// using DurableClientOptions when they create a DurableClient from an external app (e.g. ASP.NET Core app).
         /// The appSettings dictionary acts like appsettings.json and durableClientOptions are the
         /// settings passed in during a call to DurableClient (IDurableClientFactory.CreateClient(durableClientOptions)).

--- a/test/Common/TestHelpers.cs
+++ b/test/Common/TestHelpers.cs
@@ -251,11 +251,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
 #pragma warning disable CS0612 // Type or member is obsolete
         public static IPlatformInformationService GetMockPlatformInformationService(
-            bool inConsumption = false,
-            bool inLinuxConsumption = false,
-            bool inWindowsConsumption = false,
-            bool inLinuxAppsService = false,
-            bool isPython = false,
+            AppServicePlan appServicePlan = AppServicePlan.AppService,
+            OperatingSystem operatingSystem = OperatingSystem.Windows,
+            ProgLanguage language = ProgLanguage.Csharp,
             string getLinuxStampName = "",
             string getContainerName = "")
 #pragma warning restore CS0612 // Type or member is obsolete
@@ -263,13 +261,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 #pragma warning disable CS0612 // Type or member is obsolete
             var mockPlatformProvider = new Mock<IPlatformInformationService>();
 #pragma warning restore CS0612 // Type or member is obsolete
-            mockPlatformProvider.Setup(x => x.InConsumption()).Returns(inConsumption);
-            mockPlatformProvider.Setup(x => x.InLinuxConsumption()).Returns(inLinuxConsumption);
-            mockPlatformProvider.Setup(x => x.InWindowsConsumption()).Returns(inWindowsConsumption);
-            mockPlatformProvider.Setup(x => x.InLinuxAppService()).Returns(inLinuxAppsService);
+            mockPlatformProvider.Setup(x => x.GetOperatingSystem()).Returns(operatingSystem);
+            mockPlatformProvider.Setup(x => x.GetAppSevicePlan()).Returns(appServicePlan);
             mockPlatformProvider.Setup(x => x.GetLinuxStampName()).Returns(getLinuxStampName);
             mockPlatformProvider.Setup(x => x.GetContainerName()).Returns(getContainerName);
-            mockPlatformProvider.Setup(x => x.IsPython()).Returns(isPython);
+            mockPlatformProvider.Setup(x => x.GetProgLanguage()).Returns(language);
             return mockPlatformProvider.Object;
         }
 

--- a/test/FunctionsV2/AzureStorageDurabilityProviderFactoryTests.cs
+++ b/test/FunctionsV2/AzureStorageDurabilityProviderFactoryTests.cs
@@ -46,7 +46,7 @@ namespace WebJobs.Extensions.DurableTask.Tests.V2
                 connectionStringResolver,
                 nameResolver,
                 NullLoggerFactory.Instance,
-                TestHelpers.GetMockPlatformInformationService(inConsumption: true));
+                TestHelpers.GetMockPlatformInformationService(appServicePlan: AppServicePlan.Consumption));
 
             var settings = factory.GetAzureStorageOrchestrationServiceSettings();
 
@@ -68,7 +68,7 @@ namespace WebJobs.Extensions.DurableTask.Tests.V2
                 connectionStringResolver,
                 nameResolver,
                 NullLoggerFactory.Instance,
-                TestHelpers.GetMockPlatformInformationService(inConsumption: true, isPython: true));
+                TestHelpers.GetMockPlatformInformationService(appServicePlan: AppServicePlan.Consumption, language: ProgLanguage.Python));
 
             var settings = factory.GetAzureStorageOrchestrationServiceSettings();
 
@@ -90,7 +90,7 @@ namespace WebJobs.Extensions.DurableTask.Tests.V2
                 connectionStringResolver,
                 nameResolver,
                 NullLoggerFactory.Instance,
-                TestHelpers.GetMockPlatformInformationService(inConsumption: false));
+                TestHelpers.GetMockPlatformInformationService(appServicePlan: AppServicePlan.Consumption));
 
             var settings = factory.GetAzureStorageOrchestrationServiceSettings();
 
@@ -120,7 +120,7 @@ namespace WebJobs.Extensions.DurableTask.Tests.V2
                 connectionStringResolver,
                 nameResolver,
                 NullLoggerFactory.Instance,
-                TestHelpers.GetMockPlatformInformationService(inConsumption: true));
+                TestHelpers.GetMockPlatformInformationService(appServicePlan: AppServicePlan.Consumption));
 
             var settings = factory.GetAzureStorageOrchestrationServiceSettings();
 


### PR DESCRIPTION
<!-- Start the PR description with some context for the change. -->
Refactors the `PlatformInformationProvider` to utilize `Enum`s more heavily to represent the enviroment. This allows for a pattern-matching-style approach to platform-aware configuration, and requires fewer methods to maintain.

<!-- Make sure to delete the markdown comments and the below sections when squash merging -->
### Issue describing the changes in this PR
N/A

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)