### PR TITLE
Add support for implicit entity deletion in the durability provider

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/DurabilityProvider.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurabilityProvider.cs
@@ -76,6 +76,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         public virtual bool GuaranteesOrderedDelivery => false;
 
         /// <summary>
+        /// Specifies whether this backend supports implicit deletion of entities.
+        /// </summary>
+        public virtual bool SupportsImplicitEntityDeletion => false;
+
+        /// <summary>
         /// JSON representation of configuration to emit in telemetry.
         /// </summary>
         public virtual JObject ConfigurationJson => EmptyConfig;

--- a/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
@@ -258,6 +258,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         internal TimeSpan MessageReorderWindow
             => this.defaultDurabilityProvider.GuaranteesOrderedDelivery ? TimeSpan.Zero : TimeSpan.FromMinutes(this.Options.EntityMessageReorderWindowInMinutes);
 
+        internal bool UseImplicitEntityDeletion => this.defaultDurabilityProvider.SupportsImplicitEntityDeletion;
+
         internal IApplicationLifetimeWrapper HostLifetimeService { get; } = HostLifecycleService.NoOp;
 
         internal OutOfProcOrchestrationProtocol OutOfProcProtocol { get; }


### PR DESCRIPTION
In the Azure Storage provider, some metadata state has to be kept in storage even after entities are deleted, which has led to some confusion in the past (#1364, #1418) and may require users to calls to `CleanEntityStorage` to remove garbage.

With the new backends, there is no longer any need to keep such metadata. However, by default that data still remains there because there is not currently a mechanism in place to remove it.

This PR fixes this by allowing durability providers to remove entity state from storage immediately when an entity is deleted. The trick behind this mechanism is to use the conceptual "inverse" of the autostart feature: any auto-started orchestration that ends with a continueAsNew(null) can be considered to be implicitly deleted. If it should be needed again, such as if the entity receives more signals, it will just be autostarted again with input null, as if it had not been deleted.

### Pull request checklist

* [x] My changes **do not** require documentation changes
* [x] My changes **should not** be added to the release notes for the next release
* [x] My changes **do not** need to be backported to a previous version
* [x] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
* [x] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
 
