### PR TITLE
Fix GetInput issues due to object casting

### DIFF
--- a/src/Worker.Extensions.DurableTask/Constants.cs
+++ b/src/Worker.Extensions.DurableTask/Constants.cs
@@ -1,0 +1,12 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+namespace Microsoft.Azure.Functions.Worker.Extensions.DurableTask;
+
+internal static class Constants
+{
+    // TODO: Need to add call to action, i.e., pointer to some documentation.
+    public const string IllegalAwaitErrorMessage =
+        "An invalid asynchronous invocation was detected. This can be caused by awaiting non-durable tasks " +
+        "in an orchestrator function's implementation or by middleware that invokes asynchronous code.";
+}

--- a/src/Worker.Extensions.DurableTask/DurableTaskFunctionsMiddleware.cs
+++ b/src/Worker.Extensions.DurableTask/DurableTaskFunctionsMiddleware.cs
@@ -3,25 +3,14 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.Functions.Worker.Middleware;
-using Microsoft.DurableTask;
-using Microsoft.DurableTask.Worker;
 using Microsoft.DurableTask.Worker.Grpc;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 
 namespace Microsoft.Azure.Functions.Worker.Extensions.DurableTask;
 
 internal class DurableTaskFunctionsMiddleware : IFunctionsWorkerMiddleware
 {
-    // TODO: Need to add call to action, i.e., pointer to some documentation.
-    private const string IllegalAwaitErrorMessage =
-        "An invalid asynchronous invocation was detected. This can be caused by awaiting non-durable tasks " +
-        "in an orchestrator function's implementation or by middleware that invokes asynchronous code.";
-
     public async Task Invoke(FunctionContext functionContext, FunctionExecutionDelegate next)
     {
         if (!IsOrchestrationTrigger(functionContext, out BindingMetadata? triggerMetadata))
@@ -87,7 +76,7 @@ internal class DurableTaskFunctionsMiddleware : IFunctionsWorkerMiddleware
             // If the middleware returns before the orchestrator function's context object was accessed and before
             // it completes its execution, then we know that either some middleware component went async or that the
             // orchestrator function did some illegal await as its very first action.
-            throw new InvalidOperationException(IllegalAwaitErrorMessage);
+            throw new InvalidOperationException(Constants.IllegalAwaitErrorMessage);
         }
 
         await orchestratorTask;
@@ -95,142 +84,5 @@ internal class DurableTaskFunctionsMiddleware : IFunctionsWorkerMiddleware
         // This will throw if either the orchestrator performed an illegal await or if some middleware ahead of this
         // one performed some illegal await.
         orchestrationContext.ThrowIfIllegalAccess();
-    }
-
-    private sealed class FunctionsOrchestrationContext : TaskOrchestrationContext
-    {
-        private readonly TaskOrchestrationContext innerContext;
-        private readonly FunctionContext functionContext;
-
-        private readonly DurableTaskWorkerOptions options;
-        private string? serializedInput;
-
-        public FunctionsOrchestrationContext(TaskOrchestrationContext innerContext, FunctionContext functionContext)
-        {
-            this.innerContext = innerContext;
-            this.functionContext = functionContext;
-            this.options = this.functionContext.InstanceServices
-                .GetRequiredService<IOptions<DurableTaskWorkerOptions>>().Value;
-        }
-
-        public bool IsAccessed { get; private set; }
-
-        public override TaskName Name => this.innerContext.Name;
-
-        public override string InstanceId => this.innerContext.InstanceId;
-
-        public override DateTime CurrentUtcDateTime => this.innerContext.CurrentUtcDateTime;
-
-        public override bool IsReplaying => this.innerContext.IsReplaying;
-
-        public override ParentOrchestrationInstance? Parent => this.innerContext.Parent;
-
-        public override T GetInput<T>()
-        {
-            this.EnsureLegalAccess();
-
-            // TODO: address this hack.
-            // The default TaskOrchestrationContext is not actually dynamic with GetInput - it was set
-            // once based on the declared input type of the orchestrator. Since we do not know the
-            // desired input type upfront, we were initialized to object. So we must serialize and
-            // deserialize again to convert to our desired type.
-            if (this.serializedInput is null)
-            {
-                object? input = this.innerContext.GetInput<object>();
-                if (input is null)
-                {
-                    return default!;
-                }
-
-                this.serializedInput = this.options.DataConverter.Serialize(input);
-            }
-
-            return this.options.DataConverter.Deserialize<T>(this.serializedInput)!;
-        }
-
-        public override Guid NewGuid()
-        {
-            this.EnsureLegalAccess();
-            return this.innerContext.NewGuid();
-        }
-
-        public override Task<T> CallActivityAsync<T>(TaskName name, object? input = null, TaskOptions? options = null)
-        {
-            this.EnsureLegalAccess();
-            return this.innerContext.CallActivityAsync<T>(name, input, options);
-        }
-
-        [Obsolete("Not yet supported")]
-        public override Task<T> CallActivityAsync<T>(
-            Func<object?, T> activityLambda,
-            object? input = null,
-            TaskOptions? options = null)
-        {
-            this.EnsureLegalAccess();
-            return this.innerContext.CallActivityAsync(activityLambda, input, options);
-        }
-
-        public override Task<TResult> CallSubOrchestratorAsync<TResult>(
-            TaskName orchestratorName, object? input = null, TaskOptions? options = null)
-        {
-            this.EnsureLegalAccess();
-            return this.innerContext.CallSubOrchestratorAsync<TResult>(orchestratorName, input, options);
-        }
-
-        public override void ContinueAsNew(object newInput, bool preserveUnprocessedEvents = true)
-        {
-            this.EnsureLegalAccess();
-            this.innerContext.ContinueAsNew(newInput, preserveUnprocessedEvents);
-        }
-
-        public override Task CreateTimer(DateTime fireAt, CancellationToken cancellationToken)
-        {
-            this.EnsureLegalAccess();
-            return this.innerContext.CreateTimer(fireAt, cancellationToken);
-        }
-
-        public override void SetCustomStatus(object? customStatus)
-        {
-            this.EnsureLegalAccess();
-            this.innerContext.SetCustomStatus(customStatus);
-        }
-
-        public override void SendEvent(string instanceId, string eventName, object payload)
-        {
-            this.EnsureLegalAccess();
-            this.innerContext.SendEvent(instanceId, eventName, payload);
-        }
-
-        public override Task<T> WaitForExternalEvent<T>(string eventName, CancellationToken cancellationToken = default)
-        {
-            this.EnsureLegalAccess();
-            return this.innerContext.WaitForExternalEvent<T>(eventName, cancellationToken);
-        }
-
-        /// <summary>
-        /// Throws if accessed by a non-orchestrator thread or marks the current object as accessed successfully.
-        /// </summary>
-        private void EnsureLegalAccess()
-        {
-            this.ThrowIfIllegalAccess();
-            this.IsAccessed = true;
-        }
-
-        internal void ThrowIfIllegalAccess()
-        {
-            // Only the orchestrator thread is allowed to run the task continuation. If we detect that some other thread
-            // got involved, it means that the orchestrator function (or some middleware that executed after it)
-            // performed an await which scheduled a callback onto a worker pool thread, which isn't allowed. We throw
-            // because the orchestrator is effectively stuck at this point.
-            if (!global::DurableTask.Core.OrchestrationContext.IsOrchestratorThread)
-            {
-                InvalidOperationException exception = new(IllegalAwaitErrorMessage);
-
-                // Log an error, since this exception will likely go unobserved.
-                ILogger logger = this.functionContext.GetLogger<DurableTaskFunctionsMiddleware>();
-                logger.LogError(exception, "The orchestrator function completed on a non-orchestrator thread!");
-                throw exception;
-            }
-        }
     }
 }

--- a/src/Worker.Extensions.DurableTask/FunctionsOrchestrationContext.InputConverter.cs
+++ b/src/Worker.Extensions.DurableTask/FunctionsOrchestrationContext.InputConverter.cs
@@ -1,0 +1,67 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Text.Json;
+using Microsoft.DurableTask;
+
+namespace Microsoft.Azure.Functions.Worker.Extensions.DurableTask;
+
+internal sealed partial class FunctionsOrchestrationContext
+{
+    private abstract class InputConverter
+    {
+        public abstract T Get<T>();
+
+        public static InputConverter Create(object? baseInput, DataConverter converter)
+        {
+            return baseInput switch
+            {
+                JsonElement json => new JsonElementInputConverter(json),
+                null => NullInputConverter.Instance,
+                _ => new DefaultInputConverter(baseInput, converter),
+            };
+        }
+    }
+
+    private class DefaultInputConverter : InputConverter
+    {
+        private readonly DataConverter converter;
+        private readonly string serializedInput;
+
+        public DefaultInputConverter(object input, DataConverter converter)
+        {
+            this.converter = converter;
+            this.serializedInput = converter.Serialize(input);
+        }
+
+        public override T Get<T>()
+        {
+            return this.converter.Deserialize<T>(this.serializedInput);
+        }
+    }
+
+    private class JsonElementInputConverter : InputConverter
+    {
+        private readonly JsonElement json;
+
+        public JsonElementInputConverter(JsonElement json)
+        {
+            this.json = json;
+        }
+
+        public override T Get<T>()
+        {
+            return this.json.Deserialize<T>()!;
+        }
+    }
+
+    private class NullInputConverter : InputConverter
+    {
+        public static readonly NullInputConverter Instance = new();
+
+        public override T Get<T>()
+        {
+            return default!;
+        }
+    }
+}

--- a/src/Worker.Extensions.DurableTask/FunctionsOrchestrationContext.cs
+++ b/src/Worker.Extensions.DurableTask/FunctionsOrchestrationContext.cs
@@ -46,11 +46,17 @@ internal sealed partial class FunctionsOrchestrationContext : TaskOrchestrationC
     {
         this.EnsureLegalAccess();
 
+        object? input = this.innerContext.GetInput<object>();
+        if (input is T typed)
+        {
+            return typed;
+        }
+
         // The wrapped TaskOrchestrationContext is not actually dynamic with GetInput - it was set
         // once based on the declared input type of the orchestrator. Since we do not know the
         // desired input type upfront, we were initialized to object. So we must serialize and
         // deserialize again to convert to our desired type.
-        this.inputConverter ??= InputConverter.Create(this.innerContext.GetInput<object>(), this.options.DataConverter);
+        this.inputConverter ??= InputConverter.Create(input, this.options.DataConverter);
         return this.inputConverter.Get<T>();
     }
 

--- a/src/Worker.Extensions.DurableTask/FunctionsOrchestrationContext.cs
+++ b/src/Worker.Extensions.DurableTask/FunctionsOrchestrationContext.cs
@@ -1,0 +1,146 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.DurableTask;
+using Microsoft.DurableTask.Worker;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.Azure.Functions.Worker.Extensions.DurableTask;
+
+internal sealed partial class FunctionsOrchestrationContext : TaskOrchestrationContext
+{
+    private readonly TaskOrchestrationContext innerContext;
+    private readonly FunctionContext functionContext;
+
+    private readonly DurableTaskWorkerOptions options;
+
+    private InputConverter? inputConverter;
+
+    public FunctionsOrchestrationContext(TaskOrchestrationContext innerContext, FunctionContext functionContext)
+    {
+        this.innerContext = innerContext;
+        this.functionContext = functionContext;
+        this.options = this.functionContext.InstanceServices
+            .GetRequiredService<IOptions<DurableTaskWorkerOptions>>().Value;
+    }
+
+    public bool IsAccessed { get; private set; }
+
+    public override TaskName Name => this.innerContext.Name;
+
+    public override string InstanceId => this.innerContext.InstanceId;
+
+    public override DateTime CurrentUtcDateTime => this.innerContext.CurrentUtcDateTime;
+
+    public override bool IsReplaying => this.innerContext.IsReplaying;
+
+    public override ParentOrchestrationInstance? Parent => this.innerContext.Parent;
+
+    public override T GetInput<T>()
+    {
+        this.EnsureLegalAccess();
+
+        // The wrapped TaskOrchestrationContext is not actually dynamic with GetInput - it was set
+        // once based on the declared input type of the orchestrator. Since we do not know the
+        // desired input type upfront, we were initialized to object. So we must serialize and
+        // deserialize again to convert to our desired type.
+        this.inputConverter ??= InputConverter.Create(this.innerContext.GetInput<object>(), this.options.DataConverter);
+        return this.inputConverter.Get<T>();
+    }
+
+    public override Guid NewGuid()
+    {
+        this.EnsureLegalAccess();
+        return this.innerContext.NewGuid();
+    }
+
+    public override Task<T> CallActivityAsync<T>(TaskName name, object? input = null, TaskOptions? options = null)
+    {
+        this.EnsureLegalAccess();
+        return this.innerContext.CallActivityAsync<T>(name, input, options);
+    }
+
+    [Obsolete("Not yet supported")]
+    public override Task<T> CallActivityAsync<T>(
+        Func<object?, T> activityLambda,
+        object? input = null,
+        TaskOptions? options = null)
+    {
+        this.EnsureLegalAccess();
+        return this.innerContext.CallActivityAsync(activityLambda, input, options);
+    }
+
+    public override Task<TResult> CallSubOrchestratorAsync<TResult>(
+        TaskName orchestratorName, object? input = null, TaskOptions? options = null)
+    {
+        this.EnsureLegalAccess();
+        return this.innerContext.CallSubOrchestratorAsync<TResult>(orchestratorName, input, options);
+    }
+
+    public override void ContinueAsNew(object newInput, bool preserveUnprocessedEvents = true)
+    {
+        this.EnsureLegalAccess();
+        this.innerContext.ContinueAsNew(newInput, preserveUnprocessedEvents);
+    }
+
+    public override Task CreateTimer(DateTime fireAt, CancellationToken cancellationToken)
+    {
+        this.EnsureLegalAccess();
+        return this.innerContext.CreateTimer(fireAt, cancellationToken);
+    }
+
+    public override void SetCustomStatus(object? customStatus)
+    {
+        this.EnsureLegalAccess();
+        this.innerContext.SetCustomStatus(customStatus);
+    }
+
+    public override void SendEvent(string instanceId, string eventName, object payload)
+    {
+        this.EnsureLegalAccess();
+        this.innerContext.SendEvent(instanceId, eventName, payload);
+    }
+
+    public override Task<T> WaitForExternalEvent<T>(string eventName, CancellationToken cancellationToken = default)
+    {
+        this.EnsureLegalAccess();
+        return this.innerContext.WaitForExternalEvent<T>(eventName, cancellationToken);
+    }
+
+    /// <summary>
+    /// Throws if accessed by a non-orchestrator thread or marks the current object as accessed successfully.
+    /// </summary>
+    private void EnsureLegalAccess()
+    {
+        this.ThrowIfIllegalAccess();
+        this.IsAccessed = true;
+    }
+
+    internal void ThrowIfIllegalAccess()
+    {
+        // Only the orchestrator thread is allowed to run the task continuation. If we detect that some other thread
+        // got involved, it means that the orchestrator function (or some middleware that executed after it)
+        // performed an await which scheduled a callback onto a worker pool thread, which isn't allowed. We throw
+        // because the orchestrator is effectively stuck at this point.
+        if (!global::DurableTask.Core.OrchestrationContext.IsOrchestratorThread)
+        {
+            try
+            {
+                throw new InvalidOperationException(Constants.IllegalAwaitErrorMessage);
+            }
+            catch (Exception ex) // stack not set until after a 'throw' statement.
+            {
+                // Log an error, since this exception will likely go unobserved.
+                ILogger logger = this.functionContext.GetLogger<DurableTaskFunctionsMiddleware>();
+                logger.LogError(ex, "The orchestrator function completed on a non-orchestrator thread!");
+                throw;
+            }
+        }
+    }
+}

--- a/test/SmokeTests/OOProcSmokeTests/DotNetIsolated/GreetUser.cs
+++ b/test/SmokeTests/OOProcSmokeTests/DotNetIsolated/GreetUser.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
+using Microsoft.DurableTask;
+using Microsoft.Extensions.Logging;
+
+namespace DotNetIsolated;
+
+public static class GreetUser
+{
+    [Function(nameof(GreetUser))]
+    public static async Task<HttpResponseData> Start(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "post")] HttpRequestData req,
+        [DurableClient] DurableClientContext durableContext,
+        FunctionContext executionContext)
+    {
+        ILogger logger = executionContext.GetLogger(nameof(GreetUser));
+
+        SayHelloPayload? payload = await req.ReadFromJsonAsync<SayHelloPayload>();
+        string instanceId = await durableContext.Client
+            .ScheduleNewOrchestrationInstanceAsync(nameof(GreetUserOrchestration), payload);
+        logger.LogInformation("Created new orchestration with instance ID = {instanceId}", instanceId);
+
+        return durableContext.CreateCheckStatusResponse(req, instanceId);
+    }
+
+    [Function(nameof(GreetUserOrchestration))]
+    public static async Task<SayHelloPayload> GreetUserOrchestration([OrchestrationTrigger] TaskOrchestrationContext context)
+    {
+        SayHelloPayload? input = context.GetInput<SayHelloPayload>();
+        SayHelloPayload result = await context.CallActivityAsync<SayHelloPayload>(nameof(GreetUserActivity), input);
+        return result;
+    }
+
+    [Function(nameof(GreetUserActivity))]
+    public static SayHelloPayload GreetUserActivity([ActivityTrigger] SayHelloPayload input, FunctionContext executionContext)
+    {
+        ILogger logger = executionContext.GetLogger(nameof(GreetUserActivity));
+        logger.LogInformation("Saying hello to {input}", input);
+        return input;
+    }
+
+    public record SayHelloPayload(string First, string Last, int Age);
+}


### PR DESCRIPTION
This is a sub-optimal solution to https://github.com/microsoft/durabletask-dotnet/issues/36. The problem lies in the fact that input is [already deserialized](https://github.com/microsoft/durabletask-dotnet/blob/main/src/Worker/Core/Shims/TaskOrchestrationShim.cs#L47) based on the input type provided to `GrpcOrchestrationRunner`. We use `object` because we do not know what their actual input type is, which ends up being the default type of whatever serializer we are using (`JsonElement` for example).

This PR introduces a workaround by re-serializing and then deserializing to the desired type. A better solution will be considered later. I think overall `GetInput<T>` should go away entirely, and we should use functions binding to let the input be a parameter.

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)
* [x] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk
* [x] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
    * [ ] Otherwise: major or minor version updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
