### PR TITLE
Patch binding expressions for OOProc

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/Bindings/ActivityTriggerAttributeBindingProvider.cs
+++ b/src/WebJobs.Extensions.DurableTask/Bindings/ActivityTriggerAttributeBindingProvider.cs
@@ -161,11 +161,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
                 // Non-dotnet payloads are doubly-serialized for protection against being interpreted/mutated within dotNET.
                 // Therefore, they also need to be doubly-deserialized when binding to expression-bindings.
+                // We avoid double-deserialized when the worker is unknown, for safety.
                 var workerRuntime = this.durableTaskConfig.PlatformInformationService.GetWorkerRuntimeType();
                 var isNotDotNetWorker = workerRuntime != WorkerRuntimeType.DotNet;
-                if (isNotDotNetWorker && convertedValue is string convertedValueStr)
+                var isNotUnknownWorker = workerRuntime != WorkerRuntimeType.Unknown;
+                if (isNotDotNetWorker && isNotUnknownWorker && convertedValue is string convertedValueStr)
                 {
-                    convertedValue = this.durableTaskConfig.MessageDataConverter.Deserialize<string>(convertedValueStr);
+                    convertedValue = this.durableTaskConfig.MessageDataConverter.Deserialize<object>(convertedValueStr);
                 }
 
                 bindingData[this.parameterInfo.Name] = convertedValue;

--- a/src/WebJobs.Extensions.DurableTask/Bindings/ActivityTriggerAttributeBindingProvider.cs
+++ b/src/WebJobs.Extensions.DurableTask/Bindings/ActivityTriggerAttributeBindingProvider.cs
@@ -155,11 +155,22 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
                 // Note that there could be conflicts in thiese dictionary keys, in which case
                 // the order here determines which binding rule will win.
+
                 var bindingData = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
                 bindingData[InstanceIdBindingPropertyName] = ((IDurableActivityContext)activityContext).InstanceId;
-                bindingData[this.parameterInfo.Name] = convertedValue;
-                bindingData[DataBindingPropertyName] = activityContext.GetInputAsJson();
 
+                // Non-dotnet payloads are doubly-serialized for protection against being interpreted/mutated within dotNET.
+                // Therefore, they also need to be doubly-deserialized when binding to expression-bindings.
+                var workerRuntime = this.durableTaskConfig.PlatformInformationService.GetWorkerRuntimeType();
+                var isNotDotNetWorker = workerRuntime != WorkerRuntimeType.DotNet;
+                if (isNotDotNetWorker && convertedValue is string convertedValueStr)
+                {
+                    convertedValue = this.durableTaskConfig.MessageDataConverter.Deserialize<string>(convertedValueStr);
+                }
+
+                bindingData[this.parameterInfo.Name] = convertedValue;
+
+                bindingData[DataBindingPropertyName] = activityContext.GetInputAsJson();
                 var triggerData = new TriggerData(inputValueProvider, bindingData);
                 triggerData.ReturnValueProvider = new ActivityTriggerReturnValueBinder(
                     activityContext,


### PR DESCRIPTION
<!-- Start the PR description with some context for the change. -->
Related to: https://github.com/Azure/azure-functions-durable-python/issues/282, https://github.com/Azure/azure-functions-durable-js/issues/231

<!-- Make sure to delete the markdown comments and the below sections when squash merging -->
### Issue describing the changes in this PR
OOProc activity inputs are doubly-serialized to prevent the data from being mutated within .NET; a recurring problem we've had in the past. However, this prevents expression bindings from receiving the right payload. For example, consider a Python activity containing a blob input binding which sets the blob to be read as the input to the activity.

This would look as follows

```JSON
{
  "scriptFile": "__init__.py",
  "bindings": [
    {
      "name": "name",
      "type": "activityTrigger",
      "direction": "in"
    },
    {
      "type": "blob",
      "direction": "in",
      "name": "inputBlob",
      "path": "incontainer/{name}",
      "connection": "AzureWebJobsStorage"
    }
  ]
}
```
Assume the given Activity input is "Tokyo".
In the input binding for the blob, we would expect the `path` to resolve to `incontainer/Tokyo`. However, due to our double serialization strategy, it currently receives `incontainer/"Tokyo"`. Notice the inserted quotes.

This PR removes those newly-inserted quotes by explicitly de-serializing the input payload right before assigning the data to the expression binding.

**TODO:** By fixing this bug, we're also potentially introducing a breaking change. If we're able to detect the end-user's JS/Python SDK **in this code-path**, then we should be able to properly version this logic and maintain backwards compatibility. However, I'm not sure that we have access to that information in this code-path. We should discuss this _asap_.

resolves N/A
### Pull request checklist

* [ ] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)
* [ ] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk