### PR TITLE
Add GitHub triage helper app

### DIFF
--- a/tools/triageHelper/.funcignore
+++ b/tools/triageHelper/.funcignore
@@ -1,0 +1,8 @@
+.git*
+.vscode
+__azurite_db*__.json
+__blobstorage__
+__queuestorage__
+local.settings.json
+test
+.venv

--- a/tools/triageHelper/.gitignore
+++ b/tools/triageHelper/.gitignore
@@ -1,0 +1,135 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don’t work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# Azure Functions artifacts
+bin
+obj
+appsettings.json
+local.settings.json
+
+# Azurite artifacts
+__blobstorage__
+__queuestorage__
+__azurite_db*__.json
+.python_packages

--- a/tools/triageHelper/README.md
+++ b/tools/triageHelper/README.md
@@ -1,0 +1,14 @@
+# A GitHub triage helper for Durable Functions
+
+## What is it?
+
+An serverless app that automatically lists all issues to be triaged across Durable Functions repos.
+
+## How to use it?
+
+This app can be executed on the cloud or locally. Irrespective of the location, you can obtain the list of issues to triage by GET requesting the `<appHost>/api/triage` endpoint.
+
+## Next Steps
+
+The current implementation is subject to hourly rate limits, which means it error out if too many users attempt to run it within a given hour window.
+To make the implementation more reliable, we should register the app with a GitHub API token so that our hourly rate limit can be increased.

--- a/tools/triageHelper/README.md
+++ b/tools/triageHelper/README.md
@@ -2,7 +2,7 @@
 
 ## What is it?
 
-An serverless app that automatically lists all issues to be triaged across Durable Functions repos.
+A serverless app that automatically lists all issues to be triaged across Durable Functions repos.
 
 ## How to use it?
 

--- a/tools/triageHelper/function_app.py
+++ b/tools/triageHelper/function_app.py
@@ -1,0 +1,67 @@
+import azure.functions as func
+import logging
+import requests
+import urllib.parse
+
+app = func.FunctionApp(http_auth_level=func.AuthLevel.ANONYMOUS)
+
+REPOS = [
+    "Azure/azure-functions-durable-extension",
+    "Azure/durabletask",
+    "Azure/azure-functions-durable-python",
+    "microsoft/durabletask-java",
+    "microsoft/durabletask-dotnet",
+    "microsoft/durabletask-mssql",
+    "microsoft/durabletask-netherite",
+    "microsoft/DurableFunctionsMonitor"
+]
+
+
+@app.route(route="triage")
+def HttpTrigger(req: func.HttpRequest) -> func.HttpResponse:
+    logging.info('Python HTTP trigger function processed a request.')
+
+    results = []
+    for repo in REPOS:
+        results.append(get_triage_issues(repo))
+
+    report = "\n".join(results)
+    return func.HttpResponse(report)
+
+def get_triage_issues(repository):
+    # Define the label
+    label = "Needs: Triage"
+
+    payload = {
+    'labels': label, 
+}
+
+    payload_str = urllib.parse.urlencode(payload, safe=':+')
+    print(payload_str)
+
+    # Define the GitHub API endpoint
+    api_endpoint = f"https://api.github.com/repos/{repository}/issues"
+    query_str = "?labels=Needs%3A%20Triage%20%3Amag%3A" # the mag% segment represents the emoji on the label
+
+    # Send a GET request to the API
+    response = requests.get(api_endpoint + query_str)
+
+    # Check if the request was successful
+    if response.status_code == 200:
+        # Get the list of issues from the response
+        issues = response.json()
+
+        # Create an empty string to store the issue information
+        issues_info = "# Repository: " + repository + "\n\n"
+
+        # Iterate over each issue and append its title and URL to the string
+        for issue in issues:
+            issue_title = issue["title"]
+            issue_url = issue["html_url"]
+            issues_info += f"Issue Title: {issue_title}\n"
+            issues_info += f"Issue URL: {issue_url}\n"
+            issues_info += "------------------------------------\n"
+
+        return issues_info
+    else:
+        return f"Error: {response.status_code} - {response.text}"

--- a/tools/triageHelper/function_app.py
+++ b/tools/triageHelper/function_app.py
@@ -5,10 +5,14 @@ import urllib.parse
 
 app = func.FunctionApp(http_auth_level=func.AuthLevel.ANONYMOUS)
 
+# this repo is an exception to our labeling system, so we store it in a different variable to detect it later
+powershell_worker_repo = "Azure/azure-functions-powershell-worker"
 REPOS = [
-    "Azure/azure-functions-durable-extension",
     "Azure/durabletask",
+    "Azure/azure-functions-durable-extension",
+    "Azure/azure-functions-durable-js",
     "Azure/azure-functions-durable-python",
+    powershell_worker_repo,
     "microsoft/durabletask-java",
     "microsoft/durabletask-dotnet",
     "microsoft/durabletask-mssql",
@@ -37,11 +41,11 @@ def get_triage_issues(repository):
 }
 
     payload_str = urllib.parse.urlencode(payload, safe=':+')
-    print(payload_str)
-
     # Define the GitHub API endpoint
     api_endpoint = f"https://api.github.com/repos/{repository}/issues"
-    query_str = "?labels=Needs%3A%20Triage%20%3Amag%3A" # the mag% segment represents the emoji on the label
+    query_str1 = "?labels=Needs%3A%20Triage%20%3Amag%3A"
+    query_str2 = "?labels=Needs%3A%20Triage%20%28Functions%29"
+    query_str = query_str2 if repository == powershell_worker_repo else query_str1
 
     # Send a GET request to the API
     response = requests.get(api_endpoint + query_str)

--- a/tools/triageHelper/host.json
+++ b/tools/triageHelper/host.json
@@ -1,0 +1,15 @@
+{
+  "version": "2.0",
+  "logging": {
+    "applicationInsights": {
+      "samplingSettings": {
+        "isEnabled": true,
+        "excludedTypes": "Request"
+      }
+    }
+  },
+  "extensionBundle": {
+    "id": "Microsoft.Azure.Functions.ExtensionBundle",
+    "version": "[4.*, 5.0.0)"
+  }
+}

--- a/tools/triageHelper/requirements.txt
+++ b/tools/triageHelper/requirements.txt
@@ -1,0 +1,6 @@
+# DO NOT include azure-functions-worker in this file
+# The Python Worker is managed by Azure Functions platform
+# Manually managing azure-functions-worker may cause unexpected issues
+
+azure-functions
+requests


### PR DESCRIPTION
<!-- Start the PR description with some context for the change. -->
Our GitHub issue triage process spans several repos, meaning that normally we need to do the manual work of collect all open issues with the "needs: triage" label across all DF repositories.

This PR implements a Functions app that does this work for us. It utilizes the GitHub API to automatically query all "needs: triage" labels across all our repos. It can be executed both locally and on Azure.