### PR TITLE
Fixed a regression in Functions v3

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/WebJobsConnectionInfoProvider.cs
+++ b/src/WebJobs.Extensions.DurableTask/WebJobsConnectionInfoProvider.cs
@@ -22,19 +22,43 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         {
             this.hostConfiguration = hostConfiguration ?? throw new ArgumentNullException(nameof(hostConfiguration));
         }
+#endif
 
         /// <inheritdoc />
         public IConfigurationSection Resolve(string name)
         {
-            return this.hostConfiguration.GetWebJobsConnectionSection(name);
-        }
-#else
-        /// <inheritdoc />
-        public IConfigurationSection Resolve(string name)
-        {
+#if FUNCTIONS_V1
             // The returned key doesn't reflect whether the ConnectionString section was used or if the name was ultimately prefixed.
             return new ReadOnlyConfigurationValue(name, Host.AmbientConnectionStringProvider.Instance.GetConnectionString(name));
-        }
+#elif NET6_0_OR_GREATER
+            return this.hostConfiguration.GetWebJobsConnectionSection(name);
+#else
+            // The below represents the implementation of this.hostConfiguration.GetWebJobsConnectionSection(name), defined in the WebJobs SDK
+            // but not available to Functions v3 at runtime.
+            // Source: https://github.com/Azure/azure-webjobs-sdk/blob/b6d5b52da5d2fb457efbf359cbdd733186aacf7c/src/Microsoft.Azure.WebJobs.Host/Extensions/IConfigurationExtensions.cs#L103-L133
+            static IConfigurationSection GetConnectionStringOrSettingSection(IConfiguration configuration, string connectionName)
+            {
+                IConfigurationSection connectionStringSection = configuration?.GetSection("ConnectionStrings").GetSection(connectionName);
+
+                if (connectionStringSection.Exists())
+                {
+                    return connectionStringSection;
+                }
+
+                return configuration?.GetSection(connectionName);
+            }
+
+            string prefixedConnectionStringName = IConfigurationExtensions.GetPrefixedConnectionStringName(name);
+            IConfigurationSection section = GetConnectionStringOrSettingSection(this.hostConfiguration, prefixedConnectionStringName);
+
+            if (!section.Exists())
+            {
+                // next try a direct unprefixed lookup
+                section = GetConnectionStringOrSettingSection(this.hostConfiguration, name);
+            }
+
+            return section;
 #endif
+        }
     }
 }


### PR DESCRIPTION
Manual testing on Functions v3 revealed a runtime issue related to the managed identity PR.  The issue is that a particular API (`GetWebJobsConnectionSection`) in the WebJobs SDK can be compiled against but doesn't exist at runtime. This seems to be a problem with the WebJobs SDK or perhaps the packaging of the Functions core tools. Regardless, this PR works around the problem by copying the WebJobs SDK code that we rely on.

The issue only impacts Functions v3. Functions v4 (running on .NET 6) works fine as-is. The conditional compilation flags attempt to isolate the workaround to just Functions v3.

FYI @wsugarman, who helped me identify this workaround. 