### PR TITLE
Throw on illegal await

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -1,6 +1,6 @@
 ## New Features
 
-None
+- Improve telemetry to detect "illegal"/non-DF Tasks being awaited (https://github.com/Azure/azure-functions-durable-extension/pull/2168)
 
 ## Bug fixes
 

--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableEntityContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableEntityContext.cs
@@ -549,7 +549,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             return interfaces.Select(i => i.GetMethod(context.OperationName, bindingFlags)).FirstOrDefault(m => m != null);
         }
 
-        internal void ThrowIfInvalidAccess()
+        private void ThrowIfInvalidAccess()
         {
             if (this.CurrentOperation == null)
             {

--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableEntityContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableEntityContext.cs
@@ -549,7 +549,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             return interfaces.Select(i => i.GetMethod(context.OperationName, bindingFlags)).FirstOrDefault(m => m != null);
         }
 
-        private void ThrowIfInvalidAccess()
+        internal void ThrowIfInvalidAccess()
         {
             if (this.CurrentOperation == null)
             {

--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableOrchestrationContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableOrchestrationContext.cs
@@ -1151,7 +1151,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             }
         }
 
-        private void ThrowIfInvalidAccess()
+        internal void ThrowIfInvalidAccess()
         {
             if (this.InnerContext == null)
             {

--- a/src/WebJobs.Extensions.DurableTask/Listener/TaskOrchestrationShim.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/TaskOrchestrationShim.cs
@@ -148,6 +148,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     // Orchestrator threads cannot perform async I/O, so block on such out-of-proc threads.
                     // Possible performance implications; may need revisiting.
                     object returnValue = orchestratorInfo.IsOutOfProc ? resultTask.Result : await resultTask;
+
+                    // If an "illegal await" (awaiting a non DF API) is detected, we throw an exception.
+                    // This exception will not transition the orchestrator to a Failed state.
+                    // TODO: look to fail orchestrator in illegal awaits. This may require DTFx support.
+                    this.context.ThrowIfInvalidAccess();
+                    
                     if (returnValue != null)
                     {
                         if (orchestratorInfo.IsOutOfProc)

--- a/src/WebJobs.Extensions.DurableTask/Listener/TaskOrchestrationShim.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/TaskOrchestrationShim.cs
@@ -153,7 +153,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     // This exception will not transition the orchestrator to a Failed state.
                     // TODO: look to fail orchestrator in illegal awaits. This may require DTFx support.
                     this.context.ThrowIfInvalidAccess();
-                    
+
                     if (returnValue != null)
                     {
                         if (orchestratorInfo.IsOutOfProc)


### PR DESCRIPTION
<!-- Start the PR description with some context for the change. -->

This adds a check for "illegal awaits" at the end of orchestrator code execution. If an illegal await is detected, we throw an exception.

This is necessary because currently we only check for illegal awaits each time a DF API is invoked, so we're missing the case where the illegal await occurs **without** a subsequent DF API being used.

This exception will not transition the DTFx-level orchestrator state to `Failed`, but it should result in Functions-level telemetry indicating that an illegal await took place.

<!-- Make sure to delete the markdown comments and the below sections when squash merging -->
### Issue describing the changes in this PR

Related to: https://github.com/Azure/durabletask/pull/725

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)
* [x] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk
* [x] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
    * [ ] Otherwise: major or minor version updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
