### PR TITLE
updated environment variable read to TryAdd

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/DefaultPlatformInformation.cs
+++ b/src/WebJobs.Extensions.DurableTask/DefaultPlatformInformation.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 {
                     this.cachedEnviromentVariables.Add(variableName, value);
                 }
-                catch
+                catch (ArgumentException)
                 {
                     // The environment variable was already added. This could happen in the case of concurrent reads.
                 }

--- a/src/WebJobs.Extensions.DurableTask/DefaultPlatformInformation.cs
+++ b/src/WebJobs.Extensions.DurableTask/DefaultPlatformInformation.cs
@@ -37,9 +37,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             if (!this.cachedEnviromentVariables.TryGetValue(variableName, out value))
             {
                 value = this.nameResolver.Resolve(variableName);
-                if (!this.cachedEnviromentVariables.ContainsKey(variableName))
+                try
                 {
                     this.cachedEnviromentVariables.Add(variableName, value);
+                }
+                catch
+                {
+                    // The environment variable was already added. This could happen in the case of concurrent reads.
                 }
             }
 

--- a/src/WebJobs.Extensions.DurableTask/DefaultPlatformInformation.cs
+++ b/src/WebJobs.Extensions.DurableTask/DefaultPlatformInformation.cs
@@ -37,7 +37,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             if (!this.cachedEnviromentVariables.TryGetValue(variableName, out value))
             {
                 value = this.nameResolver.Resolve(variableName);
-                this.cachedEnviromentVariables.TryAdd(variableName, value);
+                if (!this.cachedEnviromentVariables.ContainsKey(variableName))
+                {
+                    this.cachedEnviromentVariables.Add(variableName, value);
+                }
             }
 
             return value;

--- a/src/WebJobs.Extensions.DurableTask/DefaultPlatformInformation.cs
+++ b/src/WebJobs.Extensions.DurableTask/DefaultPlatformInformation.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             if (!this.cachedEnviromentVariables.TryGetValue(variableName, out value))
             {
                 value = this.nameResolver.Resolve(variableName);
-                this.cachedEnviromentVariables.Add(variableName, value);
+                this.cachedEnviromentVariables.TryAdd(variableName, value);
             }
 
             return value;


### PR DESCRIPTION
This PR addresses an issue where the customer's function can fail occasionally with and ArgumentException "An item with the same key has already been added." In the case of concurrent reads.


### Pull request checklist

* [ ] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)
* [ ] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk
* [ ] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
    * [ ] Otherwise: major or minor version updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
* [ ] My changes **do not** add EventIds to our EventSource logs
    * [ ] Otherwise: Ensure the EventIds are within the supported range in our existing Windows infrastructure. You may validate this with a deployed app's telemetry. You may also extend the range by completing a PR such as [this one](https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files).