### PR TITLE
Use AspNetCore.Http 2.1.x track on netstandard2.0

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/LocalHttpListener.cs
+++ b/src/WebJobs.Extensions.DurableTask/LocalHttpListener.cs
@@ -77,9 +77,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 {
                     this.InternalRpcUri = new Uri($"http://127.0.0.1:{listeningPort}/durabletask/");
                     var listenUri = new Uri(this.InternalRpcUri.GetLeftPart(UriPartial.Authority));
-                    this.localWebHost = new WebHostBuilder()
-                        .UseKestrel()
-                        .ConfigureKestrel(o =>
+                    this.localWebHost = new WebHostBuilder().UseKestrel(o =>
                         {
                             // remove request's Content size limits
                             o.Limits.MaxRequestBodySize = null;

--- a/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
+++ b/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
@@ -7,7 +7,7 @@
     <MajorVersion>2</MajorVersion>
     <MinorVersion>9</MinorVersion>
     <PatchVersion>3</PatchVersion>
-    <Version>$(MajorVersion).$(MinorVersion).$(PatchVersion)</Version>
+    <Version>$(MajorVersion).$(MinorVersion).$(PatchVersion)-preview3</Version>
     <FileVersion>$(MajorVersion).$(MinorVersion).$(PatchVersion)</FileVersion>
     <AssemblyVersion>$(MajorVersion).0.0.0</AssemblyVersion>
     <Company>Microsoft Corporation</Company>
@@ -69,9 +69,14 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Azure.Identity" Version="1.5.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.31" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.WebApiCompatShim" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Routing" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.2.0" />
+    
+    <!-- Use 2.1.x track of these AspNetCore packages because 2.2.x track is affected by CVE-2020-1045.
+     This CVE may be ignored when .NET Core 3.1 or higher is used.-->
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.WebApiCompatShim" Version="2.1.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Routing" Version="2.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.1.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.1.34" />
+    
     <PackageReference Include="Microsoft.Extensions.Azure" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="2.2.0" />
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.12.2" />

--- a/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
+++ b/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
@@ -7,7 +7,7 @@
     <MajorVersion>2</MajorVersion>
     <MinorVersion>9</MinorVersion>
     <PatchVersion>3</PatchVersion>
-    <Version>$(MajorVersion).$(MinorVersion).$(PatchVersion)-preview3</Version>
+    <Version>$(MajorVersion).$(MinorVersion).$(PatchVersion)</Version>
     <FileVersion>$(MajorVersion).$(MinorVersion).$(PatchVersion)</FileVersion>
     <AssemblyVersion>$(MajorVersion).0.0.0</AssemblyVersion>
     <Company>Microsoft Corporation</Company>


### PR DESCRIPTION
<!-- Start the PR description with some context for the change. -->

We've recently been informed by an automated dependency scan that AspNetCore.Http 2.2.x is affected by [CVE-2020-1045](https://github.com/dotnet/aspnetcore/issues/25701)
.
[This CVE was resolved in AspNetCore.Http 2.1.x](https://github.com/github/advisory-database/issues/302) but not in AspNetCore.Http 2.2.x. This is apparently because the 2.2.x track went EOL before 2.1.x.

 _From my understanding thus far_, this CVE may also be ignored when .NET Core app 3.1 or greater is used. This is still to be confirmed.

Given that our project uses multi-targeting, one target being netstandard2.0 and another being netcoreapp3.1, this PR only addresses the vulnerability in the netstandard2.0 target. This PR does this by downgrading our AspNetCore dependencies to the 2.1.x track, and pinning to the AspNetCore.Http version with the CVE fix.

**Question:** do we need to backport this change to DF V1?

<!-- Make sure to delete the markdown comments and the below sections when squash merging -->
### Issue describing the changes in this PR

resolves N/A

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)
* [x] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk
* [x] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
    * [ ] Otherwise: major or minor version updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
* [x] My changes **do not** add EventIds to our EventSource logs
    * [ ] Otherwise: Ensure the EventIds are within the supported range in our existing Windows infrastructure. You may validate this with a deployed app's telemetry. You may also extend the range by completing a PR such as [this one](https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files).