### PR TITLE
Add SBOM generation task to our pipeline and prepare other compliance requirements

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -119,6 +119,14 @@ jobs:
     - task: NuGetToolInstaller@1
       displayName: 'Use NuGet '
 
+    - task: DotNetCoreCLI@2
+      displayName: 'dotnet restore'
+      inputs:
+        command: restore
+        projects: '**/**/*.csproj'
+        feedsToUse: config
+        nugetConfigPath: 'azure-functions-durable-extension/.nuget/nuget.config'
+
     - task: VSBuild@1
       displayName: 'Build Durable Extension'
       inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -165,6 +165,13 @@ jobs:
                               "ToolVersion": "1.0"
                             }
                         ]
+    - task: CopyFiles@2
+      displayName: 'Copy Files to: $(Build.ArtifactStagingDirectory)'
+      inputs:
+        SourceFolder: '$(Build.BinariesDirectory)'
+        Contents: '*.nupkg'
+        TargetFolder: '$(Build.ArtifactStagingDirectory)'
+        CleanTargetFolder: true
     - task: AzureArtifacts.drop-validator-task.manifest-generator-task.ManifestGeneratorTask@0
       displayName: "SBOM Generation Task"
       inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -213,3 +213,92 @@ jobs:
         PathtoPublish: "$(Build.ArtifactStagingDirectory)"
         ArtifactName: "drop"
         publishLocation: "Container"
+
+  - job: BuildAnalyzer 
+    pool: 
+      vmImage: 'windows-latest'
+
+    variables:
+      solution: '**/WebJobs.Extensions.DurableTask.Analyzers.sln'
+      buildPlatform: 'Any CPU'
+      buildConfiguration: 'Release'
+    
+    steps:
+    - task: NuGetToolInstaller@1
+      displayName: 'Use NuGet '
+
+    - task: DotNetCoreCLI@2
+      inputs:
+        command: 'restore'
+        projects: '**/**/*.csproj'
+        feedsToUse: 'config'
+        nugetConfigPath: '.nuget/nuget.config'
+
+    - task: VSBuild@1
+      displayName: 'Build Durable Extension'
+      inputs:
+        solution: 'WebJobs.Extensions.DurableTask.Analyzers.sln'
+        vsVersion: 16.0
+        configuration: Release
+
+    - task: DotNetCoreCLI@2
+      displayName: 'dotnet pack'
+      inputs:
+        command: pack
+        packagesToPack: 'src/WebJobs.Extensions.DurableTask/**/WebJobs.Extensions.DurableTask.Analyzers.csproj'
+        packDirectory: '$(Build.BinariesDirectory)'
+        nobuild: true
+        verbosityPack: Normal
+    - script: |
+        echo *** Searching for .symbols.nupkg files to delete...
+        dir /s /b *.symbols.nupkg
+        
+        echo *** Deleting .symbols.nupkg files...
+        del /S /Q *.symbols.nupkg
+        
+        echo *** Listing remaining packages
+        dir /s /b *.nupkg
+      displayName: 'Remove Redundant Symbols Package(s)'
+      continueOnError: true
+    - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
+      displayName: 'ESRP CodeSigning: Nupkg'
+      inputs:
+        ConnectedServiceName: 'ESRP Service'
+        FolderPath: '.'
+        Pattern: '*.nupkg'
+        signConfigType: inlineSignParams
+        inlineOperation: |
+          [    
+                            {
+                              "KeyCode": "CP-401405",
+                              "OperationCode": "NuGetSign",
+                              "Parameters": {},
+                              "ToolName": "sign",
+                              "ToolVersion": "1.0"
+                            },
+                            {
+                              "KeyCode": "CP-401405",
+                              "OperationCode": "NuGetVerify",
+                              "Parameters": {},
+                              "ToolName": "sign",
+                              "ToolVersion": "1.0"
+                            }
+                        ]
+    - task: CopyFiles@2
+      displayName: 'Copy Files to: $(Build.ArtifactStagingDirectory)'
+      inputs:
+        SourceFolder: '$(Build.BinariesDirectory)'
+        Contents: '*.nupkg'
+        TargetFolder: '$(Build.ArtifactStagingDirectory)'
+        CleanTargetFolder: true
+    - task: AzureArtifacts.drop-validator-task.manifest-generator-task.ManifestGeneratorTask@0
+      displayName: "SBOM Generation Task"
+      inputs:
+        BuildDropPath: "$(Build.ArtifactStagingDirectory)"
+        Verbosity: "Information"
+    - task: PublishBuildArtifacts@1
+      displayName: 'Publish Artifact: dist'
+      inputs:
+        PathtoPublish: "$(Build.ArtifactStagingDirectory)"
+        ArtifactName: "drop"
+        publishLocation: "Container"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -149,4 +149,6 @@ jobs:
     - task: PublishBuildArtifacts@1
       displayName: 'Publish Artifact: dist'
       inputs:
