### PR TITLE
Patch V2/V3 .NET smoke tests

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/EntityScheduler/MessageSorter.cs
+++ b/src/WebJobs.Extensions.DurableTask/EntityScheduler/MessageSorter.cs
@@ -116,7 +116,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             message.Timestamp = timestamp;
             this.LastSentToInstance[destination] = timestamp;
 
-            this.NumDestinations = countingEntries ? destinationCount : null;
+            this.NumDestinations = countingEntries ? destinationCount : (int?)null;
         }
 
         /// <summary>
@@ -192,8 +192,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 // Just pass the message through.
                 yield return message;
 
-                this.NumSources = countingEntries ? sourceCount : null;
-                this.NumMessages = countingEntries ? messageCount : null;
+                this.NumSources = countingEntries ? sourceCount : (int?)null;
+                this.NumMessages = countingEntries ? messageCount : (int?)null;
                 yield break;
             }
 
@@ -262,8 +262,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 }
             }
 
-            this.NumSources = countingEntries ? sourceCount : null;
-            this.NumMessages = countingEntries ? messageCount : null;
+            this.NumSources = countingEntries ? sourceCount : (int?)null;
+            this.NumMessages = countingEntries ? messageCount : (int?)null;
         }
 
         private bool TryDeliverNextMessage(ReceiveBuffer buffer, out RequestMessage message)


### PR DESCRIPTION
The V2/V3 smoke tests have been failing with this error:

```
/root/.nuget/packages/microsoft.build.tasks.git/1.0.0/build/Microsoft.Build.Tasks.Git.targets(24,5): warning : Unable to locate repository with working directory that contains directory '/root/src/WebJobs.Extensions.DurableTask'. [/root/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj]
/root/.nuget/packages/microsoft.build.tasks.git/1.0.0/build/Microsoft.Build.Tasks.Git.targets(47,5): warning : Unable to locate repository with working directory that contains directory '/root/src/WebJobs.Extensions.DurableTask'. [/root/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj]
/root/.nuget/packages/microsoft.sourcelink.common/1.0.0/build/Microsoft.SourceLink.Common.targets(52,5): warning : Source control information is not available - the generated source link is empty. [/root/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj]
EntityScheduler/MessageSorter.cs(119,36): error CS0173: Type of conditional expression cannot be determined because there is no implicit conversion between 'int' and '<null>' [/root/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj]
EntityScheduler/MessageSorter.cs(195,35): error CS0173: Type of conditional expression cannot be determined because there is no implicit conversion between 'int' and '<null>' [/root/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj]
EntityScheduler/MessageSorter.cs(196,36): error CS0173: Type of conditional expression cannot be determined because there is no implicit conversion between 'int' and '<null>' [/root/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj]
EntityScheduler/MessageSorter.cs(265,31): error CS0173: Type of conditional expression cannot be determined because there is no implicit conversion between 'int' and '<null>' [/root/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj]
EntityScheduler/MessageSorter.cs(266,32): error CS0173: Type of conditional expression cannot be determined because there is no implicit conversion between 'int' and '<null>' [/root/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj]
    3 Warning(s)
    5 Error(s)
```

It appears that error originated in the new statistics collected in this PR: https://github.com/Azure/azure-functions-durable-extension/pull/2390/files#diff-a7a74ac9b3dd3f8fd2a205c22fa13d34444db266bd4b275052210c224c233d2a

This PR aims to resolve that error by helping the compiler determine the result of the ternary expressions listed in the error above.