### PR TITLE
Fix NotImplementedException for management API calls from Java client

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -1,2 +1,3 @@
 ## Bug Fixes
 - Correctly Serialize HostStoppingEvent in ActivityShim (https://github.com/Azure/azure-functions-durable-extension/pull/2178)
+- Fix NotImplementedException for management API calls from Java client (https://github.com/Azure/azure-functions-durable-extension/pull/2193)

--- a/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
@@ -197,10 +197,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             {
                 this.OutOfProcProtocol = OutOfProcOrchestrationProtocol.MiddlewarePassthrough;
 #if FUNCTIONS_V3_OR_GREATER
-                this.localGrpcListener = new LocalGrpcListener(
-                    this,
-                    this.defaultDurabilityProvider,
-                    this.defaultDurabilityProvider);
+                this.localGrpcListener = new LocalGrpcListener(this, this.defaultDurabilityProvider);
                 this.HostLifetimeService.OnStopped.Register(this.StopLocalGrpcServer);
 #endif
             }

--- a/src/WebJobs.Extensions.DurableTask/ProtobufUtils.cs
+++ b/src/WebJobs.Extensions.DurableTask/ProtobufUtils.cs
@@ -4,6 +4,7 @@
 #nullable enable
 using System;
 using System.Buffers;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using DurableTask.Core;
@@ -350,6 +351,18 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 FetchInputsAndOutputs = request.Query.FetchInputsAndOutputs,
             };
 
+            // Empty lists are not allowed by the underlying code that takes in a OrchestrationQuery. However, protobuf
+            // uses empty lists by default instead of nulls. Need to overwrite empty lists will null values.
+            if (query.TaskHubNames?.Count == 0)
+            {
+                query.TaskHubNames = null;
+            }
+
+            if (query.RuntimeStatus?.Count == 0)
+            {
+                query.RuntimeStatus = null;
+            }
+
             return query;
         }
 
@@ -381,10 +394,19 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
         internal static PurgeInstanceFilter ToPurgeInstanceFilter(P.PurgeInstancesRequest request)
         {
+            // Empty lists are not allowed by the underlying code that takes in a PurgeInstanceFilter. However, some
+            // clients (like Java) may use empty lists by default instead of nulls.
+            // Long story short: we must make sure to only copy over the list if it's non-empty.
+            IEnumerable<OrchestrationStatus>? statusFilter = null;
+            if (request.PurgeInstanceFilter.RuntimeStatus != null && request.PurgeInstanceFilter.RuntimeStatus.Count > 0)
+            {
+                statusFilter = request.PurgeInstanceFilter.RuntimeStatus?.Select(status => (OrchestrationStatus)status).ToList();
+            }
+
             return new PurgeInstanceFilter(
                 request.PurgeInstanceFilter.CreatedTimeFrom.ToDateTime(),
                 request.PurgeInstanceFilter.CreatedTimeTo?.ToDateTime(),
-                request.PurgeInstanceFilter.RuntimeStatus?.Select(status => (OrchestrationStatus)status).ToList());
+                statusFilter);
         }
 
         internal static P.PurgeInstancesResponse CreatePurgeInstancesResponse(PurgeResult result)

--- a/src/WebJobs.Extensions.DurableTask/ProtobufUtils.cs
+++ b/src/WebJobs.Extensions.DurableTask/ProtobufUtils.cs
@@ -351,8 +351,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 FetchInputsAndOutputs = request.Query.FetchInputsAndOutputs,
             };
 
-            // Empty lists are not allowed by the underlying code that takes in a OrchestrationQuery. However, protobuf
-            // uses empty lists by default instead of nulls. Need to overwrite empty lists will null values.
+            // Empty lists are not allowed by the underlying code that takes in an OrchestrationQuery. However,
+            // some clients use empty lists instead of nulls. Need to overwrite empty lists with null values.
             if (query.TaskHubNames?.Count == 0)
             {
                 query.TaskHubNames = null;

--- a/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
+++ b/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
@@ -6,7 +6,7 @@
     <RootNamespace>Microsoft.Azure.WebJobs.Extensions.DurableTask</RootNamespace>
     <MajorVersion>2</MajorVersion>
     <MinorVersion>7</MinorVersion>
-    <PatchVersion>1</PatchVersion>
+    <PatchVersion>2</PatchVersion>
     <Version>$(MajorVersion).$(MinorVersion).$(PatchVersion)</Version>
     <FileVersion>$(MajorVersion).$(MinorVersion).$(PatchVersion)</FileVersion>
     <AssemblyVersion>$(MajorVersion).0.0.0</AssemblyVersion>


### PR DESCRIPTION
### Issue describing the changes in this PR

There is a regression in the v2.7.1 release when we moved the sidecar logic directly into the extension. Basically, we fail to cast the durability provider into `IOrchestrationServiceQueryClient` and `IOrchestrationServicePurgeClient` objects, resulting in `NotSupportedException`.  This PR fixes this by having `DurabilityProvider` implement this interface and delegate the actual work to the inner DTFx `IOrchestrationServiceClient` implementation.

Resolves https://github.com/Azure/azure-functions-durable-extension/issues/2191

### Testing

Here is the Java code used for testing:

```java
@FunctionName("GetAllStatus")
public String getAllStatus(
        @HttpTrigger(name = "req", methods = {HttpMethod.GET}) HttpRequestMessage<?> req,
        @DurableClientInput(name = "durableContext") DurableClientContext durableContext,
        final ExecutionContext context) {
    DurableTaskClient client = durableContext.getClient();
    OrchestrationStatusQuery noFilter = new OrchestrationStatusQuery();
    OrchestrationStatusQueryResult result = client.queryInstances(noFilter);
    return "Found " + result.getOrchestrationState().size() + " orchestrations.";
}
```

We verified that this test now works correctly with this PR.


### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)
* [x] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk
* [x] My changes **do not** change the major or minor version of the WebJobs.Extensions.DurableTask package
    * [ ] Otherwise: major or minor version updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
