### PR TITLE
Send Default Async HTTP Request Sleep Time in OOProc Payload

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/Bindings/OrchestrationTriggerAttributeBindingProvider.cs
+++ b/src/WebJobs.Extensions.DurableTask/Bindings/OrchestrationTriggerAttributeBindingProvider.cs
@@ -210,7 +210,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     new JProperty("parentInstanceId", arg.ParentInstanceId),
                     new JProperty("upperSchemaVersion", SchemaVersion.V3),
                     new JProperty("longRunningTimerIntervalDuration", arg.LongRunningTimerIntervalLength),
-                    new JProperty("maximumShortTimerDuration", arg.MaximumShortTimerDuration));
+                    new JProperty("maximumShortTimerDuration", arg.MaximumShortTimerDuration),
+                    new JProperty("defaultHttpAsyncRequestSleepTimeMillseconds", arg.DefaultHttpAsyncRequestSleepTimeMillseconds));
                 return contextObject.ToString();
             }
         }

--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableOrchestrationContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableOrchestrationContext.cs
@@ -97,6 +97,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             }
         }
 
+        internal int DefaultHttpAsyncRequestSleepTimeMillseconds
+        {
+            get
+            {
+                return this.Config.Options.HttpSettings.DefaultAsyncRequestSleepTimeMilliseconds;
+            }
+        }
+
         internal bool ContinuedAsNew { get; private set; }
 
         internal bool IsCompleted { get; set; }


### PR DESCRIPTION
Send `Config.Options.HttpSettings.DefaultAsyncRequestSleepTimeMilliseconds`, which is used to determine the default time to wait between requests when doing HTTP polling, in the payload to out of proc SDKs. This allows OOProc SDKs to recreate extension behavior to implement callHttp polling for OOProc languages


### Issue describing the changes in this PR
Unblocks https://github.com/Azure/azure-functions-durable-js/issues/284, JS SDK PR: https://github.com/Azure/azure-functions-durable-js/pull/346

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)
* [ ] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [x] Otherwise: That work is being tracked here: https://github.com/Azure/azure-functions-durable-js/pull/346
* [x] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
    * [ ] Otherwise: major or minor version updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
