### PR TITLE
Analyzer: Added Dependency Injection Analyzer

### DIFF
--- a/src/WebJobs.Extensions.DurableTask.Analyzers/Analyzers/ActivityFunction/FunctionAnalyzer.cs
+++ b/src/WebJobs.Extensions.DurableTask.Analyzers/Analyzers/ActivityFunction/FunctionAnalyzer.cs
@@ -297,7 +297,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
 
         private static bool TryGetDurableActivityContextExpression(SemanticModel semanticModel, SyntaxNode node, out SyntaxNode durableContextExpression)
         {
-            if (SyntaxNodeUtils.TryGetMethodDeclaration(node, out SyntaxNode methodDeclaration))
+            if (SyntaxNodeUtils.TryGetMethodDeclaration(node, out MethodDeclarationSyntax methodDeclaration))
             {
                 var memberAccessExpressionList = methodDeclaration.DescendantNodes().Where(x => x.IsKind(SyntaxKind.SimpleMemberAccessExpression));
                 foreach (var memberAccessExpression in memberAccessExpressionList)

--- a/src/WebJobs.Extensions.DurableTask.Analyzers/Analyzers/Entity/DispatchEntityNameAnalyzer.cs
+++ b/src/WebJobs.Extensions.DurableTask.Analyzers/Analyzers/Entity/DispatchEntityNameAnalyzer.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
                 var name = expression.Name;
                 if (name.ToString().StartsWith("DispatchAsync"))
                 {
-                    if(SyntaxNodeUtils.TryGetMethodDeclaration(expression, out SyntaxNode methodDeclaration))
+                    if(SyntaxNodeUtils.TryGetMethodDeclaration(expression, out MethodDeclarationSyntax methodDeclaration))
                     {
                         methodDeclarations.Add(methodDeclaration);
                     }

--- a/src/WebJobs.Extensions.DurableTask.Analyzers/Analyzers/Entity/StaticFunctionAnalyzer.cs
+++ b/src/WebJobs.Extensions.DurableTask.Analyzers/Analyzers/Entity/StaticFunctionAnalyzer.cs
@@ -22,8 +22,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
 
         public static void ReportProblems(CompilationAnalysisContext context, SyntaxNode methodDeclaration)
         {
-            var staticKeyword = methodDeclaration.ChildTokens().FirstOrDefault(x => x.IsKind(SyntaxKind.StaticKeyword));
-            if (staticKeyword == null || staticKeyword.IsKind(SyntaxKind.None))
+            if (!SyntaxNodeUtils.IsInStaticMethod(methodDeclaration))
             {
                 SemanticModel semanticModel = context.Compilation.GetSemanticModel(methodDeclaration.SyntaxTree);
                 if (IsInEntityClass(semanticModel, methodDeclaration))

--- a/src/WebJobs.Extensions.DurableTask.Analyzers/Analyzers/Orchestrator/DependencyInjectionAnalyzer.cs
+++ b/src/WebJobs.Extensions.DurableTask.Analyzers/Analyzers/Orchestrator/DependencyInjectionAnalyzer.cs
@@ -1,0 +1,93 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class DependencyInjectionAnalyzer
+    {
+        public const string DiagnosticId = "DF0113";
+
+        //TODO: Fix strings
+        private static readonly LocalizableString Title = new LocalizableResourceString(nameof(Resources.DependencyInjectionAnalyzerTitle), Resources.ResourceManager, typeof(Resources));
+        private static readonly LocalizableString MessageFormat = new LocalizableResourceString(nameof(Resources.DeterministicAnalyzerMessageFormat), Resources.ResourceManager, typeof(Resources));
+        private static readonly LocalizableString Description = new LocalizableResourceString(nameof(Resources.DeterministicAnalyzerDescription), Resources.ResourceManager, typeof(Resources));
+        private const string Category = SupportedCategories.Orchestrator;
+        public const DiagnosticSeverity Severity = DiagnosticSeverity.Warning;
+
+        public static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, Category, Severity, isEnabledByDefault: true, description: Description);
+
+        public static bool RegisterDiagnostic(CompilationAnalysisContext context, SyntaxNode method)
+        {
+            var diagnosedIssue = false;
+
+            if (!SyntaxNodeUtils.IsInStaticClass(method))
+            {
+                if(TryGetInjectedVariables(method, out List<SyntaxNode> injectedVariables))
+                {
+                    var methodVariablesUsed = method.DescendantNodes().Where(x => x.IsKind(SyntaxKind.IdentifierName));
+
+                    var varaiblesToDiagnose = methodVariablesUsed.Where(x => injectedVariables.Exists(y => y.ToString() == x.ToString()));
+
+                    foreach (var variable in varaiblesToDiagnose)
+                    {
+                        var diagnostic = Diagnostic.Create(Rule, variable.GetLocation(), variable);
+
+                        if (context.Compilation.ContainsSyntaxTree(method.SyntaxTree))
+                        {
+                            context.ReportDiagnostic(diagnostic);
+                        }
+
+                        diagnosedIssue = true;
+                    }
+                }
+            }
+
+            return diagnosedIssue;
+        }
+
+        private static bool TryGetInjectedVariables(SyntaxNode method, out List<SyntaxNode> injectedVariables)
+        {
+            injectedVariables = new List<SyntaxNode>();
+            var addedVariable = false;
+            if (SyntaxNodeUtils.TryGetConstructor(method, out ConstructorDeclarationSyntax constructor))
+            {
+                var parameters = constructor.ParameterList.ChildNodes();
+                var injectedParameterNames = new List<SyntaxToken>();
+                foreach (SyntaxNode parameter in parameters)
+                {
+                    injectedParameterNames.Add(parameter.ChildTokens().FirstOrDefault(x => x.IsKind(SyntaxKind.IdentifierToken)));
+                }
+
+                var assignementExpressions = constructor.DescendantNodes().Where(x => x.IsKind(SyntaxKind.SimpleAssignmentExpression));
+
+                foreach (AssignmentExpressionSyntax assignmentExpression in assignementExpressions)
+                {
+                    var injectedRightSideNode = assignmentExpression.Right.DescendantNodes().Where(x => x.IsKind(SyntaxKind.IdentifierName) && injectedParameterNames.Contains(((IdentifierNameSyntax)x).Identifier));
+
+                    if (injectedRightSideNode == null)
+                    {
+                        continue;
+                    }
+
+                    var assignedLeftSideNode = assignmentExpression.Left.DescendantNodes().FirstOrDefault(x => x.IsKind(SyntaxKind.IdentifierName));
+
+                    if (assignedLeftSideNode != null)
+                    {
+                        injectedVariables.Add(assignedLeftSideNode);
+                        addedVariable = true;
+                    }
+                }
+            }
+
+            return addedVariable;
+        }
+    }
+}

--- a/src/WebJobs.Extensions.DurableTask.Analyzers/Analyzers/Orchestrator/DependencyInjectionAnalyzer.cs
+++ b/src/WebJobs.Extensions.DurableTask.Analyzers/Analyzers/Orchestrator/DependencyInjectionAnalyzer.cs
@@ -15,7 +15,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
     {
         public const string DiagnosticId = "DF0113";
 
-        //TODO: Fix strings
         private static readonly LocalizableString Title = new LocalizableResourceString(nameof(Resources.DependencyInjectionAnalyzerTitle), Resources.ResourceManager, typeof(Resources));
         private static readonly LocalizableString MessageFormat = new LocalizableResourceString(nameof(Resources.DeterministicAnalyzerMessageFormat), Resources.ResourceManager, typeof(Resources));
         private static readonly LocalizableString Description = new LocalizableResourceString(nameof(Resources.DeterministicAnalyzerDescription), Resources.ResourceManager, typeof(Resources));

--- a/src/WebJobs.Extensions.DurableTask.Analyzers/Analyzers/Orchestrator/DeterministicMethodAnalyzer.cs
+++ b/src/WebJobs.Extensions.DurableTask.Analyzers/Analyzers/Orchestrator/DeterministicMethodAnalyzer.cs
@@ -31,7 +31,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
                     TimerAnalyzer.V2Rule,
                     CancellationTokenAnalyzer.Rule,
                     BindingAnalyzer.Rule,
-                    MethodInvocationAnalyzer.Rule);
+                    MethodInvocationAnalyzer.Rule,
+                    DependencyInjectionAnalyzer.Rule);
             }
         }
 
@@ -65,7 +66,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
                     | ThreadTaskAnalyzer.RegisterDiagnostic(context, semanticModel, methodDeclaration)
                     | TimerAnalyzer.RegisterDiagnostic(context, semanticModel, methodDeclaration)
                     | CancellationTokenAnalyzer.RegisterDiagnostic(context, methodDeclaration)
-                    | BindingAnalyzer.RegisterDiagnostic(context, methodDeclaration))
+                    | BindingAnalyzer.RegisterDiagnostic(context, methodDeclaration)
+                    | DependencyInjectionAnalyzer.RegisterDiagnostic(context, methodDeclaration))
                 {
                     methodInvocationAnalyzer.RegisterDiagnostics(context, methodInformation);
                 }

--- a/src/WebJobs.Extensions.DurableTask.Analyzers/Analyzers/Orchestrator/ThreadTaskAnalyzer.cs
+++ b/src/WebJobs.Extensions.DurableTask.Analyzers/Analyzers/Orchestrator/ThreadTaskAnalyzer.cs
@@ -163,28 +163,22 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
 
         private static bool HasExecuteSynchronously(SyntaxNode node)
         {
-            if(!SyntaxNodeUtils.TryGetInvocationExpression(node, out SyntaxNode invocationExpression))
+            if(!SyntaxNodeUtils.TryGetInvocationExpression(node, out InvocationExpressionSyntax invocationExpression))
             {
                 return false;
             }
 
-            var argumentList = invocationExpression.ChildNodes().FirstOrDefault(x => x.IsKind(SyntaxKind.ArgumentList));
-
-            if (argumentList != null)
+            var argumentList = invocationExpression.ArgumentList;
+            foreach (ArgumentSyntax argument in argumentList.ChildNodes())
             {
-                foreach (SyntaxNode argument in argumentList.ChildNodes())
+                if (argument.Expression is MemberAccessExpressionSyntax expression)
                 {
-                    var simpleMemberAccessExpression = argument.ChildNodes().FirstOrDefault(x => x.IsKind(SyntaxKind.SimpleMemberAccessExpression));
-
-                    if (simpleMemberAccessExpression != null)
+                    var identifierNames = expression.ChildNodes().Where(x => x.IsKind(SyntaxKind.IdentifierName));
+                    foreach (SyntaxNode identifier in identifierNames)
                     {
-                        var identifierNames = simpleMemberAccessExpression.ChildNodes().Where(x => x.IsKind(SyntaxKind.IdentifierName));
-                        foreach (SyntaxNode identifier in identifierNames)
+                        if (identifier.ToString().Equals("ExecuteSynchronously"))
                         {
-                            if (identifier.ToString().Equals("ExecuteSynchronously"))
-                            {
-                                return true;
-                            }
+                            return true;
                         }
                     }
                 }

--- a/src/WebJobs.Extensions.DurableTask.Analyzers/CodeFixProviderUtils.cs
+++ b/src/WebJobs.Extensions.DurableTask.Analyzers/CodeFixProviderUtils.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -24,9 +25,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
 
         public static bool TryGetDurableOrchestrationContextVariableName(SyntaxNode node, out string variableName)
         {
-            if (SyntaxNodeUtils.TryGetMethodDeclaration(node, out SyntaxNode methodDeclaration))
+            if (SyntaxNodeUtils.TryGetMethodDeclaration(node, out MethodDeclarationSyntax methodDeclaration))
             {
-                var parameterList = methodDeclaration.ChildNodes().First(x => x.IsKind(SyntaxKind.ParameterList));
+                var parameterList = methodDeclaration.ParameterList;
 
                 foreach (SyntaxNode parameter in parameterList.ChildNodes())
                 {

--- a/src/WebJobs.Extensions.DurableTask.Analyzers/CodefixProviders/Entity/StaticFunctionCodeFixProvider.cs
+++ b/src/WebJobs.Extensions.DurableTask.Analyzers/CodefixProviders/Entity/StaticFunctionCodeFixProvider.cs
@@ -46,9 +46,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
         private async Task<Document> AddStaticModifierAsync(Document document, SyntaxNode identifierNode, CancellationToken cancellationToken)
         {
             var root = await document.GetSyntaxRootAsync(cancellationToken);
-            if (SyntaxNodeUtils.TryGetMethodDeclaration(identifierNode, out SyntaxNode methodDeclaration))
+            if (SyntaxNodeUtils.TryGetMethodDeclaration(identifierNode, out MethodDeclarationSyntax methodDeclaration))
             {
-                var newMethodDeclaration = ((MethodDeclarationSyntax)methodDeclaration).AddModifiers(SyntaxFactory.Token(SyntaxKind.StaticKeyword));
+                var newMethodDeclaration = methodDeclaration.AddModifiers(SyntaxFactory.Token(SyntaxKind.StaticKeyword));
                 var newRoot = root.ReplaceNode(methodDeclaration, newMethodDeclaration);
 
                 return document.WithSyntaxRoot(newRoot);

--- a/src/WebJobs.Extensions.DurableTask.Analyzers/Resources.Designer.cs
+++ b/src/WebJobs.Extensions.DurableTask.Analyzers/Resources.Designer.cs
@@ -232,6 +232,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Injected dependencies cannot be used inside an orchestrator function..
+        /// </summary>
+        public static string DependencyInjectionAnalyzerTitle {
+            get {
+                return ResourceManager.GetString("DependencyInjectionAnalyzerTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to An orchestrator function must be deterministic. For more information on orchestrator code constraints, see:
         ///https://docs.microsoft.com/azure/azure-functions/durable/durable-functions-checkpointing-and-replay#orchestrator-code-constraints.
         /// </summary>

--- a/src/WebJobs.Extensions.DurableTask.Analyzers/Resources.resx
+++ b/src/WebJobs.Extensions.DurableTask.Analyzers/Resources.resx
@@ -174,6 +174,9 @@
   <data name="DateTimeAnalyzerTitle" xml:space="preserve">
     <value>DateTime calls must be deterministic inside an orchestrator function.</value>
   </data>
+  <data name="DependencyInjectionAnalyzerTitle" xml:space="preserve">
+    <value>Injected dependencies cannot be used inside an orchestrator function.</value>
+  </data>
   <data name="DeterministicAnalyzerDescription" xml:space="preserve">
     <value>An orchestrator function must be deterministic. For more information on orchestrator code constraints, see:
 https://docs.microsoft.com/azure/azure-functions/durable/durable-functions-checkpointing-and-replay#orchestrator-code-constraints</value>

--- a/src/WebJobs.Extensions.DurableTask.Analyzers/SyntaxNodeUtils.cs
+++ b/src/WebJobs.Extensions.DurableTask.Analyzers/SyntaxNodeUtils.cs
@@ -120,17 +120,17 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
 
         public static bool IsInsideOrchestrationTrigger(SyntaxNode node)
         {
-            if (TryGetMethodDeclaration(node, out SyntaxNode methodDeclaration))
+            if (TryGetMethodDeclaration(node, out MethodDeclarationSyntax methodDeclaration))
             {
-                var parameters = ((MethodDeclarationSyntax)methodDeclaration).ParameterList.ChildNodes();
+                var parameters = methodDeclaration.ParameterList.ChildNodes();
 
                 foreach (SyntaxNode parameter in parameters)
                 {
                     var attributeLists = parameter.ChildNodes().Where(x => x.IsKind(SyntaxKind.AttributeList));
-                    foreach (SyntaxNode attribute in attributeLists)
+                    foreach (SyntaxNode attributeList in attributeLists)
                     {
                         //An AttributeList will always have a child node Attribute
-                        if (attribute.ChildNodes().First().ToString().Equals("OrchestrationTrigger"))
+                        if (attributeList.ChildNodes().First().ToString().Equals("OrchestrationTrigger"))
                         {
                             return true;
                         }
@@ -148,9 +148,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
 
         internal static bool TryGetMethodReturnTypeNode(SyntaxNode node, out SyntaxNode returnTypeNode)
         {
-            if (TryGetMethodDeclaration(node, out SyntaxNode methodDeclaration))
+            if (TryGetMethodDeclaration(node, out MethodDeclarationSyntax methodDeclaration))
             {
-                return TryGetChildTypeNode(methodDeclaration, out returnTypeNode);
+                returnTypeNode = methodDeclaration.ReturnType;
+                return returnTypeNode != null;
             }
 
             returnTypeNode = null;
@@ -172,7 +173,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
 
         private static bool TryGetAttribute(SyntaxNode node, string attributeName, out SyntaxNode attribute)
         {
-            if (TryGetMethodDeclaration(node, out SyntaxNode methodDeclaration))
+            if (TryGetMethodDeclaration(node, out MethodDeclarationSyntax methodDeclaration))
             {
                 var attributeLists = methodDeclaration.ChildNodes().Where(x => x.IsKind(SyntaxKind.AttributeList));
                 foreach (var attributeList in attributeLists)
@@ -192,32 +193,37 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
 
         }
 
-        internal static bool TryGetMethodDeclaration(SyntaxNode node, out SyntaxNode methodDeclaration) => TryGetContainingSyntaxNode(node, SyntaxKind.MethodDeclaration, out methodDeclaration);
+        internal static bool TryGetMethodDeclaration(SyntaxNode node, out MethodDeclarationSyntax methodDeclaration) => TryGetContainingSyntaxNode(node, SyntaxKind.MethodDeclaration, out methodDeclaration);
 
-        internal static bool TryGetInvocationExpression(SyntaxNode node, out SyntaxNode invocationExpression) => TryGetContainingSyntaxNode(node, SyntaxKind.InvocationExpression, out invocationExpression);
+        internal static bool TryGetInvocationExpression(SyntaxNode node, out InvocationExpressionSyntax invocationExpression) => TryGetContainingSyntaxNode(node, SyntaxKind.InvocationExpression, out invocationExpression);
 
-        internal static bool TryGetClassDeclaration(SyntaxNode node, out SyntaxNode classDeclaration) => TryGetContainingSyntaxNode(node, SyntaxKind.ClassDeclaration, out classDeclaration);
+        internal static bool TryGetClassDeclaration(SyntaxNode node, out ClassDeclarationSyntax classDeclaration) => TryGetContainingSyntaxNode(node, SyntaxKind.ClassDeclaration, out classDeclaration);
 
-        private static bool TryGetContainingSyntaxNode(SyntaxNode node, SyntaxKind kind, out SyntaxNode kindNode)
+        private static bool TryGetContainingSyntaxNode<T>(SyntaxNode node, SyntaxKind kind, out T kindNode)
         {
+            kindNode = default(T);
             var currNode = node.IsKind(kind) ? node : node.Parent;
             while (!currNode.IsKind(kind))
             {
                 if (currNode.IsKind(SyntaxKind.CompilationUnit))
                 {
-                    kindNode = null;
-                    return false;
+                    break;
                 }
                 currNode = currNode.Parent;
             }
 
-            kindNode = currNode;
-            return true;
+            if (currNode is T)
+            {
+                kindNode = (T)(object)currNode;
+                return true;
+            }
+
+            return false;
         }
 
         internal static bool TryGetConstructor(SyntaxNode node, out ConstructorDeclarationSyntax constructor)
         {
-            if (TryGetClassDeclaration(node, out SyntaxNode classDeclaration))
+            if (TryGetClassDeclaration(node, out ClassDeclarationSyntax classDeclaration))
             {
                 var constructorNode = classDeclaration.ChildNodes().FirstOrDefault(x => x.IsKind(SyntaxKind.ConstructorDeclaration));
                 if (constructorNode != null)
@@ -233,9 +239,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
 
         internal static bool TryGetClassName(SyntaxNode node, out string className)
         {
-            if (TryGetClassDeclaration(node, out SyntaxNode classDeclaration))
+            if (TryGetClassDeclaration(node, out ClassDeclarationSyntax classDeclaration))
             {
-                className = ((ClassDeclarationSyntax)classDeclaration).Identifier.ToString();
+                className = classDeclaration.Identifier.ToString();
                 return true;
             }
 
@@ -245,7 +251,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
 
         internal static bool IsInStaticClass(SyntaxNode node)
         {
-            if (TryGetClassDeclaration(node, out SyntaxNode classDeclaration))
+            if (TryGetClassDeclaration(node, out ClassDeclarationSyntax classDeclaration))
             {
                 if (HasStaticChildNode(classDeclaration))
                 {
@@ -258,7 +264,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
 
         internal static bool IsInStaticMethod(SyntaxNode node)
         {
-            if (TryGetMethodDeclaration(node, out SyntaxNode methodDeclaration))
+            if (TryGetMethodDeclaration(node, out MethodDeclarationSyntax methodDeclaration))
             {
                 if (HasStaticChildNode(methodDeclaration))
                 {

--- a/src/WebJobs.Extensions.DurableTask.Analyzers/WebJobs.Extensions.DurableTask.Analyzers.csproj
+++ b/src/WebJobs.Extensions.DurableTask.Analyzers/WebJobs.Extensions.DurableTask.Analyzers.csproj
@@ -8,7 +8,7 @@
 
   <PropertyGroup>
     <PackageId>Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers</PackageId>
-    <PackageVersion>0.4.2</PackageVersion>
+    <PackageVersion>0.5.0</PackageVersion>
     <Authors>Microsoft</Authors>
     <PackageLicenseUrl>https://go.microsoft.com/fwlink/?linkid=2028464</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/Azure/azure-functions-durable-extension</PackageProjectUrl>

--- a/test/WebJobs.Extensions.DurableTask.Analyzers.Test/Orchestrator/DependencyInjectionAnalyzerTests.cs
+++ b/test/WebJobs.Extensions.DurableTask.Analyzers.Test/Orchestrator/DependencyInjectionAnalyzerTests.cs
@@ -27,8 +27,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers.Test.Orchestr
     {
         public class HelloSequence
         {
-            public HelloSequence()
+            private string injectedVariable;
+
+            public HelloSequence(string injectedVariable)
             {
+                this.injectedVariable = injectedVariable;
             }
 
             [FunctionName(""DIAnalyzerTestCases"")]
@@ -36,6 +39,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers.Test.Orchestr
             [OrchestrationTrigger] IDurableOrchestrationContext context)
             {
                 var noninjectedVariable = ""test"";
+            }
+
+            [FunctionName(""DI_Activity"")]
+            public static void DIActivity([ActivityTrigger] IDurableActivityContext context)
+            {
+                var usingDIVar = injectedVariable;
             }
         }
     }";

--- a/test/WebJobs.Extensions.DurableTask.Analyzers.Test/Orchestrator/DependencyInjectionAnalyzerTests.cs
+++ b/test/WebJobs.Extensions.DurableTask.Analyzers.Test/Orchestrator/DependencyInjectionAnalyzerTests.cs
@@ -1,0 +1,161 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using TestHelper;
+
+namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers.Test.Orchestrator
+{
+    [TestClass]
+    public class DependencyInjectionAnalyzerTests : CodeFixVerifier
+    {
+        private static readonly string DiagnosticId = DependencyInjectionAnalyzer.DiagnosticId;
+        private static readonly DiagnosticSeverity Severity = DiagnosticSeverity.Warning;
+
+        [TestMethod]
+        public void DI_NoDiagnosticTestCase()
+        {
+            var test = @"
+    using System;
+    using System.Threading;
+    using Microsoft.Azure.WebJobs;
+    using Microsoft.Azure.WebJobs.Extensions.DurableTask;
+
+    namespace VSSample
+    {
+        public class HelloSequence
+        {
+            public HelloSequence()
+            {
+            }
+
+            [FunctionName(""DIAnalyzerTestCases"")]
+            public static async Task Run(
+            [OrchestrationTrigger] IDurableOrchestrationContext context)
+            {
+                var noninjectedVariable = ""test"";
+            }
+        }
+    }";
+
+            VerifyCSharpDiagnostic(test);
+        }
+
+        [TestMethod]
+        public void DI_InjectedSameNameTest()
+        {
+            var test = @"
+    using System;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Extensions.DurableTask;
+
+namespace VSSample
+{
+    public class HelloSequence
+    {
+        private string injectedVariable;
+
+        public HelloSequence(string injectedVariable)
+        {
+            this.injectedVariable = injectedVariable;
+        }
+
+        [FunctionName(""DIAnalyzerTestCases"")]
+        public async Task Run(
+        [OrchestrationTrigger] IDurableOrchestrationContext context)
+            {
+                var usingDIVar = injectedVariable;
+                var usingDISimpleMemberAccessExpression = this.injectedVariable;
+            }
+        }
+    }";
+            var expectedDiagnostics = new DiagnosticResult[2];
+            expectedDiagnostics[0] = new DiagnosticResult
+            {
+                Id = DiagnosticId,
+                Message = string.Format(Resources.DeterministicAnalyzerMessageFormat, "injectedVariable"),
+                Severity = Severity,
+                Locations =
+                    new[] {
+                            new DiagnosticResultLocation("Test0.cs", 22, 34)
+                        }
+            };
+
+            expectedDiagnostics[1] = new DiagnosticResult
+            {
+                Id = DiagnosticId,
+                Message = string.Format(Resources.DeterministicAnalyzerMessageFormat, "injectedVariable"),
+                Severity = Severity,
+                Locations =
+                    new[] {
+                            new DiagnosticResultLocation("Test0.cs", 23, 64)
+                        }
+            };
+
+            VerifyCSharpDiagnostic(test, expectedDiagnostics);
+        }
+
+        [TestMethod]
+        public void DI_InjectedDifferentNameTest()
+        {
+            var test = @"
+    using System;
+    using System.Threading;
+    using Microsoft.Azure.WebJobs;
+    using Microsoft.Azure.WebJobs.Extensions.DurableTask;
+
+    namespace VSSample
+    {
+        public class HelloSequence
+        {
+            private string diffVariableName;
+
+            public HelloSequence(string injectedVariable)
+            {
+                this.diffVariableName = injectedVariable;
+            }
+
+            [FunctionName(""DIAnalyzerTestCases"")]
+            public static async Task Run(
+            [OrchestrationTrigger] IDurableOrchestrationContext context)
+            {
+               var usingDIVar = diffVariableName;
+                var usingDISimpleMemberAccessExpression = this.diffVariableName;
+            }
+        }
+    }";
+            var expectedDiagnostics = new DiagnosticResult[2];
+            expectedDiagnostics[0] = new DiagnosticResult
+            {
+                Id = DiagnosticId,
+                Message = string.Format(Resources.DeterministicAnalyzerMessageFormat, "diffVariableName"),
+                Severity = Severity,
+                Locations =
+                    new[] {
+                            new DiagnosticResultLocation("Test0.cs", 22, 33)
+                        }
+            };
+
+            expectedDiagnostics[1] = new DiagnosticResult
+            {
+                Id = DiagnosticId,
+                Message = string.Format(Resources.DeterministicAnalyzerMessageFormat, "diffVariableName"),
+                Severity = Severity,
+                Locations =
+                    new[] {
+                            new DiagnosticResultLocation("Test0.cs", 23, 64)
+                        }
+            };
+
+            VerifyCSharpDiagnostic(test, expectedDiagnostics);
+        }
+
+        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+        {
+            return new DeterministicMethodAnalyzer();
+        }
+    }
+}


### PR DESCRIPTION
Added Dependency Injection Analyzer to our Deterministic Method Analyzers to flag variables used in deterministic methods that have been injected in orchestrator classes.

### Pull request checklist

* [ ] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)
* [ ] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk
* [ ] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
    * [ ] Otherwise: major or minor version updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
