### PR TITLE
Support for custom handlers with the V2 OOProc middleware

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -1,0 +1,3 @@
+## Updates
+
+* Added V2 middleware support for custom handlers

--- a/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
@@ -193,7 +193,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             // Starting with .NET isolated and Java, we have a more efficient out-of-process
             // function invocation protocol. Other languages will use the existing protocol.
             WorkerRuntimeType runtimeType = this.PlatformInformationService.GetWorkerRuntimeType();
-            if (runtimeType == WorkerRuntimeType.DotNetIsolated || runtimeType == WorkerRuntimeType.Java)
+            if (runtimeType == WorkerRuntimeType.DotNetIsolated ||
+                runtimeType == WorkerRuntimeType.Java ||
+                runtimeType == WorkerRuntimeType.Custom)
             {
                 this.OutOfProcProtocol = OutOfProcOrchestrationProtocol.MiddlewarePassthrough;
 #if FUNCTIONS_V3_OR_GREATER

--- a/src/WebJobs.Extensions.DurableTask/IPlatformInformation.cs
+++ b/src/WebJobs.Extensions.DurableTask/IPlatformInformation.cs
@@ -57,6 +57,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         Java,
 
         /// <summary>
+        /// Custom handler (see https://learn.microsoft.com/en-us/azure/azure-functions/functions-custom-handlers).
+        /// </summary>
+        Custom,
+
+        /// <summary>
         /// Unknown worker runtime.
         /// </summary>
         Unknown,

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
@@ -3598,6 +3598,11 @@
             Java.
             </summary>
         </member>
+        <member name="F:Microsoft.Azure.WebJobs.Extensions.DurableTask.WorkerRuntimeType.Custom">
+            <summary>
+            Custom handler (see https://learn.microsoft.com/en-us/azure/azure-functions/functions-custom-handlers).
+            </summary>
+        </member>
         <member name="F:Microsoft.Azure.WebJobs.Extensions.DurableTask.WorkerRuntimeType.Unknown">
             <summary>
             Unknown worker runtime.

--- a/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
+++ b/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
@@ -5,8 +5,8 @@
     <AssemblyName>Microsoft.Azure.WebJobs.Extensions.DurableTask</AssemblyName>
     <RootNamespace>Microsoft.Azure.WebJobs.Extensions.DurableTask</RootNamespace>
     <MajorVersion>2</MajorVersion>
-    <MinorVersion>8</MinorVersion>
-    <PatchVersion>1</PatchVersion>
+    <MinorVersion>9</MinorVersion>
+    <PatchVersion>0</PatchVersion>
     <Version>$(MajorVersion).$(MinorVersion).$(PatchVersion)</Version>
     <FileVersion>$(MajorVersion).$(MinorVersion).$(PatchVersion)</FileVersion>
     <AssemblyVersion>$(MajorVersion).0.0.0</AssemblyVersion>

--- a/src/Worker.Extensions.DurableTask/AssemblyInfo.cs
+++ b/src/Worker.Extensions.DurableTask/AssemblyInfo.cs
@@ -4,4 +4,4 @@
 using Microsoft.Azure.Functions.Worker.Extensions.Abstractions;
 
 // TODO: Find a way to generate this dynamically at build-time
-[assembly: ExtensionInformation("Microsoft.Azure.WebJobs.Extensions.DurableTask", "2.8.*")]
+[assembly: ExtensionInformation("Microsoft.Azure.WebJobs.Extensions.DurableTask", "2.9.*")]

--- a/test/FunctionsV2/OutOfProcTests.cs
+++ b/test/FunctionsV2/OutOfProcTests.cs
@@ -321,6 +321,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         [InlineData("python", true, "http RPC")]
         [InlineData("dotnet", false, null)]
         [InlineData("dotnet-isolated", true, "gRPC")]
+        [InlineData("custom", true, "gRPC")]
         public async Task TestLocalRcpEndpointRuntimeVersion(string runtimeVersion, bool enabledExpected, string expectedProtocol)
         {
             INameResolver nameResolver = new SimpleNameResolver(

--- a/test/SmokeTests/e2e-test.ps1
+++ b/test/SmokeTests/e2e-test.ps1
@@ -9,7 +9,7 @@ param(
 	[string]$ContainerName="app",
 	[switch]$NoSetup=$false,
 	[switch]$NoValidation=$false,
-	[string]$AzuriteVersion="3.15.0",
+	[string]$AzuriteVersion="3.20.1",
 	[int]$Sleep=30
 )
 


### PR DESCRIPTION
This is a follow-up from my hackathon project ([Durable Functions in Go](https://twitter.com/cgillum/status/1585491737438351362)). I had to make a change to the extension so that it understood "Custom" as a language worker type, and also make sure that it activated the v2 OOProc middleware code path. With these changes, it should be much easier for anyone to create a custom handler that supports Durable Functions.

Note that the full scenario also requires a change in the Azure Functions host (see https://github.com/Azure/azure-functions-host/pull/8874).


### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)
* [x] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk
* [ ] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
    * [x] Otherwise: major or minor version updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
