### PR TITLE
Analyzer: Resolved compilation bug and stack overflow bug

### DIFF
--- a/src/WebJobs.Extensions.DurableTask.Analyzers/Analyzers/Orchestrator/BindingAnalyzer.cs
+++ b/src/WebJobs.Extensions.DurableTask.Analyzers/Analyzers/Orchestrator/BindingAnalyzer.cs
@@ -35,9 +35,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
                     if (attributeName != "OrchestrationTrigger")
                     {
                         var diagnostic = Diagnostic.Create(Rule, attribute.GetLocation(), attributeName);
-                        
-                        context.ReportDiagnostic(diagnostic);
-                        
+
+                        if (context.Compilation.ContainsSyntaxTree(method.SyntaxTree))
+                        {
+                            context.ReportDiagnostic(diagnostic);
+                        }
+
                         diagnosedIssue = true;
                     }
                 }

--- a/src/WebJobs.Extensions.DurableTask.Analyzers/Analyzers/Orchestrator/CancellationTokenAnalyzer.cs
+++ b/src/WebJobs.Extensions.DurableTask.Analyzers/Analyzers/Orchestrator/CancellationTokenAnalyzer.cs
@@ -34,7 +34,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
                         {
                             var diagnostic = Diagnostic.Create(Rule, parameter.GetLocation());
 
-                            context.ReportDiagnostic(diagnostic);
+                            if (context.Compilation.ContainsSyntaxTree(method.SyntaxTree))
+                            {
+                                context.ReportDiagnostic(diagnostic);
+                            }
 
                             diagnosedIssue = true;
                         }

--- a/src/WebJobs.Extensions.DurableTask.Analyzers/Analyzers/Orchestrator/DateTimeAnalyzer.cs
+++ b/src/WebJobs.Extensions.DurableTask.Analyzers/Analyzers/Orchestrator/DateTimeAnalyzer.cs
@@ -39,7 +39,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
                             {
                                 var diagnostic = Diagnostic.Create(Rule, memberAccessExpression.GetLocation(), memberAccessExpression);
 
-                                context.ReportDiagnostic(diagnostic);
+                                if (context.Compilation.ContainsSyntaxTree(method.SyntaxTree))
+                                {
+                                    context.ReportDiagnostic(diagnostic);
+                                }
 
                                 diagnosedIssue = true;
                             }

--- a/src/WebJobs.Extensions.DurableTask.Analyzers/Analyzers/Orchestrator/EnvironmentVariableAnalyzer.cs
+++ b/src/WebJobs.Extensions.DurableTask.Analyzers/Analyzers/Orchestrator/EnvironmentVariableAnalyzer.cs
@@ -39,7 +39,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
                             {
                                 var diagnostic = Diagnostic.Create(Rule, invocationExpression.GetLocation(), memberAccessExpression);
 
-                                context.ReportDiagnostic(diagnostic);
+                                if (context.Compilation.ContainsSyntaxTree(method.SyntaxTree))
+                                {
+                                    context.ReportDiagnostic(diagnostic);
+                                }
 
                                 diagnosedIssue = true;
                             }

--- a/src/WebJobs.Extensions.DurableTask.Analyzers/Analyzers/Orchestrator/GuidAnalyzer.cs
+++ b/src/WebJobs.Extensions.DurableTask.Analyzers/Analyzers/Orchestrator/GuidAnalyzer.cs
@@ -38,7 +38,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
                             {
                                 var diagnostic = Diagnostic.Create(Rule, invocationExpression.GetLocation(), memberAccessExpression);
 
-                                context.ReportDiagnostic(diagnostic);
+                                if (context.Compilation.ContainsSyntaxTree(method.SyntaxTree))
+                                {
+                                    context.ReportDiagnostic(diagnostic);
+                                }
 
                                 diagnosedIssue = true;
                             }

--- a/src/WebJobs.Extensions.DurableTask.Analyzers/Analyzers/Orchestrator/IOTypesAnalyzer.cs
+++ b/src/WebJobs.Extensions.DurableTask.Analyzers/Analyzers/Orchestrator/IOTypesAnalyzer.cs
@@ -34,7 +34,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
                         {
                             var diagnostic = Diagnostic.Create(Rule, identifierName.Identifier.GetLocation(), type);
 
-                            context.ReportDiagnostic(diagnostic);
+                            if (context.Compilation.ContainsSyntaxTree(method.SyntaxTree))
+                            {
+                                context.ReportDiagnostic(diagnostic);
+                            }
 
                             diagnosedIssue = true;
                         }

--- a/src/WebJobs.Extensions.DurableTask.Analyzers/Analyzers/Orchestrator/MethodInvocationAnalyzer.cs
+++ b/src/WebJobs.Extensions.DurableTask.Analyzers/Analyzers/Orchestrator/MethodInvocationAnalyzer.cs
@@ -43,7 +43,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
                 {
                     var diagnostic = Diagnostic.Create(Rule, invocation.GetLocation(), invocation);
 
-                    context.ReportDiagnostic(diagnostic);
+                    if (context.Compilation.ContainsSyntaxTree(invocation.SyntaxTree))
+                    {
+                        context.ReportDiagnostic(diagnostic);
+                    }
                 }
 
                 RegisterDiagnosticsOnParents(context, methodInformation, methodsVisited);

--- a/src/WebJobs.Extensions.DurableTask.Analyzers/Analyzers/Orchestrator/OrchestratorMethodCollector.cs
+++ b/src/WebJobs.Extensions.DurableTask.Analyzers/Analyzers/Orchestrator/OrchestratorMethodCollector.cs
@@ -79,7 +79,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
 
                             this.orchestratorMethodDeclarations.Add(invokedSymbol, invokedMethodInformation);
 
