### PR TITLE
[Do not merge] Add instrumentation to debug "stuck" sub-orchestrations

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
@@ -820,6 +820,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
             if (!context.IsCompleted && !context.IsLongRunningTimer)
             {
+                this.TraceHelper.ExtensionInformationalEvent(
+                   context.HubName,
+                   context.InstanceId,
+                   context.Name,
+                   $"INSTRUMENTATION: Orchestration awaiting. IsCompleted: {context.IsCompleted} | IsLongRunningTimer: {context.IsLongRunningTimer}",
+                   true);
+
                 this.TraceHelper.FunctionAwaited(
                     context.HubName,
                     context.Name,

--- a/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
@@ -825,7 +825,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                    context.InstanceId,
                    context.Name,
                    $"INSTRUMENTATION: Orchestration awaiting. IsCompleted: {context.IsCompleted} | IsLongRunningTimer: {context.IsLongRunningTimer}",
-                   true);
+                   false);
 
                 this.TraceHelper.FunctionAwaited(
                     context.HubName,

--- a/src/WebJobs.Extensions.DurableTask/Listener/TaskOrchestrationShim.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/TaskOrchestrationShim.cs
@@ -207,7 +207,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                    this.context.InstanceId,
                    this.context.Name,
                    $"INSTRUMENTATION: in `finally` statement, `isCompleted` set to `true`.",
-                   true);
+                   false);
+
                 this.context.IsCompleted = true;
             }
         }

--- a/src/WebJobs.Extensions.DurableTask/Listener/TaskOrchestrationShim.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/TaskOrchestrationShim.cs
@@ -202,6 +202,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             }
             finally
             {
+                this.config.TraceHelper.ExtensionInformationalEvent(
+                   this.context.HubName,
+                   this.context.InstanceId,
+                   this.context.Name,
+                   $"INSTRUMENTATION: in `finally` statement, `isCompleted` set to `true`.",
+                   true);
                 this.context.IsCompleted = true;
             }
         }


### PR DESCRIPTION
_**Do not merge, for discussion only**_
Related: https://github.com/Azure/azure-functions-durable-extension/issues/2133, https://github.com/Azure/azure-functions-durable-extension/issues/2135

We recently received a few incident reports (internal and external) describing orchestrations that randomly started getting "stuck" in the past few months. They all share a few similarities:
* These orchestrations technically complete all work that they scheduled, but in their last replay they fail to actually change their status from "Running" to "Completed"
* These orchestrations all seem to log "FunctionAwaited" in their last replay, but schedule no new tasks
* As far as I can tell, these orchestrations all log the following sequence of telemetry events in their last replay: "OrchestrationExecuting, FunctionAwaited, OrchestrationExecuted, FunctionCompleted, ...". As far as I'm aware, we should not see `FunctionAwaited` and `FunctionCompleted` in the same replay, so something appears to have gone wrong.

From discussion with @cgillum, it seems that behavior like this would normally occur if an "illegal await" took place in the orchestration code, i.e that a non-durable API was awaited. So far, from the user code we've seen, we have gathered no evidence of this being the case.

To help us gather more evidence, I'm hoping to create an instrumented _private_ release to help us track what path the extension (and maybe DTFx) is taking. I added two new logs in areas I thought were relevant, but I could use more help in finding more.

Can folks point me to areas of the code where we could detect / gather more context around illegal awaits? Thanks!

