### PR TITLE
Change 'defauls' to 'defaults'

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/ContextInterfaces/IDurableOrchestrationClient.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextInterfaces/IDurableOrchestrationClient.cs
@@ -294,7 +294,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// </summary>
         /// <param name="instanceId">InstanceId of a previously run orchestrator to restart.</param>
         /// <param name="restartWithNewInstanceId">Optional parameter that configures if restarting an orchestration will use a new instanceId or if it will
-        /// reuse the old instanceId. Defauls to <c>true</c>.</param>
+        /// reuse the old instanceId. Defaults to <c>true</c>.</param>
         /// <returns>A task that completes when the orchestration is started. The task contains the instance id of the started
         /// orchestratation instance.</returns>
         Task<string> RestartAsync(string instanceId, bool restartWithNewInstanceId = true);

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net461.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net461.xml
@@ -1021,7 +1021,7 @@
             </summary>
             <param name="instanceId">InstanceId of a previously run orchestrator to restart.</param>
             <param name="restartWithNewInstanceId">Optional parameter that configures if restarting an orchestration will use a new instanceId or if it will
-            reuse the old instanceId. Defauls to <c>true</c>.</param>
+            reuse the old instanceId. Defaults to <c>true</c>.</param>
             <returns>A task that completes when the orchestration is started. The task contains the instance id of the started
             orchestratation instance.</returns>
         </member>

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
@@ -1029,7 +1029,7 @@
             </summary>
             <param name="instanceId">InstanceId of a previously run orchestrator to restart.</param>
             <param name="restartWithNewInstanceId">Optional parameter that configures if restarting an orchestration will use a new instanceId or if it will
-            reuse the old instanceId. Defauls to <c>true</c>.</param>
+            reuse the old instanceId. Defaults to <c>true</c>.</param>
             <returns>A task that completes when the orchestration is started. The task contains the instance id of the started
             orchestratation instance.</returns>
         </member>

--- a/test/FunctionsV2/AzureStorageDurabilityProviderFactoryTests.cs
+++ b/test/FunctionsV2/AzureStorageDurabilityProviderFactoryTests.cs
@@ -104,7 +104,7 @@ namespace WebJobs.Extensions.DurableTask.Tests.V2
 
         [Fact]
         [Trait("Category", PlatformSpecificHelpers.TestCategory)]
-        public void ConsumptionDefaulstDoNotOverrideCustomerOptions()
+        public void ConsumptionDefaultsDoNotOverrideCustomerOptions()
         {
             var connectionStringResolver = new TestConnectionStringResolver();
             var options = new DurableTaskOptions();


### PR DESCRIPTION
While using `Microsoft.Azure.WebJobs.Extensions.DurableTask` I noticed a typo in `IDurableOrchestrationClient`. I figured I'd create a PR to address all instances of this same typo throughout the repository.

All instances of "defauls" have been changed to "defaults".

<!-- Make sure to delete the markdown comments and the below sections when squash merging -->
### Issue describing the changes in this PR

No issue. 

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [x] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [x] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [x] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)
* [x] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [x] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk