### PR TITLE
Update gRPC implementation used by out-of-proc v2 SDKs

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -1,3 +1,5 @@
 ## Updates
 
 * Added V2 middleware support for custom handlers
+* Added suspend, resume, and rewind operation handling for V2 out-of-proc
+* Updated Microsoft.DurableTask.Sidecar.Protobuf dependency to v1.0.0

--- a/src/WebJobs.Extensions.DurableTask/LocalGrpcListener.cs
+++ b/src/WebJobs.Extensions.DurableTask/LocalGrpcListener.cs
@@ -194,6 +194,24 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 return new P.TerminateResponse();
             }
 
+            public override async Task<P.SuspendResponse> SuspendInstance(P.SuspendRequest request, ServerCallContext context)
+            {
+                await this.durabilityProvider.SuspendTaskOrchestrationAsync(request.InstanceId, request.Reason);
+                return new P.SuspendResponse();
+            }
+
+            public override async Task<P.ResumeResponse> ResumeInstance(P.ResumeRequest request, ServerCallContext context)
+            {
+                await this.durabilityProvider.ResumeTaskOrchestrationAsync(request.InstanceId, request.Reason);
+                return new P.ResumeResponse();
+            }
+
+            public override async Task<P.RewindInstanceResponse> RewindInstance(P.RewindInstanceRequest request, ServerCallContext context)
+            {
+                await this.durabilityProvider.RewindAsync(request.InstanceId, request.Reason);
+                return new P.RewindInstanceResponse();
+            }
+
             public override async Task<P.GetInstanceResponse> GetInstance(P.GetInstanceRequest request, ServerCallContext context)
             {
                 OrchestrationState state = await this.durabilityProvider.GetOrchestrationStateAsync(request.InstanceId, executionId: null);

--- a/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
+++ b/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
@@ -101,9 +101,8 @@
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.12.2" />
     <!-- Explicitly pinned transitive dependencies with CVE vulnerabilities.-->
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets" Version="2.2.1" />
-    <!-- The gRPC dependencies are not compatible with .NET Standard 2.0 and will fail at runtime -->
-    <PackageReference Include="Grpc" Version="2.38.0" />
-    <PackageReference Include="Microsoft.DurableTask.Sidecar.Protobuf" Version="0.3.1" />
+    <!-- The gRPC dependencies in this package are not compatible with older frameworks, like .NET Core 2.x -->
+    <PackageReference Include="Microsoft.DurableTask.Sidecar.Protobuf" Version="1.0.0" />
   </ItemGroup>
 
 


### PR DESCRIPTION
This PR updates the version of the Microsoft.DurableTask.Sidecar.Protobuf dependency, which includes a fix for CVE-2022-1941, due to Google.ProtoBuf and also includes support for suspend and resume operations over gRPC. This PR also updates the gRPC server implementation in this Durable extension to support rewind, suspend, and resume operations in gRPC.

Resolves https://github.com/Azure/azure-functions-durable-extension/issues/2309

This change unblocks the following parity items for .NET and Java out-of-proc SDKs:
- https://github.com/microsoft/durabletask-dotnet/issues/21
- https://github.com/microsoft/durabletask-dotnet/issues/83
- https://github.com/microsoft/durabletask-java/issues/65
- https://github.com/microsoft/durabletask-java/issues/96

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [x] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)
* [ ] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [x] Otherwise: That work is being tracked here: (see above)
* [x] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
    * [ ] Otherwise: major or minor version updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
