### PR TITLE
Update release instructions to include changes to bundles and templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-release-template.md
+++ b/.github/ISSUE_TEMPLATE/new-release-template.md
@@ -39,8 +39,9 @@ _Due: <release-deadline>_
 - [ ] Delete Durable Functions packages from myget.
 - [ ] Run Durable Functions release pipeline.
 - [ ] Push myget package to nuget (nuget.org extensions package option).
-- [ ] Create a PR in the [Azure Functions templates repo](https://github.com/Azure/azure-functions-templates) to update templates to the latest version.
-- [ ] Create a PR in the [Azure Functions bundles repo](https://github.com/Azure/azure-functions-extension-bundles) to update bundles to the latest version.
+- [ ] Create a PR in the [Azure Functions templates repo](https://github.com/Azure/azure-functions-templates) targeting branch `v3.x` to update *only the dotnet* templates (`template.json` files) to the latest version.
+- [ ] Create a PR in the [Azure Functions templates repo](https://github.com/Azure/azure-functions-templates) targeting branch `v4.x` to update *only the dotnet* templates (`template.json` files) to the latest version.
+- [ ] Create a PR in the [Azure Functions bundles repo](https://github.com/Azure/azure-functions-extension-bundles) to update bundles to the latest version _if and only if this is a new major release_.
 - [ ] Merge all pending PR docs from `pending_docs.md.`
 - [ ] Reset `pending_docs.md` and `release_notes.md` in the `dev` branch. You will want to save `release_notes.md` somewhere for when you publish release notes.
 - [ ] Publish release notes from the pre-reset `release_notes.md.`

--- a/.github/ISSUE_TEMPLATE/new-release-template.md
+++ b/.github/ISSUE_TEMPLATE/new-release-template.md
@@ -41,7 +41,7 @@ _Due: <release-deadline>_
 - [ ] Push myget package to nuget (nuget.org extensions package option).
 - [ ] Create a PR in the [Azure Functions templates repo](https://github.com/Azure/azure-functions-templates) targeting branch `v3.x` to update *only the dotnet* templates (`template.json` files) to the latest version.
 - [ ] Create a PR in the [Azure Functions templates repo](https://github.com/Azure/azure-functions-templates) targeting branch `v4.x` to update *only the dotnet* templates (`template.json` files) to the latest version.
-- [ ] Create a PR in the [Azure Functions bundles repo](https://github.com/Azure/azure-functions-extension-bundles) to update bundles to the latest version _if and only if this is a new major release_.
+- [ ] _if and only if this is a new major release_, Create a PR in the [Azure Functions bundles repo](https://github.com/Azure/azure-functions-extension-bundles) to update bundles to the latest version .
 - [ ] Merge all pending PR docs from `pending_docs.md.`
 - [ ] Reset `pending_docs.md` and `release_notes.md` in the `dev` branch. You will want to save `release_notes.md` somewhere for when you publish release notes.
 - [ ] Publish release notes from the pre-reset `release_notes.md.`


### PR DESCRIPTION
With the latest changes to bundles, we no longer need to create a PR to update them at every extension release. The bundles repo now automatically tracks every release within a major version, so we only need to create PRs against them when releasing a new major version, which is seldom.

As for the templates repo, now we only need to update dotnet samples (`template.json files). When creating PRs against the dotnet templates, we need to target both the v3.x and v4.x branch, so two PRs will be needed in total.