-                            FindInvokedMethods(semanticModel, invokedMethodInformation);
+                            FindInvokedMethods(invocationModel, invokedMethodInformation);
                         }
                     }
                 }

--- a/src/WebJobs.Extensions.DurableTask.Analyzers/Analyzers/Orchestrator/ThreadTaskAnalyzer.cs
+++ b/src/WebJobs.Extensions.DurableTask.Analyzers/Analyzers/Orchestrator/ThreadTaskAnalyzer.cs
@@ -49,7 +49,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
                             {
                                 var diagnostic = Diagnostic.Create(Rule, memberAccessExpression.GetLocation(), memberAccessExpression);
 
-                                context.ReportDiagnostic(diagnostic);
+                                if (context.Compilation.ContainsSyntaxTree(method.SyntaxTree))
+                                {
+                                    context.ReportDiagnostic(diagnostic);
+                                }
 
                                 diagnosedIssue = true;
                             }
@@ -79,7 +82,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
                             {
                                 var diagnostic = Diagnostic.Create(Rule, memberAccessExpression.GetLocation(), memberAccessExpression);
 
-                                context.ReportDiagnostic(diagnostic);
+                                if (context.Compilation.ContainsSyntaxTree(method.SyntaxTree))
+                                {
+                                    context.ReportDiagnostic(diagnostic);
+                                }
 
                                 diagnosedIssue = true;
                             }
@@ -109,7 +115,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
                             {
                                 var diagnostic = Diagnostic.Create(Rule, memberAccessExpression.GetLocation(), "Thread.Start");
 
-                                context.ReportDiagnostic(diagnostic);
+                                if (context.Compilation.ContainsSyntaxTree(method.SyntaxTree))
+                                {
+                                    context.ReportDiagnostic(diagnostic);
+                                }
 
                                 diagnosedIssue = true;
                             }
@@ -138,8 +147,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
 
                             var diagnostic = Diagnostic.Create(Rule, memberAccessExpression.GetLocation(), "Task.ContinueWith");
 
-                            context.ReportDiagnostic(diagnostic);
-                            
+                            if (context.Compilation.ContainsSyntaxTree(method.SyntaxTree))
+                            {
+                                context.ReportDiagnostic(diagnostic);
+                            }
+
                             diagnosedIssue = true;
                         }
                     }

--- a/src/WebJobs.Extensions.DurableTask.Analyzers/Analyzers/Orchestrator/TimerAnalyzer.cs
+++ b/src/WebJobs.Extensions.DurableTask.Analyzers/Analyzers/Orchestrator/TimerAnalyzer.cs
@@ -56,7 +56,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
 
                                     var diagnostic = Diagnostic.Create(rule, expression.GetLocation(), expression);
 
-                                    context.ReportDiagnostic(diagnostic);
+                                    if (context.Compilation.ContainsSyntaxTree(method.SyntaxTree))
+                                    {
+                                        context.ReportDiagnostic(diagnostic);
+                                    }
 
                                     diagnosedIssue = true;
                                 }
@@ -105,7 +108,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
 
                                     var diagnostic = Diagnostic.Create(rule, expression.GetLocation(), expression);
 
-                                    context.ReportDiagnostic(diagnostic);
+                                    if (context.Compilation.ContainsSyntaxTree(method.SyntaxTree))
+                                    {
+                                        context.ReportDiagnostic(diagnostic);
+                                    }
 
                                     diagnosedIssue = true;
                                 }

--- a/src/WebJobs.Extensions.DurableTask.Analyzers/SyntaxNodeUtils.cs
+++ b/src/WebJobs.Extensions.DurableTask.Analyzers/SyntaxNodeUtils.cs
@@ -40,8 +40,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
                 var compilation = model.Compilation;
                 if (!compilation.ContainsSyntaxTree(node.SyntaxTree))
                 {
-                    var newComplilation = model.Compilation.AddSyntaxTrees(node.SyntaxTree);
-                    newModel = newComplilation.GetSemanticModel(node.SyntaxTree);
+                    var newCompilation = compilation.AddSyntaxTrees(node.SyntaxTree);
+                    newModel = newCompilation.GetSemanticModel(node.SyntaxTree);
                 }
                 else
                 {

--- a/src/WebJobs.Extensions.DurableTask.Analyzers/WebJobs.Extensions.DurableTask.Analyzers.csproj
+++ b/src/WebJobs.Extensions.DurableTask.Analyzers/WebJobs.Extensions.DurableTask.Analyzers.csproj
@@ -8,7 +8,7 @@
 
   <PropertyGroup>
     <PackageId>Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers</PackageId>
-    <PackageVersion>0.4.1</PackageVersion>
+    <PackageVersion>0.4.2</PackageVersion>
     <Authors>Microsoft</Authors>
     <PackageLicenseUrl>https://go.microsoft.com/fwlink/?linkid=2028464</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/Azure/azure-functions-durable-extension</PackageProjectUrl>


### PR DESCRIPTION
Incremented Analyzer version to 0.4.2

Fixed bug related to deterministic orchestrator analyzers where diagnostics created in another project caused the analyzer to crash because the syntax tree was not in the compilation being analyzed. Reserved analysis of these files to allow warnings to surface to the orchestrator calling these methods.

Fixed stack overflow bug caused by passing around the wrong semantic model when analyzing methods in other projects.

resolves #2031 