### PR TITLE
Support instanceIdPrefix query parameter for HTTP instance queries

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -1,3 +1,6 @@
 ## Bug Fixes
 - Correctly Serialize HostStoppingEvent in ActivityShim (https://github.com/Azure/azure-functions-durable-extension/pull/2178)
 - Fix NotImplementedException for management API calls from Java client (https://github.com/Azure/azure-functions-durable-extension/pull/2193)
+
+## Enhancements
+- add optional 'instanceIdPrefix' query parameter to the HTTP API for instance queries

--- a/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
+++ b/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         private const string ShowHistoryOutputParameter = "showHistoryOutput";
         private const string ShowInputParameter = "showInput";
         private const string FetchStateParameter = "fetchState";
-        private const string InstanceIdStartsWithParameter = "instanceIdStartsWith";
+        private const string instanceIdPrefixParameter = "instanceIdPrefix";
         private const string CreatedTimeFromParameter = "createdTimeFrom";
         private const string CreatedTimeToParameter = "createdTimeTo";
         private const string RuntimeStatusParameter = "runtimeStatus";
@@ -443,9 +443,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
             var condition = new OrchestrationStatusQueryCondition();
 
-            if (TryGetStringQueryParameterValue(queryNameValuePairs, InstanceIdStartsWithParameter, out string instanceIdStartsWith))
+            if (TryGetStringQueryParameterValue(queryNameValuePairs, instanceIdPrefixParameter, out string instanceIdPrefix))
             {
-                condition.InstanceIdPrefix = instanceIdStartsWith;
+                condition.InstanceIdPrefix = instanceIdPrefix;
             }
 
             if (TryGetDateTimeQueryParameterValue(queryNameValuePairs, CreatedTimeFromParameter, out DateTime createdTimeFrom))

--- a/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
+++ b/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         private const string ShowHistoryOutputParameter = "showHistoryOutput";
         private const string ShowInputParameter = "showInput";
         private const string FetchStateParameter = "fetchState";
-        private const string instanceIdPrefixParameter = "instanceIdPrefix";
+        private const string InstanceIdPrefixParameter = "instanceIdPrefix";
         private const string CreatedTimeFromParameter = "createdTimeFrom";
         private const string CreatedTimeToParameter = "createdTimeTo";
         private const string RuntimeStatusParameter = "runtimeStatus";
@@ -443,7 +443,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
             var condition = new OrchestrationStatusQueryCondition();
 
-            if (TryGetStringQueryParameterValue(queryNameValuePairs, instanceIdPrefixParameter, out string instanceIdPrefix))
+            if (TryGetStringQueryParameterValue(queryNameValuePairs, InstanceIdPrefixParameter, out string instanceIdPrefix))
             {
                 condition.InstanceIdPrefix = instanceIdPrefix;
             }

--- a/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
+++ b/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
@@ -47,6 +47,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         private const string ShowHistoryOutputParameter = "showHistoryOutput";
         private const string ShowInputParameter = "showInput";
         private const string FetchStateParameter = "fetchState";
+        private const string InstanceIdStartsWithParameter = "instanceIdStartsWith";
         private const string CreatedTimeFromParameter = "createdTimeFrom";
         private const string CreatedTimeToParameter = "createdTimeTo";
         private const string RuntimeStatusParameter = "runtimeStatus";
@@ -442,6 +443,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
             var condition = new OrchestrationStatusQueryCondition();
 
+            if (TryGetStringQueryParameterValue(queryNameValuePairs, InstanceIdStartsWithParameter, out string instanceIdStartsWith))
+            {
+                condition.InstanceIdPrefix = instanceIdStartsWith;
+            }
+
             if (TryGetDateTimeQueryParameterValue(queryNameValuePairs, CreatedTimeFromParameter, out DateTime createdTimeFrom))
             {
                 condition.CreatedTimeFrom = createdTimeFrom;
@@ -715,6 +721,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             }
 
             return false;
+        }
+
+        private static bool TryGetStringQueryParameterValue(NameValueCollection queryStringNameValueCollection, string queryParameterName, out string stringValue)
+        {
+            stringValue = queryStringNameValueCollection[queryParameterName];
+            return stringValue != null;
         }
 
         private static bool TryGetDateTimeQueryParameterValue(NameValueCollection queryStringNameValueCollection, string queryParameterName, out DateTime dateTimeValue)

--- a/test/Common/HttpApiHandlerTests.cs
+++ b/test/Common/HttpApiHandlerTests.cs
@@ -529,6 +529,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             var runtimeStatus = new List<OrchestrationRuntimeStatus>();
             runtimeStatus.Add(OrchestrationRuntimeStatus.Running);
             var runtimeStatusString = OrchestrationRuntimeStatus.Running.ToString();
+            var instanceIdStartsWith = "Do";
 
             var clientMock = new Mock<IDurableClient>();
             clientMock
@@ -540,7 +541,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             // Build uri
             var getStatusRequestUriBuilder = new UriBuilder(TestConstants.NotificationUrl);
             getStatusRequestUriBuilder.Path += $"/Instances/";
-            getStatusRequestUriBuilder.Query = $"createdTimeFrom={WebUtility.UrlEncode(createdTimeFrom.ToString())}&createdTimeTo={WebUtility.UrlEncode(createdTimeTo.ToString())}&runtimeStatus={runtimeStatusString}";
+            getStatusRequestUriBuilder.Query = $"createdTimeFrom={WebUtility.UrlEncode(createdTimeFrom.ToString())}&createdTimeTo={WebUtility.UrlEncode(createdTimeTo.ToString())}&runtimeStatus={runtimeStatusString}&instanceIdStartsWith={instanceIdStartsWith}";
 
             // Test HttpApiHandler response
             var responseMessage = await httpApiHandler.HandleRequestAsync(
@@ -593,6 +594,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             var runtimeStatusString = OrchestrationRuntimeStatus.Running.ToString();
             var pageSize = 100;
             var continuationToken = "XXXX-XXXXXXXX-XXXXXXXXXXXX";
+            var instanceIdStartsWith = "Do";
 
             var clientMock = new Mock<IDurableClient>();
             clientMock
@@ -605,6 +607,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                     Assert.Equal(OrchestrationRuntimeStatus.Running, condition.RuntimeStatus.FirstOrDefault());
                     Assert.Equal(pageSize, condition.PageSize);
                     Assert.Equal(continuationToken, condition.ContinuationToken);
+                    Assert.Equal(instanceIdStartsWith, condition.InstanceIdPrefix);
                 });
 
             var httpApiHandler = new ExtendedHttpApiHandler(clientMock.Object);
@@ -612,7 +615,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             // Build uri
             var getStatusRequestUriBuilder = new UriBuilder(TestConstants.NotificationUrl);
             getStatusRequestUriBuilder.Path += $"/Instances/";
-            getStatusRequestUriBuilder.Query = $"createdTimeFrom={WebUtility.UrlEncode(createdTimeFrom.ToString())}&createdTimeTo={WebUtility.UrlEncode(createdTimeTo.ToString())}&runtimeStatus={runtimeStatusString}&top=100";
+            getStatusRequestUriBuilder.Query = $"createdTimeFrom={WebUtility.UrlEncode(createdTimeFrom.ToString())}&createdTimeTo={WebUtility.UrlEncode(createdTimeTo.ToString())}&runtimeStatus={runtimeStatusString}&top=100&instanceIdStartsWith={instanceIdStartsWith}";
 
             // Test HttpApiHandler response
             var requestMessage = new HttpRequestMessage

--- a/test/Common/HttpApiHandlerTests.cs
+++ b/test/Common/HttpApiHandlerTests.cs
@@ -529,7 +529,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             var runtimeStatus = new List<OrchestrationRuntimeStatus>();
             runtimeStatus.Add(OrchestrationRuntimeStatus.Running);
             var runtimeStatusString = OrchestrationRuntimeStatus.Running.ToString();
-            var instanceIdStartsWith = "Do";
+            var instanceIdPrefix = "Do";
 
             var clientMock = new Mock<IDurableClient>();
             clientMock
@@ -541,7 +541,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             // Build uri
             var getStatusRequestUriBuilder = new UriBuilder(TestConstants.NotificationUrl);
             getStatusRequestUriBuilder.Path += $"/Instances/";
-            getStatusRequestUriBuilder.Query = $"createdTimeFrom={WebUtility.UrlEncode(createdTimeFrom.ToString())}&createdTimeTo={WebUtility.UrlEncode(createdTimeTo.ToString())}&runtimeStatus={runtimeStatusString}&instanceIdStartsWith={instanceIdStartsWith}";
+            getStatusRequestUriBuilder.Query = $"createdTimeFrom={WebUtility.UrlEncode(createdTimeFrom.ToString())}&createdTimeTo={WebUtility.UrlEncode(createdTimeTo.ToString())}&runtimeStatus={runtimeStatusString}&instanceIdPrefix={instanceIdPrefix}";
 
             // Test HttpApiHandler response
             var responseMessage = await httpApiHandler.HandleRequestAsync(
@@ -594,7 +594,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             var runtimeStatusString = OrchestrationRuntimeStatus.Running.ToString();
             var pageSize = 100;
             var continuationToken = "XXXX-XXXXXXXX-XXXXXXXXXXXX";
-            var instanceIdStartsWith = "Do";
+            var instanceIdPrefix = "Do";
 
             var clientMock = new Mock<IDurableClient>();
             clientMock
@@ -607,7 +607,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                     Assert.Equal(OrchestrationRuntimeStatus.Running, condition.RuntimeStatus.FirstOrDefault());
                     Assert.Equal(pageSize, condition.PageSize);
                     Assert.Equal(continuationToken, condition.ContinuationToken);
-                    Assert.Equal(instanceIdStartsWith, condition.InstanceIdPrefix);
+                    Assert.Equal(instanceIdPrefix, condition.InstanceIdPrefix);
                 });
 
             var httpApiHandler = new ExtendedHttpApiHandler(clientMock.Object);
@@ -615,7 +615,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             // Build uri
             var getStatusRequestUriBuilder = new UriBuilder(TestConstants.NotificationUrl);
             getStatusRequestUriBuilder.Path += $"/Instances/";
-            getStatusRequestUriBuilder.Query = $"createdTimeFrom={WebUtility.UrlEncode(createdTimeFrom.ToString())}&createdTimeTo={WebUtility.UrlEncode(createdTimeTo.ToString())}&runtimeStatus={runtimeStatusString}&top=100&instanceIdStartsWith={instanceIdStartsWith}";
+            getStatusRequestUriBuilder.Query = $"createdTimeFrom={WebUtility.UrlEncode(createdTimeFrom.ToString())}&createdTimeTo={WebUtility.UrlEncode(createdTimeTo.ToString())}&runtimeStatus={runtimeStatusString}&top=100&instanceIdPrefix={instanceIdPrefix}";
 
             // Test HttpApiHandler response
             var requestMessage = new HttpRequestMessage


### PR DESCRIPTION
It appears that the instancePrefix parameter is not currently available in the HTTP API when querying instances.

This is probably a simple oversight. This PR adds an optional query parameter 'instanceIdStartsWith' so that instances can be filtered by the instance prefix, just like already supported for the internal query SDKs.

[ ] Documentation PR is ready to merge and referenced in `pending_docs.md`
[x] I've added my notes to `release_notes.md`
[x] My changes **do not** need to be backported to a previous version
[x] I have added all required tests
[x] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
[x] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
