### PR TITLE
Update host.json in DFPerfScenarios

### DIFF
--- a/test/DFPerfScenarios/host.json
+++ b/test/DFPerfScenarios/host.json
@@ -5,6 +5,7 @@
       "routePrefix": "tests"
     },
     "durableTask": {
+      "hubName": "DFPerfHub",
       "maxConcurrentActivityFunctions": 400,
       "maxConcurrentOrchestratorFunctions": 400,
       "extendedSessionsEnabled": true,

--- a/test/DFPerfScenarios/host.json
+++ b/test/DFPerfScenarios/host.json
@@ -9,6 +9,7 @@
       "maxConcurrentOrchestratorFunctions": 400,
       "extendedSessionsEnabled": true,
       "extendedSessionIdleTimeoutInSeconds": 30,
+      "maxOrchestrationActions": 200000,
       "storageProvider": {
         "partitionCount": 6,
         "controlQueueBufferThreshold": 1000


### PR DESCRIPTION
Adding `"maxOrchestrationActions": 200000` to host.json to allow load tests to exceed 100,000 orchestrations. The default for `maxOrchestrationActions` is 100000.

This change avoids this failure message:
`Maximum amount of orchestration actions 100,000 has been reached. This value can be configured in host.json file as MaxOrchestrationActions.`

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)
* [x] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk