### PR TITLE
.NET Isolated middleware for orchestrator functions

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -1,6 +1,6 @@
 ## New Features
 
-None
+- Improve telemetry to detect "illegal"/non-DF Tasks being awaited (https://github.com/Azure/azure-functions-durable-extension/pull/2168)
 
 ## Bug fixes
 

--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableOrchestrationContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableOrchestrationContext.cs
@@ -1151,7 +1151,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             }
         }
 
-        private void ThrowIfInvalidAccess()
+        internal void ThrowIfInvalidAccess()
         {
             if (this.InnerContext == null)
             {

--- a/src/WebJobs.Extensions.DurableTask/Listener/TaskOrchestrationShim.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/TaskOrchestrationShim.cs
@@ -148,6 +148,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     // Orchestrator threads cannot perform async I/O, so block on such out-of-proc threads.
                     // Possible performance implications; may need revisiting.
                     object returnValue = orchestratorInfo.IsOutOfProc ? resultTask.Result : await resultTask;
+
+                    // If an "illegal await" (awaiting a non DF API) is detected, we throw an exception.
+                    // This exception will not transition the orchestrator to a Failed state.
+                    // TODO: look to fail orchestrator in illegal awaits. This may require DTFx support.
+                    this.context.ThrowIfInvalidAccess();
+
                     if (returnValue != null)
                     {
                         if (orchestratorInfo.IsOutOfProc)

--- a/src/Worker.Extensions.DurableTask/.editorconfig
+++ b/src/Worker.Extensions.DurableTask/.editorconfig
@@ -11,3 +11,6 @@ csharp_using_directive_placement = outside_namespace
 csharp_style_namespace_declarations = file_scoped:silent
 
 file_header_template = Copyright (c) .NET Foundation. All rights reserved.\nLicensed under the MIT License. See License.txt in the project root for license information.
+
+# https://marketplace.visualstudio.com/items?itemName=PaulHarrington.EditorGuidelinesPreview
+guidelines = 120

--- a/src/Worker.Extensions.DurableTask/DefaultDurableClientContext.cs
+++ b/src/Worker.Extensions.DurableTask/DefaultDurableClientContext.cs
@@ -98,7 +98,13 @@ internal sealed class DefaultDurableClientContext : DurableClientContext
             try
             {
                 DurableTaskGrpcClient.Builder builder = DurableTaskGrpcClient.CreateBuilder();
-                builder.UseAddress(inputData.rpcBaseUrl);
+                if (!Uri.TryCreate(inputData.rpcBaseUrl, UriKind.Absolute, out Uri? baseUriResult))
+                {
+                    InvalidOperationException exception = new($"Failed to parse the {nameof(inputData.rpcBaseUrl)} field from the input binding data.");
+                    return new ValueTask<ConversionResult>(ConversionResult.Failed(exception));
+                }
+
+                builder.UseAddress(baseUriResult.Host, baseUriResult.Port);
                 if (this.serviceProvider != null)
                 {
                     // The builder will use the host's service provider to look up DI-registered

--- a/src/Worker.Extensions.DurableTask/DurableTaskExtensionStartup.cs
+++ b/src/Worker.Extensions.DurableTask/DurableTaskExtensionStartup.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Microsoft.Azure.Functions.Worker.Core;
+using Microsoft.Azure.Functions.Worker.Extensions.DurableTask;
+using Microsoft.Extensions.Hosting;
+
+[assembly: WorkerExtensionStartup(typeof(DurableTaskExtensionStartup))]
+
+namespace Microsoft.Azure.Functions.Worker.Extensions.DurableTask;
+
+/// <summary>
+/// Startup class that registers the Durable Task middleware with the function app.
+/// </summary>
+public sealed class DurableTaskExtensionStartup : WorkerExtensionStartup
+{
+    /// <inheritdoc/>
+    public override void Configure(IFunctionsWorkerApplicationBuilder applicationBuilder)
+    {
+        applicationBuilder.UseMiddleware<DurableTaskFunctionsMiddleware>();
+    }
+}

--- a/src/Worker.Extensions.DurableTask/DurableTaskFunctionsMiddleware.cs
+++ b/src/Worker.Extensions.DurableTask/DurableTaskFunctionsMiddleware.cs
@@ -1,0 +1,193 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.Functions.Worker.Middleware;
+using Microsoft.DurableTask;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Azure.Functions.Worker.Extensions.DurableTask;
+
+internal class DurableTaskFunctionsMiddleware : IFunctionsWorkerMiddleware
+{
+    // TODO: Need to add call to action, i.e., pointer to some documentation.
+    private const string IllegalAwaitErrorMessage =
+        "An invalid asynchronous invocation was detected. This can be caused by awaiting non-durable tasks " +
+        "in an orchestrator function's implementation or by middleware that invokes asynchronous code.";
+
+    public async Task Invoke(FunctionContext functionContext, FunctionExecutionDelegate next)
+    {
+        if (!IsOrchestrationTrigger(functionContext, out BindingMetadata? triggerMetadata))
+        {
+            await next(functionContext);
+            return;
+        }
+
+        InputBindingData<object> triggerInputData = await functionContext.BindInputAsync<object>(triggerMetadata);
+        if (triggerInputData?.Value is not string encodedOrchestratorState)
+        {
+            throw new InvalidOperationException("Orchestration history state was either missing from the input or not a string value.");
+        }
+
+        // Wrap the function implementation in a lambda orchestrator
+        string orchestratorOutput = OrchestrationRunner.LoadAndRun<object, object>(
+            encodedOrchestratorState,
+            async (orchestrationContext, input) =>
+            {
+                // Set the function input to be the orchestration context wrapped in our own object so that we can
+                // intercept any of the calls and inject our own logic or tracking.
+                FunctionsOrchestrationContext wrapperContext = new(orchestrationContext, functionContext);
+                triggerInputData.Value = wrapperContext;
+
+                // This method will advance to the next middleware and throw if it detects an asynchronous execution.
+                await EnsureSynchronousExecution(functionContext, next, wrapperContext);
+
+                // Set the raw function output as the orchestrator output
+                object? functionOutput = functionContext.GetInvocationResult().Value;
+                return functionOutput;
+            },
+            functionContext.InstanceServices);
+
+        // Send the encoded orchestrator output as the return value seen by the functions host extension
+        functionContext.GetInvocationResult().Value = orchestratorOutput;
+    }
+
+    private static bool IsOrchestrationTrigger(
+        FunctionContext context,
+        [NotNullWhen(true)] out BindingMetadata? orchestrationTriggerBinding)
+    {
+        foreach (BindingMetadata binding in context.FunctionDefinition.InputBindings.Values)
+        {
+            if (string.Equals(binding.Type, "orchestrationTrigger"))
+            {
+                orchestrationTriggerBinding = binding;
+                return true;
+            }
+        }
+
+        orchestrationTriggerBinding = null;
+        return false;
+    }
+
+    private static async Task EnsureSynchronousExecution(
+        FunctionContext functionContext,
+        FunctionExecutionDelegate next,
+        FunctionsOrchestrationContext orchestrationContext)
+    {
+        Task orchestratorTask = next(functionContext);
+        if (!orchestratorTask.IsCompleted && !orchestrationContext.IsAccessed)
+        {
+            // If the middleware returns before the orchestrator function's context object was accessed, then we
+            // know that either some middleware component went async or that the orchestrator function did some illegal
+            // await as its very first action.
+            throw new InvalidOperationException(IllegalAwaitErrorMessage);
+        }
+
+        await orchestratorTask;
+
+        // This will throw if either the orchestrator performed an illegal await or if some middleware ahead of this
+        // one performed some illegal await.
+        orchestrationContext.ThrowIfIllegalAccess();
+    }
+
+    private sealed class FunctionsOrchestrationContext : TaskOrchestrationContext
+    {
+        private readonly TaskOrchestrationContext innerContext;
+        private readonly FunctionContext functionContext;
+        
+        public FunctionsOrchestrationContext(TaskOrchestrationContext innerContext, FunctionContext functionContext)
+        {
+            this.innerContext = innerContext;
+            this.functionContext = functionContext;
+        }
+
+        public bool IsAccessed { get; private set; }
+
+        public override TaskName Name => this.innerContext.Name;
+
+        public override string InstanceId => this.innerContext.InstanceId;
+
+        public override DateTime CurrentUtcDateTime => this.innerContext.CurrentUtcDateTime;
+
+        public override bool IsReplaying => this.innerContext.IsReplaying;
+
+        public override Task<T> CallActivityAsync<T>(TaskName name, object? input = null, TaskOptions? options = null)
+        {
+            this.EnsureLegalAccess();
+            return this.innerContext.CallActivityAsync<T>(name, input, options);
+        }
+
+        [Obsolete("Not yet supported")]
+        public override Task<T> CallActivityAsync<T>(
+            Func<object?, T> activityLambda,
+            object? input = null,
+            TaskOptions? options = null)
+        {
+            this.EnsureLegalAccess();
+            return this.innerContext.CallActivityAsync(activityLambda, input, options);
+        }
+
+        public override Task<TResult> CallSubOrchestratorAsync<TResult>(
+            TaskName orchestratorName,
+            string? instanceId = null,
+            object? input = null, 
+            TaskOptions? options = null)
+        {
+            this.EnsureLegalAccess();
+            return this.innerContext.CallSubOrchestratorAsync<TResult>(orchestratorName, instanceId, input, options);
+        }
+
+        public override void ContinueAsNew(object newInput, bool preserveUnprocessedEvents = true)
+        {
+            this.EnsureLegalAccess();
+            this.innerContext.ContinueAsNew(newInput, preserveUnprocessedEvents);
+        }
+
+        public override Task CreateTimer(DateTime fireAt, CancellationToken cancellationToken)
+        {
+            this.EnsureLegalAccess();
+            return this.innerContext.CreateTimer(fireAt, cancellationToken);
+        }
+
+        public override void SetCustomStatus(object? customStatus)
+        {
+            this.EnsureLegalAccess();
+            this.SetCustomStatus(customStatus);
+        }
+
+        public override Task<T> WaitForExternalEvent<T>(string eventName, CancellationToken cancellationToken = default)
+        {
+            this.EnsureLegalAccess();
+            return this.innerContext.WaitForExternalEvent<T>(eventName, cancellationToken);
+        }
+
+        /// <summary>
+        /// Throws if accessed by a non-orchestrator thread or marks the current object as accessed successfully.
+        /// </summary>
+        private void EnsureLegalAccess()
+        {
+            this.ThrowIfIllegalAccess();
+            this.IsAccessed = true;
+        }
+
+        internal void ThrowIfIllegalAccess()
+        {
+            // Only the orchestrator thread is allowed to run the task continuation. If we detect that some other thread
+            // got involved, it means that the orchestrator function (or some middleware that executed after it)
+            // performed an await which scheduled a callback onto a worker pool thread, which isn't allowed. We throw
+            // because the orchestrator is effectively stuck at this point.
+            if (!global::DurableTask.Core.OrchestrationContext.IsOrchestratorThread)
+            {
+                InvalidOperationException exception = new(IllegalAwaitErrorMessage);
+
+                // Log an error, since this exception will likely go unobserved.
+                ILogger logger = this.functionContext.GetLogger<DurableTaskFunctionsMiddleware>();
+                logger.LogError(exception, "The orchestrator function completed on a non-orchestrator thread!");
+                throw exception;
+            }
+        }
+    }
+}

--- a/src/Worker.Extensions.DurableTask/DurableTaskFunctionsMiddleware.cs
+++ b/src/Worker.Extensions.DurableTask/DurableTaskFunctionsMiddleware.cs
@@ -80,9 +80,9 @@ internal class DurableTaskFunctionsMiddleware : IFunctionsWorkerMiddleware
         Task orchestratorTask = next(functionContext);
         if (!orchestratorTask.IsCompleted && !orchestrationContext.IsAccessed)
         {
-            // If the middleware returns before the orchestrator function's context object was accessed, then we
-            // know that either some middleware component went async or that the orchestrator function did some illegal
-            // await as its very first action.
+            // If the middleware returns before the orchestrator function's context object was accessed and before
+            // it completes its execution, then we know that either some middleware component went async or that the
+            // orchestrator function did some illegal await as its very first action.
             throw new InvalidOperationException(IllegalAwaitErrorMessage);
         }
 

--- a/src/Worker.Extensions.DurableTask/DurableTaskFunctionsMiddleware.cs
+++ b/src/Worker.Extensions.DurableTask/DurableTaskFunctionsMiddleware.cs
@@ -114,6 +114,18 @@ internal class DurableTaskFunctionsMiddleware : IFunctionsWorkerMiddleware
 
         public override bool IsReplaying => this.innerContext.IsReplaying;
 
+        public override T GetInput<T>()
+        {
+            this.EnsureLegalAccess();
+            return this.innerContext.GetInput<T>()!;
+        }
+
+        public override Guid NewGuid()
+        {
+            this.EnsureLegalAccess();
+            return this.innerContext.NewGuid();
+        }
+
         public override Task<T> CallActivityAsync<T>(TaskName name, object? input = null, TaskOptions? options = null)
         {
             this.EnsureLegalAccess();

--- a/src/Worker.Extensions.DurableTask/Worker.Extensions.DurableTask.csproj
+++ b/src/Worker.Extensions.DurableTask/Worker.Extensions.DurableTask.csproj
@@ -28,7 +28,7 @@
     <AssemblyOriginatorKeyFile>..\..\sign.snk</AssemblyOriginatorKeyFile>
 
     <!-- Version information -->
-    <VersionPrefix>0.3.0</VersionPrefix>
+    <VersionPrefix>0.4.0</VersionPrefix>
     <VersionSuffix>beta</VersionSuffix>
     <FileVersion>$(VersionPrefix)</FileVersion>
     <AssemblyVersion>$(VersionPrefix).0</AssemblyVersion>
@@ -39,12 +39,12 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Core" Version="1.5.0-preview1" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Core" Version="1.6.0-preview1" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Abstractions" Version="1.1.0" />
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.DurableTask" Version="0.3.0-beta" />
+    <PackageReference Include="Microsoft.DurableTask" Version="0.4.0-beta" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/SmokeTests/OOProcSmokeTests/DotNetIsolated/DotNetIsolated.csproj
+++ b/test/SmokeTests/OOProcSmokeTests/DotNetIsolated/DotNetIsolated.csproj
@@ -9,10 +9,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.7.0-preview1" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Abstractions" Version="1.1.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.8.0-preview3" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask" Version="0.4.0-beta" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.0.13" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.2.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.5.0-preview2" OutputItemType="Analyzer" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/SmokeTests/OOProcSmokeTests/DotNetIsolated/HelloCitiesUntyped.cs
+++ b/test/SmokeTests/OOProcSmokeTests/DotNetIsolated/HelloCitiesUntyped.cs
@@ -42,8 +42,7 @@ internal static class HelloSequenceUntyped
     /// <param name="requestState">The serialized orchestration state that gets passed to the function.</param>
     /// <returns>Returns an opaque output string with instructions about what actions to persist into the orchestration history.</returns>
     [Function(nameof(HelloCitiesUntyped))]
-    public static async Task<string> HelloCitiesUntyped(
-        [OrchestrationTrigger] TaskOrchestrationContext context, string? input)
+    public static async Task<string> HelloCitiesUntyped([OrchestrationTrigger] TaskOrchestrationContext context)
     {
         string result = "";
         result += await context.CallActivityAsync<string>(nameof(SayHelloUntyped), "Tokyo") + " ";

--- a/test/SmokeTests/OOProcSmokeTests/DotNetIsolated/HelloCitiesUntyped.cs
+++ b/test/SmokeTests/OOProcSmokeTests/DotNetIsolated/HelloCitiesUntyped.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
+using Microsoft.DurableTask;
 using Microsoft.Extensions.Logging;
 
 namespace DurableNetIsolated.Untyped;
@@ -41,16 +42,15 @@ internal static class HelloSequenceUntyped
     /// <param name="requestState">The serialized orchestration state that gets passed to the function.</param>
     /// <returns>Returns an opaque output string with instructions about what actions to persist into the orchestration history.</returns>
     [Function(nameof(HelloCitiesUntyped))]
-    public static string HelloCitiesUntyped([OrchestrationTrigger] string requestState, FunctionContext functionContext) =>
-        Microsoft.DurableTask.OrchestrationRunner.LoadAndRun<string, string>(requestState, async (context, _) =>
-        {
-            string result = "";
-            result += await context.CallActivityAsync<string>(nameof(SayHelloUntyped), "Tokyo") + " ";
-            result += await context.CallActivityAsync<string>(nameof(SayHelloUntyped), "London") + " ";
-            result += await context.CallActivityAsync<string>(nameof(SayHelloUntyped), "Seattle");
-            return result;
-        },
-        functionContext.InstanceServices);
+    public static async Task<string> HelloCitiesUntyped(
+        [OrchestrationTrigger] TaskOrchestrationContext context, string? input)
+    {
+        string result = "";
+        result += await context.CallActivityAsync<string>(nameof(SayHelloUntyped), "Tokyo") + " ";
+        result += await context.CallActivityAsync<string>(nameof(SayHelloUntyped), "London") + " ";
+        result += await context.CallActivityAsync<string>(nameof(SayHelloUntyped), "Seattle");
+        return result;
+    }
 
     /// <summary>
     /// Simple activity function that returns the string "Hello, {input}!".


### PR DESCRIPTION
This PR enables a cleaner coding experience for orchestrator functions in .NET Isolated.

**Before**:
```csharp
[Function(nameof(HelloCitiesUntyped))]
public static string HelloCitiesUntyped([OrchestrationTrigger] string requestState, FunctionContext functionContext) =>
    Microsoft.DurableTask.OrchestrationRunner.LoadAndRun<string, string>(requestState, async (context, _) =>
    {
        string result = "";
        result += await context.CallActivityAsync<string>(nameof(SayHelloUntyped), "Tokyo") + " ";
        result += await context.CallActivityAsync<string>(nameof(SayHelloUntyped), "London") + " ";
        result += await context.CallActivityAsync<string>(nameof(SayHelloUntyped), "Seattle");
        return result;
    },
    functionContext.InstanceServices);
```

**After**:
```csharp
[Function(nameof(HelloCitiesUntyped))]
public static async Task<string> HelloCitiesUntyped([OrchestrationTrigger] TaskOrchestrationContext context)
{
    string result = "";
    result += await context.CallActivityAsync<string>(nameof(SayHelloUntyped), "Tokyo") + " ";
    result += await context.CallActivityAsync<string>(nameof(SayHelloUntyped), "London") + " ";
    result += await context.CallActivityAsync<string>(nameof(SayHelloUntyped), "Seattle");
    return result;
}
```

It works by automatically injecting middleware into the .NET worker that does pretty much exactly what the "before" example was doing so that we could remove that boilerplate from user code.

Dependencies on both the .NET Isolated worker SDK and the new Durable Task .NET SDK (including its source generator) needed to be updated to support this.

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)
* [x] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk
* [x] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
    * [ ] Otherwise: major or minor version updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
