### PR TITLE
Allow durability provider to disable status checks on RaiseEventAsync

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableClient.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableClient.cs
@@ -231,7 +231,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 throw new ArgumentNullException(nameof(eventName));
             }
 
-            return this.RaiseEventInternalAsync(this.client, this.TaskHubName, instanceId, eventName, eventData);
+            return this.RaiseEventInternalAsync(this.client, this.TaskHubName, instanceId, eventName, eventData, this.durabilityProvider.CheckStatusBeforeRaiseEvent);
         }
 
         /// <inheritdoc />
@@ -256,7 +256,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             DurableClient durableClient = (DurableClient)this.GetDurableClient(taskHubName, connectionName);
             TaskHubClient taskHubClient = durableClient.client;
 
-            return this.RaiseEventInternalAsync(taskHubClient, taskHubName, instanceId, eventName, eventData);
+            return this.RaiseEventInternalAsync(taskHubClient, taskHubName, instanceId, eventName, eventData, this.durabilityProvider.CheckStatusBeforeRaiseEvent);
         }
 
         /// <inheritdoc />
@@ -690,7 +690,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                             ParentInstanceId = lockOwner,
                             LockRequestId = "fix-orphaned-lock", // we don't know the original id but it does not matter
                         };
-                        await this.RaiseEventInternalAsync(this.client, this.TaskHubName, status.InstanceId, EntityMessageEventNames.ReleaseMessageEventName, message);
+                        await this.RaiseEventInternalAsync(this.client, this.TaskHubName, status.InstanceId, EntityMessageEventNames.ReleaseMessageEventName, message, checkStatusFirst: false);
                         Interlocked.Increment(ref finalResult.NumberOfOrphanedLocksRemoved);
                     }
                 }
@@ -729,38 +729,48 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             string taskHubName,
             string instanceId,
             string eventName,
-            object eventData)
+            object eventData,
+            bool checkStatusFirst)
         {
-            OrchestrationState status = await GetOrchestrationInstanceStateAsync(taskHubClient, instanceId);
-            if (status == null)
+            if (checkStatusFirst)
             {
-                return;
-            }
+                OrchestrationState status = await GetOrchestrationInstanceStateAsync(taskHubClient, instanceId);
+                if (status == null)
+                {
+                    return;
+                }
 
-            if (IsOrchestrationRunning(status))
-            {
-                // External events are not supposed to target any particular execution ID.
-                // We need to clear it to avoid sending messages to an expired ContinueAsNew instance.
-                status.OrchestrationInstance.ExecutionId = null;
+                if (IsOrchestrationRunning(status))
+                {
+                    // External events are not supposed to target any particular execution ID.
+                    // We need to clear it to avoid sending messages to an expired ContinueAsNew instance.
+                    status.OrchestrationInstance.ExecutionId = null;
 
-                await taskHubClient.RaiseEventAsync(status.OrchestrationInstance, eventName, eventData);
+                    await taskHubClient.RaiseEventAsync(status.OrchestrationInstance, eventName, eventData);
 
-                this.traceHelper.FunctionScheduled(
-                    taskHubName,
-                    status.Name,
-                    instanceId,
-                    reason: "RaiseEvent:" + eventName,
-                    functionType: FunctionType.Orchestrator,
-                    isReplay: false);
+                    this.traceHelper.FunctionScheduled(
+                        taskHubName,
+                        status.Name,
+                        instanceId,
+                        reason: "RaiseEvent:" + eventName,
+                        functionType: FunctionType.Orchestrator,
+                        isReplay: false);
+                }
+                else
+                {
+                    this.traceHelper.ExtensionWarningEvent(
+                        hubName: taskHubName,
+                        functionName: status.Name,
+                        instanceId: instanceId,
+                        message: $"Cannot raise event for instance in {status.OrchestrationStatus} state");
+                    throw new InvalidOperationException($"Cannot raise event {eventName} for orchestration instance {instanceId} because instance is in {status.OrchestrationStatus} state");
+                }
             }
             else
             {
-                this.traceHelper.ExtensionWarningEvent(
-                    hubName: taskHubName,
-                    functionName: status.Name,
-                    instanceId: instanceId,
-                    message: $"Cannot raise event for instance in {status.OrchestrationStatus} state");
-                throw new InvalidOperationException($"Cannot raise event {eventName} for orchestration instance {instanceId} because instance is in {status.OrchestrationStatus} state");
+                // fast path: always raise the event (it will be silently discarded
+                // if the instance does not exist or is not running)
+                await taskHubClient.RaiseEventAsync(new OrchestrationInstance() { InstanceId = instanceId }, eventName, eventData);
             }
         }
 

--- a/src/WebJobs.Extensions.DurableTask/ContextInterfaces/IDurableOrchestrationClient.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextInterfaces/IDurableOrchestrationClient.cs
@@ -190,7 +190,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// event named <paramref name="eventName"/> using the
         /// <see cref="IDurableOrchestrationContext.WaitForExternalEvent{T}(string)"/> API.
         /// </para><para>
-        /// If the specified instance is not found or not running, this operation will throw an exception.
+        /// If the specified instance is not found or not running, an exception may be thrown. This behavior depends on the configured
+        /// provider.
         /// </para>
         /// </remarks>
         /// <exception cref="ArgumentException">The instance id does not corespond to a valid orchestration instance.</exception>

--- a/src/WebJobs.Extensions.DurableTask/DurabilityProvider.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurabilityProvider.cs
@@ -82,6 +82,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         public virtual bool SupportsImplicitEntityDeletion => false;
 
         /// <summary>
+        /// Whether or not to check the instance status before raising an event.
+        /// </summary>
+        public virtual bool CheckStatusBeforeRaiseEvent => true;
+
+        /// <summary>
         /// JSON representation of configuration to emit in telemetry.
         /// </summary>
         public virtual JObject ConfigurationJson => EmptyConfig;


### PR DESCRIPTION
 ## Problem Description

The current implementation of RaiseEventAsync first reads the status of the orchestration instance from storage, before enqueueing the raised events. This has negative performance implications on Netherite where the status check is not a quick cheap operation as for Azure Storage (see microsoft/durabletask-netherite#276)

Interestingly, our documentation is ambiguous about whether this check should happen:

- our Azure docs [Handling external events in Durable Functions - Azure | Microsoft Learn](https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-external-events?tabs=csharp) do just say the "event is discarded" if there is no orchestration instance with that instance id. It does not say anything about an exception being thrown. Also, it does not mention what happens if the instance is not in a running state. 
- For the isolated client (FunctionsDurableTaskClient), the Intellisense on the RaiseEventAsync says  "Raised events for a completed or non-existent instance will be silently discarded". This matches the semantics of DurableTask. I would like this to be the behavior when using Netherite. This makes sense particularly because Netherite is meant for high-scale situations where performance is more important than helping beginning users to understand how to correctly use events.
- For the in-process client (DurableClient), the Intellisense on the RaiseEventAsync says "If the specified instance is not found or not running, this operation will throw an exception." This is indeed what that method does. I expect that seeing these exception can be helpful for users who are unsure about how to design their application in a way that avoids races.
 
## Proposed Solution

This PR adds a flag to the durability provider that allows the durability provider to disable the status check.

It also disables the status check in the case where RaiseEventAsyncInternal is called by CleanEntityStorageAsync since the check is unwanted in that case also.

### Pull request checklist

[ ]  Documentation PR is ready to merge and referenced in `pending_docs.md`
[ ]  I've added my notes to `release_notes.md`
 