-        PathtoPublish: dist
+        PathtoPublish: "$(Build.ArtifactStagingDirectory)"
+        ArtifactName: "drop"
+        publishLocation: "Container"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -245,6 +245,7 @@ jobs:
       inputs:
         command: pack
         packagesToPack: 'src/**/**/WebJobs.Extensions.DurableTask.Analyzers.csproj'
+        configuration: Release
         packDirectory: '$(Build.BinariesDirectory)'
         nobuild: true
         verbosityPack: Diagnostic

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -120,7 +120,7 @@ jobs:
       displayName: 'dotnet pack'
       inputs:
         command: pack
-        packagesToPack: 'src/**/WebJobs.Extensions.DurableTask.csproj.csproj'
+        packagesToPack: '**/WebJobs.Extensions.DurableTask.csproj.csproj'
         packDirectory: '$(Build.BinariesDirectory)'
         nobuild: true
         verbosityPack: Normal

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -221,7 +221,7 @@ jobs:
   - job: BuildAnalyzer 
     pool: 
       vmImage: 'windows-latest'
-    
+
     steps:
     - task: NuGetToolInstaller@1
       displayName: 'Use NuGet '
@@ -247,7 +247,7 @@ jobs:
         packagesToPack: 'src/**/**/WebJobs.Extensions.DurableTask.Analyzers.csproj'
         packDirectory: '$(Build.BinariesDirectory)'
         nobuild: true
-        verbosityPack: Normal
+        verbosityPack: Diagnostic
     - script: |
         echo *** Searching for .symbols.nupkg files to delete...
         dir /s /b *.symbols.nupkg

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -129,6 +129,11 @@ jobs:
   - job: BuildExtensionV2 
     pool: 
       vmImage: 'windows-latest'
+
+    variables:
+      solution: '**/WebJobs.Extensions.DurableTask.sln'
+      buildPlatform: 'Any CPU'
+      buildConfiguration: 'Release'
     
     steps:
     - task: NuGetToolInstaller@1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -237,7 +237,7 @@ jobs:
     - task: VSBuild@1
       displayName: 'Build Durable Extension Analyzer'
       inputs:
-        solution: 'WebJobs.Extensions.DurableTask.Analyzers.sln'
+        solution: 'src/**/**/WebJobs.Extensions.DurableTask.Analyzers.sln'
         vsVersion: 16.0
         configuration: Release
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -149,7 +149,7 @@ jobs:
         Pattern: '*.nupkg'
         signConfigType: inlineSignParams
         inlineOperation: |
