### PR TITLE
Protect OOProc replay loop from Activity exceptions

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/Listener/OutOfProcOrchestrationShim.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/OutOfProcOrchestrationShim.cs
@@ -197,7 +197,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         {
             foreach (AsyncAction action in actions)
             {
-                await this.InvokeAPIFromAction(action);
+                // Before awaiting the task, we wrap it in a `WhenAny` call
+                // to protect against possible exceptions. Exception handling
+                // and exception throwing is managed in the OOProc SDKs and
+                // should not affect / interrupt this replay loop
+                var task = this.InvokeAPIFromAction(action);
+                await Task.WhenAny(task);
             }
         }
 

--- a/src/WebJobs.Extensions.DurableTask/Listener/OutOfProcOrchestrationShim.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/OutOfProcOrchestrationShim.cs
@@ -201,8 +201,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 // to protect against possible exceptions. Exception handling
                 // and exception throwing is managed in the OOProc SDKs and
                 // should not affect / interrupt this replay loop
-                var task = this.InvokeAPIFromAction(action);
-                await Task.WhenAny(task);
+                try
+                {
+                    await this.InvokeAPIFromAction(action);
+                }
+                catch (Exception)
+                {
+                    // ignore exceptions, they should be handled by user-code instead.
+                }
             }
         }
 

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net461.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net461.xml
@@ -396,6 +396,27 @@
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableOrchestrationContext.Microsoft#Azure#WebJobs#Extensions#DurableTask#IDurableOrchestrationContext#CreateEntityProxy``1(Microsoft.Azure.WebJobs.Extensions.DurableTask.EntityId)">
             <inheritdoc/>
         </member>
+        <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableOrchestrationContext.IEventTaskCompletionSource">
+            <summary>
+            A non-generic tcs interface.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableOrchestrationContext.IEventTaskCompletionSource.EventType">
+            <summary>
+            The type of the event stored in the completion source.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableOrchestrationContext.IEventTaskCompletionSource.Next">
+            <summary>
+            The next task completion source in the stack.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableOrchestrationContext.IEventTaskCompletionSource.TrySetResult(System.Object)">
+            <summary>
+            Tries to set the result on tcs.
+            </summary>
+            <param name="result">The result.</param>
+        </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableContextExtensions">
             <summary>
             Defines convenient overloads for calling the context methods, for all the contexts.
@@ -3505,21 +3526,6 @@
             of scale out performance.
             </summary>
             <value>A boolean indicating whether we use the legacy partition strategy. Defaults to false.</value>
-        </member>
-        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureStorageOptions.EnableOrchestrationStartDeduplication">
-            <summary>
-            Gets or sets whether to enable the orchestration-start de-duplication feature
-            of the Durable Task Framework's Azure Storage provider.
-            </summary>
-            <remarks>
-            When enabled, this feature will try to detect and discard orchestration-start
-            messages for the same instance ID that are scheduled around the same time. There
-            is a slight performance impact when this feature is enabled due to additional
-            storage account queries that occur for every received orchestration start message.
-            It's generally recommended to enable this feature unless the performance impact
-            is too burdensome for an important workload.
-            </remarks>
-            <value>A boolean value indicating whether to enable orchestration-start de-duplication.</value>
         </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureStorageOptions.ValidateHubName(System.String)">
             <summary>

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
@@ -399,6 +399,27 @@
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableOrchestrationContext.Microsoft#Azure#WebJobs#Extensions#DurableTask#IDurableOrchestrationContext#CreateEntityProxy``1(Microsoft.Azure.WebJobs.Extensions.DurableTask.EntityId)">
             <inheritdoc/>
         </member>
+        <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableOrchestrationContext.IEventTaskCompletionSource">
+            <summary>
+            A non-generic tcs interface.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableOrchestrationContext.IEventTaskCompletionSource.EventType">
+            <summary>
+            The type of the event stored in the completion source.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableOrchestrationContext.IEventTaskCompletionSource.Next">
+            <summary>
+            The next task completion source in the stack.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableOrchestrationContext.IEventTaskCompletionSource.TrySetResult(System.Object)">
+            <summary>
+            Tries to set the result on tcs.
+            </summary>
+            <param name="result">The result.</param>
+        </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableContextExtensions">
             <summary>
             Defines convenient overloads for calling the context methods, for all the contexts.
@@ -3787,21 +3808,6 @@
             of scale out performance.
             </summary>
             <value>A boolean indicating whether we use the legacy partition strategy. Defaults to false.</value>
-        </member>
-        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureStorageOptions.EnableOrchestrationStartDeduplication">
-            <summary>
-            Gets or sets whether to enable the orchestration-start de-duplication feature
-            of the Durable Task Framework's Azure Storage provider.
-            </summary>
-            <remarks>
-            When enabled, this feature will try to detect and discard orchestration-start
-            messages for the same instance ID that are scheduled around the same time. There
-            is a slight performance impact when this feature is enabled due to additional
-            storage account queries that occur for every received orchestration start message.
-            It's generally recommended to enable this feature unless the performance impact
-            is too burdensome for an important workload.
-            </remarks>
-            <value>A boolean value indicating whether to enable orchestration-start de-duplication.</value>
         </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureStorageOptions.ValidateHubName(System.String)">
             <summary>


### PR DESCRIPTION
<!-- Start the PR description with some context for the change. -->
We recently introduced a new OOProc replay procedure that more accurately represents composite tasks (WhenAll/WhenAny) in the extension.

In the **old** approach, **all** OOProc SDK actions would be awaited **inside** a `WhenAny` Task, which ran the risk of creating a race condition where not all tasks were scheduled at the end of the replay loop. In the new replay procedure, we instead await each task one at a time, avoiding this race condition.

However, in doing so, we've lost the ability to try-catch Activity exceptions in orchestrators. This is because awaiting a failed Task will throw an exception in the replay loop whereas, before, that exception would be "swallowed" by the surrounding `WhenAny` task.

This PR simply introduces a `WhenAny` wrapper to awaited tasks in the OOProc Shim, so that the replay procedure can continue in the presence of errors.

<!-- Make sure to delete the markdown comments and the below sections when squash merging -->
### Issue describing the changes in this PR

N/A

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)
* [ ] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk