### PR TITLE
Update DTFx version dependencies

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -4,3 +4,7 @@
 
 ## Enhancements
 - add optional 'instanceIdPrefix' query parameter to the HTTP API for instance queries
+
+## Dependencies
+- DurableTask.Core --> v2.10.*
+- DurableTask.AzureStorage --> v1.12.*

--- a/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
+++ b/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
@@ -109,8 +109,8 @@
 
   <!-- Common dependencies across all targets -->
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.DurableTask.Core" Version="2.9.*" />
-    <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage" Version="1.11.*" />
+    <PackageReference Include="Microsoft.Azure.DurableTask.Core" Version="2.10.*" />
+    <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage" Version="1.12.*" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers" Version="0.4.*" />
     <!-- Build-time dependencies -->
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.*" PrivateAssets="All" />


### PR DESCRIPTION
This is to address a compatibility issue for .NET Framework, which has stricter assembly versioning requirements.


### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)
* [x] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk
* [x] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
    * [ ] Otherwise: major or minor version updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
