### PR TITLE
Update DT.AzureStorage to 1.9.2

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -3,5 +3,9 @@
 * This required a breaking change to `IDurableOrchestrationContext` adding an overload to `CallHttpAsync` which takes the parameter
 
 ## Bug fixes
+* Updated DurableTask.AzureStorage dependency to v1.9.2, which includes the following fixes:
+* * Fix fetching of large inputs for pending orchestrations on Azure Storage
+* * Updated TableQuery filter condition string generation to resolve invalid character issues
+* * Fixed stuck orchestration with duplicate message warning issue
 
 ## Breaking Changes

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net461.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net461.xml
@@ -1122,7 +1122,7 @@
             Makes an HTTP call using the information in the DurableHttpRequest.
             </summary>
             <param name="req">The DurableHttpRequest used to make the HTTP call.</param>
-            <param name="retryOptions">The retry option for the orchestrator function.</param>
+            <param name="retryOptions">The retry option for the HTTP task.</param>
             <returns>A <see cref="T:System.Threading.Tasks.Task`1"/>Result of the HTTP call.</returns>
         </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableOrchestrationContext.CallEntityAsync``1(Microsoft.Azure.WebJobs.Extensions.DurableTask.EntityId,System.String)">
@@ -3506,6 +3506,21 @@
             </summary>
             <value>A boolean indicating whether we use the legacy partition strategy. Defaults to false.</value>
         </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureStorageOptions.EnableOrchestrationStartDeduplication">
+            <summary>
+            Gets or sets whether to enable the orchestration-start de-duplication feature
+            of the Durable Task Framework's Azure Storage provider.
+            </summary>
+            <remarks>
+            When enabled, this feature will try to detect and discard orchestration-start
+            messages for the same instance ID that are scheduled around the same time. There
+            is a slight performance impact when this feature is enabled due to additional
+            storage account queries that occur for every received orchestration start message.
+            It's generally recommended to enable this feature unless the performance impact
+            is too burdensome for an important workload.
+            </remarks>
+            <value>A boolean value indicating whether to enable orchestration-start de-duplication.</value>
+        </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureStorageOptions.ValidateHubName(System.String)">
             <summary>
             Throws an exception if the provided hub name violates any naming conventions for the storage provider.
@@ -4077,7 +4092,7 @@
             Gets or sets a delegate to call on exception to determine if retries should proceed.
             </summary>
             <value>
-            The delegate to handle exception to determie if retries should proceed.
+            The delegate to handle exception to determine if retries should proceed.
             </value>
         </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.StandardConnectionStringProvider">

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
@@ -1130,7 +1130,7 @@
             Makes an HTTP call using the information in the DurableHttpRequest.
             </summary>
             <param name="req">The DurableHttpRequest used to make the HTTP call.</param>
-            <param name="retryOptions">The retry option for the orchestrator function.</param>
+            <param name="retryOptions">The retry option for the HTTP task.</param>
             <returns>A <see cref="T:System.Threading.Tasks.Task`1"/>Result of the HTTP call.</returns>
         </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableOrchestrationContext.CallEntityAsync``1(Microsoft.Azure.WebJobs.Extensions.DurableTask.EntityId,System.String)">
@@ -3788,6 +3788,21 @@
             </summary>
             <value>A boolean indicating whether we use the legacy partition strategy. Defaults to false.</value>
         </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureStorageOptions.EnableOrchestrationStartDeduplication">
+            <summary>
+            Gets or sets whether to enable the orchestration-start de-duplication feature
+            of the Durable Task Framework's Azure Storage provider.
+            </summary>
+            <remarks>
+            When enabled, this feature will try to detect and discard orchestration-start
+            messages for the same instance ID that are scheduled around the same time. There
+            is a slight performance impact when this feature is enabled due to additional
+            storage account queries that occur for every received orchestration start message.
+            It's generally recommended to enable this feature unless the performance impact
+            is too burdensome for an important workload.
+            </remarks>
+            <value>A boolean value indicating whether to enable orchestration-start de-duplication.</value>
+        </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureStorageOptions.ValidateHubName(System.String)">
             <summary>
             Throws an exception if the provided hub name violates any naming conventions for the storage provider.
@@ -4372,7 +4387,7 @@
             Gets or sets a delegate to call on exception to determine if retries should proceed.
             </summary>
             <value>
-            The delegate to handle exception to determie if retries should proceed.
+            The delegate to handle exception to determine if retries should proceed.
             </value>
         </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.StandardConnectionStringProvider">

--- a/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
+++ b/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
@@ -85,7 +85,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage" Version="1.9.0" />
+    <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage" Version="1.9.2" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers" Version="0.4.0" />
     <PackageReference Include="Azure.Identity" Version="1.1.1" />
 

--- a/test/Common/DurableHttpTests.cs
+++ b/test/Common/DurableHttpTests.cs
@@ -112,8 +112,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
       ""tenantid"": ""tenant_id""
     }
   },
-  ""AsynchronousPatternEnabled"": true,
-  ""Timeout"": null
+  ""AsynchronousPatternEnabled"": true
 }";
 
             Dictionary<string, string> headers = new Dictionary<string, string>();

--- a/test/Common/TestDurableHttpRequest.cs
+++ b/test/Common/TestDurableHttpRequest.cs
@@ -51,13 +51,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         [DataMember]
         public bool AsynchronousPatternEnabled { get; set; } = true;
 
-        [DataMember]
+        [DataMember(EmitDefaultValue = false)]
         public TimeSpan? Timeout { get; set; }
 
-        [DataMember]
+        [DataMember(EmitDefaultValue = false)]
         public TimeSpan? FirstRetryInterval { get; set; }
 
-        [DataMember]
+        [DataMember(EmitDefaultValue = false)]
         public int? MaxNumberOfAttempts { get; set; }
     }
 }


### PR DESCRIPTION
Updating DurableTask.AzureStorage dependency to v1.9.2.

We're about to do a release of v1.9.2 and I want to ensure that the changes in that release don't cause any issues with the Durable Functions extension.

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)
* [x] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk