### PR TITLE
Fix NullReferenceExceptions in DurableClient

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -7,5 +7,6 @@
 * * Fix fetching of large inputs for pending orchestrations on Azure Storage
 * * Updated TableQuery filter condition string generation to resolve invalid character issues
 * * Fixed stuck orchestration with duplicate message warning issue
+* * Fixed null reference exceptions thrown in DurableClient
 
 ## Breaking Changes

--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableClientFactory.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableClientFactory.cs
@@ -81,7 +81,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.ContextImplementations
                 attr =>
                 {
                     DurabilityProvider innerClient = this.durabilityProviderFactory.GetDurabilityProvider(attribute);
-                    return new DurableClient(innerClient, null, attribute, this.MessageDataConverter, this.TraceHelper, this.durableTaskOptions);
+                    return new DurableClient(innerClient, null, attribute, this.MessageDataConverter, this.TraceHelper, this.durableTaskOptions, this);
                 });
 
             return client;


### PR DESCRIPTION
Fixes a bug reported by @scale-tone (#1958).

The problem is that `DurableClient` objects are sometimes constructed without a reference to a DurabeExtension. This can cause NullReferenceExceptions when methods are accessing `this.config`. There are a number of those situations (beyond just the one found in #1958). 

This PR fixes all of them:
- `CleanEntityStorageAsync` now gets the necessary information from the durableTaskOptions and from the durabilityProvider
- Added a constructor that can pass in a client factory, when constructing DurableClient without a DurableTaskExtension 
- This client factory is used (in place of `this.config.GetClient()`) when constructing another client from within DurableClient 
- Added null checks in a few more places
 
### Pull request checklist

* [ x] My changes **do not** require documentation changes
* [ x] I've added my notes to `release_notes.md`
* [ x] My changes **do not** need to be backported to a previous version
* [ ] I have added all required tests (Unit tests, E2E tests)
* [ x] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs