### PR TITLE
Fix tests for CleanEntityStorage

### DIFF
--- a/test/Common/TestOrchestrations.cs
+++ b/test/Common/TestOrchestrations.cs
@@ -136,10 +136,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         {
             var input = context.GetInput<(EntityId entityId, bool createNondeterminismFailure)>();
 
-            await context.LockAsync(input.entityId);
-
             if (!(input.createNondeterminismFailure && context.IsReplaying))
             {
+                await context.LockAsync(input.entityId);
+
                 await context.CallActivityAsync<string>(nameof(TestActivities.Hello), "Tokyo");
             }
         }


### PR DESCRIPTION
The tests for CleanEntityStorage started failing after recent changes to the AzureStorage backend.

The reason is that the implementation seems to have improved the error handling path under nondeterminism in orchestrator, so it now properly sends unlock messages to all locks that were acquired prior to failing the orchestrator. This is a good thing... but it means that these tests were failing because they are trying to test the removal of orphaned locks, but no orphaned locks were created.

To keep this test working, I needed to use a more reliable way to create the orphaned lock. One way to do this is described in https://github.com/Azure/azure-functions-durable-extension/issues/1977#issuecomment-946240630 - essentially, the idea is to have the replay fail earlier, before the lock is even acquired. Then the orchestrator does not know that it has to release it.  With that change, these tests are once more passing.

* [ x] My changes **do not** require documentation changes
* [ x] My changes **should not** be added to the release notes for the next release
* [ x] My changes **do not** need to be backported to a previous version
* [ x] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    