### PR TITLE
Serialize Host Stopping Event in ActivityShim

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -1,0 +1,2 @@
+## Bug Fixes
+- Correctly Serialize HostStoppingEvent in ActivityShim (https://github.com/Azure/azure-functions-durable-extension/pull/2178)

--- a/src/WebJobs.Extensions.DurableTask/Listener/TaskActivityShim.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/TaskActivityShim.cs
@@ -122,7 +122,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                             $"Activity function '{this.activityName}' failed: {exceptionToReport.Message}",
                             Utils.SerializeCause(exceptionToReport, this.config.ErrorDataConverter));
                 default:
-                    throw new InvalidOperationException($"{nameof(TaskActivityShim.RunAsync)} does not handle the function execution status {result.ExecutionStatus}.");
+                    // we throw a TaskFailureException to ensure deserialization is possible.
+                    var innerException = new Exception($"{nameof(TaskActivityShim.RunAsync)} does not handle the function execution status {result.ExecutionStatus}.");
+                    throw new TaskFailureException(
+                            $"Activity function '{this.activityName}' failed: {innerException}",
+                            Utils.SerializeCause(innerException, this.config.ErrorDataConverter));
             }
         }
 

--- a/src/WebJobs.Extensions.DurableTask/Listener/TaskActivityShim.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/TaskActivityShim.cs
@@ -83,6 +83,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                         taskEventId: this.taskEventId);
 
                     return serializedOutput;
+                case WrappedFunctionResult.FunctionResultStatus.FunctionsHostStoppingError:
                 case WrappedFunctionResult.FunctionResultStatus.FunctionsRuntimeError:
                     this.config.TraceHelper.FunctionAborted(
                         this.config.Options.HubName,


### PR DESCRIPTION
<!-- Start the PR description with some context for the change. -->

This PR adds `FunctionsHostStoppingError` to the list of recognized Activity states in the ActivityShim. In particular, it makes `FunctionsHostStoppingError` behave like `FunctionsRuntimeError`, meaning that the Activity would be retried.

Currently, on a `FunctionsHostStoppingError`, we default to a case where an `InvalidOperationException` is thrown. This causes the result to be stored in the History as an error which cannot be de-serialized, which leads to the exception described in: https://github.com/Azure/azure-functions-durable-extension/issues/2162

A second contribution of this PR is that we change the exception type of this default case from `InvalidOperationException` to a `TaskFailure`. This is because all exceptions thrown by our shim ought to be de-serializable. 

<!-- Make sure to delete the markdown comments and the below sections when squash merging -->
### Issue describing the changes in this PR

Related to: https://github.com/Azure/azure-functions-durable-extension/issues/2162

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)
* [x] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk
* [x] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
    * [ ] Otherwise: major or minor version updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
