### PR TITLE
Add SBOM to Release NuGet package

### DIFF
--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -47,6 +47,8 @@ steps:
     command: 'publish'
     publishWebProjects: false
     projects: 'src\WebJobs.Extensions.DurableTask\WebJobs.Extensions.DurableTask.csproj' 
+    configuration: Release
+    arguments: "-f netstandard2.0"
 
 #- task: PowerShell@2
 #  displayName: 'Installing ManifestTool'

--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -64,6 +64,7 @@ steps:
     publishWebProjects: false
     projects: 'src\WebJobs.Extensions.DurableTask\WebJobs.Extensions.DurableTask.csproj' 
     arguments: "-c Release -f net461"
+    zipAfterPublish: false
 
 - task: DotNetCoreCLI@2
   displayName: 'dotnet publish'
@@ -72,6 +73,7 @@ steps:
     publishWebProjects: false
     projects: 'src\WebJobs.Extensions.DurableTask\WebJobs.Extensions.DurableTask.csproj' 
     arguments: "-c Release -f netstandard2.0"
+    zipAfterPublish: false
 
 # Manifest Generator Task
 - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0

--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -64,30 +64,38 @@ steps:
     publishWebProjects: false
     projects: 'src\WebJobs.Extensions.DurableTask\WebJobs.Extensions.DurableTask.csproj' 
     configuration: Release
+    arguments: "-f net461"
+
+- task: DotNetCoreCLI@2
+  displayName: 'dotnet publish'
+  inputs:
+    command: 'publish'
+    publishWebProjects: false
+    projects: 'src\WebJobs.Extensions.DurableTask\WebJobs.Extensions.DurableTask.csproj' 
+    configuration: Release
     arguments: "-f netstandard2.0"
-
-#- task: PowerShell@2
-#  displayName: 'Installing ManifestTool'
-#  inputs:
-#    targetType: 'inline'
-#    script: 'Install-Package Microsoft.ManifestTool.CrossPlatform -MinimumVersion 2.1.15'
-
-# Generating manifest
-#- task: DotNetCoreCLI@2
-#  displayName: 'Generate manifest'
-#  inputs:
-#    command: 'custom'
-#    custom: 'Microsoft.ManifestTool.dll'
-#    arguments: '-b $(System.DefaultWorkingDirectory) -bc $(System.DefaultWorkingDirectory) -pn WebJobs.Extensions.DurableTask.nuspec'
 
 # Manifest Generator Task
 - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
   displayName: 'Manifest Generator '
   inputs:
     BuildDropPath: '$(System.DefaultWorkingDirectory)'
-    ManifestDirPath: '$(System.DefaultWorkingDirectory)\src\WebJobs.Extensions.DurableTask\bin\**\publish\'
-    PackageName: 'WebJobs.Extensions.DurableTask.nuspec'
 
+# Lists file structure for work folder (temporarily using for debugging)
+- powershell: |
+   Write-Host "Show all folder content"
+   Get-ChildItem -Path $(Agent.WorkFolder)\*.* -Recurse -Force
+  errorActionPreference: continue
+  displayName: 'PowerShell Script List folder structure'
+  continueOnError: true
+
+# Lists file structure for default working directory (temporarily using for debugging)
+- powershell: |
+   Write-Host "Show all folder content"
+   Get-ChildItem -Path $(System.DefaultWorkingDirectory)\*.* -Recurse -Force
+  errorActionPreference: continue
+  displayName: 'PowerShell Script List folder structure'
+  continueOnError: true
 - task: EsrpCodeSigning@1
   inputs:
     ConnectedServiceName: 'ESRP Service'

--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -33,6 +33,22 @@ steps:
     feedsToUse: config
     nugetConfigPath: '.nuget/nuget.config'
 
+# Lists file structure for work folder (temporarily using for debugging)
+- powershell: |
+   Write-Host "Show all folder content"
+   Get-ChildItem -Path $(Agent.WorkFolder)\*.* -Recurse -Force
+  errorActionPreference: continue
+  displayName: 'PowerShell Script List folder structure'
+  continueOnError: true
+
+# Lists file structure for default working directory (temporarily using for debugging)
+- powershell: |
+   Write-Host "Show all folder content"
+   Get-ChildItem -Path $(System.DefaultWorkingDirectory)\*.* -Recurse -Force
+  errorActionPreference: continue
+  displayName: 'PowerShell Script List folder structure'
+  continueOnError: true
+
 # Build durable-extension
 - task: VSBuild@1
   displayName: 'Build Durable Extension'
@@ -49,22 +65,6 @@ steps:
     projects: 'src\WebJobs.Extensions.DurableTask\WebJobs.Extensions.DurableTask.csproj' 
     configuration: Release
     arguments: "-f netstandard2.0"
-
-# Lists file structure for work folder (temporarily using for debugging)
-- powershell: |
-   Write-Host "Show all folder content"
-   Get-ChildItem -Path $(Agent.WorkFolder)\*.* -Recurse -Force
-  errorActionPreference: continue
-  displayName: 'PowerShell Script List folder structure'
-  continueOnError: true
-
-# Lists file structure for default working directory (temporarily using for debugging)
-- powershell: |
-   Write-Host "Show all folder content"
-   Get-ChildItem -Path $(System.DefaultWorkingDirectory)\*.* -Recurse -Force
-  errorActionPreference: continue
-  displayName: 'PowerShell Script List folder structure'
-  continueOnError: true
 
 #- task: PowerShell@2
 #  displayName: 'Installing ManifestTool'

--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -41,6 +41,25 @@ steps:
     vsVersion: "16.0"
     configuration: Release
 
+- task: DotNetCoreCLI@2
+  inputs:
+    command: 'publish'
+    publishWebProjects: true
+
+- task: PowerShell@2
+  displayName: 'Installing ManifestTool'
+  inputs:
+    targetType: 'inline'
+    script: 'Install-Package Microsoft.ManifestTool.CrossPlatform -version 2.1.15'
+
+# Generating manifest
+- task: DotNetCoreCLI@2
+  displayName: 'Generate manifest'
+  inputs:
+    command: 'custom'
+    custom: 'Microsoft.ManifestTool.dll'
+    arguments: '-b $(System.DefaultWorkingDirectory) -bc $(System.DefaultWorkingDirectory) -pn WebJobs.Extensions.DurableTask.nuspec'
+
 # Lists file structure for work folder (temporarily using for debugging)
 - powershell: |
    Write-Host "Show all folder content"
@@ -58,11 +77,11 @@ steps:
   continueOnError: true
 
 # Manifest Generator Task
-- task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
-  displayName: 'Manifest Generator '
-  inputs:
-    BuildDropPath: '$(System.DefaultWorkingDirectory)'
-    ManifestDirPath: '$(System.DefaultWorkingDirectory)'
+#- task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
+#  displayName: 'Manifest Generator '
+#  inputs:
+#    BuildDropPath: '$(System.DefaultWorkingDirectory)'
+#    ManifestDirPath: '$(System.DefaultWorkingDirectory)'
 
 - task: EsrpCodeSigning@1
   inputs:

--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -46,7 +46,7 @@ steps:
   displayName: 'Manifest Generator '
   inputs:
     BuildDropPath: '$(System.DefaultWorkingDirectory)'
-    ManifestDirPath: '$(System.DefaultWorkingDirectory)/azure-functions-durable-extension'
+    ManifestDirPath: '**/azure-functions-durable-extension'
 
 - task: EsrpCodeSigning@1
   inputs:

--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -46,6 +46,7 @@ steps:
   inputs:
     command: 'publish'
     publishWebProjects: true
+    arguments: '**/WebJobs.Extensions.DurableTask.sln'
 
 #- task: PowerShell@2
 #  displayName: 'Installing ManifestTool'

--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -42,6 +42,7 @@ steps:
     configuration: Release
 
 - task: DotNetCoreCLI@2
+  displayName: 'dotnet publish'
   inputs:
     command: 'publish'
     publishWebProjects: true
@@ -50,7 +51,7 @@ steps:
   displayName: 'Installing ManifestTool'
   inputs:
     targetType: 'inline'
-    script: 'Install-Package Microsoft.ManifestTool.CrossPlatform -version 2.1.15'
+    script: 'Install-Package Microsoft.ManifestTool.CrossPlatform -MinimumVersion 2.1.15'
 
 # Generating manifest
 - task: DotNetCoreCLI@2

