### PR TITLE
Ensure function abort on shutdown

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/OutOfProcMiddleware.cs
+++ b/src/WebJobs.Extensions.DurableTask/OutOfProcMiddleware.cs
@@ -135,8 +135,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     context.SetResult(
                         response.Actions.Select(ProtobufUtils.ToOrchestratorAction),
                         response.CustomStatus);
-#pragma warning restore CS0618 // Type or member is obsolete (not intended for general public use)
                 },
+#pragma warning restore CS0618 // Type or member is obsolete (not intended for general public use)
             };
 
             FunctionResult functionResult;
@@ -145,6 +145,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 functionResult = await function.Executor.TryExecuteAsync(
                     input,
                     cancellationToken: this.HostLifetimeService.OnStopping);
+                if (!functionResult.Succeeded)
+                {
+                    // Shutdown can surface as a completed invocation in a failed state.
+                    // Re-throw so we can abort this invocation.
+                    this.HostLifetimeService.OnStopping.ThrowIfCancellationRequested();
+                }
             }
             catch (Exception hostRuntimeException)
             {
@@ -295,6 +301,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 result = await function.Executor.TryExecuteAsync(
                     triggerInput,
                     cancellationToken: this.HostLifetimeService.OnStopping);
+                if (!result.Succeeded)
+                {
+                    // Shutdown can surface as a completed invocation in a failed state.
+                    // Re-throw so we can abort this invocation.
+                    this.HostLifetimeService.OnStopping.ThrowIfCancellationRequested();
+                }
             }
             catch (Exception hostRuntimeException)
             {


### PR DESCRIPTION
Fixes an issue with gRPC out-of-proc durable workers where all in-flight activities and orchestrations would fail during host shutdown. The root issue is that the function invocation actually _completes_, but in a failed state, during host shutdown. The fix is to check for a combination of failure and host shutting down post invocation, then ensure we abort the session in this case.

resolves #2454

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)
* [ ] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk
* [ ] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
    * [ ] Otherwise: major or minor version updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
* [ ] My changes **do not** add EventIds to our EventSource logs
    * [ ] Otherwise: Ensure the EventIds are within the supported range in our existing Windows infrastructure. You may validate this with a deployed app's telemetry. You may also extend the range by completing a PR such as [this one](https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files).