### PR TITLE
Document, in PR template, that new EventIds should lie within our supported range

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -19,3 +19,5 @@ resolves #issue_for_this_pr
     * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk
 * [ ] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
     * [ ] Otherwise: major or minor version updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
+* [ ] My changes **do not** add EventIds to our EventSource logs
+    * [ ] Otherwise: Ensure the EventIds are within the supported range in our existing Windows infrastructure. You may validate this with a deployed app's telemetry. You may also extend the range by completing a PR such as [this one](https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files).


### PR DESCRIPTION
As in title. It also links to a PR example showing how to extend that range.