### PR TITLE
Add typename-preserving serializer for new PS external SDK

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/Bindings/OrchestrationTriggerAttributeBindingProvider.cs
+++ b/src/WebJobs.Extensions.DurableTask/Bindings/OrchestrationTriggerAttributeBindingProvider.cs
@@ -219,8 +219,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             {
                 var input = arg.GetInputAsJson();
 
-                var usesExternalDurableSDK = this.platormInformation.UsesExternalPowerShellSDK();
-                JsonSerializer serializer = usesExternalDurableSDK ? TypePreservingSerializer : DefaultSerializer;
+                var usesExternalPowerShellSDK = this.platormInformation.UsesExternalPowerShellSDK();
+                JsonSerializer serializer = usesExternalPowerShellSDK ? TypePreservingSerializer : DefaultSerializer;
                 var history = JArray.FromObject(arg.History, serializer);
 
                 // due to Python only supporting up to SchemaVersion V2 from SDK versions 1.1.0 to 1.1.3,

--- a/src/WebJobs.Extensions.DurableTask/DefaultPlatformInformation.cs
+++ b/src/WebJobs.Extensions.DurableTask/DefaultPlatformInformation.cs
@@ -79,6 +79,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             return string.Equals(value, "Dynamic", StringComparison.OrdinalIgnoreCase);
         }
 
+        public bool UsesExternalPowerShellSDK()
+        {
+            string? value = this.ReadEnviromentVariable("ExternalDurablePowerShellSDK");
+            var parsingSucceeded = bool.TryParse(value, out var usesExternalPowerShellSDK);
+            return parsingSucceeded ? usesExternalPowerShellSDK : false;
+        }
+
         public bool IsInConsumptionPlan()
         {
             return this.IsInLinuxConsumption() || this.IsInWindowsConsumption();

--- a/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
@@ -418,7 +418,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 : null;
 
             context.AddBindingRule<OrchestrationTriggerAttribute>()
-                .BindToTrigger(new OrchestrationTriggerAttributeBindingProvider(this, connectionName));
+                .BindToTrigger(new OrchestrationTriggerAttributeBindingProvider(this, connectionName, this.PlatformInformationService));
 
             context.AddBindingRule<ActivityTriggerAttribute>()
                 .BindToTrigger(new ActivityTriggerAttributeBindingProvider(this, connectionName));

--- a/src/WebJobs.Extensions.DurableTask/IPlatformInformation.cs
+++ b/src/WebJobs.Extensions.DurableTask/IPlatformInformation.cs
@@ -112,5 +112,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// </summary>
         /// <returns>The application container name.</returns>
         string GetContainerName();
+
+        /// <summary>
+        /// Determines whether the user has opted in to the external PowerShell SDK.
+        /// </summary>
+        /// <returns>True if the user has opted in to the external PowerShell SDK. False otherwise.</returns>
+        bool UsesExternalPowerShellSDK();
     }
 }

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
@@ -3677,6 +3677,12 @@
             </summary>
             <returns>The application container name.</returns>
         </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.IPlatformInformation.UsesExternalPowerShellSDK">
+            <summary>
+            Determines whether the user has opted in to the external PowerShell SDK.
+            </summary>
+            <returns>True if the user has opted in to the external PowerShell SDK. False otherwise.</returns>
+        </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.IStorageAccountProvider">
             <summary>
             Defines methods for retrieving Azure Storage account metadata.


### PR DESCRIPTION
<!-- Start the PR description with some context for the change. -->

The new external PowerShell SDK requires the provided History JSON array to have enough information to reconstruct its .NET types. This is because we will feed the History to initialize the replay logic of the C#-isolated logic, which manages the replay of this new PS SDK.

To that purpose, this PR modifies `OrchestrationTriggerBinding` so that, when the external PS SDK is enabled (controlled by envvar "ExternalDurablePowerShellSDK"), the provided History JSON array includes the necessary fields to de-serialize the events back into their original DurableTask types in the new PS SDK.

<!-- Make sure to delete the markdown comments and the below sections when squash merging -->
### Issue describing the changes in this PR

N/A

### Pull request checklist

* [ ] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)
* [ ] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk
* [ ] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
    * [ ] Otherwise: major or minor version updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
