### PR TITLE
Make environment dictionary concurrency-safe

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/DefaultPlatformInformation.cs
+++ b/src/WebJobs.Extensions.DurableTask/DefaultPlatformInformation.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 #nullable enable
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using Microsoft.Extensions.Logging;
 
@@ -16,7 +17,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 #pragma warning restore CS0612 // Type or member is obsolete
     {
         private readonly INameResolver nameResolver;
-        private readonly Dictionary<string, string> cachedEnviromentVariables;
+        private readonly ConcurrentDictionary<string, string> cachedEnviromentVariables;
         private readonly EndToEndTraceHelper traceHelper;
 
         private WorkerRuntimeType? workerRuntimeType;
@@ -28,7 +29,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             ILogger logger = loggerFactory.CreateLogger(DurableTaskExtension.LoggerCategoryName);
             this.traceHelper = new EndToEndTraceHelper(logger, traceReplayEvents: false);
 
-            this.cachedEnviromentVariables = new Dictionary<string, string>();
+            this.cachedEnviromentVariables = new ConcurrentDictionary<string, string>();
         }
 
         private string? ReadEnviromentVariable(string variableName)
@@ -37,7 +38,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             if (!this.cachedEnviromentVariables.TryGetValue(variableName, out value))
             {
                 value = this.nameResolver.Resolve(variableName);
-                this.cachedEnviromentVariables.Add(variableName, value);
+                this.cachedEnviromentVariables.TryAdd(variableName, value);
             }
 
             return value;


### PR DESCRIPTION
<!-- Start the PR description with some context for the change. -->
Replaces: https://github.com/Azure/azure-functions-durable-extension/pull/2450

From the old description: This PR addresses an issue where the customer's function can fail occasionally with an ArgumentException "An item with the same key has already been added". This may occur on current accesses to the dictionary. To make these operations safe, we use a concurrent dictionary.

<!-- Make sure to delete the markdown comments and the below sections when squash merging -->
### Issue describing the changes in this PR

resolves #issue_for_this_pr

### Pull request checklist

* [ ] My changes **do not** require documentation changes
    * [x] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [x] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)
* [ ] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [x] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk
* [ ] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
    * [x] Otherwise: major or minor version updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
* [ ] My changes **do not** add EventIds to our EventSource logs
    * [x] Otherwise: Ensure the EventIds are within the supported range in our existing Windows infrastructure. You may validate this with a deployed app's telemetry. You may also extend the range by completing a PR such as [this one](https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files).