### PR TITLE
Reset release_notes.md

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -1,21 +1,7 @@
 ## New Features
-* New `HttpRetryOptions` class for passing retry options to `CallHttpAsync()` invocations to add & customize retry behavior
-* Added `HttpRetryOptions` to `DurableHttpRequest`; when using the `CallHttpAsync` overload that takes the full object, set this property in order to affect retry logic.
-* Log trace events whenever entities are created or deleted
 
 ## Bug fixes
-* Updated DurableTask.AzureStorage dependency to v1.9.2, which includes the following fixes:
-* Fix fetching of large inputs for pending orchestrations on Azure Storage
-* Updated TableQuery filter condition string generation to resolve invalid character issues
-* Fixed stuck orchestration with duplicate message warning issue
-* Throw meaningful exceptions inside orchestrations when they try to call, signal, or lock a non-existing entity
-* Fixed null reference exceptions thrown in DurableClient
 
 ## Breaking Changes
-* `IDurableOrchestrationContext`'s `CallHttpAsync(HttpMethod, Uri, string)` overload now has a `HttpRetryOptions` parameter
-* `IDurableActivityContext` now has a Name property.
 
 ## Dependency Updates
-Microsoft.Azure.DurableTask.AzureStorage --> 1.9.4
-Microsoft.Azure.DurableTask.Core --> 2.6.0
-Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers --> 0.4.1


### PR DESCRIPTION
Resetting release_notes.md after v2.6.0 release.

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)
* [x] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk