### PR TITLE
Fix missing dedupe states for gRPC client server impl

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableClient.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableClient.cs
@@ -195,7 +195,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 throw new ArgumentException($"Instance ID lengths must not exceed {MaxInstanceIdLength} characters.");
             }
 
-            var dedupeStatuses = this.GetStatusesNotToOverride();
+            OrchestrationStatus[] dedupeStatuses = this.GetStatusesNotToOverride();
             Task<OrchestrationInstance> createTask = this.client.CreateOrchestrationInstanceAsync(
                 orchestratorFunctionName, DefaultVersion, instanceId, input, null, dedupeStatuses);
 
@@ -213,18 +213,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
         private OrchestrationStatus[] GetStatusesNotToOverride()
         {
-            var overridableStates = this.durableTaskOptions.OverridableExistingInstanceStates;
-            if (overridableStates == OverridableStates.NonRunningStates)
-            {
-                return new OrchestrationStatus[]
-                {
-                    OrchestrationStatus.Running,
-                    OrchestrationStatus.ContinuedAsNew,
-                    OrchestrationStatus.Pending,
-                };
-            }
-
-            return new OrchestrationStatus[0];
+            OverridableStates overridableStates = this.durableTaskOptions.OverridableExistingInstanceStates;
+            return overridableStates.ToDedupeStatuses();
         }
 
         private static bool IsInvalidCharacter(char c)

--- a/src/WebJobs.Extensions.DurableTask/LocalGrpcListener.cs
+++ b/src/WebJobs.Extensions.DurableTask/LocalGrpcListener.cs
@@ -159,7 +159,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                             ScheduledStartTime = request.ScheduledStartTimestamp?.ToDateTime(),
                         },
                         OrchestrationInstance = instance,
-                    });
+                    },
+                    this.GetStatusesNotToOverride());
 
                 return new P.CreateInstanceResponse
                 {
@@ -331,6 +332,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 string? connectionName = context.RequestHeaders.GetValue("Durable-ConnectionName");
                 var attribute = new DurableClientAttribute() { TaskHub = taskHub, ConnectionName = connectionName };
                 return this.extension.GetDurabilityProvider(attribute);
+            }
+
+            private OrchestrationStatus[] GetStatusesNotToOverride()
+            {
+                OverridableStates overridableStates = this.extension.Options.OverridableExistingInstanceStates;
+                return overridableStates.ToDedupeStatuses();
             }
         }
     }

--- a/src/WebJobs.Extensions.DurableTask/OverridableStates.cs
+++ b/src/WebJobs.Extensions.DurableTask/OverridableStates.cs
@@ -37,6 +37,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             OrchestrationStatus.Running,
             OrchestrationStatus.ContinuedAsNew,
             OrchestrationStatus.Pending,
+            OrchestrationStatus.Suspended,
         };
 
         /// <summary>

--- a/src/WebJobs.Extensions.DurableTask/OverridableStates.cs
+++ b/src/WebJobs.Extensions.DurableTask/OverridableStates.cs
@@ -1,6 +1,9 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System;
+using DurableTask.Core;
+
 namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 {
     /// <summary>
@@ -20,5 +23,34 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// instance is in a terminated, failed, or completed state.
         /// </summary>
         NonRunningStates,
+    }
+
+    /// <summary>
+    /// Extension methods for <see cref="OverridableStates"/>.
+    /// </summary>
+#pragma warning disable SA1649 // File name should match first type name Justification: pairing extension methods with enum.
+    internal static class OverridableStatesExtensions
+#pragma warning restore SA1649 // File name should match first type name
+    {
+        private static readonly OrchestrationStatus[] NonRunning = new OrchestrationStatus[]
+        {
+            OrchestrationStatus.Running,
+            OrchestrationStatus.ContinuedAsNew,
+            OrchestrationStatus.Pending,
+        };
+
+        /// <summary>
+        /// Gets the dedupe <see cref="OrchestrationStatus"/> for a given <see cref="OverridableStates"/>.
+        /// </summary>
+        /// <param name="states">The overridable states.</param>
+        /// <returns>An array of statuses to dedupe.</returns>
+        public static OrchestrationStatus[] ToDedupeStatuses(this OverridableStates states)
+        {
+            return states switch
+            {
+                OverridableStates.NonRunningStates => NonRunning,
+                _ => Array.Empty<OrchestrationStatus>(),
+            };
+        }
     }
 }


### PR DESCRIPTION
Fixes missing dedupe states in the gRPC server client when scheduling a new orchestration via `IOrchestrationServiceClient`. Without the dedupe states, we would effectively restart already running orchestrations when it was scheduled again.

### Issue describing the changes in this PR

resolves #2466

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md` -- TODO
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)
* [x] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk
* [x] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
    * [ ] Otherwise: major or minor version updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
* [x] My changes **do not** add EventIds to our EventSource logs
    * [ ] Otherwise: Ensure the EventIds are within the supported range in our existing Windows infrastructure. You may validate this with a deployed app's telemetry. You may also extend the range by completing a PR such as [this one](https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files).