### PR TITLE
Configure dotnet out-of-proc worker options

### DIFF
--- a/src/Worker.Extensions.DurableTask/DurableTaskExtensionStartup.cs
+++ b/src/Worker.Extensions.DurableTask/DurableTaskExtensionStartup.cs
@@ -59,7 +59,11 @@ public sealed class DurableTaskExtensionStartup : WorkerExtensionStartup
 
     private static DataConverter? GetConverter(IServiceProvider services)
     {
+        // We intentionally do not consider a DataConverter in the DI provider, or if one was already set. This is to
+        // ensure serialization is consistent with the rest of Azure Functions. This is particularly important because
+        // TaskActivity bindings use ObjectSerializer directly for the time being. Due to this, allowing DataConverter
+        // to be set separately from ObjectSerializer would give an inconsistent serialization solution.
         WorkerOptions? worker = services.GetRequiredService<IOptions<WorkerOptions>>()?.Value;
-        return worker?.Serializer is ObjectSerializer serializer ? new ObjectConverterShim(serializer) : null;
+        return worker?.Serializer is not null ? new ObjectConverterShim(worker.Serializer) : null;
     }
 }

--- a/src/Worker.Extensions.DurableTask/ObjectConverterShim.cs
+++ b/src/Worker.Extensions.DurableTask/ObjectConverterShim.cs
@@ -1,0 +1,47 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Text;
+using Azure.Core.Serialization;
+using Microsoft.DurableTask;
+
+namespace Microsoft.Azure.Functions.Worker.Extensions.DurableTask;
+
+/// <summary>
+/// A shim to go from <see cref="ObjectSerializer" /> to <see cref="DataConverter" />.
+/// </summary>
+internal class ObjectConverterShim : DataConverter
+{
+    private readonly ObjectSerializer serializer;
+
+    public ObjectConverterShim(ObjectSerializer serializer)
+    {
+        this.serializer = serializer;
+    }
+
+    public override object? Deserialize(string? data, Type targetType)
+    {
+        if (data is null)
+        {
+            return null;
+        }
+
+        using MemoryStream stream = new(Encoding.Unicode.GetBytes(data), false);
+        return this.serializer.Deserialize(stream, targetType, default);
+    }
+
+    public override string? Serialize(object? value)
+    {
+        if (value is null)
+        {
+            return null;
+        }
+
+        using MemoryStream stream = new();
+        this.serializer.Serialize(stream, value, value.GetType(), default);
+        using StreamReader reader = new(stream, Encoding.Unicode);
+        return reader.ReadToEnd();
+    }
+}


### PR DESCRIPTION
Introduces an `ObjectConverterShim` which bridges the `WorkerOptions.Serializer` (from Azure Functions SDK) with the durable `DataConverter`, aligning serialization between the two.

<!-- Make sure to delete the markdown comments and the below sections when squash merging -->
### Issue describing the changes in this PR

resolves #issue_for_this_pr

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)
* [x] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk
* [x] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
    * [ ] Otherwise: major or minor version updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
