### PR TITLE
Add handling NRE on httpApiHandler when doing WaitForCompletionOrCrea…

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableClient.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableClient.cs
@@ -801,6 +801,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             TimeSpan retryInterval,
             bool returnInternalServerErrorOnFailure)
         {
+            if (this.httpApiHandler == null)
+            {
+                throw new InvalidOperationException("IDurableClient.WaitForCompletionOrCreateCheckStatusResponseAsync is not supported for IDurableClient instances created outside of a Durable Functions application.");
+            }
+
             return await this.httpApiHandler.WaitForCompletionOrCreateCheckStatusResponseAsync(
                 request,
                 instanceId,


### PR DESCRIPTION
Add handling NRE on httpApiHandler when doing WaitForCompletionOrCreateCheckStatusResponseAsync.

Resolves #2543

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)
* [x] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk
* [x] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
    * [ ] Otherwise: major or minor version updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
* [x] My changes **do not** add EventIds to our EventSource logs
    * [ ] Otherwise: Ensure the EventIds are within the supported range in our existing Windows infrastructure. You may validate this with a deployed app's telemetry. You may also extend the range by completing a PR such as [this one](https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files).