### PR TITLE
Adding RetryOptions to CallHttpAsync()

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -1,5 +1,6 @@
 ## New Features
 * Ability to pass `RetryOptions` object to `CallHttpAsync()` invocations to add & customize retry behavior
+* This required a breaking change to `IDurableOrchestrationContext` adding an overload to `CallHttpAsync` which takes the parameter
 
 ## Bug fixes
 

--- a/release_notes.md
+++ b/release_notes.md
@@ -1,4 +1,5 @@
 ## New Features
+* Ability to pass `RetryOptions` object to `CallHttpAsync()` invocations to add & customize retry behavior
 
 ## Bug fixes
 

--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableOrchestrationContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableOrchestrationContext.cs
@@ -248,19 +248,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
         async Task<DurableHttpResponse> IDurableOrchestrationContext.CallHttpAsync(DurableHttpRequest req, RetryOptions retryOptions)
         {
-            if (retryOptions != null)
-            {
-                if (!this.durabilityProvider.ValidateDelayTime(retryOptions.MaxRetryInterval, out string errorMessage))
-                {
-                    throw new ArgumentException(errorMessage, nameof(retryOptions.MaxRetryInterval));
-                }
-
-                if (!this.durabilityProvider.ValidateDelayTime(retryOptions.FirstRetryInterval, out errorMessage))
-                {
-                    throw new ArgumentException(errorMessage, nameof(retryOptions.FirstRetryInterval));
-                }
-            }
-
             DurableHttpResponse durableHttpResponse = await this.ScheduleDurableHttpActivityAsync(req, retryOptions);
 
             HttpStatusCode currStatusCode = durableHttpResponse.StatusCode;

--- a/src/WebJobs.Extensions.DurableTask/ContextInterfaces/IDurableOrchestrationContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextInterfaces/IDurableOrchestrationContext.cs
@@ -125,6 +125,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         Task<DurableHttpResponse> CallHttpAsync(DurableHttpRequest req);
 
         /// <summary>
+        /// Makes an HTTP call using the information in the DurableHttpRequest.
+        /// </summary>
+        /// <param name="req">The DurableHttpRequest used to make the HTTP call.</param>
+        /// <param name="retryOptions">The retry option for the orchestrator function.</param>
+        /// <returns>A <see cref="Task{DurableHttpResponse}"/>Result of the HTTP call.</returns>
+        Task<DurableHttpResponse> CallHttpAsync(DurableHttpRequest req, RetryOptions retryOptions);
+
+        /// <summary>
         /// Calls an operation on an entity and returns the result asynchronously.
         /// </summary>
         /// <typeparam name="TResult">The JSON-serializable result type of the operation.</typeparam>

--- a/src/WebJobs.Extensions.DurableTask/ContextInterfaces/IDurableOrchestrationContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextInterfaces/IDurableOrchestrationContext.cs
@@ -128,7 +128,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// Makes an HTTP call using the information in the DurableHttpRequest.
         /// </summary>
         /// <param name="req">The DurableHttpRequest used to make the HTTP call.</param>
-        /// <param name="retryOptions">The retry option for the orchestrator function.</param>
+        /// <param name="retryOptions">The retry option for the HTTP task.</param>
         /// <returns>A <see cref="Task{DurableHttpResponse}"/>Result of the HTTP call.</returns>
         Task<DurableHttpResponse> CallHttpAsync(DurableHttpRequest req, RetryOptions retryOptions);
 

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net461.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net461.xml
@@ -1117,6 +1117,14 @@
             <param name="req">The DurableHttpRequest used to make the HTTP call.</param>
             <returns>A <see cref="T:System.Threading.Tasks.Task`1"/>Result of the HTTP call.</returns>
         </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableOrchestrationContext.CallHttpAsync(Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableHttpRequest,Microsoft.Azure.WebJobs.Extensions.DurableTask.RetryOptions)">
+            <summary>
+            Makes an HTTP call using the information in the DurableHttpRequest.
+            </summary>
+            <param name="req">The DurableHttpRequest used to make the HTTP call.</param>
+            <param name="retryOptions">The retry option for the orchestrator function.</param>
+            <returns>A <see cref="T:System.Threading.Tasks.Task`1"/>Result of the HTTP call.</returns>
+        </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableOrchestrationContext.CallEntityAsync``1(Microsoft.Azure.WebJobs.Extensions.DurableTask.EntityId,System.String)">
             <summary>
             Calls an operation on an entity and returns the result asynchronously.

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net461.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net461.xml
@@ -4045,7 +4045,7 @@
             Gets or sets the max retry interval.
             </summary>
             <value>
-            The TimeSpan of the max retry interval, defaults to <see cref="F:System.TimeSpan.MaxValue"/>.
+            The TimeSpan of the max retry interval, defaults to 6 days.
             </value>
         </member>
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.RetryOptions.BackoffCoefficient">

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
@@ -4340,7 +4340,7 @@
             Gets or sets the max retry interval.
             </summary>
             <value>
-            The TimeSpan of the max retry interval, defaults to <see cref="F:System.TimeSpan.MaxValue"/>.
+            The TimeSpan of the max retry interval, defaults to 6 days.
             </value>
         </member>
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.RetryOptions.BackoffCoefficient">

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
@@ -1125,6 +1125,14 @@
             <param name="req">The DurableHttpRequest used to make the HTTP call.</param>
             <returns>A <see cref="T:System.Threading.Tasks.Task`1"/>Result of the HTTP call.</returns>
         </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableOrchestrationContext.CallHttpAsync(Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableHttpRequest,Microsoft.Azure.WebJobs.Extensions.DurableTask.RetryOptions)">
+            <summary>
+            Makes an HTTP call using the information in the DurableHttpRequest.
+            </summary>
+            <param name="req">The DurableHttpRequest used to make the HTTP call.</param>
+            <param name="retryOptions">The retry option for the orchestrator function.</param>
+            <returns>A <see cref="T:System.Threading.Tasks.Task`1"/>Result of the HTTP call.</returns>
+        </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableOrchestrationContext.CallEntityAsync``1(Microsoft.Azure.WebJobs.Extensions.DurableTask.EntityId,System.String)">
             <summary>
             Calls an operation on an entity and returns the result asynchronously.

--- a/src/WebJobs.Extensions.DurableTask/RetryOptions.cs
+++ b/src/WebJobs.Extensions.DurableTask/RetryOptions.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// Gets or sets the max retry interval.
         /// </summary>
         /// <value>
-        /// The TimeSpan of the max retry interval, defaults to <see cref="TimeSpan.MaxValue"/>.
+        /// The TimeSpan of the max retry interval, defaults to 6 days.
         /// </value>
         public TimeSpan MaxRetryInterval
         {

--- a/test/Common/DurableHttpTests.cs
+++ b/test/Common/DurableHttpTests.cs
@@ -29,6 +29,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
         private readonly TestLoggerProvider loggerProvider;
 
+        private static int mockSynchronousHttpMessageHandlerWithHttpRequestExceptionCount;
+
         public DurableHttpTests(ITestOutputHelper output)
         {
             this.output = output;
@@ -395,7 +397,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 var status = await client.WaitForCompletionAsync(this.output, timeout: TimeSpan.FromSeconds(400));
 
                 var output = status?.Output;
-                Assert.Equal(3, _mockSynchronousHttpMessageHandlerWithHttpRequestExceptionCount);
+                Assert.Equal(3, mockSynchronousHttpMessageHandlerWithHttpRequestExceptionCount);
                 Assert.Contains("No such host is known.", output.ToString());
                 Assert.Equal(OrchestrationRuntimeStatus.Failed, status?.RuntimeStatus);
 
@@ -434,7 +436,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 var status = await client.WaitForCompletionAsync(this.output);
 
                 var output = status?.Output;
-                Assert.Equal(1, _mockSynchronousHttpMessageHandlerWithHttpRequestExceptionCount);
+                Assert.Equal(1, mockSynchronousHttpMessageHandlerWithHttpRequestExceptionCount);
                 Assert.Contains("No such host is known.", output.ToString());
                 Assert.Equal(OrchestrationRuntimeStatus.Failed, status?.RuntimeStatus);
 
@@ -1589,10 +1591,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             return handlerMock.Object;
         }
 
-        private static int _mockSynchronousHttpMessageHandlerWithHttpRequestExceptionCount;
         private static HttpMessageHandler MockSynchronousHttpMessageHandlerWithHttpRequestException()
         {
-            _mockSynchronousHttpMessageHandlerWithHttpRequestExceptionCount = 0;
+            mockSynchronousHttpMessageHandlerWithHttpRequestExceptionCount = 0;
             var handlerMock = new Mock<HttpMessageHandler>(MockBehavior.Strict);
             handlerMock
                .Protected()
@@ -1601,7 +1602,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                {
                    // We create a new response every time because by the virtue of completing, the response object gets disposed
                    // so if we reused the same object in our ReturnsAsync() an ObjectDisposedException gets thrown
-                   _mockSynchronousHttpMessageHandlerWithHttpRequestExceptionCount++;
+                   mockSynchronousHttpMessageHandlerWithHttpRequestExceptionCount++;
 
                    HttpResponseMessage httpResponseMessage = CreateTestHttpResponseMessage(HttpStatusCode.NotFound);
 

--- a/test/Common/TestDurableHttpRequest.cs
+++ b/test/Common/TestDurableHttpRequest.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
     [DataContract]
     public class TestDurableHttpRequest
     {
-        public TestDurableHttpRequest(HttpMethod httpMethod, string uri = "https://www.dummy-url.com", IDictionary<string, string> headers = null, string content = null, ITokenSource tokenSource = null, TimeSpan? timeout = null)
+        public TestDurableHttpRequest(HttpMethod httpMethod, string uri = "https://www.dummy-url.com", IDictionary<string, string> headers = null, string content = null, ITokenSource tokenSource = null, TimeSpan? timeout = null, TimeSpan? firstRetryInterval = null, int? maxNumberOfAttempts = null)
         {
             this.HttpMethod = httpMethod;
             this.Uri = uri;
@@ -26,6 +26,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             this.Content = content;
             this.TokenSource = tokenSource;
             this.Timeout = timeout;
+            this.FirstRetryInterval = firstRetryInterval;
+            this.MaxNumberOfAttempts = maxNumberOfAttempts;
         }
 
         [DataMember]
@@ -51,5 +53,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
         [DataMember]
         public TimeSpan? Timeout { get; set; }
+
+        [DataMember]
+        public TimeSpan? FirstRetryInterval { get; set; }
+
+        [DataMember]
+        public int? MaxNumberOfAttempts { get; set; }
     }
 }

--- a/test/Common/TestOrchestrations.cs
+++ b/test/Common/TestOrchestrations.cs
@@ -7,7 +7,6 @@ using System.Linq;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Azure.WebJobs.Host.TestCommon;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Primitives;
 using Xunit;
@@ -498,7 +497,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         {
             TestDurableHttpRequest testRequest = ctx.GetInput<TestDurableHttpRequest>();
             DurableHttpRequest durableHttpRequest = ConvertTestRequestToDurableHttpRequest(testRequest);
-            DurableHttpResponse response = await ctx.CallHttpAsync(durableHttpRequest);
+
+            RetryOptions retryOptions = null;
+            if (testRequest.FirstRetryInterval.HasValue && testRequest.MaxNumberOfAttempts.HasValue)
+            {
+                retryOptions = new RetryOptions(testRequest.FirstRetryInterval.Value, testRequest.MaxNumberOfAttempts.Value);
+            }
+
+            DurableHttpResponse response = await ctx.CallHttpAsync(durableHttpRequest, retryOptions);
             return response;
         }
 
@@ -586,11 +592,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
         public static async Task ParallelBatchActor([OrchestrationTrigger] IDurableOrchestrationContext ctx)
         {
-           Task item1 = ctx.WaitForExternalEvent<string>("newItem");
-           Task item2 = ctx.WaitForExternalEvent<string>("newItem");
-           Task item3 = ctx.WaitForExternalEvent<string>("newItem");
-           Task item4 = ctx.WaitForExternalEvent<string>("newItem");
-           await Task.WhenAll(item1, item2, item3, item4);
+            Task item1 = ctx.WaitForExternalEvent<string>("newItem");
+            Task item2 = ctx.WaitForExternalEvent<string>("newItem");
+            Task item3 = ctx.WaitForExternalEvent<string>("newItem");
+            Task item4 = ctx.WaitForExternalEvent<string>("newItem");
+            await Task.WhenAll(item1, item2, item3, item4);
         }
 
         public static async Task<int> Counter2([OrchestrationTrigger] IDurableOrchestrationContext ctx)


### PR DESCRIPTION
<!-- Start the PR description with some context for the change. -->
Adding in `RetryOptions` parameter to the `CallHttpAsync` context method. Allows for automatically retrying Http calls

<!-- Make sure to delete the markdown comments and the below sections when squash merging -->
### Issue describing the changes in this PR
* Adds an interface method (non-breaking)
* Implements interface method (non-breaking)
* Adds Unit tests (non-breaking)

resolves #1559 

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)


