### PR TITLE
Fix bug in entity batch processing that caused entity state size explosion

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -2,7 +2,11 @@
 
 ### New Features
 
+- Added more detail to entity batch processing instrumentation, to help diagnose issues
+
 ### Bug Fixes
+
+- Fix bug in entity batch processing that caused entity state size explosion
 
 ### Breaking Changes
 

--- a/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
@@ -876,6 +876,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
             try
             {
+                entityShim.AddTraceFlag('1');
+
                 // 1. First time through the history
                 // we count events, add any under-lock op to the batch, and process lock releases
                 foreach (HistoryEvent e in runtimeState.Events)
@@ -967,6 +969,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                                 // this is a continue message.
                                 // Resumes processing of previously queued operations, if any.
                                 entityContext.State.Suspended = false;
+                                entityShim.AddTraceFlag(EntityTraceFlags.Resumed);
                             }
 
                             break;
@@ -981,6 +984,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
                 if (!entityContext.State.Suspended)
                 {
+                    entityShim.AddTraceFlag('2');
+
                     // 2. We add as many requests from the queue to the batch as possible,
                     // stopping at lock requests or when the maximum batch size is reached
                     while (entityContext.State.MayDequeue())
@@ -989,6 +994,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                         {
                             // we have reached the maximum batch size already
                             // insert a delay after this batch to ensure write back
+                            entityShim.AddTraceFlag(EntityTraceFlags.BatchSizeLimit);
                             entityShim.ToBeContinuedWithDelay();
                             break;
                         }
@@ -1009,14 +1015,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             }
             catch (Exception e)
             {
-                entityContext.CaptureInternalError(e);
+                entityContext.CaptureInternalError(e, entityShim);
             }
 
             WrappedFunctionResult result;
 
             if (entityShim.OperationBatch.Count > 0 && !this.HostLifetimeService.OnStopping.IsCancellationRequested)
             {
-                // 3a. Start the functions invocation pipeline (billing, logging, bindings, and timeout tracking).
+                // 3a. (function execution) Start the functions invocation pipeline (billing, logging, bindings, and timeout tracking).
                 result = await FunctionExecutionHelper.ExecuteFunctionInOrchestrationMiddleware(
                     entityShim.GetFunctionInfo().Executor,
                     new TriggeredFunctionData
@@ -1037,6 +1043,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                                     FunctionType.Entity,
                                     isReplay: false);
 
+                                entityShim.AddTraceFlag('3');
+
                                 // 3. Run all the operations in the batch
                                 if (entityContext.InternalError == null)
                                 {
@@ -1046,9 +1054,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                                     }
                                     catch (Exception e)
                                     {
-                                        entityContext.CaptureInternalError(e);
+                                        entityContext.CaptureInternalError(e, entityShim);
                                     }
                                 }
+
+                                entityShim.AddTraceFlag('4');
 
                                 // 4. Run the DTFx orchestration to persist the effects,
                                 // send the outbox, and continue as new
@@ -1110,7 +1120,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             }
             else
             {
-                // 3b. We do not need to call into user code because we are not going to run any operations.
+                entityShim.AddTraceFlag(EntityTraceFlags.DirectExecution);
+
+                // 3b. (direct execution) We do not need to call into user code because we are not going to run any operations.
                 // In this case we can execute without involving the functions runtime.
                 if (entityContext.InternalError == null)
                 {
@@ -1121,14 +1133,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     }
                     catch (Exception e)
                     {
-                        entityContext.CaptureInternalError(e);
+                        entityContext.CaptureInternalError(e, entityShim);
                     }
                 }
             }
 
             // If there were internal errors, throw a SessionAbortedException
             // here so DTFx can abort the batch and back off the work item
-            entityContext.AbortOnInternalError();
+            entityContext.AbortOnInternalError(entityShim.TraceFlags);
 
             await entityContext.RunDeferredTasks();
         }

--- a/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
@@ -876,7 +876,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
             try
             {
-                entityShim.AddTraceFlag('1');
+                entityShim.AddTraceFlag('1'); // add a bread crumb for the entity batch tracing
 
                 // 1. First time through the history
                 // we count events, add any under-lock op to the batch, and process lock releases
@@ -983,7 +983,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     entityContext.State.PutBack(lockHolderMessages);
                 }
 
-                // mitigation for ICM358210295 : un-suspend an entity if the last continue-as-new happened at least 10 seconds ago
+                // mitigation for ICM358210295 : if an entity has been in suspended state for at least 10 seconds, resume
+                // (suspended state is never meant to last long, it is needed just so the history gets persisted to storage)
                 if (entityContext.State.Suspended
                     && runtimeState.ExecutionStartedEvent?.Timestamp < DateTime.UtcNow - TimeSpan.FromSeconds(10))
                 {

--- a/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
@@ -931,7 +931,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
                                 foreach (var message in deliverNow)
                                 {
-                                    if (entityContext.State.LockedBy == message.ParentInstanceId)
+                                    if (entityContext.State.LockedBy != null
+                                        && entityContext.State.LockedBy == message.ParentInstanceId)
                                     {
                                         if (lockHolderMessages == null)
                                         {

--- a/src/WebJobs.Extensions.DurableTask/EndToEndTraceHelper.cs
+++ b/src/WebJobs.Extensions.DurableTask/EndToEndTraceHelper.cs
@@ -755,6 +755,79 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             }
         }
 
+        public void EntityBatchCompleted(
+            string hubName,
+            string functionName,
+            string instanceId,
+            int eventsReceived,
+            int operationsInBatch,
+            int operationsExecuted,
+            int? outOfOrderMessages,
+            int queuedMessages,
+            int userStateSize,
+            int? sources,
+            int? destinations,
+            string lockedBy,
+            bool suspended,
+            string traceFlags)
+        {
+            FunctionType functionType = FunctionType.Entity;
+
+            EtwEventSource.Instance.EntityBatchCompleted(
+                hubName,
+                LocalAppName,
+                LocalSlotName,
+                functionName,
+                instanceId,
+                eventsReceived,
+                operationsInBatch,
+                operationsExecuted,
+                outOfOrderMessages?.ToString() ?? "",
+                queuedMessages,
+                userStateSize,
+                sources?.ToString() ?? "",
+                destinations?.ToString() ?? "",
+                lockedBy ?? "",
+                suspended,
+                traceFlags,
+                functionType.ToString(),
+                ExtensionVersion,
+                IsReplay: false);
+
+            this.logger.LogInformation(
+                "{instanceId}: Function '{functionName} ({functionType})' received {eventsReceived} events and processed {operationsExecuted}/{operationsInBatch} entity operations. OutOfOrderMessages: {outOfOrderMessages}. QueuedMessages: {queuedMessages}. UserStateSize: {userStateSize}. Sources: {sources}. Destinations: {destinations}. LockedBy: {lockedBy}. Suspended: {suspended}. TraceFlags: {traceFlags}. State: {state}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}. SequenceNumber: {sequenceNumber}.",
+                instanceId, functionName, functionType,
+                eventsReceived, operationsExecuted, operationsInBatch, outOfOrderMessages, queuedMessages, userStateSize, sources, destinations, lockedBy, suspended, traceFlags,
+                FunctionState.EntityBatch, hubName, LocalAppName, LocalSlotName, ExtensionVersion, this.sequenceNumber++);
+        }
+
+        public void EntityBatchFailed(
+            string hubName,
+            string functionName,
+            string instanceId,
+            string traceFlags,
+            string details)
+        {
+            FunctionType functionType = FunctionType.Entity;
+
+            EtwEventSource.Instance.EntityBatchFailed(
+                hubName,
+                LocalAppName,
+                LocalSlotName,
+                functionName,
+                instanceId,
+                traceFlags,
+                details,
+                functionType.ToString(),
+                ExtensionVersion);
+
+            this.logger.LogError(
+                "{instanceId}: Function '{functionName} ({functionType})' failed. TraceFlags: {traceFlags}. Details: {details}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}. SequenceNumber: {sequenceNumber}.",
+                instanceId, functionName, functionType,
+                traceFlags, details,
+                hubName, LocalAppName, LocalSlotName, ExtensionVersion, this.sequenceNumber++);
+        }
+
         public void EventGridSuccess(
             string hubName,
             string functionName,
@@ -768,19 +841,19 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             FunctionType functionType = FunctionType.Orchestrator;
 
             EtwEventSource.Instance.EventGridNotificationCompleted(
-                hubName,
-                LocalAppName,
-                LocalSlotName,
-                functionName,
-                functionState,
-                instanceId,
-                details,
-                (int)statusCode,
-                reason,
-                functionType,
-                ExtensionVersion,
-                IsReplay: false,
-                latencyMs);
+               hubName,
+               LocalAppName,
+               LocalSlotName,
+               functionName,
+               functionState,
+               instanceId,
+               details,
+               (int)statusCode,
+               reason,
+               functionType,
+               ExtensionVersion,
+               IsReplay: false,
+               latencyMs);
 
             this.logger.LogInformation(
                 "{instanceId}: Function '{functionName} ({functionType})' sent a '{functionState}' notification event to Azure Event Grid. Status code: {statusCode}. Details: {details}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}. SequenceNumber: {sequenceNumber}. Latency: {latencyMs} ms.",
@@ -801,19 +874,19 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             FunctionType functionType = FunctionType.Orchestrator;
 
             EtwEventSource.Instance.EventGridNotificationFailed(
-                hubName,
-                LocalAppName,
-                LocalSlotName,
-                functionName,
-                functionState,
-                instanceId,
-                details,
-                (int)statusCode,
-                reason,
-                functionType,
-                ExtensionVersion,
-                IsReplay: false,
-                latencyMs);
+               hubName,
+               LocalAppName,
+               LocalSlotName,
+               functionName,
+               functionState,
+               instanceId,
+               details,
+               (int)statusCode,
+               reason,
+               functionType,
+               ExtensionVersion,
+               IsReplay: false,
+               latencyMs);
 
             this.logger.LogError(
                 "{instanceId}: Function '{functionName} ({functionType})' failed to send a '{functionState}' notification event to Azure Event Grid. Status code: {statusCode}. Details: {details}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}. SequenceNumber: {sequenceNumber}. Latency: {latencyMs} ms.",

--- a/src/WebJobs.Extensions.DurableTask/EndToEndTraceHelper.cs
+++ b/src/WebJobs.Extensions.DurableTask/EndToEndTraceHelper.cs
@@ -841,19 +841,19 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             FunctionType functionType = FunctionType.Orchestrator;
 
             EtwEventSource.Instance.EventGridNotificationCompleted(
-               hubName,
-               LocalAppName,
-               LocalSlotName,
-               functionName,
-               functionState,
-               instanceId,
-               details,
-               (int)statusCode,
-               reason,
-               functionType,
-               ExtensionVersion,
-               IsReplay: false,
-               latencyMs);
+                hubName,
+                LocalAppName,
+                LocalSlotName,
+                functionName,
+                functionState,
+                instanceId,
+                details,
+                (int)statusCode,
+                reason,
+                functionType,
+                ExtensionVersion,
+                IsReplay: false,
+                latencyMs);
 
             this.logger.LogInformation(
                 "{instanceId}: Function '{functionName} ({functionType})' sent a '{functionState}' notification event to Azure Event Grid. Status code: {statusCode}. Details: {details}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}. SequenceNumber: {sequenceNumber}. Latency: {latencyMs} ms.",
@@ -874,19 +874,19 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             FunctionType functionType = FunctionType.Orchestrator;
 
             EtwEventSource.Instance.EventGridNotificationFailed(
-               hubName,
-               LocalAppName,
-               LocalSlotName,
-               functionName,
-               functionState,
-               instanceId,
-               details,
-               (int)statusCode,
-               reason,
-               functionType,
-               ExtensionVersion,
-               IsReplay: false,
-               latencyMs);
+                hubName,
+                LocalAppName,
+                LocalSlotName,
+                functionName,
+                functionState,
+                instanceId,
+                details,
+                (int)statusCode,
+                reason,
+                functionType,
+                ExtensionVersion,
+                IsReplay: false,
+                latencyMs);
 
             this.logger.LogError(
                 "{instanceId}: Function '{functionName} ({functionType})' failed to send a '{functionState}' notification event to Azure Event Grid. Status code: {statusCode}. Details: {details}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}. SequenceNumber: {sequenceNumber}. Latency: {latencyMs} ms.",

--- a/src/WebJobs.Extensions.DurableTask/EntityScheduler/EntityTraceFlags.cs
+++ b/src/WebJobs.Extensions.DurableTask/EntityScheduler/EntityTraceFlags.cs
@@ -1,0 +1,44 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+using System.Text;
+
+namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
+{
+    internal struct EntityTraceFlags
+    {
+        // state was rehydrated
+        public const char Rehydrated = 'Y';
+
+        // the execution was suspended (to be continued in a fresh batch), or resumed
+        public const char Suspended = 'S';
+        public const char Resumed = 'R';
+        public const char MitigationResumed = 'M';
+
+        // reasons for suspending execution
+        public const char TimedOut = 'T';
+        public const char HostShutdown = 'H';
+        public const char SignificantTimeElapsed = 'E';
+        public const char BatchSizeLimit = 'L';
+
+        // execution is waiting for new messages after a continue-as-new
+        public const char WaitForEvents = 'W';
+
+        // the execution bypassed the functions middleware because no user code is called
+        public const char DirectExecution = 'D';
+
+        // an internal error was captured
+        public const char InternalError = '!';
+
+        // trace flags
+        private StringBuilder traceFlags;
+
+        public string TraceFlags => this.traceFlags.ToString();
+
+        public void AddFlag(char flag)
+        {
+            (this.traceFlags ??= new StringBuilder()).Append(flag);
+        }
+    }
+}

--- a/src/WebJobs.Extensions.DurableTask/EntityScheduler/EntityTraceFlags.cs
+++ b/src/WebJobs.Extensions.DurableTask/EntityScheduler/EntityTraceFlags.cs
@@ -38,6 +38,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
         public void AddFlag(char flag)
         {
+            // we concatenate the trace flag characters, they serve as a 'trail of bread crumbs' to reconstruct code path
             (this.traceFlags ??= new StringBuilder()).Append(flag);
         }
     }

--- a/src/WebJobs.Extensions.DurableTask/EntityScheduler/SchedulerState.cs
+++ b/src/WebJobs.Extensions.DurableTask/EntityScheduler/SchedulerState.cs
@@ -50,6 +50,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         [JsonIgnore]
         public bool IsEmpty => !this.EntityExists && (this.Queue == null || this.Queue.Count == 0) && this.LockedBy == null;
 
+        [JsonIgnore]
+        public int UserStateSize => this.EntityState?.Length ?? 0;
+
         internal void Enqueue(RequestMessage operationMessage)
         {
             if (this.Queue == null)

--- a/src/WebJobs.Extensions.DurableTask/EtwEventSource.cs
+++ b/src/WebJobs.Extensions.DurableTask/EtwEventSource.cs
@@ -514,6 +514,46 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             this.WriteEvent(232, TaskHub, AppName, SlotName, FunctionName, InstanceId, Reason, FunctionType, ExtensionVersion, IsReplay);
         }
 
+        [Event(233, Level = EventLevel.Informational, Version = 4)]
+        public void EntityBatchCompleted(
+            string TaskHub,
+            string AppName,
+            string SlotName,
+            string FunctionName,
+            string InstanceId,
+            int EventsReceived,
+            int OperationsInBatch,
+            int OperationsExecuted,
+            string OutOfOrderMessages,
+            int QueuedMessages,
+            int UserStateSize,
+            string Sources,
+            string Destinations,
+            string LockedBy,
+            bool Suspended,
+            string TraceFlags,
+            string FunctionType,
+            string ExtensionVersion,
+            bool IsReplay)
+        {
+            this.WriteEvent(233, TaskHub, AppName, SlotName, FunctionName, InstanceId, EventsReceived, OperationsInBatch, OperationsExecuted, OutOfOrderMessages, QueuedMessages, UserStateSize, Sources, Destinations, LockedBy, Suspended, TraceFlags, FunctionType, ExtensionVersion, IsReplay);
+        }
+
+        [Event(234, Level = EventLevel.Error, Version = 4)]
+        public void EntityBatchFailed(
+            string TaskHub,
+            string AppName,
+            string SlotName,
+            string FunctionName,
+            string InstanceId,
+            string TraceFlags,
+            string Details,
+            string FunctionType,
+            string ExtensionVersion)
+        {
+            this.WriteEvent(234, TaskHub, AppName, SlotName, FunctionName, InstanceId, TraceFlags, Details, FunctionType, ExtensionVersion);
+        }
+
 #pragma warning restore SA1313 // Parameter names should begin with lower-case letter
     }
 }

--- a/src/WebJobs.Extensions.DurableTask/FunctionState.cs
+++ b/src/WebJobs.Extensions.DurableTask/FunctionState.cs
@@ -21,5 +21,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         EntityStateCreated,
         EntityStateDeleted,
         Suspended,
+        EntityBatch,
     }
 }


### PR DESCRIPTION
The current implementation of the entity batching contained a bug which caused entities that experienced a high load to stay in a suspended state for a long time (because the resume message was starved).

As a result, we observed situations in which the internal queue in the entity state grows explosively.

This PR
- fixes the suspected reason causing the long delay of the resume message.
- adds a safety measure that un-suspends any entity if it has been suspended for 10 seconds.
- adds very detailed tracing to make it easier to diagnose issues with entity size and entity batch processing in the future.

### Pull request checklist

* [x] My changes **do not** require documentation changes
* [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
* [x] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
* [x] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
* [x] Otherwise: Ensure the EventIds are within the supported range in our existing Windows infrastructure. 