### PR TITLE
Simplify DTFx release instructions

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-release-template.md
+++ b/.github/ISSUE_TEMPLATE/new-release-template.md
@@ -11,8 +11,8 @@ assignees: comcmaho, amdeel, davidmrdavid, bachuv
 _Due: <2-3-business-days-before-release>_
 - [ ] Check DTFx package versions (either DT-AzureStorage only or if there were Core changes DT-AzureStorage, DT-Core, DT-Emulator, and DT-Redis)
 - [ ] Delete DTFx test packages from staging myget.
-- [ ] Run the [DTFx release pipeline](https://github.com/Azure/durabletask/blob/main/azure-pipelines-release.yml) to obtain new packages.
-- [ ] Publish DTFx packages to staging myget for testing.
+- [ ] Run the [DTFx release pipeline](https://durabletaskframework.visualstudio.com/Durable%20Task%20Framework%20CI/_build?definitionId=21) ([defined here](https://github.com/Azure/durabletask/blob/main/azure-pipelines-release.yml)) to obtain new packages.
+- [ ] Publish DTFx packages to staging myget (https://www.myget.org/feed/Packages/azure-appservice) for testing.
 
 **Prep Release (assigned to: )**
 _Due: <2-business-days-before-release>_

--- a/.github/ISSUE_TEMPLATE/new-release-template.md
+++ b/.github/ISSUE_TEMPLATE/new-release-template.md
@@ -11,9 +11,8 @@ assignees: comcmaho, amdeel, davidmrdavid, bachuv
 _Due: <2-3-business-days-before-release>_
 - [ ] Check DTFx package versions (either DT-AzureStorage only or if there were Core changes DT-AzureStorage, DT-Core, DT-Emulator, and DT-Redis)
 - [ ] Delete DTFx test packages from staging myget.
-- [ ] Update OneBranch durabletask repo, run signing pipeline (using these notes:  [Durable Task Framework Build Pipeline] (https://microsoft.sharepoint.com/teams/AzureWebjobs/_layouts/OneNote.aspx?id=%2Fteams%2FAzureWebjobs%2FSiteAssets%2FAzureWebjobs%20Notebook&wd=target%28Planning%2FFunctions%20Post-GA.one%7CA43CF112-7272-481A-B23E-9AA5CA8EEE06%2FDurable%20Task%20Framework%20Build%20Pipeline%7CD0946823-6FB0-44E3-A57F-E252617B69CD%2F%29
-onenote:https://microsoft.sharepoint.com/teams/AzureWebjobs/SiteAssets/AzureWebjobs%20Notebook/Planning/Functions%20Post-GA.one#Durable%20Task%20Framework%20Build%20Pipeline&section-id={A43CF112-7272-481A-B23E-9AA5CA8EEE06}&page-id={D0946823-6FB0-44E3-A57F-E252617B69CD}&end) ).
-- [ ] Publish DTFx packages to staging myget for testing. (either DT-AzureStorage only or if there were Core changes DT-AzureStorage and DT-Core)
+- [ ] Run the [DTFx release pipeline](https://github.com/Azure/durabletask/blob/main/azure-pipelines-release.yml) to obtain new packages.
+- [ ] Publish DTFx packages to staging myget for testing.
 
 **Prep Release (assigned to: )**
 _Due: <2-business-days-before-release>_


### PR DESCRIPTION
Our current DTFx release instructions are out of date. This PR updates the instructions to describe the simpler, pipeline-driven, release procedure.