### PR TITLE
handle internal errors like OOM in entity processing by aborting the …

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -1,6 +1,7 @@
 ## Bug Fixes
 - Correctly Serialize HostStoppingEvent in ActivityShim (https://github.com/Azure/azure-functions-durable-extension/pull/2178)
 - Fix NotImplementedException for management API calls from Java client (https://github.com/Azure/azure-functions-durable-extension/pull/2193)
+- Handle OOM and other exceptions in entity shim by aborting the session (https://github.com/Azure/azure-functions-durable-extension/pull/2234)
 
 ## Enhancements
 - add optional 'instanceIdPrefix' query parameter to the HTTP API for instance queries

--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableEntityContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableEntityContext.cs
@@ -8,6 +8,8 @@ using System.Reflection;
 using System.Runtime.ExceptionServices;
 using System.Threading.Tasks;
 using DurableTask.Core;
+using DurableTask.Core.Common;
+using DurableTask.Core.Exceptions;
 using Microsoft.Azure.WebJobs.Host.Bindings;
 using Newtonsoft.Json;
 
@@ -130,6 +132,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             }
 
             this.ApplicationErrors.Add(ExceptionDispatchInfo.Capture(e));
+        }
+
+        public void AbortOnInternalError()
+        {
+            if (this.InternalError != null)
+            {
+                throw new SessionAbortedException($"Session aborted because of {this.InternalError.SourceException.GetType().Name}", this.InternalError.SourceException);
+            }
         }
 
         public void ThrowInternalExceptionIfAny()

--- a/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
@@ -1128,11 +1128,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 }
             }
 
-            await entityContext.RunDeferredTasks();
-
-            // If there were internal errors, do not commit the batch, but instead rethrow
+            // If there were internal errors, throw a SessionAbortedException
             // here so DTFx can abort the batch and back off the work item
-            entityContext.ThrowInternalExceptionIfAny();
+            entityContext.AbortOnInternalError();
+
+            await entityContext.RunDeferredTasks();
         }
 
         internal string GetDefaultConnectionName()

--- a/src/WebJobs.Extensions.DurableTask/Listener/TaskEntityShim.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/TaskEntityShim.cs
@@ -188,7 +188,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 #endif
             try
             {
-
                 if (this.operationBatch.Count == 0
                     && this.lockRequest == null
                     && (this.toBeRescheduled == null || this.toBeRescheduled.Count == 0)


### PR DESCRIPTION
Customer observed a case (#2166) where an entity goes into a permanently failed state after encountering an OOM error.

This PR addresses this issue by
- catching OOM (and other) exceptions inside the `TaskEntityShim.Execute` method
- throwing a SessionAbortedException at some later point to ensure the workitem gets aborted

### Issue describing the changes in this PR

resolves #2166

### Pull request checklist

* [x] My changes **do not** require documentation changes
* [x] I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
* [x] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
* [x] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
