### PR TITLE
Pr/nonexisting entity

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -7,5 +7,6 @@
 * * Fix fetching of large inputs for pending orchestrations on Azure Storage
 * * Updated TableQuery filter condition string generation to resolve invalid character issues
 * * Fixed stuck orchestration with duplicate message warning issue
+* * Throw meaningful exceptions inside orchestrations when they try to call, signal, or lock a non-existing entity
 
 ## Breaking Changes

--- a/test/Common/DurableTaskEndToEndTests.cs
+++ b/test/Common/DurableTaskEndToEndTests.cs
@@ -3300,6 +3300,37 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         }
 
         /// <summary>
+        /// End-to-end test which validates batching of entity signals.
+        /// </summary>
+        [Theory]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task DurableEntity_NonexistentEntity(bool extendedSessions)
+        {
+            string[] orchestratorFunctionNames =
+            {
+                nameof(TestOrchestrations.NonexistentEntity),
+            };
+
+            using (var host = TestHelpers.GetJobHost(
+                this.loggerProvider,
+                nameof(this.DurableEntity_NonexistentEntity),
+                extendedSessions))
+            {
+                await host.StartAsync();
+
+                var client = await host.StartOrchestratorAsync(orchestratorFunctionNames[0], null, this.output);
+                var status = await client.WaitForCompletionAsync(this.output);
+
+                Assert.Equal(OrchestrationRuntimeStatus.Completed, status?.RuntimeStatus);
+                Assert.Equal("ok", status?.Output);
+
+                await host.StopAsync();
+            }
+        }
+
+        /// <summary>
         /// End-to-end test which validates exception handling in entity operations.
         /// </summary>
         [Theory]

--- a/test/Common/TestOrchestrations.cs
+++ b/test/Common/TestOrchestrations.cs
@@ -790,6 +790,40 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             return "ok";
         }
 
+        public static async Task<string> NonexistentEntity([OrchestrationTrigger] IDurableOrchestrationContext ctx)
+        {
+            var entityId = new EntityId("ThisEntityDoesNotExist", "33");
+
+            try
+            {
+                await ctx.CallEntityAsync(entityId, "hi");
+                return $"test failed: expected error message because CallEntityAsync refers to a non-existing entity";
+            }
+            catch (ArgumentException e)
+            {
+            }
+
+            try
+            {
+                ctx.SignalEntity(entityId, "hi");
+                return $"test failed: expected error message because SignalEntity refers to a non-existing entity";
+            }
+            catch (ArgumentException e)
+            {
+            }
+
+            try
+            {
+                await ctx.LockAsync(entityId);
+                return $"test failed: expected error message because LockAsync refers to a non-existing entity";
+            }
+            catch (ArgumentException e)
+            {
+            }
+
+            return "ok";
+        }
+
         public static async Task<string> CallFaultyEntity([OrchestrationTrigger] IDurableOrchestrationContext ctx)
         {
             var (entityId, rollbackOnException) = ctx.GetInput<(EntityId, bool)>();


### PR DESCRIPTION
Problem was found in #1882.

Need to generate meaningful error message when orchestration tries to call, signal, or lock an entity that does not have a corresponding entity function defined.

### Pull request checklist

* [x] My changes **do not** require documentation changes
* [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
* [x] I have added all required tests (Unit tests, E2E tests)
* [x] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