--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -69,7 +69,7 @@ steps:
   displayName: 'Manifest Generator '
   inputs:
     BuildDropPath: '$(System.DefaultWorkingDirectory)'
-    ManifestDirPath: '$(System.DefaultWorkingDirectory)'
+    ManifestDirPath: '$(System.DefaultWorkingDirectory)\src\WebJobs.Extensions.DurableTask\bin\Debug\netstandard2.0\publish\'
 
 # Lists file structure for work folder (temporarily using for debugging)
 - powershell: |

--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -136,7 +136,7 @@ steps:
     MaxRetryAttempts: '5'
 
 # Make the nuget packages available for download in the ADO portal UI
-- publish: '$(System.DefaultWorkingDirectory)'
+- publish: '$(System.DefaultWorkingDirectory)/azure-functions-durable-extension'
   displayName: 'Publish nuget packages to Artifacts'
   artifact: PackageOutput
 

--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -41,6 +41,22 @@ steps:
     vsVersion: "16.0"
     configuration: Release
 
+# Lists file structure for work folder (temporarily using for debugging)
+- powershell: |
+   Write-Host "Show all folder content"
+   Get-ChildItem -Path $(Agent.WorkFolder)\*.* -Recurse -Force
+  errorActionPreference: continue
+  displayName: 'PowerShell Script List folder structure'
+  continueOnError: true
+
+# Lists file structure for default working directory (temporarily using for debugging)
+- powershell: |
+   Write-Host "Show all folder content"
+   Get-ChildItem -Path $(System.DefaultWorkingDirectory)\*.* -Recurse -Force
+  errorActionPreference: continue
+  displayName: 'PowerShell Script List folder structure'
+  continueOnError: true
+
 # Manifest Generator Task
 - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
   displayName: 'Manifest Generator '

--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -45,8 +45,8 @@ steps:
   displayName: 'dotnet publish'
   inputs:
     command: 'publish'
-    publishWebProjects: true
-    arguments: '**/WebJobs.Extensions.DurableTask.sln'
+    publishWebProjects: false
+    projects: 'src\WebJobs.Extensions.DurableTask\WebJobs.Extensions.DurableTask.csproj' 
 
 #- task: PowerShell@2
 #  displayName: 'Installing ManifestTool'

--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -62,7 +62,7 @@ steps:
   displayName: 'Manifest Generator '
   inputs:
     BuildDropPath: '$(System.DefaultWorkingDirectory)'
-    ManifestDirPath: '**/azure-functions-durable-extension'
+    ManifestDirPath: '$(System.DefaultWorkingDirectory)'
 
 - task: EsrpCodeSigning@1
   inputs:

--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -41,6 +41,13 @@ steps:
     vsVersion: "16.0"
     configuration: Release
 
+# Manifest Generator Task
+- task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
+  displayName: 'Manifest Generator '
+  inputs:
+    BuildDropPath: '$(System.DefaultWorkingDirectory)'
+    ManifestDirPath: '$(System.DefaultWorkingDirectory)/azure-functions-durable-extension'
+
 - task: EsrpCodeSigning@1
   inputs:
     ConnectedServiceName: 'ESRP Service'
@@ -127,12 +134,6 @@ steps:
     SessionTimeout: '60'
     MaxConcurrency: '50'
     MaxRetryAttempts: '5'
-
-# Manifest Generator Task
-- task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
-  displayName: 'Manifest Generator '
-  inputs:
-    BuildDropPath: '$(System.DefaultWorkingDirectory)'
 
 # Make the nuget packages available for download in the ADO portal UI
 - publish: '$(System.DefaultWorkingDirectory)'

--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -50,6 +50,22 @@ steps:
     configuration: Release
     arguments: "-f netstandard2.0"
 
+# Lists file structure for work folder (temporarily using for debugging)
+- powershell: |
+   Write-Host "Show all folder content"
+   Get-ChildItem -Path $(Agent.WorkFolder)\*.* -Recurse -Force
+  errorActionPreference: continue
+  displayName: 'PowerShell Script List folder structure'
+  continueOnError: true
+
+# Lists file structure for default working directory (temporarily using for debugging)
+- powershell: |
+   Write-Host "Show all folder content"
+   Get-ChildItem -Path $(System.DefaultWorkingDirectory)\*.* -Recurse -Force
+  errorActionPreference: continue
+  displayName: 'PowerShell Script List folder structure'
+  continueOnError: true
+
 #- task: PowerShell@2
 #  displayName: 'Installing ManifestTool'
 #  inputs:
@@ -69,23 +85,8 @@ steps:
   displayName: 'Manifest Generator '
   inputs:
     BuildDropPath: '$(System.DefaultWorkingDirectory)'
-    ManifestDirPath: '$(System.DefaultWorkingDirectory)\src\WebJobs.Extensions.DurableTask\bin\Debug\netstandard2.0\publish\'
-
-# Lists file structure for work folder (temporarily using for debugging)
-- powershell: |
-   Write-Host "Show all folder content"
-   Get-ChildItem -Path $(Agent.WorkFolder)\*.* -Recurse -Force
-  errorActionPreference: continue
-  displayName: 'PowerShell Script List folder structure'
-  continueOnError: true
-
-# Lists file structure for default working directory (temporarily using for debugging)
-- powershell: |
-   Write-Host "Show all folder content"
-   Get-ChildItem -Path $(System.DefaultWorkingDirectory)\*.* -Recurse -Force
-  errorActionPreference: continue
-  displayName: 'PowerShell Script List folder structure'
-  continueOnError: true
+    ManifestDirPath: '$(System.DefaultWorkingDirectory)\src\WebJobs.Extensions.DurableTask\bin\**\publish\'
+    PackageName: 'WebJobs.Extensions.DurableTask.nuspec'
 
 - task: EsrpCodeSigning@1
   inputs:

--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -33,22 +33,6 @@ steps:
     feedsToUse: config
     nugetConfigPath: '.nuget/nuget.config'
 
-# Lists file structure for work folder (temporarily using for debugging)
-- powershell: |
-   Write-Host "Show all folder content"
-   Get-ChildItem -Path $(Agent.WorkFolder)\*.* -Recurse -Force
-  errorActionPreference: continue
-  displayName: 'PowerShell Script List folder structure'
-  continueOnError: true
-
-# Lists file structure for default working directory (temporarily using for debugging)
-- powershell: |
-   Write-Host "Show all folder content"
-   Get-ChildItem -Path $(System.DefaultWorkingDirectory)\*.* -Recurse -Force
-  errorActionPreference: continue
-  displayName: 'PowerShell Script List folder structure'
-  continueOnError: true
-
 # Build durable-extension
 - task: VSBuild@1
   displayName: 'Build Durable Extension'
@@ -81,21 +65,6 @@ steps:
   inputs:
     BuildDropPath: '$(System.DefaultWorkingDirectory)'
 
-# Lists file structure for work folder (temporarily using for debugging)
-- powershell: |
-   Write-Host "Show all folder content"
-   Get-ChildItem -Path $(Agent.WorkFolder)\*.* -Recurse -Force
-  errorActionPreference: continue
-  displayName: 'PowerShell Script List folder structure'
-  continueOnError: true
-
-# Lists file structure for default working directory (temporarily using for debugging)
-- powershell: |
-   Write-Host "Show all folder content"
-   Get-ChildItem -Path $(System.DefaultWorkingDirectory)\*.* -Recurse -Force
-  errorActionPreference: continue
-  displayName: 'PowerShell Script List folder structure'
-  continueOnError: true
 - task: EsrpCodeSigning@1
   inputs:
     ConnectedServiceName: 'ESRP Service'

--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -63,8 +63,7 @@ steps:
     command: 'publish'
     publishWebProjects: false
     projects: 'src\WebJobs.Extensions.DurableTask\WebJobs.Extensions.DurableTask.csproj' 
-    configuration: Release
-    arguments: "-f net461"
+    arguments: "-c Release -f net461"
 
 - task: DotNetCoreCLI@2
   displayName: 'dotnet publish'
@@ -72,8 +71,7 @@ steps:
     command: 'publish'
     publishWebProjects: false
     projects: 'src\WebJobs.Extensions.DurableTask\WebJobs.Extensions.DurableTask.csproj' 
-    configuration: Release
-    arguments: "-f netstandard2.0"
+    arguments: "-c Release -f netstandard2.0"
 
 # Manifest Generator Task
 - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0

--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -47,19 +47,26 @@ steps:
     command: 'publish'
     publishWebProjects: true
 
-- task: PowerShell@2
-  displayName: 'Installing ManifestTool'
-  inputs:
-    targetType: 'inline'
-    script: 'Install-Package Microsoft.ManifestTool.CrossPlatform -MinimumVersion 2.1.15'
+#- task: PowerShell@2
+#  displayName: 'Installing ManifestTool'
+#  inputs:
+#    targetType: 'inline'
+#    script: 'Install-Package Microsoft.ManifestTool.CrossPlatform -MinimumVersion 2.1.15'
 
 # Generating manifest
-- task: DotNetCoreCLI@2
-  displayName: 'Generate manifest'
+#- task: DotNetCoreCLI@2
+#  displayName: 'Generate manifest'
+#  inputs:
+#    command: 'custom'
+#    custom: 'Microsoft.ManifestTool.dll'
+#    arguments: '-b $(System.DefaultWorkingDirectory) -bc $(System.DefaultWorkingDirectory) -pn WebJobs.Extensions.DurableTask.nuspec'
+
+# Manifest Generator Task
+- task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
+  displayName: 'Manifest Generator '
   inputs:
-    command: 'custom'
-    custom: 'Microsoft.ManifestTool.dll'
-    arguments: '-b $(System.DefaultWorkingDirectory) -bc $(System.DefaultWorkingDirectory) -pn WebJobs.Extensions.DurableTask.nuspec'
+    BuildDropPath: '$(System.DefaultWorkingDirectory)'
+    ManifestDirPath: '$(System.DefaultWorkingDirectory)'
 
 # Lists file structure for work folder (temporarily using for debugging)
 - powershell: |
@@ -76,13 +83,6 @@ steps:
   errorActionPreference: continue
   displayName: 'PowerShell Script List folder structure'
   continueOnError: true
-
-# Manifest Generator Task
-#- task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
-#  displayName: 'Manifest Generator '
-#  inputs:
-#    BuildDropPath: '$(System.DefaultWorkingDirectory)'
-#    ManifestDirPath: '$(System.DefaultWorkingDirectory)'
 
 - task: EsrpCodeSigning@1
   inputs:

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net461.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask-net461.xml
@@ -2354,7 +2354,7 @@
         </member>
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.EntityQuery.IncludeDeleted">
             <summary>
-            Determines whether the query will include deleted entities.
+            Determines whether the results should include recently deleted entities.
             </summary>
         </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.EntityQueryResult">
@@ -2644,7 +2644,7 @@
         </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.RequestMessage">
             <summary>
-            A message that represents an operation request or a lock request.
+            A message sent to an entity, such as operation, signal, lock, release, or continue messages.
             </summary>
         </member>
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.RequestMessage.Operation">
@@ -2729,6 +2729,11 @@
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.SchedulerState.LockedBy">
             <summary>
             The instance id of the orchestration that currently holds the lock of this entity.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.SchedulerState.Suspended">
+            <summary>
+            Whether processing on this entity is currently suspended.
             </summary>
         </member>
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.SchedulerState.MessageSorter">
@@ -3760,6 +3765,18 @@
             </list>
             </remarks>
         </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskOptions.MaxEntityOperationBatchSize">
+            <summary>
+            Gets or sets the maximum number of entity operations that are processed as a single batch.
+            </summary>
+            <remarks>
+            Reducing this number can help to avoid timeouts on consumption plans. If set to 1, batching is disabled, and each operation
+            message executes and is billed as a separate function invocation.
+            </remarks>
+            <value>
+            A positive integer configured by the host.
+            </value>
+        </member>
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskOptions.ExtendedSessionsEnabled">
             <summary>
             Gets or sets a flag indicating whether to enable extended sessions.
@@ -4048,8 +4065,12 @@
         </member>
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.OrchestrationStatusQueryCondition.PageSize">
             <summary>
-            Number of records per one request. The default value is 100.
+            Maximum number of records that can be returned by the request. The default value is 100.
             </summary>
+            <remarks>
+            Requests may return fewer records than the specified page size, even if there are more records.
+            Always check the continuation token to determine whether there are more records.
+            </remarks>
         </member>
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.OrchestrationStatusQueryCondition.ContinuationToken">
             <summary>

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
@@ -2607,7 +2607,7 @@
         </member>
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.EntityQuery.IncludeDeleted">
             <summary>
-            Determines whether the query will include deleted entities.
+            Determines whether the results should include recently deleted entities.
             </summary>
         </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.EntityQueryResult">
@@ -2897,7 +2897,7 @@
         </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.RequestMessage">
             <summary>
-            A message that represents an operation request or a lock request.
+            A message sent to an entity, such as operation, signal, lock, release, or continue messages.
             </summary>
         </member>
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.RequestMessage.Operation">
@@ -2982,6 +2982,11 @@
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.SchedulerState.LockedBy">
             <summary>
             The instance id of the orchestration that currently holds the lock of this entity.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.SchedulerState.Suspended">
+            <summary>
+            Whether processing on this entity is currently suspended.
             </summary>
         </member>
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.SchedulerState.MessageSorter">
@@ -4042,6 +4047,18 @@
             </list>
             </remarks>
         </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskOptions.MaxEntityOperationBatchSize">
+            <summary>
+            Gets or sets the maximum number of entity operations that are processed as a single batch.
+            </summary>
+            <remarks>
+            Reducing this number can help to avoid timeouts on consumption plans. If set to 1, batching is disabled, and each operation
+            message executes and is billed as a separate function invocation.
+            </remarks>
+            <value>
+            A positive integer configured by the host.
+            </value>
+        </member>
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskOptions.ExtendedSessionsEnabled">
             <summary>
             Gets or sets a flag indicating whether to enable extended sessions.
@@ -4343,8 +4360,12 @@
         </member>
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.OrchestrationStatusQueryCondition.PageSize">
             <summary>
-            Number of records per one request. The default value is 100.
+            Maximum number of records that can be returned by the request. The default value is 100.
             </summary>
+            <remarks>
+            Requests may return fewer records than the specified page size, even if there are more records.
+            Always check the continuation token to determine whether there are more records.
+            </remarks>
         </member>
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.OrchestrationStatusQueryCondition.ContinuationToken">
             <summary>

--- a/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
+++ b/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
@@ -109,8 +109,6 @@
     <RepositoryUrl>https://github.com/Azure/azure-functions-durable-extension/</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <NuspecFile>WebJobs.Extensions.DurableTask.nuspec</NuspecFile>
-    <NuspecProperties>configuration=$(Configuration);targetFramework=$(TargetFramework);version=$(Version)</NuspecProperties>
   </PropertyGroup>
 
 </Project>

--- a/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
+++ b/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
@@ -109,6 +109,8 @@
     <RepositoryUrl>https://github.com/Azure/azure-functions-durable-extension/</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <NuspecFile>WebJobs.Extensions.DurableTask.nuspec</NuspecFile>
+    <NuspecProperties>configuration=$(Configuration);targetFramework=$(TargetFramework);version=$(Version)</NuspecProperties>
   </PropertyGroup>
 
 </Project>

--- a/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
+++ b/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
@@ -108,7 +108,13 @@
     <IncludeReferenceProjects>true</IncludeReferenceProjects>
     <RepositoryUrl>https://github.com/Azure/azure-functions-durable-extension/</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)'=='Debug'">
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)'=='Release'">
     <NuspecFile>WebJobs.Extensions.DurableTask.nuspec</NuspecFile>
     <NuspecProperties>configuration=$(Configuration);targetFramework=$(TargetFramework);version=$(Version)</NuspecProperties>
   </PropertyGroup>

--- a/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.nuspec
+++ b/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.nuspec
@@ -17,8 +17,14 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
     <description>Azure WebJobs SDK Extension for the Durable Task Framework</description>
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <tags>azure,functions,azure-function,durable-functions</tags>
+    <dependencies>
+      <group targetFramework=".NETFramework4.6.1" />
+      <group targetFramework=".NETStandard2.0" />
+    </dependencies>
   </metadata>
   <files>
-    <file src="..\WebJobs.Extensions.DurableTask\" target="contentFiles\any"/>
+    <file src=".\bin\$configuration$\net461\publish\**" target="lib/net461"/>
+    <file src=".\bin\$configuration$\netstandard2.0\publish\**" target="lib/netstandard2.0"/>
+    <file src="..\_manifest\**" target="content/manifest"/>
   </files>
 </package>

