### PR TITLE
Fix hashcode/equality for client cache key

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -8,6 +8,7 @@
 
 - Fix bug in entity batch processing that caused entity state size explosion
 - Fix orchestration scheduled start time not being respected for gRPC-based workers.
+- Fix connection exhaustion and memory leak due to incorrect caching of `DurableTaskClient`'s in dotnet isolated extension.
 
 ### Breaking Changes
 

--- a/src/Worker.Extensions.DurableTask/FunctionsDurableClientProvider.cs
+++ b/src/Worker.Extensions.DurableTask/FunctionsDurableClientProvider.cs
@@ -18,6 +18,8 @@ using Grpc.Net.Client;
 using GrpcChannel = Grpc.Core.Channel;
 #endif
 
+using ClientKey = System.ValueTuple<System.Uri, System.String, System.String>;
+
 namespace Microsoft.Azure.Functions.Worker.Extensions.DurableTask;
 
 /// <summary>
@@ -178,13 +180,13 @@ internal partial class FunctionsDurableClientProvider : IAsyncDisposable
 
     private record ClientKey(Uri Address, string? Name, string? Connection)
     {
-        private readonly Dictionary<string, string> emptyHeaders = new();
+        private static readonly Dictionary<string, string> EmptyHeaders = new();
 
         public IReadOnlyDictionary<string, string> GetHeaders()
         {
             if (string.IsNullOrEmpty(this.Name) && string.IsNullOrEmpty(this.Connection))
             {
-                return this.emptyHeaders;
+                return EmptyHeaders;
             }
 
             Dictionary<string, string> headers = new();


### PR DESCRIPTION
<!-- Start the PR description with some context for the change. -->

The `emptyHeaders` dictionary was being included in record-types built in equality & hash-code calculations, thus the cache checks were always a miss. This led to the cache growing for every function invocation and eventually we would hit connection limits (and if that werent there, memory limits). The fix is very simple. I did not add unit tests as there is no test project for the isolated worker extension yet. I did manually verify before/after via debug.

<!-- Make sure to delete the markdown comments and the below sections when squash merging -->
### Issue describing the changes in this PR

resolves #2439

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)
* [x] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk
* [x] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
    * [ ] Otherwise: major or minor version updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
* [x] My changes **do not** add EventIds to our EventSource logs
    * [ ] Otherwise: Ensure the EventIds are within the supported range in our existing Windows infrastructure. You may validate this with a deployed app's telemetry. You may also extend the range by completing a PR such as [this one](https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files).