### PR TITLE
Suspend/resume history event support

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/ProtobufUtils.cs
+++ b/src/WebJobs.Extensions.DurableTask/ProtobufUtils.cs
@@ -204,6 +204,20 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                         },
                     };
                     break;
+                case EventType.ExecutionSuspended:
+                    var suspendedEvent = (ExecutionSuspendedEvent)e;
+                    payload.ExecutionSuspended = new P.ExecutionSuspendedEvent
+                    {
+                        Input = suspendedEvent.Reason,
+                    };
+                    break;
+                case EventType.ExecutionResumed:
+                    var resumedEvent = (ExecutionResumedEvent)e;
+                    payload.ExecutionResumed = new P.ExecutionResumedEvent
+                    {
+                        Input = resumedEvent.Reason,
+                    };
+                    break;
                 default:
                     throw new NotSupportedException($"Found unsupported history event '{e.EventType}'.");
             }


### PR DESCRIPTION
This PR adds support for handling suspend/resume history events. This is required to unblock suspend/resume support for Java and .NET Isolated.

FYI @kaibocai 

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)
* [x] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk
* [x] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
    * [ ] Otherwise: major or minor version updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
* [x] My changes **do not** add EventIds to our EventSource logs
    * [ ] Otherwise: Ensure the EventIds are within the supported range in our existing Windows infrastructure. You may validate this with a deployed app's telemetry. You may also extend the range by completing a PR such as [this one](https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files).