### PR TITLE
Update out-of-proc extension to newest durable SDK bits

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -1,3 +1,7 @@
+# Release Notes
+
 ## Updates
 
-* Added V2 middleware support for custom handlers
+* Updated Worker.Extensions.DurableTask to 1.0.0-preview1 and Microsoft.DurableTask.* dependencies to the same.
+  * Includes breaking change adjustments as necessary.
+* Added V2 middleware support for custom handlers.

--- a/release_notes.md
+++ b/release_notes.md
@@ -2,6 +2,9 @@
 
 ## Updates
 
-* Updated Worker.Extensions.DurableTask to 1.0.0-preview1 and Microsoft.DurableTask.* dependencies to the same.
+* Updated Worker.Extensions.DurableTask to 1.0.0-rc.1 and Microsoft.DurableTask.* dependencies to the same.
   * Includes breaking change adjustments as necessary.
+  * Microsoft.DurableTask.Generators is still preview and must now be explicitly referenced.
+    * This means that class-based syntax will remain a preview feature.
+    * Other code-gen are also remaining as preview features.
 * Added V2 middleware support for custom handlers.

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
@@ -4614,7 +4614,7 @@
         <member name="F:Microsoft.Azure.WebJobs.Extensions.DurableTask.OutOfProcOrchestrationProtocol.MiddlewarePassthrough">
             <summary>
             Out-of-proc works by forwarding all outputs directly to the Durable Task Framework
-            without using any orchestrator "shims" or attemping any interpretation. This is
+            without using any orchestrator "shims" or attempting any interpretation. This is
             sometimes referred to as "out of proc v2".
             </summary>
         </member>

--- a/src/WebJobs.Extensions.DurableTask/OutOfProcMiddleware.cs
+++ b/src/WebJobs.Extensions.DurableTask/OutOfProcMiddleware.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             OrchestrationRuntimeState? runtimeState = dispatchContext.GetProperty<OrchestrationRuntimeState>();
             if (runtimeState == null)
             {
-                // This should never happen, but it's almost certainly non-retriable if it does.
+                // This should never happen, but it's almost certainly non-retryable if it does.
                 dispatchContext.SetProperty(OrchestratorExecutionResult.ForFailure(
                     message: "Orchestration runtime state was missing!",
                     details: null));
@@ -56,7 +56,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             OrchestrationInstance? instance = dispatchContext.GetProperty<OrchestrationInstance>();
             if (instance == null)
             {
-                // This should never happen, but it's almost certainly non-retriable if it does.
+                // This should never happen, but it's almost certainly non-retryable if it does.
                 dispatchContext.SetProperty(OrchestratorExecutionResult.ForFailure(
                     message: "Instance ID metadata was missing!",
                     details: null));

--- a/src/WebJobs.Extensions.DurableTask/OutOfProcOrchestrationProtocol.cs
+++ b/src/WebJobs.Extensions.DurableTask/OutOfProcOrchestrationProtocol.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
         /// <summary>
         /// Out-of-proc works by forwarding all outputs directly to the Durable Task Framework
-        /// without using any orchestrator "shims" or attemping any interpretation. This is
+        /// without using any orchestrator "shims" or attempting any interpretation. This is
         /// sometimes referred to as "out of proc v2".
         /// </summary>
         MiddlewarePassthrough = 1,

--- a/src/Worker.Extensions.DurableTask/DurableClientContext.cs
+++ b/src/Worker.Extensions.DurableTask/DurableClientContext.cs
@@ -3,7 +3,7 @@
 
 using Microsoft.Azure.Functions.Worker.Converters;
 using Microsoft.Azure.Functions.Worker.Http;
-using Microsoft.DurableTask;
+using Microsoft.DurableTask.Client;
 
 namespace Microsoft.Azure.Functions.Worker;
 

--- a/src/Worker.Extensions.DurableTask/DurableTaskExtensionStartup.cs
+++ b/src/Worker.Extensions.DurableTask/DurableTaskExtensionStartup.cs
@@ -1,8 +1,13 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System;
 using Microsoft.Azure.Functions.Worker.Core;
 using Microsoft.Azure.Functions.Worker.Extensions.DurableTask;
+using Microsoft.DurableTask;
+using Microsoft.DurableTask.Client;
+using Microsoft.DurableTask.Converters;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
 [assembly: WorkerExtensionStartup(typeof(DurableTaskExtensionStartup))]
@@ -17,6 +22,17 @@ public sealed class DurableTaskExtensionStartup : WorkerExtensionStartup
     /// <inheritdoc/>
     public override void Configure(IFunctionsWorkerApplicationBuilder applicationBuilder)
     {
+        applicationBuilder.Services.AddSingleton<IDurableTaskClientProvider, FunctionsDurableClientProvider>();
+        applicationBuilder.Services.AddOptions<DurableTaskClientOptions>()
+            .PostConfigure<IServiceProvider>((opt, sp) =>
+            {
+                if (sp.GetService<DataConverter>() is DataConverter converter
+                    && !ReferenceEquals(opt.DataConverter, JsonDataConverter.Default))
+                {
+                    opt.DataConverter = converter;
+                }
+            });
+
         applicationBuilder.UseMiddleware<DurableTaskFunctionsMiddleware>();
     }
 }

--- a/src/Worker.Extensions.DurableTask/FunctionsDurableClientProvider.cs
+++ b/src/Worker.Extensions.DurableTask/FunctionsDurableClientProvider.cs
@@ -78,7 +78,7 @@ internal class FunctionsDurableClientProvider : IDurableTaskClientProvider, IAsy
     {
         if (!Uri.TryCreate(grpcEndpointUri, UriKind.Absolute, out Uri uri))
         {
-            throw new ArgumentException("Client name must be a valid gRPC address.", nameof(grpcEndpointUri));
+            throw new ArgumentException("Not a valid gRPC address.", nameof(grpcEndpointUri));
         }
 
         string address = $"{uri.Host}:{uri.Port}";

--- a/src/Worker.Extensions.DurableTask/FunctionsDurableClientProvider.cs
+++ b/src/Worker.Extensions.DurableTask/FunctionsDurableClientProvider.cs
@@ -1,0 +1,128 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.DurableTask.Client;
+using Microsoft.DurableTask.Client.Grpc;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.Azure.Functions.Worker.Extensions.DurableTask;
+
+/// <summary>
+/// The functions implementation of the durable task client provider.
+/// </summary>
+internal class FunctionsDurableClientProvider : IDurableTaskClientProvider, IAsyncDisposable
+{
+    private readonly ReaderWriterLockSlim sync = new();
+    private readonly ILoggerFactory loggerFactory;
+    private readonly DurableTaskClientOptions options;
+    private Dictionary<string, DurableTaskClient>? clients = new();
+
+    private bool disposed;
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="FunctionsDurableClientProvider" /> class.
+    /// </summary>
+    /// <param name="loggerFactory">The service provider.</param>
+    /// <param name="options">The client options.</param>
+    public FunctionsDurableClientProvider(ILoggerFactory loggerFactory, IOptions<DurableTaskClientOptions> options)
+    {
+        this.loggerFactory = loggerFactory ?? throw new ArgumentNullException(nameof(loggerFactory));
+        this.options = options?.Value ?? throw new ArgumentNullException(nameof(options));
+    }
+
+    /// <inheritdoc />
+    public async ValueTask DisposeAsync()
+    {
+        if (this.disposed)
+        {
+            return;
+        }
+
+        try
+        {
+            this.sync.EnterWriteLock();
+            try
+            {
+                if (this.disposed)
+                {
+                    return;
+                }
+
+                foreach (DurableTaskClient client in this.clients!.Values)
+                {
+                    await client.DisposeAsync();
+                }
+
+                this.clients = null;
+                this.disposed = true;
+            }
+            finally
+            {
+                this.sync.ExitWriteLock();
+            }
+        }
+        catch (ObjectDisposedException)
+        {
+            // this can happen when 'this.sync' is disposed from concurrent DisposeAsync() calls.
+        }
+
+        this.sync.Dispose();
+    }
+
+    public DurableTaskClient GetClient(string? name = null)
+    {
+        if (!Uri.TryCreate(name, UriKind.Absolute, out Uri uri))
+        {
+            throw new NotSupportedException("Client name must be a valid gRPC address.");
+        }
+
+        string address = $"{uri.Host}:{uri.Port}";
+        this.VerifyNotDisposed();
+        this.sync.EnterReadLock();
+        try
+        {
+            this.VerifyNotDisposed();
+            if (this.clients!.TryGetValue(address, out DurableTaskClient client))
+            {
+                return client;
+            }
+        }
+        finally
+        {
+            this.sync.ExitReadLock();
+        }
+
+        this.sync.EnterWriteLock();
+        try
+        {
+            this.VerifyNotDisposed();
+            GrpcDurableTaskClientOptions options = new()
+            {
+                Address = address,
+                DataConverter = this.options.DataConverter,
+            };
+
+            ILogger logger = this.loggerFactory.CreateLogger<GrpcDurableTaskClient>();
+            GrpcDurableTaskClient client = new(string.Empty, options, logger);
+            this.clients[address] = client;
+            return client;
+        }
+        finally
+        {
+            this.sync.ExitWriteLock();
+        }
+    }
+
+    private void VerifyNotDisposed()
+    {
+        if (this.disposed)
+        {
+            throw new ObjectDisposedException(nameof(FunctionsDurableClientProvider));
+        }
+    }
+}

--- a/src/Worker.Extensions.DurableTask/Worker.Extensions.DurableTask.csproj
+++ b/src/Worker.Extensions.DurableTask/Worker.Extensions.DurableTask.csproj
@@ -30,7 +30,7 @@
 
     <!-- Version information -->
     <VersionPrefix>1.0.0</VersionPrefix>
-    <VersionSuffix>preview1</VersionSuffix>
+    <VersionSuffix>rc.1</VersionSuffix>
     <AssemblyVersion>$(VersionPrefix).0</AssemblyVersion>
     <!-- FileVersionRevision is expected to be set by the CI. -->
     <FileVersion Condition="'$(FileVersionRevision)' != ''">$(VersionPrefix).$(FileVersionRevision)</FileVersion>
@@ -39,8 +39,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Core" Version="1.8.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Abstractions" Version="1.1.0" />
-    <PackageReference Include="Microsoft.DurableTask.Client.Grpc" Version="1.0.0-preview1" />
-    <PackageReference Include="Microsoft.DurableTask.Worker.Grpc" Version="1.0.0-preview1" />
+    <PackageReference Include="Microsoft.DurableTask.Client.Grpc" Version="1.0.0-rc.1" />
+    <PackageReference Include="Microsoft.DurableTask.Worker.Grpc" Version="1.0.0-rc.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Worker.Extensions.DurableTask/Worker.Extensions.DurableTask.csproj
+++ b/src/Worker.Extensions.DurableTask/Worker.Extensions.DurableTask.csproj
@@ -29,18 +29,18 @@
     <AssemblyOriginatorKeyFile>..\..\sign.snk</AssemblyOriginatorKeyFile>
 
     <!-- Version information -->
-    <VersionPrefix>0.5.0</VersionPrefix>
-    <VersionSuffix>beta</VersionSuffix>
+    <VersionPrefix>1.0.0</VersionPrefix>
+    <VersionSuffix>preview1</VersionSuffix>
     <AssemblyVersion>$(VersionPrefix).0</AssemblyVersion>
     <!-- FileVersionRevision is expected to be set by the CI. -->
     <FileVersion Condition="'$(FileVersionRevision)' != ''">$(VersionPrefix).$(FileVersionRevision)</FileVersion>
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Core" Version="1.6.0-preview3" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Core" Version="1.8.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Abstractions" Version="1.1.0" />
-    <PackageReference Include="Microsoft.DurableTask.Client.Grpc" Version="0.5.0-beta" />
-    <PackageReference Include="Microsoft.DurableTask.Worker.Grpc" Version="0.5.0-beta" />
+    <PackageReference Include="Microsoft.DurableTask.Client.Grpc" Version="1.0.0-preview1" />
+    <PackageReference Include="Microsoft.DurableTask.Worker.Grpc" Version="1.0.0-preview1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Worker.Extensions.DurableTask/Worker.Extensions.DurableTask.csproj
+++ b/src/Worker.Extensions.DurableTask/Worker.Extensions.DurableTask.csproj
@@ -29,7 +29,7 @@
     <AssemblyOriginatorKeyFile>..\..\sign.snk</AssemblyOriginatorKeyFile>
 
     <!-- Version information -->
-    <VersionPrefix>0.4.1</VersionPrefix>
+    <VersionPrefix>0.5.0</VersionPrefix>
     <VersionSuffix>beta</VersionSuffix>
     <AssemblyVersion>$(VersionPrefix).0</AssemblyVersion>
     <!-- FileVersionRevision is expected to be set by the CI. -->
@@ -39,7 +39,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Core" Version="1.6.0-preview3" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Abstractions" Version="1.1.0" />
-    <PackageReference Include="Microsoft.DurableTask.Client" Version="0.4.1-beta" />
+    <PackageReference Include="Microsoft.DurableTask.Client.Grpc" Version="0.5.0-beta" />
+    <PackageReference Include="Microsoft.DurableTask.Worker.Grpc" Version="0.5.0-beta" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/SmokeTests/OOProcSmokeTests/DotNetIsolated/DotNetIsolated.csproj
+++ b/test/SmokeTests/OOProcSmokeTests/DotNetIsolated/DotNetIsolated.csproj
@@ -9,10 +9,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.8.0-preview3" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask" Version="0.4.0-beta" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.10.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask" Version="0.4.1-beta" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.0.13" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.5.0-preview2" OutputItemType="Analyzer" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.7.0" OutputItemType="Analyzer" />
+    <PackageReference Include="Microsoft.DurableTask.Generators" Version="1.0.0-preview.1" OutputItemType="Analyzer" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/SmokeTests/OOProcSmokeTests/DotNetIsolated/DotNetIsolated.csproj
+++ b/test/SmokeTests/OOProcSmokeTests/DotNetIsolated/DotNetIsolated.csproj
@@ -10,7 +10,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.10.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask" Version="0.4.1-beta" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.0.13" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.7.0" OutputItemType="Analyzer" />
     <PackageReference Include="Microsoft.DurableTask.Generators" Version="1.0.0-preview.1" OutputItemType="Analyzer" />

--- a/test/SmokeTests/OOProcSmokeTests/DotNetIsolated/HelloCitiesTyped.cs
+++ b/test/SmokeTests/OOProcSmokeTests/DotNetIsolated/HelloCitiesTyped.cs
@@ -42,9 +42,9 @@ public static class HelloCitiesTypedStarter
 /// that invokes the <see cref="OnRunAsync"/> method.
 /// </summary>
 [DurableTask(nameof(HelloCitiesTyped))]
-public class HelloCitiesTyped : TaskOrchestratorBase<string, string>
+public class HelloCitiesTyped : TaskOrchestrator<string?, string>
 {
-    protected async override Task<string?> OnRunAsync(TaskOrchestrationContext context, string? input)
+    public async override Task<string> RunAsync(TaskOrchestrationContext context, string? input)
     {
         // Source generators are used to generate the type-safe activity function
         // call extension methods on the context object. The names of these generated
@@ -63,7 +63,7 @@ public class HelloCitiesTyped : TaskOrchestratorBase<string, string>
 /// definition that creates an instance of this class and invokes its <see cref="OnRun"/> method.
 /// </summary>
 [DurableTask(nameof(SayHelloTyped))]
-public class SayHelloTyped : TaskActivityBase<string, string>
+public class SayHelloTyped : TaskActivity<string, string>
 {
     private readonly ILogger? logger;
 
@@ -81,9 +81,9 @@ public class SayHelloTyped : TaskActivityBase<string, string>
         this.logger = loggerFactory?.CreateLogger<SayHelloTyped>();
     }
 
-    protected override string OnRun(TaskActivityContext context, string? cityName)
+    public override Task<string> RunAsync(TaskActivityContext context, string cityName)
     {
         this.logger?.LogInformation("Saying hello to {name}", cityName);
-        return $"Hello, {cityName}!";
+        return Task.FromResult($"Hello, {cityName}!");
     }
 }


### PR DESCRIPTION
This PR updates the dotnet isolated worker extension to the latest changes from https://github.com/microsoft/durabletask-dotnet

The packages have yet to be published to MyGet, so this is not buildable yet.

### Pull request checklist

* [ ] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md` - **will consider this separately from this PR**
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md` - TODO
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests) - TODO
* [x] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: **no issue available**
* [x] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
    * [ ] Otherwise: major or minor version updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
