### PR TITLE
Analyzer: Excluded null-state attributes from BindingAnalyzer

### DIFF
--- a/src/WebJobs.Extensions.DurableTask.Analyzers/Analyzers/Orchestrator/BindingAnalyzer.cs
+++ b/src/WebJobs.Extensions.DurableTask.Analyzers/Analyzers/Orchestrator/BindingAnalyzer.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System.Collections.Generic;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -32,7 +33,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
                 if (descendant is AttributeSyntax attribute)
                 {
                     var attributeName = attribute.Name.ToString();
-                    if (attributeName != "OrchestrationTrigger")
+                    if (attributeName != "OrchestrationTrigger" && !IsExcludedAttributeName(attributeName))
                     {
                         var diagnostic = Diagnostic.Create(Rule, attribute.GetLocation(), attributeName);
 
@@ -47,6 +48,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
             }
             
             return diagnosedIssue;
+        }
+
+        private static bool IsExcludedAttributeName(string attributeName)
+        {
+            var excludedAttributeNames = new List<string> { "AllowNull", "DisallowNull", "MaybeNull", "NotNull", "MaybeNullWhen", 
+                "NotNullWhen", "NotNullIfNotNull", "MemberNotNull", "MemberNotNullWhen", "DoesNotReturn", "DoesNotReturnIf" };
+            return excludedAttributeNames.Contains(attributeName);
         }
     }
 }

--- a/test/WebJobs.Extensions.DurableTask.Analyzers.Test/Orchestrator/BindingAnalyzerTersts.cs
+++ b/test/WebJobs.Extensions.DurableTask.Analyzers.Test/Orchestrator/BindingAnalyzerTersts.cs
@@ -15,7 +15,18 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers.Test.Orchestr
         private static readonly DiagnosticSeverity Severity = DiagnosticSeverity.Warning;
 
         [TestMethod]
-        public void Binding_NoDiagnosticTestCase()
+        [DataRow("AllowNull")]
+        [DataRow("DisallowNull")]
+        [DataRow("MaybeNull")]
+        [DataRow("NotNull")]
+        [DataRow("MaybeNullWhen")]
+        [DataRow("NotNullWhen")]
+        [DataRow("NotNullIfNotNull")]
+        [DataRow("MemberNotNull")]
+        [DataRow("MemberNotNullWhen")]
+        [DataRow("DoesNotReturn")]
+        [DataRow("DoesNotReturnIf")]
+        public void Binding_NoDiagnosticTestCase(string excludedAttribute)
         {
             var test = @"
     using System;
@@ -30,6 +41,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers.Test.Orchestr
             [FunctionName(""BindingAnalyzerTestCases"")]
             public static async Task Run(
             [OrchestrationTrigger] IDurableOrchestrationContext context)
+            {
+                ExcludedAttributeTest(""test"");
+            }
+
+            public void ExcludedAttributeTest([" + excludedAttribute + @"] string input)
             {
             }
         }


### PR DESCRIPTION
This PR explicitly excludes null-state attributes from analysis when using the BindingAnalyzer.

resolves #2222 

### Pull request checklist

* [ ] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)
* [ ] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk
* [ ] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
    * [ ] Otherwise: major or minor version updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
