### PR TITLE
Update dotnet isolated release build def

### DIFF
--- a/azure-pipelines-release-dotnet-isolated.yml
+++ b/azure-pipelines-release-dotnet-isolated.yml
@@ -26,17 +26,17 @@ steps:
   inputs:
     command: restore
     verbosityRestore: Minimal
+    feedsToUse: 'config'
+    nugetConfigPath: 'nuget.config'
     projects: 'src/Worker.Extensions.DurableTask/*.csproj'
 
 # Build just the .NET Isolated worker extension project
-- task: VSBuild@1
+- task: DotNetCoreCLI@2
   displayName: 'Build'
   inputs:
-    solution: 'src/Worker.Extensions.DurableTask/*.csproj'
-    vsVersion: 'latest'
-    logFileVerbosity: minimal
-    configuration: Release
-    msbuildArgs: /p:FileVersionRevision=$(Build.BuildId) /p:ContinuousIntegrationBuild=true
+    command: build
+    arguments: --no-restore -c release -p:FileVersionRevision=$(Build.BuildId) -p:ContinuousIntegrationBuild=true
+    projects: 'src/Worker.Extensions.DurableTask/*.csproj'
 
 # Authenticode sign all the DLLs with the Microsoft certificate.
 # This appears to be an in-place signing job, which is convenient.


### PR DESCRIPTION
Updates the dotnet isolated extension release build: (1) use `nuget.config` for restore. (2) VSBuild --> DotNetCoreCLI

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)
* [x] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk
* [x] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
    * [ ] Otherwise: major or minor version updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
