### PR TITLE
Automatically generate version suffixes for private packages

### DIFF
--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -7,7 +7,8 @@ pool:
     - ImageOverride -equals MMS2022TLS
 
 variables:
-  BuildVersion: ''
+  # the build version will become the preview package version suffix
+  PreviewPackageSuffix: ''
 
 steps:
 
@@ -16,10 +17,11 @@ steps:
   inputs:
     targetType: 'inline'
     script: |
-      # if trigger branch is not dev then populate BuildVersion environment variable
+      # if source branch is not dev then we're generating a preview package
+      # therefore, we populate the environment variable "PreviewPackageSuffix"
       if($Env:BUILD_SOURCEBRANCHNAME -ne 'dev'){
         $buildNumber = $(Build.BuildNumber)
-        Write-Host "##vso[task.setvariable variable=BuildVersion;]$buildNumber"
+        Write-Host "##vso[task.setvariable variable=PreviewPackageSuffix;]$buildNumber"
       }
 
 # Configure all the .NET SDK versions we need
@@ -63,38 +65,38 @@ steps:
     configuration: Release
 
 # Authenticode sign all the DLLs with the Microsoft certificate.
-# - task: EsrpCodeSigning@1
-#   inputs:
-#     ConnectedServiceName: 'ESRP Service'
-#     FolderPath: 'src/WebJobs.Extensions.DurableTask/bin/Release'
-#     Pattern: '*DurableTask.dll'
-#     signConfigType: 'inlineSignParams'
-#     inlineOperation: |
-#       [    
-#           {
-#             "KeyCode": "CP-230012",
-#             "OperationCode": "SigntoolSign",
-#             "Parameters": {
-#               "OpusName": "Microsoft",
-#               "OpusInfo": "http://www.microsoft.com",
-#               "FileDigest": "/fd \"SHA256\"",
-#               "PageHash": "/NPH",
-#               "TimeStamp": "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
-#             },
-#             "ToolName": "sign",
-#             "ToolVersion": "1.0"
-#           },
-#           {
-#             "KeyCode": "CP-230012",
-#             "OperationCode": "SigntoolVerify",
-#             "Parameters": {},
-#             "ToolName": "sign",
-#             "ToolVersion": "1.0"
-#           }
-#       ]
-#     SessionTimeout: '60'
-#     MaxConcurrency: '50'
-#     MaxRetryAttempts: '5'
+- task: EsrpCodeSigning@1
+  inputs:
+    ConnectedServiceName: 'ESRP Service'
+    FolderPath: 'src/WebJobs.Extensions.DurableTask/bin/Release'
+    Pattern: '*DurableTask.dll'
+    signConfigType: 'inlineSignParams'
+    inlineOperation: |
+      [    
+          {
+            "KeyCode": "CP-230012",
+            "OperationCode": "SigntoolSign",
+            "Parameters": {
+              "OpusName": "Microsoft",
+              "OpusInfo": "http://www.microsoft.com",
+              "FileDigest": "/fd \"SHA256\"",
+              "PageHash": "/NPH",
+              "TimeStamp": "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
+            },
+            "ToolName": "sign",
+            "ToolVersion": "1.0"
+          },
+          {
+            "KeyCode": "CP-230012",
+            "OperationCode": "SigntoolVerify",
+            "Parameters": {},
+            "ToolName": "sign",
+            "ToolVersion": "1.0"
+          }
+      ]
+    SessionTimeout: '60'
+    MaxConcurrency: '50'
+    MaxRetryAttempts: '5'
 
 # SBOM generator task for additional supply chain protection
 - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0

--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -6,7 +6,21 @@ pool:
   demands:
     - ImageOverride -equals MMS2022TLS
 
+variables:
+  BuildVersion: ''
+
 steps:
+
+- task: PowerShell@2
+  displayName: 'Set Package Version Type'
+  inputs:
+    targetType: 'inline'
+    script: |
+      # if trigger branch is not dev then populate BuildVersion environment variable
+      if($Env:BUILD_SOURCEBRANCHNAME -ne 'dev'){
+        $buildNumber = $(Build.BuildNumber)
+        Write-Host "##vso[task.setvariable variable=BuildVersion;]$buildNumber"
+      }
 
 # Configure all the .NET SDK versions we need
 - task: UseDotNet@2

--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -12,7 +12,7 @@ variables:
 steps:
 
 - task: PowerShell@2
-  displayName: 'Set Package Version Type'
+  displayName: 'Populating PackageSuffix iff source branch is not dev'
   inputs:
     targetType: 'inline'
     script: |

--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -7,8 +7,7 @@ pool:
     - ImageOverride -equals MMS2022TLS
 
 variables:
-  # the build version will become the preview package version suffix
-  PreviewPackageSuffix: ''
+  PackageSuffix: ''
 
 steps:
 
@@ -17,11 +16,11 @@ steps:
   inputs:
     targetType: 'inline'
     script: |
-      # if source branch is not dev then we're generating a preview package
-      # therefore, we populate the environment variable "PreviewPackageSuffix"
+      # if source branch is not dev then we're generating a preview package.
+      # In that case, we populate the environment variable "PackageSuffix"
       if($Env:BUILD_SOURCEBRANCHNAME -ne 'dev'){
         $buildNumber = $(Build.BuildNumber)
-        Write-Host "##vso[task.setvariable variable=PreviewPackageSuffix;]$buildNumber"
+        Write-Host "##vso[task.setvariable variable=PackageSuffix;]$buildNumber"
       }
 
 # Configure all the .NET SDK versions we need

--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -63,38 +63,38 @@ steps:
     configuration: Release
 
 # Authenticode sign all the DLLs with the Microsoft certificate.
-- task: EsrpCodeSigning@1
-  inputs:
-    ConnectedServiceName: 'ESRP Service'
-    FolderPath: 'src/WebJobs.Extensions.DurableTask/bin/Release'
-    Pattern: '*DurableTask.dll'
-    signConfigType: 'inlineSignParams'
-    inlineOperation: |
-      [    
-          {
-            "KeyCode": "CP-230012",
-            "OperationCode": "SigntoolSign",
-            "Parameters": {
-              "OpusName": "Microsoft",
-              "OpusInfo": "http://www.microsoft.com",
-              "FileDigest": "/fd \"SHA256\"",
-              "PageHash": "/NPH",
-              "TimeStamp": "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
-            },
-            "ToolName": "sign",
-            "ToolVersion": "1.0"
-          },
-          {
-            "KeyCode": "CP-230012",
-            "OperationCode": "SigntoolVerify",
-            "Parameters": {},
-            "ToolName": "sign",
-            "ToolVersion": "1.0"
-          }
-      ]
-    SessionTimeout: '60'
-    MaxConcurrency: '50'
-    MaxRetryAttempts: '5'
+# - task: EsrpCodeSigning@1
+#   inputs:
+#     ConnectedServiceName: 'ESRP Service'
+#     FolderPath: 'src/WebJobs.Extensions.DurableTask/bin/Release'
+#     Pattern: '*DurableTask.dll'
+#     signConfigType: 'inlineSignParams'
+#     inlineOperation: |
+#       [    
+#           {
+#             "KeyCode": "CP-230012",
+#             "OperationCode": "SigntoolSign",
+#             "Parameters": {
+#               "OpusName": "Microsoft",
+#               "OpusInfo": "http://www.microsoft.com",
+#               "FileDigest": "/fd \"SHA256\"",
+#               "PageHash": "/NPH",
+#               "TimeStamp": "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
+#             },
+#             "ToolName": "sign",
+#             "ToolVersion": "1.0"
+#           },
+#           {
+#             "KeyCode": "CP-230012",
+#             "OperationCode": "SigntoolVerify",
+#             "Parameters": {},
+#             "ToolName": "sign",
+#             "ToolVersion": "1.0"
+#           }
+#       ]
+#     SessionTimeout: '60'
+#     MaxConcurrency: '50'
+#     MaxRetryAttempts: '5'
 
 # SBOM generator task for additional supply chain protection
 - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0

--- a/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
+++ b/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
@@ -7,7 +7,7 @@
     <MajorVersion>2</MajorVersion>
     <MinorVersion>9</MinorVersion>
     <PatchVersion>6</PatchVersion>
-    <VersionSuffix>$(BuildVersion)</VersionSuffix>
+    <VersionSuffix>$(PreviewPackageSuffix)</VersionSuffix>
     <FileVersion>$(MajorVersion).$(MinorVersion).$(PatchVersion)</FileVersion>
     <AssemblyVersion>$(MajorVersion).0.0.0</AssemblyVersion>
     <Company>Microsoft Corporation</Company>
