### PR TITLE
Patch GH automation

### DIFF
--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -1,105 +1,105 @@
-id: 
+id:
 name: GitOps.PullRequestIssueManagement
 description: GitOps.PullRequestIssueManagement primitive
-owner: 
+owner:
 resource: repository
 disabled: false
-where: 
+where:
 configuration:
   resourceManagementConfiguration:
     scheduledSearches:
-    - description: 
-      frequencies:
-      - hourly:
-          hour: 6
-      filters:
-      - isIssue
-      - isOpen
-      - hasLabel:
-          label: 'Needs: Author Feedback'
-      - hasLabel:
-          label: no-recent-activity
-      - noActivitySince:
-          days: 3
-      actions:
-      - closeIssue
-    - description: 
-      frequencies:
-      - hourly:
-          hour: 6
-      filters:
-      - isIssue
-      - isOpen
-      - hasLabel:
-          label: 'Needs: Author Feedback'
-      - noActivitySince:
-          days: 4
-      - isNotLabeledWith:
-          label: no-recent-activity
-      actions:
-      - addLabel:
-          label: no-recent-activity
-      - addReply:
-          reply: This issue has been automatically marked as stale because it has been marked as requiring author feedback but has not had any activity for **4 days**. It will be closed if no further activity occurs **within 3 days of this comment**.
-    - description: 
-      frequencies:
-      - hourly:
-          hour: 6
-      filters:
-      - isIssue
-      - isOpen
-      - hasLabel:
-          label: duplicate
-      - noActivitySince:
-          days: 1
-      actions:
-      - addReply:
-          reply: This issue has been marked as duplicate and has not had any activity for **1 day**. It will be closed for housekeeping purposes.
-      - closeIssue
+      - description:
+        frequencies:
+          - hourly:
+              hour: 3
+        filters:
+          - isIssue
+          - isOpen
+          - hasLabel:
+              label: "Needs: Author Feedback"
+          - hasLabel:
+              label: no-recent-activity
+          - noActivitySince:
+              days: 3
+        actions:
+          - closeIssue
+      - description:
+        frequencies:
+          - hourly:
+              hour: 3
+        filters:
+          - isIssue
+          - isOpen
+          - hasLabel:
+              label: "Needs: Author Feedback"
+          - noActivitySince:
+              days: 4
+          - isNotLabeledWith:
+              label: no-recent-activity
+        actions:
+          - addLabel:
+              label: no-recent-activity
+          - addReply:
+              reply: This issue has been automatically marked as stale because it has been marked as requiring author feedback but has not had any activity for **4 days**. It will be closed if no further activity occurs **within 3 days of this comment**.
+      - description:
+        frequencies:
+          - hourly:
+              hour: 3
+        filters:
+          - isIssue
+          - isOpen
+          - hasLabel:
+              label: duplicate
+          - noActivitySince:
+              days: 1
+        actions:
+          - addReply:
+              reply: This issue has been marked as duplicate and has not had any activity for **1 day**. It will be closed for housekeeping purposes.
+          - closeIssue
     eventResponderTasks:
-    - if:
-      - payloadType: Issues
-      - and:
-        - isOpen
-        - not:
-           and:
-             - isAssignedToSomeone
-             - isLabeled
-      then:
-        - addLabel:
-          label: "Needs: Triage :mag:"
-    - if:
-      - payloadType: Issue_Comment
-      - isAction:
-          action: Created
-      - isActivitySender:
-          issueAuthor: True
-      - hasLabel:
-          label: 'Needs: Author Feedback'
-      then:
-      - addLabel:
-          label: 'Needs: Attention :wave:'
-      - removeLabel:
-          label: 'Needs: Author Feedback'
-      description: 
-    - if:
-      - payloadType: Issues
-      - not:
-          isAction:
-            action: Closed
-      - hasLabel:
-          label: no-recent-activity
-      then:
-      - removeLabel:
-          label: no-recent-activity
-      description: 
-    - if:
-      - payloadType: Issue_Comment
-      - hasLabel:
-          label: no-recent-activity
-      then:
-      - removeLabel:
-          label: no-recent-activity
-      description: 
-onFailure: 
-onSuccess: 
+      - if:
+          - payloadType: Issues
+          - and:
+              - isOpen
+              - not:
+                  and:
+                    - isAssignedToSomeone
+                    - isLabeled
+        then:
+          - addLabel:
+              label: "Needs: Triage :mag:"
+      - if:
+          - payloadType: Issue_Comment
+          - isAction:
+              action: Created
+          - isActivitySender:
+              issueAuthor: True
+          - hasLabel:
+              label: "Needs: Author Feedback"
+        then:
+          - addLabel:
+              label: "Needs: Attention :wave:"
+          - removeLabel:
+              label: "Needs: Author Feedback"
+        description:
+      - if:
+          - payloadType: Issues
+          - not:
+              isAction:
+                action: Closed
+          - hasLabel:
+              label: no-recent-activity
+        then:
+          - removeLabel:
+              label: no-recent-activity
+        description:
+      - if:
+          - payloadType: Issue_Comment
+          - hasLabel:
+              label: no-recent-activity
+        then:
+          - removeLabel:
+              label: no-recent-activity
+        description:
+onFailure:
+onSuccess:

--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -60,14 +60,14 @@ configuration:
     - if:
       - payloadType: Issues
       - and:
-            - isOpen
-            - not:
-                and:
-                - isAssignedToSomeone
-                - isLabeled
-        then:
+        - isOpen
+        - not:
+           and:
+             - isAssignedToSomeone
+             - isLabeled
+      then:
         - addLabel:
-            label: "Needs: Triage :mag:"
+          label: "Needs: Triage :mag:"
     - if:
       - payloadType: Issue_Comment
       - isAction:

--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -58,6 +58,17 @@ configuration:
       - closeIssue
     eventResponderTasks:
     - if:
+      - payloadType: Issues
+      - and:
+            - isOpen
+            - not:
+                and:
+                - isAssignedToSomeone
+                - isLabeled
+        then:
+        - addLabel:
+            label: "Needs: Triage :mag:"
+    - if:
       - payloadType: Issue_Comment
       - isAction:
           action: Created

--- a/.github/workflows/smoketest-python37-v4.yml
+++ b/.github/workflows/smoketest-python37-v4.yml
@@ -1,4 +1,4 @@
-name: Smoke Test - Python 3.7 on Functions V2
+name: Smoke Test - Python 3.7 on Functions V4
 
 on:
   push:
@@ -17,6 +17,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Run V2 Python 3.7 Smoke Test
+    - name: Run V4 Python 3.7 Smoke Test
       run: test/SmokeTests/e2e-test.ps1 -DockerfilePath test/SmokeTests/OOProcSmokeTests/durablePy/Dockerfile -HttpStartPath api/DurableFunctionsHttpStart -ContainerName pyApp
       shell: pwsh

--- a/WebJobs.Extensions.DurableTask.sln
+++ b/WebJobs.Extensions.DurableTask.sln
@@ -89,7 +89,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "pipelines", "pipelines", "{
 		.github\workflows\smoketest-dotnet-v2.yml = .github\workflows\smoketest-dotnet-v2.yml
 		.github\workflows\smoketest-dotnet-v3.yml = .github\workflows\smoketest-dotnet-v3.yml
 		.github\workflows\smoketest-node14-v4.yml = .github\workflows\smoketest-node14-v4.yml
-		.github\workflows\smoketest-python37-v2.yml = .github\workflows\smoketest-python37-v2.yml
+		.github\workflows\smoketest-python37-v4.yml = .github\workflows\smoketest-python37-v4.yml
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DFPerfScenariosV1", "test\DFPerfScenariosV1\DFPerfScenariosV1.csproj", "{65F904AA-0F6F-48CB-BE19-593B7D68152A}"

--- a/test/SmokeTests/OOProcSmokeTests/durablePy/Dockerfile
+++ b/test/SmokeTests/OOProcSmokeTests/durablePy/Dockerfile
@@ -9,7 +9,7 @@ RUN cd /root/test/SmokeTests/OOProcSmokeTests/durablePy && \
     dotnet build -o bin
 
 # Step 2: Deploy and run pip install to get the Durable Functions SDK
-FROM mcr.microsoft.com/azure-functions/python:2.0-python3.7
+FROM mcr.microsoft.com/azure-functions/python:4-python3.7
 COPY --from=build-env /root/test/SmokeTests/OOProcSmokeTests/durablePy /home/site/wwwroot
 ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     AzureFunctionsJobHost__Logging__Console__IsEnabled=true


### PR DESCRIPTION
This PR makes 2 changes to our GH automation:
(1) It makes our Python smoke test run on Functions V4, given that Functions V2 is EOL and is incompatible with some of the new "Python V2 programming model" changes
(2) It fixes our GH automation so that new issues have the "needs: triage" label added automatically again. This stopped working recently when FabricBot migrated to a new config language