### PR TITLE
.NET Isolated release pipeline + .NET Standard 2.0 support

### DIFF
--- a/WebJobs.Extensions.DurableTask.sln
+++ b/WebJobs.Extensions.DurableTask.sln
@@ -21,6 +21,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{9850DECF-CBA2-43E7-B5E2-55053DD308E9}"
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
+		azure-pipelines-release-dotnet-isolated.yml = azure-pipelines-release-dotnet-isolated.yml
 		azure-pipelines-release.yml = azure-pipelines-release.yml
 		README.md = README.md
 		release_notes.md = release_notes.md

--- a/azure-pipelines-release-dotnet-isolated.yml
+++ b/azure-pipelines-release-dotnet-isolated.yml
@@ -1,0 +1,122 @@
+trigger: none
+pr: none
+
+# Use an internally approved MS host for building, signing, and SBOM generation
+pool:
+  name: '1ES-Hosted-DurableTaskFramework'
+  demands:
+    - ImageOverride -equals MMS2022TLS
+
+steps:
+- task: UseDotNet@2
+  displayName: 'Use the .NET Core 2.1 SDK (required for build signing)'
+  inputs:
+    packageType: 'sdk'
+    version: '2.1.x'
+
+- task: UseDotNet@2
+  displayName: 'Use the .NET 6 SDK'
+  inputs:
+    packageType: 'sdk'
+    version: '6.0.x'
+
+# Start by restoring all the .NET Isolated worker extension dependencies. This needs to be its own task.
+- task: DotNetCoreCLI@2
+  displayName: 'Restore nuget dependencies'
+  inputs:
+    command: restore
+    verbosityRestore: Minimal
+    projects: 'src/Worker.Extensions.DurableTask/*.csproj'
+
+# Build just the .NET Isolated worker extension project
+- task: VSBuild@1
+  displayName: 'Build'
+  inputs:
+    solution: 'src/Worker.Extensions.DurableTask/*.csproj'
+    vsVersion: 'latest'
+    logFileVerbosity: minimal
+    configuration: Release
+    msbuildArgs: /p:FileVersionRevision=$(Build.BuildId) /p:ContinuousIntegrationBuild=true
+
+# Authenticode sign all the DLLs with the Microsoft certificate.
+# This appears to be an in-place signing job, which is convenient.
+- task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
+  displayName: 'ESRP CodeSigning: Authenticode'
+  inputs:
+    ConnectedServiceName: 'ESRP Service'
+    FolderPath: 'src/Worker.Extensions.DurableTask/bin/Release'
+    Pattern: 'Microsoft.Azure.Functions.Worker.Extensions.DurableTask.dll'
+    signConfigType: inlineSignParams
+    inlineOperation: |
+     [    
+        {
+            "KeyCode": "CP-230012",
+            "OperationCode": "SigntoolSign",
+            "Parameters": {
+                "OpusName": "Microsoft",
+                "OpusInfo": "http://www.microsoft.com",
+                "FileDigest": "/fd \"SHA256\"",
+                "PageHash": "/NPH",
+                "TimeStamp": "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
+            },
+            "ToolName": "sign",
+            "ToolVersion": "1.0"
+          },
+          {
+              "KeyCode": "CP-230012",
+              "OperationCode": "SigntoolVerify",
+              "Parameters": {},
+              "ToolName": "sign",
+              "ToolVersion": "1.0"
+          }
+      ]
+
+# SBOM generator task for additional supply chain protection
+- task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
+  displayName: 'SBOM Manifest Generator'
+  inputs:
+    BuildDropPath: '$(System.DefaultWorkingDirectory)'
+
+# Packaging needs to be a separate step from build.
+# This will automatically pick up any signed DLLs.
+- task: DotNetCoreCLI@2
+  displayName: Generate nuget packages
+  inputs:
+    command: pack
+    verbosityPack: Minimal
+    configuration: Release
+    nobuild: true
+    packDirectory: $(build.artifactStagingDirectory)
+    packagesToPack: 'src/Worker.Extensions.DurableTask/*.csproj'
+
+# Digitally sign all the nuget packages with the Microsoft certificate.
+# This appears to be an in-place signing job, which is convenient.
+- task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
+  displayName: 'ESRP CodeSigning: Nupkg'
+  inputs:
+    ConnectedServiceName: 'ESRP Service'
+    FolderPath: $(build.artifactStagingDirectory)
+    Pattern: '*.nupkg'
+    signConfigType: inlineSignParams
+    inlineOperation: |
+     [    
+        {
+            "KeyCode": "CP-401405",
+            "OperationCode": "NuGetSign",
+            "Parameters": {},
+            "ToolName": "sign",
+            "ToolVersion": "1.0"
+        },
+        {
+            "KeyCode": "CP-401405",
+            "OperationCode": "NuGetVerify",
+            "Parameters": {},
+            "ToolName": "sign",
+            "ToolVersion": "1.0"
+        }
+     ]
+
+# Make the nuget packages available for download in the ADO portal UI
+- publish: $(build.artifactStagingDirectory)
+  displayName: 'Publish nuget packages to Artifacts'
+  artifact: PackageOutput

--- a/src/Worker.Extensions.DurableTask/DefaultDurableClientContext.cs
+++ b/src/Worker.Extensions.DurableTask/DefaultDurableClientContext.cs
@@ -26,8 +26,15 @@ internal sealed class DefaultDurableClientContext : DurableClientContext
         this.Client = client ?? throw new ArgumentNullException(nameof(client));
         this.inputData = inputData ?? throw new ArgumentNullException(nameof(inputData));
 
-        ArgumentNullException.ThrowIfNull(inputData.taskHubName, nameof(inputData.taskHubName));
-        ArgumentNullException.ThrowIfNull(inputData.requiredQueryStringParameters, nameof(inputData.requiredQueryStringParameters));
+        if (string.IsNullOrEmpty(inputData.taskHubName))
+        {
+            throw new ArgumentNullException(nameof(inputData.taskHubName));
+        }
+
+        if (string.IsNullOrEmpty(inputData.requiredQueryStringParameters))
+        {
+            throw new ArgumentNullException(nameof(inputData.requiredQueryStringParameters));
+        }
     }
 
     /// <inheritdoc/>

--- a/src/Worker.Extensions.DurableTask/Worker.Extensions.DurableTask.csproj
+++ b/src/Worker.Extensions.DurableTask/Worker.Extensions.DurableTask.csproj
@@ -29,7 +29,7 @@
     <AssemblyOriginatorKeyFile>..\..\sign.snk</AssemblyOriginatorKeyFile>
 
     <!-- Version information -->
-    <VersionPrefix>0.4.0</VersionPrefix>
+    <VersionPrefix>0.4.1</VersionPrefix>
     <VersionSuffix>beta</VersionSuffix>
     <AssemblyVersion>$(VersionPrefix).0</AssemblyVersion>
     <!-- FileVersionRevision is expected to be set by the CI. -->
@@ -39,7 +39,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Core" Version="1.6.0-preview3" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Abstractions" Version="1.1.0" />
-    <PackageReference Include="Microsoft.DurableTask" Version="0.4.0-beta" />
+    <PackageReference Include="Microsoft.DurableTask.Client" Version="0.4.1-beta" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Worker.Extensions.DurableTask/Worker.Extensions.DurableTask.csproj
+++ b/src/Worker.Extensions.DurableTask/Worker.Extensions.DurableTask.csproj
@@ -2,10 +2,11 @@
 
   <!-- Core compiler settings -->
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <DebugType>embedded</DebugType>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <!-- Assembly/NuGet package settings & metadata -->
@@ -30,25 +31,27 @@
     <!-- Version information -->
     <VersionPrefix>0.4.0</VersionPrefix>
     <VersionSuffix>beta</VersionSuffix>
-    <FileVersion>$(VersionPrefix)</FileVersion>
     <AssemblyVersion>$(VersionPrefix).0</AssemblyVersion>
-    <Version>$(VersionPrefix)-$(VersionSuffix)</Version>
-
-    <!--Temporarily opting out of documentation. -->
-    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+    <!-- FileVersionRevision is expected to be set by the CI. -->
+    <FileVersion Condition="'$(FileVersionRevision)' != ''">$(VersionPrefix).$(FileVersionRevision)</FileVersion>
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Core" Version="1.6.0-preview1" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Core" Version="1.6.0-preview3" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Abstractions" Version="1.1.0" />
-  </ItemGroup>
-  
-  <ItemGroup>
     <PackageReference Include="Microsoft.DurableTask" Version="0.4.0-beta" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.*" PrivateAssets="All" />
+  </ItemGroup>
+
+  <!-- Embed the SBOM manifest, which is generated as part of the "official" build -->
+  <ItemGroup Condition="'$(Configuration)'=='Release'">
+    <Content Include="..\..\_manifest\**">
+      <Pack>true</Pack>
+      <PackagePath>content/SBOM</PackagePath>
+    </Content>
   </ItemGroup>
 
 </Project>

--- a/src/Worker.Extensions.DurableTask/_CSharpLanguageHelpers.cs
+++ b/src/Worker.Extensions.DurableTask/_CSharpLanguageHelpers.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+// This file defines several classes and methods that exist in .NET Core but not in .NET Standard 2.0.
+// They are defined here to enable certain C# features that otherwise require higher framework versions.
+// Redefining types in this way is a standard practice for libary authors that are forced to target .NET Standard 2.0.
+#if NETSTANDARD2_0
+
+#nullable enable
+
+using System.ComponentModel;
+
+// Copied from https://github.com/dotnet/runtime/blob/main/src/libraries/System.Private.CoreLib/src/System/Diagnostics/CodeAnalysis/NullableAttributes.cs#L69
+namespace System.Diagnostics.CodeAnalysis
+{
+    internal sealed class NotNullWhenAttribute : Attribute
+    {
+        /// <summary>Initializes the attribute with the specified return value condition.</summary>
+        /// <param name="returnValue">
+        /// The return value condition. If the method returns this value, the associated parameter will not be null.
+        /// </param>
+        public NotNullWhenAttribute(bool returnValue) => this.ReturnValue = returnValue;
+
+        /// <summary>Gets the return value condition.</summary>
+        public bool ReturnValue { get; }
+    }
+}
+
+namespace System.Runtime.CompilerServices
+{
+    /// <summary>
+    /// Reserved to be used by the compiler for tracking metadata.
+    /// This class should not be used by developers in source code.
+    /// This dummy class is required to compile records when targeting .NET Standard
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    internal static class IsExternalInit { }
+}
+#endif


### PR DESCRIPTION
This PR adds a release pipeline for the `Worker.Extensions.DurableTask` project and also updates it to target .NET Standard 2.0. The latter change is to enable .NET Framework support.


### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)
* [x] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk
* [x] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
    * [ ] Otherwise: major or minor version updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