-        [    
+          [    
                             {
                               "KeyCode": "CP-401405",
                               "OperationCode": "NuGetSign",

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -116,6 +116,24 @@ jobs:
       buildConfiguration: 'Release'
     
     steps:
+    - task: NuGetToolInstaller@1
+      displayName: 'Use NuGet '
+
+    - task: DotNetCoreCLI@2
+      displayName: 'dotnet restore'
+      inputs:
+        command: restore
+        projects: '**/**/*.csproj'
+        feedsToUse: config
+        nugetConfigPath: 'azure-functions-durable-extension/.nuget/nuget.config'
+
+    - task: VSBuild@1
+      displayName: 'Build Durable Extension'
+      inputs:
+        solution: 'WebJobs.Extensions.DurableTask.sln'
+        vsVersion: 16.0
+        configuration: Release
+
     - task: DotNetCoreCLI@2
       displayName: 'dotnet pack'
       inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -124,15 +124,11 @@ jobs:
         AzureWebJobsStorage: $(AzureWebJobsStorage)
         APPINSIGHTS_INSTRUMENTATIONKEY: $(APPINSIGHTS_INSTRUMENTATIONKEY)
 
-
+  # Build, sign, and add SBOM manifest to a Nuget payload of the extension (V2).
+  # Our release pipeline should re-use this payload at release time.
   - job: BuildExtensionV2 
     pool: 
       vmImage: 'windows-latest'
-
-    variables:
-      solution: '**/WebJobs.Extensions.DurableTask.sln'
-      buildPlatform: 'Any CPU'
-      buildConfiguration: 'Release'
     
     steps:
     - task: NuGetToolInstaller@1
@@ -202,6 +198,7 @@ jobs:
         Contents: '*.nupkg'
         TargetFolder: '$(Build.ArtifactStagingDirectory)'
         CleanTargetFolder: true
+    # This task needed to be fully qualified to disambiguate it.
     - task: AzureArtifacts.drop-validator-task.manifest-generator-task.ManifestGeneratorTask@0
       displayName: "SBOM Generation Task"
       inputs:
@@ -214,14 +211,11 @@ jobs:
         ArtifactName: "extensionV2"
         publishLocation: "Container"
 
+  # Build, sign, and add SBOM manifest to a Nuget payload of the analyzer.
+  # Our release pipeline should re-use this payload at release time.
   - job: BuildAnalyzer 
     pool: 
       vmImage: 'windows-latest'
-
-    variables:
-      solution: '**/WebJobs.Extensions.DurableTask.Analyzers.sln'
-      buildPlatform: 'Any CPU'
-      buildConfiguration: 'Release'
     
     steps:
     - task: NuGetToolInstaller@1
@@ -291,6 +285,7 @@ jobs:
         Contents: '*.nupkg'
         TargetFolder: '$(Build.ArtifactStagingDirectory)'
         CleanTargetFolder: true
+    # This task needed to be fully qualified to disambiguate it.
     - task: AzureArtifacts.drop-validator-task.manifest-generator-task.ManifestGeneratorTask@0
       displayName: "SBOM Generation Task"
       inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -120,12 +120,11 @@ jobs:
       displayName: 'Use NuGet '
 
     - task: DotNetCoreCLI@2
-      displayName: 'dotnet restore'
       inputs:
-        command: restore
+        command: 'restore'
         projects: '**/**/*.csproj'
-        feedsToUse: config
-        nugetConfigPath: 'azure-functions-durable-extension/.nuget/nuget.config'
+        feedsToUse: 'config'
+        nugetConfigPath: '.nuget/nuget.config'
 
     - task: VSBuild@1
       displayName: 'Build Durable Extension'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -141,6 +141,30 @@ jobs:
         packDirectory: '$(Build.BinariesDirectory)'
         nobuild: true
         verbosityPack: Normal
+    - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
+      displayName: 'ESRP CodeSigning: Nupkg'
+      inputs:
+        ConnectedServiceName: 'ESRP Service'
+        FolderPath: '.'
+        Pattern: '*.nupkg'
+        signConfigType: inlineSignParams
+        inlineOperation: |
+        [    
+                            {
+                              "KeyCode": "CP-401405",
+                              "OperationCode": "NuGetSign",
+                              "Parameters": {},
+                              "ToolName": "sign",
+                              "ToolVersion": "1.0"
+                            },
+                            {
+                              "KeyCode": "CP-401405",
+                              "OperationCode": "NuGetVerify",
+                              "Parameters": {},
+                              "ToolName": "sign",
+                              "ToolVersion": "1.0"
+                            }
+                        ]
     - task: AzureArtifacts.drop-validator-task.manifest-generator-task.ManifestGeneratorTask@0
       displayName: "SBOM Generation Task"
       inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -294,7 +294,7 @@ jobs:
     - task: AzureArtifacts.drop-validator-task.manifest-generator-task.ManifestGeneratorTask@0
       displayName: "SBOM Generation Task"
       inputs:
-        BuildDropPath: "$(Build.ArtifactStagingDirectory)"
+        BuildDropPath: "$(Build.ArtifactStagingDirectory)/analyzer"
         Verbosity: "Information"
     - task: PublishBuildArtifacts@1
       displayName: 'Publish Artifact: dist'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -38,7 +38,16 @@ jobs:
         rerunMaxAttempts: 2
       env:
         AzureWebJobsStorage: $(AzureWebJobsStorage)
-        APPINSIGHTS_INSTRUMENTATIONKEY: $(APPINSIGHTS_INSTRUMENTATIONKEY) 
+        APPINSIGHTS_INSTRUMENTATIONKEY: $(APPINSIGHTS_INSTRUMENTATIONKEY)
+    - task: ManifestGeneratorTask@0
+      displayName: "SBOM Generation Task"
+      inputs:
+          BuildDropPath: "$(Build.ArtifactStagingDirectory)"
+          Verbosity: "Information"
+    - task: PublishBuildArtifacts@1
+      displayName: 'Publish Artifact: dist'
+      inputs:
+        PathtoPublish: dist
 
   - job: FunctionsV2Tests
     pool: 
@@ -82,7 +91,16 @@ jobs:
         runInParallel: true
       env:
         AzureWebJobsStorage: $(AzureWebJobsStorage)
-        APPINSIGHTS_INSTRUMENTATIONKEY: $(APPINSIGHTS_INSTRUMENTATIONKEY) 
+        APPINSIGHTS_INSTRUMENTATIONKEY: $(APPINSIGHTS_INSTRUMENTATIONKEY)
+    - task: ManifestGeneratorTask@0
+      displayName: "SBOM Generation Task"
+      inputs:
+          BuildDropPath: "$(Build.ArtifactStagingDirectory)"
+          Verbosity: "Information"
+    - task: PublishBuildArtifacts@1
+      displayName: 'Publish Artifact: dist'
+      inputs:
+        PathtoPublish: dist
 
   - job: DurableAnalyzerTests
     pool: 
@@ -123,3 +141,12 @@ jobs:
       env:
         AzureWebJobsStorage: $(AzureWebJobsStorage)
         APPINSIGHTS_INSTRUMENTATIONKEY: $(APPINSIGHTS_INSTRUMENTATIONKEY)
+    - task: ManifestGeneratorTask@0
+      displayName: "SBOM Generation Task"
+      inputs:
+          BuildDropPath: "$(Build.ArtifactStagingDirectory)"
+          Verbosity: "Information"
+    - task: PublishBuildArtifacts@1
+      displayName: 'Publish Artifact: dist'
+      inputs:
+        PathtoPublish: dist

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -92,7 +92,7 @@ jobs:
       env:
         AzureWebJobsStorage: $(AzureWebJobsStorage)
         APPINSIGHTS_INSTRUMENTATIONKEY: $(APPINSIGHTS_INSTRUMENTATIONKEY)
-    - task: ManifestGeneratorTask@0
+    - task: AzureArtifacts.drop-validator-task.manifest-generator-task.ManifestGeneratorTask@0
       displayName: "SBOM Generation Task"
       inputs:
           BuildDropPath: "$(Build.ArtifactStagingDirectory)"
@@ -141,7 +141,7 @@ jobs:
       env:
         AzureWebJobsStorage: $(AzureWebJobsStorage)
         APPINSIGHTS_INSTRUMENTATIONKEY: $(APPINSIGHTS_INSTRUMENTATIONKEY)
-    - task: ManifestGeneratorTask@0
+    - task: AzureArtifacts.drop-validator-task.manifest-generator-task.ManifestGeneratorTask@0
       displayName: "SBOM Generation Task"
       inputs:
           BuildDropPath: "$(Build.ArtifactStagingDirectory)"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -47,7 +47,9 @@ jobs:
     - task: PublishBuildArtifacts@1
       displayName: 'Publish Artifact: dist'
       inputs:
-        PathtoPublish: dist
+        PathtoPublish: "$(Build.ArtifactStagingDirectory)"
+        ArtifactName: "drop"
+        publishLocation: "Container"
 
   - job: FunctionsV2Tests
     pool: 
@@ -100,7 +102,9 @@ jobs:
     - task: PublishBuildArtifacts@1
       displayName: 'Publish Artifact: dist'
       inputs:
-        PathtoPublish: dist
+        PathtoPublish: "$(Build.ArtifactStagingDirectory)"
+        ArtifactName: "drop"
+        publishLocation: "Container"
 
   - job: DurableAnalyzerTests
     pool: 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -150,8 +150,8 @@ jobs:
         
         echo *** Listing remaining packages
         dir /s /b *.nupkg
-        displayName: 'Remove Redundant Symbols Package(s)'
-        continueOnError: true
+      displayName: 'Remove Redundant Symbols Package(s)'
+      continueOnError: true
     - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
       displayName: 'ESRP CodeSigning: Nupkg'
       inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -39,17 +39,6 @@ jobs:
       env:
         AzureWebJobsStorage: $(AzureWebJobsStorage)
         APPINSIGHTS_INSTRUMENTATIONKEY: $(APPINSIGHTS_INSTRUMENTATIONKEY)
-    - task: AzureArtifacts.drop-validator-task.manifest-generator-task.ManifestGeneratorTask@0
-      displayName: "SBOM Generation Task"
-      inputs:
-          BuildDropPath: "$(Build.ArtifactStagingDirectory)"
-          Verbosity: "Information"
-    - task: PublishBuildArtifacts@1
-      displayName: 'Publish Artifact: dist'
-      inputs:
-        PathtoPublish: "$(Build.ArtifactStagingDirectory)"
-        ArtifactName: "drop"
-        publishLocation: "Container"
 
   - job: FunctionsV2Tests
     pool: 
@@ -94,19 +83,49 @@ jobs:
       env:
         AzureWebJobsStorage: $(AzureWebJobsStorage)
         APPINSIGHTS_INSTRUMENTATIONKEY: $(APPINSIGHTS_INSTRUMENTATIONKEY)
-    - task: AzureArtifacts.drop-validator-task.manifest-generator-task.ManifestGeneratorTask@0
-      displayName: "SBOM Generation Task"
-      inputs:
-          BuildDropPath: "$(Build.ArtifactStagingDirectory)"
-          Verbosity: "Information"
-    - task: PublishBuildArtifacts@1
-      displayName: 'Publish Artifact: dist'
-      inputs:
-        PathtoPublish: "$(Build.ArtifactStagingDirectory)"
-        ArtifactName: "drop"
-        publishLocation: "Container"
 
-  - job: Build 
+  - job: DurableAnalyzerTests
+    pool: 
+      vmImage: 'windows-latest'
+
+    variables:
+      solution: '**/WebJobs.Extensions.DurableTask.Analyzers.sln'
+      buildPlatform: 'Any CPU'
+      buildConfiguration: 'Release'
+
+    steps:
+    - task: NuGetToolInstaller@1
+
+    - task: DotNetCoreCLI@2
+      inputs:
+        command: 'restore'
+        projects: 'test/WebJobs.Extensions.DurableTask.Analyzers.Test/*.csproj'
+        feedsToUse: 'config'
+        nugetConfigPath: '.nuget/nuget.config'
+
+    - task: DotNetCoreCLI@2
+      inputs:
+        command: 'build'
+        projects: 'test/WebJobs.Extensions.DurableTask.Analyzers.Test/*.csproj'
+        arguments: '--configuration $(buildConfiguration)'
+      displayName: 'dotnet build $(buildConfiguration) '
+
+    - task: VSTest@2
+      inputs:
+        testSelector: 'testAssemblies'
+        testAssemblyVer2: |
+           **/bin/**/*Analyzers.Test.dll
+        distributionBatchType: basedOnExecutionTime
+        diagnosticsEnabled: true
+        rerunFailedTests: true
+        rerunFailedThreshold: 10
+        rerunMaxAttempts: 2
+      env:
+        AzureWebJobsStorage: $(AzureWebJobsStorage)
+        APPINSIGHTS_INSTRUMENTATIONKEY: $(APPINSIGHTS_INSTRUMENTATIONKEY)
+
+
+  - job: BuildExtensionV2 
     pool: 
       vmImage: 'windows-latest'
 
@@ -188,57 +207,6 @@ jobs:
       inputs:
         BuildDropPath: "$(Build.ArtifactStagingDirectory)"
         Verbosity: "Information"
-    - task: PublishBuildArtifacts@1
-      displayName: 'Publish Artifact: dist'
-      inputs:
-        PathtoPublish: "$(Build.ArtifactStagingDirectory)"
-        ArtifactName: "drop"
-        publishLocation: "Container"
-
-  - job: DurableAnalyzerTests
-    pool: 
-      vmImage: 'windows-latest'
-
-    variables:
-      solution: '**/WebJobs.Extensions.DurableTask.Analyzers.sln'
-      buildPlatform: 'Any CPU'
-      buildConfiguration: 'Release'
-
-    steps:
-    - task: NuGetToolInstaller@1
-
-    - task: DotNetCoreCLI@2
-      inputs:
-        command: 'restore'
-        projects: 'test/WebJobs.Extensions.DurableTask.Analyzers.Test/*.csproj'
-        feedsToUse: 'config'
-        nugetConfigPath: '.nuget/nuget.config'
-
-    - task: DotNetCoreCLI@2
-      inputs:
-        command: 'build'
-        projects: 'test/WebJobs.Extensions.DurableTask.Analyzers.Test/*.csproj'
-        arguments: '--configuration $(buildConfiguration)'
-      displayName: 'dotnet build $(buildConfiguration) '
-
-    - task: VSTest@2
-      inputs:
-        testSelector: 'testAssemblies'
-        testAssemblyVer2: |
-           **/bin/**/*Analyzers.Test.dll
-        distributionBatchType: basedOnExecutionTime
-        diagnosticsEnabled: true
-        rerunFailedTests: true
-        rerunFailedThreshold: 10
-        rerunMaxAttempts: 2
-      env:
-        AzureWebJobsStorage: $(AzureWebJobsStorage)
-        APPINSIGHTS_INSTRUMENTATIONKEY: $(APPINSIGHTS_INSTRUMENTATIONKEY)
-    - task: AzureArtifacts.drop-validator-task.manifest-generator-task.ManifestGeneratorTask@0
-      displayName: "SBOM Generation Task"
-      inputs:
-          BuildDropPath: "$(Build.ArtifactStagingDirectory)"
-          Verbosity: "Information"
     - task: PublishBuildArtifacts@1
       displayName: 'Publish Artifact: dist'
       inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -119,14 +119,6 @@ jobs:
     - task: NuGetToolInstaller@1
       displayName: 'Use NuGet '
 
-    - task: DotNetCoreCLI@2
-      displayName: 'dotnet restore'
-      inputs:
-        command: restore
-        projects: '**/**/*.csproj'
-        feedsToUse: config
-        nugetConfigPath: 'azure-functions-durable-extension/.nuget/nuget.config'
-
     - task: VSBuild@1
       displayName: 'Build Durable Extension'
       inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -235,7 +235,7 @@ jobs:
         nugetConfigPath: '.nuget/nuget.config'
 
     - task: VSBuild@1
-      displayName: 'Build Durable Extension'
+      displayName: 'Build Durable Extension Analyzer'
       inputs:
         solution: 'WebJobs.Extensions.DurableTask.Analyzers.sln'
         vsVersion: 16.0
@@ -245,7 +245,7 @@ jobs:
       displayName: 'dotnet pack'
       inputs:
         command: pack
-        packagesToPack: 'src/WebJobs.Extensions.DurableTask/**/WebJobs.Extensions.DurableTask.Analyzers.csproj'
+        packagesToPack: 'src/**/**/WebJobs.Extensions.DurableTask.Analyzers.csproj'
         packDirectory: '$(Build.BinariesDirectory)'
         nobuild: true
         verbosityPack: Normal

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -211,7 +211,7 @@ jobs:
       displayName: 'Publish Artifact: dist'
       inputs:
         PathtoPublish: "$(Build.ArtifactStagingDirectory)"
-        ArtifactName: "drop"
+        ArtifactName: "extensionV2"
         publishLocation: "Container"
 
   - job: BuildAnalyzer 
@@ -294,11 +294,11 @@ jobs:
     - task: AzureArtifacts.drop-validator-task.manifest-generator-task.ManifestGeneratorTask@0
       displayName: "SBOM Generation Task"
       inputs:
-        BuildDropPath: "$(Build.ArtifactStagingDirectory)/analyzer"
+        BuildDropPath: "$(Build.ArtifactStagingDirectory)"
         Verbosity: "Information"
     - task: PublishBuildArtifacts@1
       displayName: 'Publish Artifact: dist'
       inputs:
         PathtoPublish: "$(Build.ArtifactStagingDirectory)"
-        ArtifactName: "drop"
+        ArtifactName: "analyzer"
         publishLocation: "Container"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -106,6 +106,36 @@ jobs:
         ArtifactName: "drop"
         publishLocation: "Container"
 
+  - job: Build 
+    pool: 
+      vmImage: 'windows-latest'
+
+    variables:
+      solution: '**/WebJobs.Extensions.DurableTask.sln'
+      buildPlatform: 'Any CPU'
+      buildConfiguration: 'Release'
+    
+    steps:
+    - task: DotNetCoreCLI@2
+      displayName: 'dotnet pack'
+      inputs:
+        command: pack
+        packagesToPack: 'src/**/WebJobs.Extensions.DurableTask.csproj.csproj'
+        packDirectory: '$(Build.BinariesDirectory)'
+        nobuild: true
+        verbosityPack: Normal
+    - task: AzureArtifacts.drop-validator-task.manifest-generator-task.ManifestGeneratorTask@0
+      displayName: "SBOM Generation Task"
+      inputs:
+        BuildDropPath: "$(Build.ArtifactStagingDirectory)"
+        Verbosity: "Information"
+    - task: PublishBuildArtifacts@1
+      displayName: 'Publish Artifact: dist'
+      inputs:
+        PathtoPublish: "$(Build.ArtifactStagingDirectory)"
+        ArtifactName: "drop"
+        publishLocation: "Container"
+
   - job: DurableAnalyzerTests
     pool: 
       vmImage: 'windows-latest'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -131,7 +131,7 @@ jobs:
       vmImage: 'windows-latest'
 
     variables:
-      solution: '**/WebJobs.Extensions.DurableTask.sln'
+      solution: 'WebJobs.Extensions.DurableTask.sln'
       buildPlatform: 'Any CPU'
       buildConfiguration: 'Release'
     
@@ -140,6 +140,7 @@ jobs:
       displayName: 'Use NuGet '
 
     - task: DotNetCoreCLI@2
+      displayName: 'Restore project'
       inputs:
         command: 'restore'
         projects: '**/**/*.csproj'
@@ -149,9 +150,9 @@ jobs:
     - task: VSBuild@1
       displayName: 'Build Durable Extension'
       inputs:
-        solution: 'WebJobs.Extensions.DurableTask.sln'
+        solution: '$(solution)'
         vsVersion: 16.0
-        configuration: Release
+        configuration: '$(buildConfiguration)'
 
     - task: DotNetCoreCLI@2
       displayName: 'dotnet pack'
@@ -205,16 +206,16 @@ jobs:
         CleanTargetFolder: true
     # This task needed to be fully qualified to disambiguate it.
     - task: AzureArtifacts.drop-validator-task.manifest-generator-task.ManifestGeneratorTask@0
-      displayName: "SBOM Generation Task"
+      displayName: 'SBOM Generation Task'
       inputs:
-        BuildDropPath: "$(Build.ArtifactStagingDirectory)"
-        Verbosity: "Information"
+        BuildDropPath: '$(Build.ArtifactStagingDirectory)'
+        Verbosity: 'Information'
     - task: PublishBuildArtifacts@1
       displayName: 'Publish Artifact: dist'
       inputs:
-        PathtoPublish: "$(Build.ArtifactStagingDirectory)"
-        ArtifactName: "extensionV2"
-        publishLocation: "Container"
+        PathtoPublish: '$(Build.ArtifactStagingDirectory)'
+        ArtifactName: 'extensionV2'
+        publishLocation: 'Container'
 
   # Build, sign, and add SBOM manifest to a Nuget payload of the analyzer.
   # Our release pipeline should re-use this payload at release time.
@@ -222,11 +223,17 @@ jobs:
     pool: 
       vmImage: 'windows-latest'
 
+    variables:
+      solution: 'src/**/**/WebJobs.Extensions.DurableTask.Analyzers.sln'
+      buildPlatform: 'Any CPU'
+      buildConfiguration: 'Release'
+
     steps:
     - task: NuGetToolInstaller@1
       displayName: 'Use NuGet '
 
     - task: DotNetCoreCLI@2
+      displayName: 'Restore project'
       inputs:
         command: 'restore'
         projects: '**/**/*.csproj'
@@ -236,16 +243,16 @@ jobs:
     - task: VSBuild@1
       displayName: 'Build Durable Extension Analyzer'
       inputs:
-        solution: 'src/**/**/WebJobs.Extensions.DurableTask.Analyzers.sln'
+        solution: '$(solution)'
         vsVersion: 16.0
-        configuration: Release
+        configuration: $(buildConfiguration)
 
     - task: DotNetCoreCLI@2
       displayName: 'dotnet pack'
       inputs:
         command: pack
         packagesToPack: 'src/**/**/WebJobs.Extensions.DurableTask.Analyzers.csproj'
-        configuration: Release
+        configuration: $(buildConfiguration)
         packDirectory: '$(Build.BinariesDirectory)'
         nobuild: true
         verbosityPack: Diagnostic
@@ -293,13 +300,13 @@ jobs:
         CleanTargetFolder: true
     # This task needed to be fully qualified to disambiguate it.
     - task: AzureArtifacts.drop-validator-task.manifest-generator-task.ManifestGeneratorTask@0
-      displayName: "SBOM Generation Task"
+      displayName: 'SBOM Generation Task'
       inputs:
-        BuildDropPath: "$(Build.ArtifactStagingDirectory)"
-        Verbosity: "Information"
+        BuildDropPath: '$(Build.ArtifactStagingDirectory)'
+        Verbosity: 'Information'
     - task: PublishBuildArtifacts@1
       displayName: 'Publish Artifact: dist'
       inputs:
-        PathtoPublish: "$(Build.ArtifactStagingDirectory)"
-        ArtifactName: "analyzer"
-        publishLocation: "Container"
+        PathtoPublish: '$(Build.ArtifactStagingDirectory)'
+        ArtifactName: 'analyzer'
+        publishLocation: 'Container'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -141,6 +141,17 @@ jobs:
         packDirectory: '$(Build.BinariesDirectory)'
         nobuild: true
         verbosityPack: Normal
+    - script: |
+        echo *** Searching for .symbols.nupkg files to delete...
+        dir /s /b *.symbols.nupkg
+        
+        echo *** Deleting .symbols.nupkg files...
+        del /S /Q *.symbols.nupkg
+        
+        echo *** Listing remaining packages
+        dir /s /b *.nupkg
+        displayName: 'Remove Redundant Symbols Package(s)'
+        continueOnError: true
     - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
       displayName: 'ESRP CodeSigning: Nupkg'
       inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -120,7 +120,7 @@ jobs:
       displayName: 'dotnet pack'
       inputs:
         command: pack
-        packagesToPack: '**/WebJobs.Extensions.DurableTask.csproj.csproj'
+        packagesToPack: 'src/WebJobs.Extensions.DurableTask/**/WebJobs.Extensions.DurableTask.csproj'
         packDirectory: '$(Build.BinariesDirectory)'
         nobuild: true
         verbosityPack: Normal

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -39,7 +39,7 @@ jobs:
       env:
         AzureWebJobsStorage: $(AzureWebJobsStorage)
         APPINSIGHTS_INSTRUMENTATIONKEY: $(APPINSIGHTS_INSTRUMENTATIONKEY)
-    - task: ManifestGeneratorTask@0
+    - task: AzureArtifacts.drop-validator-task.manifest-generator-task.ManifestGeneratorTask@0
       displayName: "SBOM Generation Task"
       inputs:
           BuildDropPath: "$(Build.ArtifactStagingDirectory)"


### PR DESCRIPTION
<!-- Start the PR description with some context for the change. -->
Modeled after: https://github.com/Azure/azure-functions-eventgrid-extension/pull/98/files

This PR modifies our build pipeline in 2 ways:
(1) to include an SBOM manifest, which essentially documents our package dependencies.
(2) to publish built Nuget artifacts to our Azure DevOps feed (see [here](https://durabletaskframework.visualstudio.com/Durable%20Task%20Framework%20CI/_build/results?buildId=2682&view=artifacts&pathAsName=false&type=publishedArtifacts) for an examplev). For security and government compliance, we need to make sure our **release** pipeline simply _pushes_ these ADO artifacts forward to Nuget. We *cannot* rebuild the Nuget package at release time. As a result, the build pipeline now takes on some of the tasks of the release pipeline, such as code-signing.

So now, at every CI build, we'll be publishing an artifact to ADO for both the analyzer and the extension. At release time, we just need to make sure we reference the right artifact to push to Nuget. That change will come in later.

<!-- Make sure to delete the markdown comments and the below sections when squash merging -->
### Issue describing the changes in this PR

resolves N/A

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [x] Otherwise: Backport tracked by issue/PR #2034
* [x] I have added all required tests (Unit tests, E2E tests)
* [x] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk