### PR TITLE
Ensure we don't rely on global defaults when serializing OOProc payloads

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/Bindings/OrchestrationTriggerAttributeBindingProvider.cs
+++ b/src/WebJobs.Extensions.DurableTask/Bindings/OrchestrationTriggerAttributeBindingProvider.cs
@@ -20,6 +20,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
     {
         private readonly DurableTaskExtension config;
         private readonly string connectionName;
+        private static readonly JsonSerializer jsonSerializer = JsonSerializer.Create();
 
         public OrchestrationTriggerAttributeBindingProvider(
             DurableTaskExtension config,
@@ -198,7 +199,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
             private static string OrchestrationContextToString(DurableOrchestrationContext arg)
             {
-                var history = JArray.FromObject(arg.History);
+                var history = JArray.FromObject(arg.History, jsonSerializer);
                 var input = arg.GetInputAsJson();
 
                 // due to Python only supporting up to SchemaVersion V2 from SDK versions 1.1.0 to 1.1.3,

--- a/src/WebJobs.Extensions.DurableTask/Bindings/OrchestrationTriggerAttributeBindingProvider.cs
+++ b/src/WebJobs.Extensions.DurableTask/Bindings/OrchestrationTriggerAttributeBindingProvider.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
     {
         private readonly DurableTaskExtension config;
         private readonly string connectionName;
-        private static readonly JsonSerializer jsonSerializer = JsonSerializer.Create();
+        private static readonly JsonSerializer DefaultSerializer = JsonSerializer.Create();
 
         public OrchestrationTriggerAttributeBindingProvider(
             DurableTaskExtension config,
@@ -199,7 +199,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
             private static string OrchestrationContextToString(DurableOrchestrationContext arg)
             {
-                var history = JArray.FromObject(arg.History, jsonSerializer);
+                var history = JArray.FromObject(arg.History, DefaultSerializer);
                 var input = arg.GetInputAsJson();
 
                 // due to Python only supporting up to SchemaVersion V2 from SDK versions 1.1.0 to 1.1.3,


### PR DESCRIPTION
This PR partially addresses #2338 by ensuring that serialization of OOProc payloads doesn't depend on any global default settings.

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)
* [x] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk
* [x] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
    * [ ] Otherwise: major or minor version updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