--- a/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.nuspec
+++ b/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.nuspec
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+Copyright (c) Microsoft. All rights reserved.
+Licensed under the MIT license. See LICENSE file in the project root for full license information.
+-->
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+  <metadata>
+    <id>WebJobs.Extensions.DurableTask</id>
+    <!-- Needed to specify the version here for the nuspec to be valid -->
+    <version>$version$</version>
+    <title>Azure Functions Durable Task Extension</title>
+    <authors>Microsoft</authors>
+    <owners>Microsoft</owners>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <license type="expression">MIT</license>
+    <projectUrl>https://github.com/Azure/azure-functions-durable-extension</projectUrl>
+    <description>Azure WebJobs SDK Extension for the Durable Task Framework</description>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <tags>azure,functions,azure-function,durable-functions</tags>
+  </metadata>
+  <files>
+    <file src="..\src\WebJobs.Extensions.DurableTask\bin\$configuration$\$targetFramework$\publish\**\*" target="contentFiles\any"/>
+  </files>
+</package>

--- a/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.nuspec
+++ b/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.nuspec
@@ -25,6 +25,6 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
   <files>
     <file src=".\bin\$configuration$\net461\publish\**" target="lib/net461"/>
     <file src=".\bin\$configuration$\netstandard2.0\publish\**" target="lib/netstandard2.0"/>
-    <file src="..\..\_manifest\**" target="content/manifest"/>
+    <file src="..\..\_manifest\**" target="content/SBOM"/>
   </files>
 </package>

--- a/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.nuspec
+++ b/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.nuspec
@@ -19,6 +19,6 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
     <tags>azure,functions,azure-function,durable-functions</tags>
   </metadata>
   <files>
-    <file src="..\WebJobs.Extensions.DurableTask\bin\$configuration$\$targetFramework$\publish\**\*" target="contentFiles\any"/>
+    <file src="..\WebJobs.Extensions.DurableTask\" target="contentFiles\any"/>
   </files>
 </package>

--- a/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.nuspec
+++ b/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.nuspec
@@ -19,6 +19,6 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
     <tags>azure,functions,azure-function,durable-functions</tags>
   </metadata>
   <files>
-    <file src="..\src\WebJobs.Extensions.DurableTask\bin\$configuration$\$targetFramework$\publish\**\*" target="contentFiles\any"/>
+    <file src="**\WebJobs.Extensions.DurableTask\bin\$configuration$\$targetFramework$\publish\**\*" target="contentFiles\any"/>
   </files>
 </package>

--- a/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.nuspec
+++ b/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.nuspec
@@ -19,6 +19,6 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
     <tags>azure,functions,azure-function,durable-functions</tags>
   </metadata>
   <files>
-    <file src="**\WebJobs.Extensions.DurableTask\bin\$configuration$\$targetFramework$\publish\**\*" target="contentFiles\any"/>
+    <file src="\WebJobs.Extensions.DurableTask\bin\$configuration$\$targetFramework$\publish\**\*" target="contentFiles\any"/>
   </files>
 </package>

--- a/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.nuspec
+++ b/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.nuspec
@@ -19,6 +19,6 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
     <tags>azure,functions,azure-function,durable-functions</tags>
   </metadata>
   <files>
-    <file src="\WebJobs.Extensions.DurableTask\bin\$configuration$\$targetFramework$\publish\**\*" target="contentFiles\any"/>
+    <file src="..\WebJobs.Extensions.DurableTask\bin\$configuration$\$targetFramework$\publish\**\*" target="contentFiles\any"/>
   </files>
 </package>

--- a/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.nuspec
+++ b/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.nuspec
@@ -25,6 +25,6 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
   <files>
     <file src=".\bin\$configuration$\net461\publish\**" target="lib/net461"/>
     <file src=".\bin\$configuration$\netstandard2.0\publish\**" target="lib/netstandard2.0"/>
-    <file src="..\_manifest\**" target="content/manifest"/>
+    <file src="..\..\_manifest\**" target="content/manifest"/>
   </files>
 </package>


### PR DESCRIPTION
This PR adds the SBOM manifest to the release NuGet package. It adds a `dotnet publish` step and moves the manifest generator step to come before the `dotnet pack` step. It also adds a .nuspec file that specifies the additional files that need to get added to the NuGet package during `dotnet pack`.

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)
* [x] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk
* [x] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
    * [ ] Otherwise: major or minor version updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
