### PR TITLE
Fix stack overflow in SetCustomStatus

### DIFF
--- a/src/Worker.Extensions.DurableTask/DurableTaskFunctionsMiddleware.cs
+++ b/src/Worker.Extensions.DurableTask/DurableTaskFunctionsMiddleware.cs
@@ -167,7 +167,7 @@ internal class DurableTaskFunctionsMiddleware : IFunctionsWorkerMiddleware
         public override void SetCustomStatus(object? customStatus)
         {
             this.EnsureLegalAccess();
-            this.SetCustomStatus(customStatus);
+            this.innerContext.SetCustomStatus(customStatus);
         }
 
         public override Task<T> WaitForExternalEvent<T>(string eventName, CancellationToken cancellationToken = default)


### PR DESCRIPTION
Fix stack overflow exception in `FunctionsOrchestrationContext.SetCustomStatus`.
The cause is a simple incorrect call to `this.SetCustomStatus` instead of `this.innerContext.SetCustomStatus`

resolves #2246
