### PR TITLE
Improve GRPC exception type and message for duplicate instance. 

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
@@ -4674,6 +4674,18 @@
             instance is in a terminated, failed, or completed state.
             </summary>
         </member>
+        <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.OverridableStatesExtensions">
+            <summary>
+            Extension methods for <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.OverridableStates"/>.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.OverridableStatesExtensions.ToDedupeStatuses(Microsoft.Azure.WebJobs.Extensions.DurableTask.OverridableStates)">
+            <summary>
+            Gets the dedupe <see cref="T:DurableTask.Core.OrchestrationStatus"/> for a given <see cref="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.OverridableStates"/>.
+            </summary>
+            <param name="states">The overridable states.</param>
+            <returns>An array of statuses to dedupe.</returns>
+        </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.ProviderUtils">
             <summary>
             Provides access to internal functionality for the purpose of implementing durability providers.


### PR DESCRIPTION
<!-- Start the PR description with some context for the change. -->


<!-- Make sure to delete the markdown comments and the below sections when squash merging -->
### Issue describing the changes in this PR

resolves [#issue_for_this_pr](https://github.com/microsoft/durabletask-java/issues/112)

We used to get an unclear exception as shown in the above issue. This PR improves the `RPCException` status and message making it more clear for our customers. 

Tested result on Local:

![image](https://github.com/Azure/azure-functions-durable-extension/assets/89094811/0914ffe8-16ef-4dc4-822a-7c3fb163d8ed)


### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)
* [x] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk
* [x] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
    * [ ] Otherwise: major or minor version updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
* [x] My changes **do not** add EventIds to our EventSource logs
    * [ ] Otherwise: Ensure the EventIds are within the supported range in our existing Windows infrastructure. You may validate this with a deployed app's telemetry. You may also extend the range by completing a PR such as [this one](https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files).