### PR TITLE
Fixed usage of durable client attribute not used during waiting for completion

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
+++ b/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
@@ -245,7 +245,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                         status.RuntimeStatus == OrchestrationRuntimeStatus.Failed ||
                         status.RuntimeStatus == OrchestrationRuntimeStatus.Terminated)
                     {
-                        return await this.HandleGetStatusRequestAsync(request, instanceId, returnInternalServerErrorOnFailure);
+                        return await this.HandleGetStatusRequestAsync(request, instanceId, returnInternalServerErrorOnFailure, client);
                     }
                 }
 
@@ -575,9 +575,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         private async Task<HttpResponseMessage> HandleGetStatusRequestAsync(
             HttpRequestMessage request,
             string instanceId,
-            bool? returnInternalServerErrorOnFailure = null)
+            bool? returnInternalServerErrorOnFailure = null,
+            IDurableOrchestrationClient existingClient = null)
         {
-            IDurableOrchestrationClient client = this.GetClient(request);
+            IDurableOrchestrationClient client = existingClient ?? this.GetClient(request);
             var queryNameValuePairs = request.GetQueryNameValuePairs();
 
             if (!TryGetBooleanQueryParameterValue(queryNameValuePairs, ShowHistoryParameter, out bool showHistory))

--- a/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
+++ b/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
@@ -204,7 +204,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
             HttpManagementPayload httpManagementPayload = this.GetClientResponseLinks(request, instanceId, attribute?.TaskHub, attribute?.ConnectionName, returnInternalServerErrorOnFailure);
 
-            IDurableOrchestrationClient client = this.GetClient(request);
+            IDurableOrchestrationClient client = this.GetClient(request, attribute);
             Stopwatch stopwatch = Stopwatch.StartNew();
 
             // This retry loop completes either when the
@@ -1008,10 +1008,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             }
         }
 
-        private IDurableClient GetClient(HttpRequestMessage request)
+        private IDurableClient GetClient(HttpRequestMessage request, DurableClientAttribute existingAttribute = null)
         {
-            string taskHub = null;
-            string connectionName = null;
+            string taskHub = existingAttribute?.TaskHub;
+            string connectionName = existingAttribute?.ConnectionName;
 
             NameValueCollection pairs = request.GetQueryNameValuePairs();
             foreach (string key in pairs.AllKeys)

--- a/test/Common/HttpApiHandlerTests.cs
+++ b/test/Common/HttpApiHandlerTests.cs
@@ -1457,6 +1457,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 var orchestrationServiceMock = new Mock<IOrchestrationService>();
                 var storageProvider = new DurabilityProvider("Mock", orchestrationServiceMock.Object, orchestrationServiceClientMock.Object, "mock");
 
+                Assert.Equal(TestConstants.TaskHub, attribute.TaskHub);
+                Assert.Equal(TestConstants.ConnectionName, attribute.ConnectionName);
                 return new DurableClientMock(storageProvider, this, attribute);
             }
         }


### PR DESCRIPTION
There is an issue when using durable client attribute with a specific Taskhub and using the WaitForCompletionOrCreateCheckStatusResponseAsync (the timer wait the timeout before returning status)


<!-- Make sure to delete the markdown comments and the below sections when squash merging -->
### Issue describing the changes in this PR

resolves #2040

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)
* [x] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk