### PR TITLE
DurableOrchestrationContext events performance improvements

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableOrchestrationContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableOrchestrationContext.cs
@@ -29,8 +29,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
     {
         public const string DefaultVersion = "";
 
-        private readonly Dictionary<string, Stack> pendingExternalEvents =
-            new Dictionary<string, Stack>(StringComparer.OrdinalIgnoreCase);
+        private readonly Dictionary<string, IEventTaskCompletionSource> pendingExternalEvents =
+            new Dictionary<string, IEventTaskCompletionSource>(StringComparer.OrdinalIgnoreCase);
 
         private readonly Dictionary<string, Queue<string>> bufferedExternalEvents =
             new Dictionary<string, Queue<string>>(StringComparer.OrdinalIgnoreCase);
@@ -811,28 +811,25 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             {
                 // We use a stack to make it easier for users to abandon external events
                 // that they no longer care about. The common case is a Task.WhenAny in a loop.
-                Stack taskCompletionSources;
-                TaskCompletionSource<T> tcs;
+                IEventTaskCompletionSource taskCompletionSources;
+                EventTaskCompletionSource<T> tcs;
 
                 // Set up the stack for listening to external events
                 if (!this.pendingExternalEvents.TryGetValue(name, out taskCompletionSources))
                 {
-                    tcs = new TaskCompletionSource<T>();
-                    taskCompletionSources = new Stack();
-                    taskCompletionSources.Push(tcs);
-                    this.pendingExternalEvents[name] = taskCompletionSources;
+                    tcs = new EventTaskCompletionSource<T>();
+                    this.pendingExternalEvents[name] = tcs;
                 }
                 else
                 {
-                    if (taskCompletionSources.Count > 0 &&
-                        taskCompletionSources.Peek().GetType() != typeof(TaskCompletionSource<T>))
+                    if (taskCompletionSources.EventType != typeof(T))
                     {
                         throw new ArgumentException("Events with the same name should have the same type argument.");
                     }
                     else
                     {
-                        tcs = new TaskCompletionSource<T>();
-                        taskCompletionSources.Push(tcs);
+                        tcs = new EventTaskCompletionSource<T> { Next = taskCompletionSources };
+                        this.pendingExternalEvents[name] = tcs;
                     }
                 }
 
@@ -867,21 +864,24 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         {
             lock (this.pendingExternalEvents)
             {
-                Stack taskCompletionSources;
+                IEventTaskCompletionSource taskCompletionSources;
                 if (this.pendingExternalEvents.TryGetValue(name, out taskCompletionSources))
                 {
-                    object tcs = taskCompletionSources.Pop();
-                    Type tcsType = tcs.GetType();
-                    Type genericTypeArgument = tcsType.GetGenericArguments()[0];
+                    IEventTaskCompletionSource tcs = taskCompletionSources;
 
                     // If we're going to raise an event we should remove it from the pending collection
                     // because otherwise WaitForExternalEventAsync() will always find one with this key and run infinitely.
-                    if (taskCompletionSources.Count == 0)
+                    IEventTaskCompletionSource next = tcs.Next;
+                    if (next == null)
                     {
                         this.pendingExternalEvents.Remove(name);
                     }
+                    else
+                    {
+                        this.pendingExternalEvents[name] = next;
+                    }
 
-                    object deserializedObject = this.messageDataConverter.Deserialize(input, genericTypeArgument);
+                    object deserializedObject = this.messageDataConverter.Deserialize(input, tcs.EventType);
 
                     if (deserializedObject is ResponseMessage responseMessage)
                     {
@@ -905,8 +905,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                              this.IsReplaying);
                     }
 
-                    MethodInfo trySetResult = tcsType.GetMethod("TrySetResult");
-                    trySetResult.Invoke(tcs, new[] { deserializedObject });
+                    tcs.TrySetResult(deserializedObject);
                 }
                 else
                 {
@@ -1286,6 +1285,39 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     this.context.ReleaseLocks();
                 }
             }
+        }
+
+        private class EventTaskCompletionSource<T> : TaskCompletionSource<T>, IEventTaskCompletionSource
+        {
+            public Type EventType => typeof(T);
+
+            public IEventTaskCompletionSource Next { get; set; }
+
+            void IEventTaskCompletionSource.TrySetResult(object result) => this.TrySetResult((T)result);
+        }
+
+        /// <summary>
+        /// A non-generic tcs interface.
+        /// </summary>
+#pragma warning disable SA1201 // Elements should appear in the correct order
+        private interface IEventTaskCompletionSource
+#pragma warning restore SA1201 // Elements should appear in the correct order
+        {
+            /// <summary>
+            /// The type of the event stored in the completion source.
+            /// </summary>
+            Type EventType { get; }
+
+            /// <summary>
+            /// The next task completion source in the stack.
+            /// </summary>
+            IEventTaskCompletionSource Next { get; set; }
+
+            /// <summary>
+            /// Tries to set the result on tcs.
+            /// </summary>
+            /// <param name="result">The result.</param>
+            void TrySetResult(object result);
         }
     }
 }

