### PR TITLE
Update release instructions's assigness

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-release-template.md
+++ b/.github/ISSUE_TEMPLATE/new-release-template.md
@@ -3,7 +3,7 @@ name: New release template
 about: Template for creating new releases of Durable Functions
 title: ''
 labels: ''
-assignees: comcmaho, amdeel, davidmrdavid, bachuv
+assignees: amdeel, davidmrdavid, bachuv, nytiannn
 
 ---
 


### PR DESCRIPTION
Removing Connor's GitHub account and adding Naiyuan's account.
This will affect who gets auto-added as assignee when a release thread is created.