### PR TITLE
Incremented versions for 2.6.1 release

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -6,7 +6,8 @@
 ## Bug fixes
 - Fixed handling of function timeouts inside entity and activity functions and added tests
 - Skip constructor of AzureStorageDurabilityProvider if not used, to avoid spurious validation exceptions
-- Fixed stuck orchestration issue caused when CallEntityAsync was the first action in an orchestration and the entity completed before the orchestrator completed its first history checkpoint (fixed in DT.AzureStorage https://github.com/Azure/durabletask/pull/657)
+- Fixed stuck orchestration issue caused when CallEntityAsync was the first action in an orchestration and the entity completed before the orchestrator completed its first history checkpoint. (fixed in DT.AzureStorage https://github.com/Azure/durabletask/pull/657)
+- Fixed a Distributed Tracing bug where a StorageException would sometimes occur due to incorrect compression of the correlation field. (fixed in DT.AzureStorage https://github.com/Azure/durabletask/pull/649)
 
 ## Breaking Changes
 

--- a/release_notes.md
+++ b/release_notes.md
@@ -6,9 +6,12 @@
 ## Bug fixes
 - Fixed handling of function timeouts inside entity and activity functions and added tests
 - Skip constructor of AzureStorageDurabilityProvider if not used, to avoid spurious validation exceptions
+- Fixed stuck orchestration issue caused when CallEntityAsync was the first action in an orchestration and the entity completed before the orchestrator completed its first history checkpoint (fixed in DT.AzureStorage https://github.com/Azure/durabletask/pull/657)
 
 ## Breaking Changes
 
 - By default, `IDurableEntityClient.ListEntitiesAsync` no longer returns deleted entities.
 
 ## Dependency Updates
+Microsoft.Azure.DurableTask.AzureStorage 1.9.4 -> 1.10.1
+Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers 0.4.1 -> 0.4.2

--- a/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
+++ b/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
@@ -85,8 +85,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage" Version="1.9.4" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers" Version="0.4.1" />
+    <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage" Version="1.10.1" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers" Version="0.4.2" />
     <PackageReference Include="Azure.Identity" Version="1.1.1" />
 
     <!-- Explicitly pinned transitive dependencies with CVE vulnerabilities.-->


### PR DESCRIPTION
Incremented DurableTask.AzureStorage to 1.10.1 and the Analyzer to 0.4.2

## Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)
* [x] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk