### PR TITLE
Ensure backwards compat in upperSchemaVersion handling

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/Bindings/OrchestrationTriggerAttributeBindingProvider.cs
+++ b/src/WebJobs.Extensions.DurableTask/Bindings/OrchestrationTriggerAttributeBindingProvider.cs
@@ -207,7 +207,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     new JProperty("instanceId", arg.InstanceId),
                     new JProperty("isReplaying", arg.IsReplaying),
                     new JProperty("parentInstanceId", arg.ParentInstanceId),
-                    new JProperty("upperSchemaVersion", SchemaVersion.V3),
+                    new JProperty("upperSchemaVersion", SchemaVersion.V2),
+                    // due to Python only supporting up to SchemaVersion V2 from versions 1.1.0 to 1.1.3, we need a new upperSchemaVersion field
+                    // to track schema values larger than V2. This is for backwards compatibility only.
+                    new JProperty("upperSchemaVersionNew", SchemaVersion.V3),
                     new JProperty("longRunningTimerIntervalDuration", arg.LongRunningTimerIntervalLength),
                     new JProperty("maximumShortTimerDuration", arg.MaximumShortTimerDuration),
                     new JProperty("defaultHttpAsyncRequestSleepTimeMillseconds", arg.DefaultHttpAsyncRequestSleepTimeMillseconds));

--- a/src/WebJobs.Extensions.DurableTask/Bindings/OrchestrationTriggerAttributeBindingProvider.cs
+++ b/src/WebJobs.Extensions.DurableTask/Bindings/OrchestrationTriggerAttributeBindingProvider.cs
@@ -201,6 +201,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 var history = JArray.FromObject(arg.History);
                 var input = arg.GetInputAsJson();
 
+                // due to Python only supporting up to SchemaVersion V2 from SDK versions 1.1.0 to 1.1.3,
+                // we need a new upperSchemaVersion field  to track schema values larger than V2.
+                // This is for backwards compatibility only, and should be dropped in a new major release.
                 var contextObject = new JObject(
                     new JProperty("history", history),
                     new JProperty("input", input),
@@ -208,8 +211,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     new JProperty("isReplaying", arg.IsReplaying),
                     new JProperty("parentInstanceId", arg.ParentInstanceId),
                     new JProperty("upperSchemaVersion", SchemaVersion.V2),
-                    // due to Python only supporting up to SchemaVersion V2 from versions 1.1.0 to 1.1.3, we need a new upperSchemaVersion field
-                    // to track schema values larger than V2. This is for backwards compatibility only.
                     new JProperty("upperSchemaVersionNew", SchemaVersion.V3),
                     new JProperty("longRunningTimerIntervalDuration", arg.LongRunningTimerIntervalLength),
                     new JProperty("maximumShortTimerDuration", arg.MaximumShortTimerDuration),


### PR DESCRIPTION
<!-- Start the PR description with some context for the change. -->
Currently, Python SDK versions 1.1.0 to 1.1.3 only handle `upperSchemaVersion` values of 0 (V1) and 1 (V2). This is a problem, because `upperSchemaVersion` was supposed to support arbitrary integers to denote replay protocol versions and we just implemented `upperSchemaVersion.V3` in the Extension.

Technically speaking, the error is due to a bug in the Python SDK. However, due to the auto-upgrading nature of Bundles, I think it's important to consider how to avoid impacting existing SDKs when we're making a minor Extension release. This PR proposes one way to do that.

Essentially, we're "deprecating" the `upperSchemaVersion` field sent to the SDKs and instead utilizing a new field `newUpperSchemaVersion` to include protocol versions larger than V2. This will give the Python SDK the possibility of supporting new replay schemas without prevent older SDK releases from working with Extension Bundles.

Since this change is so minimal, I think we could include this change without needing to re-run all the validation work for Extension release `2.7.0`. The only affected path should be the OOProc smoke tests, which can be executed easily.  Alternatively, we can always make a `2.7.1` hotpatch release with this change after `2.7.0` is out. 

<!-- Make sure to delete the markdown comments and the below sections when squash merging -->
### Issue describing the changes in this PR

Related to # https://github.com/Azure/azure-functions-durable-python/issues/368 and https://github.com/Azure/azure-functions-durable-extension/issues/2138

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)
* [x] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk
* [x] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
    * [ ] Otherwise: major or minor version updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