--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableOrchestrationContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableOrchestrationContext.cs
@@ -809,7 +809,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         {
             lock (this.pendingExternalEvents)
             {
-                // We use a stack (a custom implementation using a single-linked list) 
+                // We use a stack (a custom implementation using a single-linked list)
                 // to make it easier for users to abandon external events
                 // that they no longer care about. The common case is a Task.WhenAny in a loop.
                 IEventTaskCompletionSource taskCompletionSources;

--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableOrchestrationContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableOrchestrationContext.cs
@@ -809,7 +809,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         {
             lock (this.pendingExternalEvents)
             {
-                // We use a stack to make it easier for users to abandon external events
+                // We use a stack (a custom implementation using a single-linked list) 
+                // to make it easier for users to abandon external events
                 // that they no longer care about. The common case is a Task.WhenAny in a loop.
                 IEventTaskCompletionSource taskCompletionSources;
                 EventTaskCompletionSource<T> tcs;


### PR DESCRIPTION
This PR optimizes the way `pendingExternalEvents` are handled by `DurableOrchestrationContext`. It reduced CPU usage by 50% and allocated memory by a lot. It replaces the stack and the generic reflection with a simpler construct that provides both, the `TaskCompletionSource<T>` and a way to retrieve the event type without obtaining the type of `tcs`

### Benchmarks

The following suite was used locally. I see no benchmarks in the repo and don't want to introduce a lot of noise in one PR.

```csharp
[Benchmark]
public Task OneEvent()
{
    var wait1 = ((IDurableOrchestrationContext)context).WaitForExternalEvent("test");
    context.RaiseEvent("test", null);
    return wait1;
} 

[Benchmark]
public Task TwoDifferentEvents()
{
    var wait1 = ((IDurableOrchestrationContext)context).WaitForExternalEvent("test");
    var wait2 = ((IDurableOrchestrationContext)context).WaitForExternalEvent("test2");
    
    context.RaiseEvent("test", null);
    context.RaiseEvent("test2", null);
    
    return Task.WhenAll(wait1, wait2);
}

[Benchmark]
public Task TwoSameEvents()
{
    var wait1 = ((IDurableOrchestrationContext)context).WaitForExternalEvent("test");
    var wait2 = ((IDurableOrchestrationContext)context).WaitForExternalEvent("test");

    context.RaiseEvent("test", null);
    context.RaiseEvent("test", null);

    return Task.WhenAll(wait1, wait2);
}
```

The results looks quite good for such a small change. Both CPU and allocations are greatly reduced

```init
BenchmarkDotNet=v0.13.1, OS=Windows 10.0.19042.1165 (20H2/October2020Update)
Intel Core i7-6700HQ CPU 2.60GHz (Skylake), 1 CPU, 8 logical and 4 physical cores
.NET SDK=6.0.100-preview.7.21379.14
  [Host]     : .NET Core 3.1.18 (CoreCLR 4.700.21.35901, CoreFX 4.700.21.36305), X64 RyuJIT
  DefaultJob : .NET Core 3.1.18 (CoreCLR 4.700.21.35901, CoreFX 4.700.21.36305), X64 RyuJIT
```

|             Method |       Mean |    Error |   StdDev |  Gen 0 | Allocated |
|------------------- |-----------:|---------:|---------:|-------:|----------:|
|           OneEvent |   653.7 ns | 12.75 ns | 11.30 ns | 0.1345 |     424 B |
| **OneEvent (after)**| 256.4 ns |  5.10 ns |  8.52 ns | 0.0558 |     176 B |
| TwoDifferentEvents | 1,398.9 ns | 27.22 ns | 26.73 ns | 0.3223 |   1,016 B |
| **TwoDifferentEvents (after)** | 628.1 ns | 12.35 ns | 15.62 ns | 0.1650 |     520 B |
|      TwoSameEvents | 1,357.4 ns | 26.82 ns | 41.75 ns | 0.2766 |     872 B |
|      **TwoSameEvents (after)** | 641.7 ns | 12.37 ns | 11.57 ns | 0.1631 |     512 B |


### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)
* [x] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk