### PR TITLE
Add explicit DTFx.Core dependency

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
@@ -2130,6 +2130,15 @@
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurabilityProvider.PurgeOrchestrationHistoryAsync(System.DateTime,DurableTask.Core.OrchestrationStateTimeRangeFilterType)">
             <inheritdoc />
         </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurabilityProvider.DurableTask#Core#Query#IOrchestrationServiceQueryClient#GetOrchestrationWithQueryAsync(DurableTask.Core.Query.OrchestrationQuery,System.Threading.CancellationToken)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurabilityProvider.DurableTask#Core#IOrchestrationServicePurgeClient#PurgeInstanceStateAsync(System.String)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurabilityProvider.DurableTask#Core#IOrchestrationServicePurgeClient#PurgeInstanceStateAsync(DurableTask.Core.PurgeInstanceFilter)">
+            <inheritdoc />
+        </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurabilityProvider.ValidateDelayTime(System.TimeSpan,System.String@)">
             <summary>
             Uses durability provider specific logic to verify whether a timespan for a timer, timeout

--- a/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
+++ b/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
@@ -109,6 +109,7 @@
 
   <!-- Common dependencies across all targets -->
   <ItemGroup>
+    <PackageReference Include="Microsoft.Azure.DurableTask.Core" Version="2.9.*" />
     <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage" Version="1.11.*" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers" Version="0.4.*" />
     <!-- Build-time dependencies -->


### PR DESCRIPTION
Currently, the Durable Extension takes a dependency on DTFx.AzureStorage, which transitively takes on a dependency on DTFx.Core.

This means that the extension cannot benefit from DTFx.Core changes without an accompanying DTFx.AzureStorage release, irrespective of whether any DTFx.AzureStorage changes warrant that release.

This PR adds an explicit DTFx.Core reference to the project, to circumvent this issue.