### PR TITLE
Update DT.Core to latest version

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -3,3 +3,4 @@
 * Added V2 middleware support for custom handlers
 * Added suspend, resume, and rewind operation handling for V2 out-of-proc
 * Updated Microsoft.DurableTask.Sidecar.Protobuf dependency to v1.0.0
+* Updated Microsoft.Azure.DurableTask.Core dependency to 2.12.*

--- a/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
+++ b/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
@@ -108,7 +108,7 @@
 
   <!-- Common dependencies across all targets -->
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.DurableTask.Core" Version="2.11.*" />
+    <PackageReference Include="Microsoft.Azure.DurableTask.Core" Version="2.12.*" />
     <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage" Version="1.13.*" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers" Version="0.5.*" />
     <!-- Build-time dependencies -->


### PR DESCRIPTION
Updates the DT.Core reference to v2.12.* (which currently corresponds to v2.12.1).

NOTE: Before merging, need to confirm that v2.12.1 is actually the version that gets resolved by the `dotnet restore` step of the build, since v2.12.1 is on myget.org but not yet nuget.org.

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] N/A - I have added all required tests (Unit tests, E2E tests)
* [x] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk
* [x] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
    * [ ] Otherwise: major or minor version updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
