### PR TITLE
Add an item on OutOfProc feature parity to PR checklist

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,5 +15,5 @@ resolves #issue_for_this_pr
 * [ ] My changes **do not** need to be backported to a previous version
     * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
 * [ ] I have added all required tests (Unit tests, E2E tests)
-
-
+* [ ] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
+    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk


### PR DESCRIPTION
<!-- Start the PR description with some context for the change. -->
To help us close, and track, the OutOfProc SDK feature gap: I'm adding an item to our PR checklist to make sure new features and interface changes in the in-proc C# implementation are tracked for support in OutOfProc SDK repos.

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)


