### PR TITLE
Remove payload size limit in localRPCEndpoint

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/LocalHttpListener.cs
+++ b/src/WebJobs.Extensions.DurableTask/LocalHttpListener.cs
@@ -82,7 +82,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                         .ConfigureKestrel(o =>
                         {
                             // remove request's Content size limits
-                            o.Limits.MaxRequestBodySize = -1;
+                            o.Limits.MaxRequestBodySize = null;
                         })
                         .UseUrls(listenUri.OriginalString)
                         .Configure(a => a.Run(this.HandleRequestAsync))

--- a/src/WebJobs.Extensions.DurableTask/LocalHttpListener.cs
+++ b/src/WebJobs.Extensions.DurableTask/LocalHttpListener.cs
@@ -79,6 +79,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     var listenUri = new Uri(this.InternalRpcUri.GetLeftPart(UriPartial.Authority));
                     this.localWebHost = new WebHostBuilder()
                         .UseKestrel()
+                        .ConfigureKestrel(o =>
+                        {
+                            // remove request's Content size limits
+                            o.Limits.MaxRequestBodySize = -1;
+                        })
                         .UseUrls(listenUri.OriginalString)
                         .Configure(a => a.Run(this.HandleRequestAsync))
                         .Build();


### PR DESCRIPTION
<!-- Start the PR description with some context for the change. -->
Currently, OOProc SDKs utilizing the local RPCEndpoint will be constrained in their payload size per request: each needs to be under 30MB. In practice, this means, among other things, that large inputs to orchestrations in OOProc are bounded to be under 30MB. While this is technically a good practice, this limit is not intended and creates divergent behavior when comparing OOProc SDKs to the in-proc C# experience.

This PR removes that limitation by configuring `Kestrel` to have no size checks per request. This should be in line with the removal of size limits on the worker's GRPC channel, which has already taken place.

**On tests:** Our testing infrastructure currently does not allow us to invoke our localRPCEndpoint directly, like OOProc would, so I opted not to add any tests for this small change. Happy to add them if others feel it's important for this change. The change has been validated locally by connecting with the JS SDK.

<!-- Make sure to delete the markdown comments and the below sections when squash merging -->
### Issue describing the changes in this PR

resolves N/A

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)
* [x] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk