### PR TITLE
Use JsonSerializerOptions during GetInput<T>()

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -5,7 +5,7 @@
 ### Bug Fixes
 
 
-#### Microsoft.Azure.WebJobs.DurableTask
+#### Microsoft.Azure.WebJobs.Extensions.DurableTask
 
 - Fix handling of in-flight orchestrations and activities during host shutdown.
     - Previously these were considered "failed", now they will be retried.

--- a/release_notes.md
+++ b/release_notes.md
@@ -4,9 +4,16 @@
 
 ### Bug Fixes
 
+
+#### Microsoft.Azure.WebJobs.DurableTask
+
 - Fix handling of in-flight orchestrations and activities during host shutdown.
     - Previously these were considered "failed", now they will be retried.
     - This only affected dotnet-isolated and java workers.
+  
+#### Microsoft.Azure.Functions.Worker.Extensions.DurableTask
+
+- Will now use DI-configured `JsonSerializerOptions` during `.GetInput<T>`. [#2470](https://github.com/Azure/azure-functions-durable-extension/issues/2470)
 
 ### Breaking Changes
 

--- a/src/Worker.Extensions.DurableTask/FunctionsOrchestrationContext.InputConverter.cs
+++ b/src/Worker.Extensions.DurableTask/FunctionsOrchestrationContext.InputConverter.cs
@@ -12,11 +12,12 @@ internal sealed partial class FunctionsOrchestrationContext
     {
         public abstract T Get<T>();
 
-        public static InputConverter Create(object? baseInput, DataConverter converter)
+        public static InputConverter Create(
+            object? baseInput, DataConverter converter, JsonSerializerOptions jsonOptions)
         {
             return baseInput switch
             {
-                JsonElement json => new JsonElementInputConverter(json),
+                JsonElement json => new JsonElementInputConverter(json, jsonOptions),
                 null => NullInputConverter.Instance,
                 _ => new DefaultInputConverter(baseInput, converter),
             };
@@ -43,15 +44,17 @@ internal sealed partial class FunctionsOrchestrationContext
     private class JsonElementInputConverter : InputConverter
     {
         private readonly JsonElement json;
+        private readonly JsonSerializerOptions jsonOptions;
 
-        public JsonElementInputConverter(JsonElement json)
+        public JsonElementInputConverter(JsonElement json, JsonSerializerOptions jsonOptions)
         {
             this.json = json;
+            this.jsonOptions = jsonOptions;
         }
 
         public override T Get<T>()
         {
-            return this.json.Deserialize<T>()!;
+            return this.json.Deserialize<T>(this.jsonOptions)!;
         }
     }
 

--- a/src/Worker.Extensions.DurableTask/FunctionsOrchestrationContext.cs
+++ b/src/Worker.Extensions.DurableTask/FunctionsOrchestrationContext.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.DurableTask;
@@ -16,6 +17,7 @@ internal sealed partial class FunctionsOrchestrationContext : TaskOrchestrationC
 {
     private readonly TaskOrchestrationContext innerContext;
     private readonly FunctionContext functionContext;
+    private readonly JsonSerializerOptions jsonOptions;
 
     private readonly DurableTaskWorkerOptions options;
 
@@ -27,6 +29,8 @@ internal sealed partial class FunctionsOrchestrationContext : TaskOrchestrationC
         this.functionContext = functionContext;
         this.options = this.functionContext.InstanceServices
             .GetRequiredService<IOptions<DurableTaskWorkerOptions>>().Value;
+        this.jsonOptions = functionContext.InstanceServices
+            .GetRequiredService<IOptions<JsonSerializerOptions>>().Value;
         this.LoggerFactory = functionContext.InstanceServices.GetRequiredService<ILoggerFactory>();
     }
 
@@ -58,7 +62,7 @@ internal sealed partial class FunctionsOrchestrationContext : TaskOrchestrationC
         // once based on the declared input type of the orchestrator. Since we do not know the
         // desired input type upfront, we were initialized to object. So we must serialize and
         // deserialize again to convert to our desired type.
-        this.inputConverter ??= InputConverter.Create(input, this.options.DataConverter);
+        this.inputConverter ??= InputConverter.Create(input, this.options.DataConverter, this.jsonOptions);
         return this.inputConverter.Get<T>();
     }
 


### PR DESCRIPTION
<!-- Start the PR description with some context for the change. -->


<!-- Make sure to delete the markdown comments and the below sections when squash merging -->
### Issue describing the changes in this PR

resolves #2470

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)
* [x] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk
* [x] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
    * [ ] Otherwise: major or minor version updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
* [x] My changes **do not** add EventIds to our EventSource logs
    * [ ] Otherwise: Ensure the EventIds are within the supported range in our existing Windows infrastructure. You may validate this with a deployed app's telemetry. You may also extend the range by completing a PR such as [this one](https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files).