@@ -25,7 +25,7 @@
     <Version>$(MajorVersion).$(MinorVersion).$(PatchVersion)</Version>
   </PropertyGroup>
   <PropertyGroup Condition="$(VersionSuffix) != ''">
-    <Version>$(MajorVersion).$(MinorVersion).$(PatchVersion)-$(VersionSuffix)</Version>
+    <Version>$(MajorVersion).$(MinorVersion).$(PatchVersion)-preview.$(VersionSuffix)</Version>
   </PropertyGroup>
 
   <!-- NuGet Publishing Metadata -->

--- a/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
+++ b/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
@@ -7,7 +7,7 @@
     <MajorVersion>2</MajorVersion>
     <MinorVersion>9</MinorVersion>
     <PatchVersion>6</PatchVersion>
-    <VersionSuffix>$(PreviewPackageSuffix)</VersionSuffix>
+    <VersionSuffix>$(PackageSuffix)</VersionSuffix>
     <FileVersion>$(MajorVersion).$(MinorVersion).$(PatchVersion)</FileVersion>
     <AssemblyVersion>$(MajorVersion).0.0.0</AssemblyVersion>
     <Company>Microsoft Corporation</Company>
@@ -21,10 +21,13 @@
     <NoWarn>NU5125;SA0001</NoWarn>
   </PropertyGroup>
 
+  <!-- VersionSuffix is populated with the BuildVersion iff the CI is not triggered from the dev branch-->
   <PropertyGroup Condition="$(VersionSuffix) == ''">
+    <!-- Generating a release candidate from dev branch-->
     <Version>$(MajorVersion).$(MinorVersion).$(PatchVersion)</Version>
   </PropertyGroup>
   <PropertyGroup Condition="$(VersionSuffix) != ''">
+    <!-- Generating private/preview package -->
     <Version>$(MajorVersion).$(MinorVersion).$(PatchVersion)-preview.$(VersionSuffix)</Version>
   </PropertyGroup>
 

--- a/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
+++ b/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
@@ -7,7 +7,7 @@
     <MajorVersion>2</MajorVersion>
     <MinorVersion>9</MinorVersion>
     <PatchVersion>6</PatchVersion>
-    <Version>$(MajorVersion).$(MinorVersion).$(PatchVersion)</Version>
+    <VersionSuffix>$(BuildVersion)</VersionSuffix>
     <FileVersion>$(MajorVersion).$(MinorVersion).$(PatchVersion)</FileVersion>
     <AssemblyVersion>$(MajorVersion).0.0.0</AssemblyVersion>
     <Company>Microsoft Corporation</Company>
@@ -19,6 +19,13 @@
     <DebugType>embedded</DebugType>
     <!-- See https://github.com/Azure/azure-functions-durable-extension/issues/1433 -->
     <NoWarn>NU5125;SA0001</NoWarn>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="$(VersionSuffix) == ''">
+    <Version>$(MajorVersion).$(MinorVersion).$(PatchVersion)</Version>
+  </PropertyGroup>
+  <PropertyGroup Condition="$(VersionSuffix) != ''">
+    <Version>$(MajorVersion).$(MinorVersion).$(PatchVersion)-$(VersionSuffix)</Version>
   </PropertyGroup>
 
   <!-- NuGet Publishing Metadata -->


### PR DESCRIPTION
<!-- Start the PR description with some context for the change. -->
When making a private extension release, we usually add a version suffix to the package so that it can be distinguished from an official release.

This PR automates that process so that the CI automatically adds a version suffix when the release pipeline is triggered in a feature branch. The version suffix will be `-preview.<buildVersion>` where `<buildVersion>` is automatically generated by the CI.

<!-- Make sure to delete the markdown comments and the below sections when squash merging -->
### Issue describing the changes in this PR
N/A

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)
* [x] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk
* [x] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
    * [ ] Otherwise: major or minor version updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
* [x] My changes **do not** add EventIds to our EventSource logs
    * [ ] Otherwise: Ensure the EventIds are within the supported range in our existing Windows infrastructure. You may validate this with a deployed app's telemetry. You may also extend the range by completing a PR such as [this one](https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files).