### PR TITLE
Enable WebJobs-initiated cancellation of orchestrators

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
@@ -783,7 +783,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                         InvokeHandler = async userCodeInvoker =>
                         {
                             // We yield control to ensure this code is executed asynchronously relative to WebJobs.
-                            // This ensures WebJobs is able to offload orchestrator code in the case of a timeout.
+                            // This ensures WebJobs is able to correctly cancel the invocation in the case of a timeout.
+
                             await Task.Yield();
                             context.ExecutorCalledBack = true;
 

--- a/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
@@ -782,6 +782,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 #pragma warning disable CS0618 // Approved for use by this extension
                         InvokeHandler = async userCodeInvoker =>
                         {
+                            // We yield control to ensure this code is executed asynchronously relative to WebJobs.
+                            // This ensures WebJobs is able to offload orchestrator code in the case of a timeout.
+                            await Task.Yield();
                             context.ExecutorCalledBack = true;
 
                             // 2. Configure the shim with the inner invoker to execute the user code.

--- a/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
@@ -808,7 +808,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
                 if (result.ExecutionStatus == WrappedFunctionResult.FunctionResultStatus.FunctionsRuntimeError
                     || result.ExecutionStatus == WrappedFunctionResult.FunctionResultStatus.FunctionsHostStoppingError
-                    || result.ExecutionSTatus == WrappedFunctionResult.FunctionResultStatus.FunctionTimeoutError)
+                    || result.ExecutionStatus == WrappedFunctionResult.FunctionResultStatus.FunctionTimeoutError)
                 {
                     this.TraceHelper.FunctionAborted(
                         this.Options.HubName,

--- a/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
@@ -807,7 +807,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     this.HostLifetimeService.OnStopping);
 
                 if (result.ExecutionStatus == WrappedFunctionResult.FunctionResultStatus.FunctionsRuntimeError
-                    || result.ExecutionStatus == WrappedFunctionResult.FunctionResultStatus.FunctionsHostStoppingError)
+                    || result.ExecutionStatus == WrappedFunctionResult.FunctionResultStatus.FunctionsHostStoppingError
+                    || result.ExecutionSTatus == WrappedFunctionResult.FunctionResultStatus.FunctionTimeoutError)
                 {
                     this.TraceHelper.FunctionAborted(
                         this.Options.HubName,


### PR DESCRIPTION
<!-- Start the PR description with some context for the change. -->

**The Problem**
Currently, orchestrator code is capable of blocking the WebJobs invocation thread. This prevents WebJobs from issuing a Timeout signal (and other cancellation requests) to the Durable Extension. 

A simple way to reproduce this behavior is by creating an orchestrator that spins in an infinite while loop and to set the Functions timeout to a small number, like 30 seconds. After 30 seconds, the Host will log that it is initiating a cancellation of the orchestrator code, but the orchestrator will remain executing until the Host is forcibly shut down.

For other Function types, including Activities, the Functions Host will shut down quickly on its own after a cancellation is issued.

**Root cause**
This behavior occurs due to an edge case in the WebJobs SDK. See below the WebJobs implementation of a Function invocation with timeout.

[Source code](https://github.com/Azure/azure-webjobs-sdk/blob/4e287eb443e2445a298a8a959f7cd01efc46e2c9/src/Microsoft.Azure.WebJobs.Host/Executors/FunctionExecutor.cs#L553-L580)
```CSharp
        internal static async Task<object> InvokeWithTimeoutAsync(IFunctionInvoker invoker, ParameterHelper parameterHelper, CancellationTokenSource timeoutTokenSource,
            CancellationTokenSource functionCancellationTokenSource, bool throwOnTimeout, TimeSpan timerInterval, IFunctionInstance instance)
        {
            Task<object> invokeTask = invoker.InvokeAsync(parameterHelper.JobInstance, parameterHelper.InvokeParameters);


            if (timerInterval > TimeSpan.Zero)
            {
                // There are three ways the function can complete:
                //   1. The invokeTask itself completes first.
                //   2. A cancellation is requested (by host.Stop(), for example).
                //      a. Continue waiting for the invokeTask to complete. Either #1 or #3 will occur.
                //   3. A timeout fires.
                //      a. If throwOnTimeout, we throw the FunctionTimeoutException.
                //      b. If !throwOnTimeout, wait for the task to complete.


                // Combine #1 and #2 with a timeout task (handled by this method).
                // functionCancellationTokenSource.Token is passed to each function that requests it, so we need to call Cancel() on it
                // if there is a timeout.
                bool isTimeout = await TryHandleTimeoutAsync(invokeTask, functionCancellationTokenSource.Token, throwOnTimeout, timeoutTokenSource.Token,
                    timerInterval, instance, () => functionCancellationTokenSource.Cancel());


                // #2 occurred. If we're going to throwOnTimeout, watch for a timeout while we wait for invokeTask to complete.
                if (throwOnTimeout && !isTimeout && functionCancellationTokenSource.IsCancellationRequested)
                {
                    await TryHandleTimeoutAsync(invokeTask, CancellationToken.None, throwOnTimeout, timeoutTokenSource.Token, timerInterval, instance, null);
                }
            }
```

You'll notice the code first invokes the user code, and then checks for timeouts while the user code is executing **asynchronously**.

Normally, the code is guaranteed to execute asynchronously because the standard implementation of `InvokeAsync` in WebJobs contains a `await Task.Yield()`. This ensures the user code cannot block the invoking thread. See below for the implementation.

[Source code](https://github.com/Azure/azure-webjobs-sdk/blob/3f4ec78be9f43bb041937425ced00b341883aa42/src/Microsoft.Azure.WebJobs.Host/Executors/FunctionInvoker.cs#L47-L54)

```CSharp
        public async Task<object> InvokeAsync(object instance, object[] arguments)
        {
            // Return a task immediately in case the method is not async.
            await Task.Yield();


            return await _methodInvoker.InvokeAsync((TReflected)instance, arguments);
        }
    }
```

However, orchestrator invocations do not use this implementation of `InvokeAsync`. Instead, they're invoked through the following utility, which yields invocation control to the Durable Extension.

[Source code](https://github.com/Azure/azure-webjobs-sdk/blob/3f4ec78be9f43bb041937425ced00b341883aa42/src/Microsoft.Azure.WebJobs.Host/Executors/TriggeredFunctionExecutor.cs#L37-L68)

```CSharp
        public async Task<FunctionResult> TryExecuteAsync(TriggeredFunctionData input, CancellationToken cancellationToken)
        {
            var context = new FunctionInstanceFactoryContext<TTriggerValue>()
            {
                TriggerValue = (TTriggerValue)input.TriggerValue,
                ParentId = input.ParentId,
                TriggerDetails = input.TriggerDetails
            };


            if (input.InvokeHandler != null)
            {
                context.InvokeHandler = async next =>
                {
                    await input.InvokeHandler(next);


                    // NOTE: The InvokeHandler code path currently does not support flowing the return 
                    // value back to the trigger.
                    return null;
                };
            }


            Func<IFunctionInstance> instanceFactory = () => _instanceFactory.Create(context);
            IDelayedException exception = await _executor.TryExecuteAsync(instanceFactory, _loggerFactory, cancellationToken);


            FunctionResult result = exception != null ?
                new FunctionResult(exception.Exception)
                : new FunctionResult(true);


            return result;
        }
    }
}
```

Notice how there's no `Task.Yield` in there. This means that the user code is capable of **blocking** the WebJobs invocation thread. This then prevents WebJobs from reliably sending Timeout signals to offload an orchestrator from running further.

**This PR**

This PR addresses this problem by adding a `await Task.Yield` as the first step in our InvocationHandler implementation. After local testing, I have validated this suffices to enable orchestrators to respond to timeout events from WebJobs.

**Next Steps**
We should file a ticket against WebJobs so they can also include this `Task.Yield` on the implementation of `TryExecuteAsync`.

<!-- Make sure to delete the markdown comments and the below sections when squash merging -->
### Issue describing the changes in this PR

resolves #issue_for_this_pr

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)
* [x] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk
* [x] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
    * [ ] Otherwise: major or minor version updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
