### PR TITLE
Update package versions

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/Correlation/TelemetryActivator.cs
+++ b/src/WebJobs.Extensions.DurableTask/Correlation/TelemetryActivator.cs
@@ -118,7 +118,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Correlation
                     message: "Reading APPINSIGHTS_INSTRUMENTATIONKEY...",
                     writeToUserLogs: true);
 
+#pragma warning disable CS0618 // Type or member is obsolete
                 config.InstrumentationKey = resolvedInstrumentationKey;
+#pragma warning restore CS0618 // Type or member is obsolete
             }
             else
             {

--- a/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
+++ b/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
@@ -5,8 +5,8 @@
     <AssemblyName>Microsoft.Azure.WebJobs.Extensions.DurableTask</AssemblyName>
     <RootNamespace>Microsoft.Azure.WebJobs.Extensions.DurableTask</RootNamespace>
     <MajorVersion>2</MajorVersion>
-    <MinorVersion>10</MinorVersion>
-    <PatchVersion>1</PatchVersion>
+    <MinorVersion>11</MinorVersion>
+    <PatchVersion>0</PatchVersion>
     <Version>$(MajorVersion).$(MinorVersion).$(PatchVersion)</Version>
     <FileVersion>$(MajorVersion).$(MinorVersion).$(PatchVersion)</FileVersion>
     <AssemblyVersion>$(MajorVersion).0.0.0</AssemblyVersion>

--- a/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
+++ b/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
@@ -6,7 +6,7 @@
     <RootNamespace>Microsoft.Azure.WebJobs.Extensions.DurableTask</RootNamespace>
     <MajorVersion>2</MajorVersion>
     <MinorVersion>10</MinorVersion>
-    <PatchVersion>0</PatchVersion>
+    <PatchVersion>1</PatchVersion>
     <Version>$(MajorVersion).$(MinorVersion).$(PatchVersion)</Version>
     <FileVersion>$(MajorVersion).$(MinorVersion).$(PatchVersion)</FileVersion>
     <AssemblyVersion>$(MajorVersion).0.0.0</AssemblyVersion>
@@ -75,6 +75,7 @@
     <PackageReference Include="Microsoft.Extensions.Azure" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="2.2.0" />
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.12.2" />
+    <PackageReference Include="Microsoft.Azure.DurableTask.ApplicationInsights" Version="0.1.0" />
 
     <!-- Explicitly pinned transitive dependencies with CVE vulnerabilities.-->
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets" Version="2.2.1" />
@@ -96,6 +97,7 @@
     <PackageReference Include="Microsoft.Extensions.Azure" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="2.2.0" />
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.12.2" />
+    <PackageReference Include="Microsoft.Azure.DurableTask.ApplicationInsights" Version="0.1.0" />
     <!-- Explicitly pinned transitive dependencies with CVE vulnerabilities.-->
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets" Version="2.2.1" />
     <!-- The gRPC dependencies in this package are not compatible with older frameworks, like .NET Core 2.x -->
@@ -104,8 +106,8 @@
 
   <!-- Common dependencies across all targets -->
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.DurableTask.Core" Version="2.13.*" />
-    <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage" Version="1.14.*" />
+    <PackageReference Include="Microsoft.Azure.DurableTask.Core" Version="2.14.*" />
+    <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage" Version="1.15.*" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers" Version="0.5.*" />
     <!-- Build-time dependencies -->
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.*" PrivateAssets="All" />

--- a/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
+++ b/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
@@ -74,7 +74,6 @@
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Azure" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="2.2.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.12.2" />
     <PackageReference Include="Microsoft.Azure.DurableTask.ApplicationInsights" Version="0.1.0" />
 
     <!-- Explicitly pinned transitive dependencies with CVE vulnerabilities.-->
@@ -96,7 +95,6 @@
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Azure" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="2.2.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.12.2" />
     <PackageReference Include="Microsoft.Azure.DurableTask.ApplicationInsights" Version="0.1.0" />
     <!-- Explicitly pinned transitive dependencies with CVE vulnerabilities.-->
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets" Version="2.2.1" />


### PR DESCRIPTION
Microsoft.Azure.WebJobs.Extensions.DurableTask 2.10.0 --> 2.11.0
Microsoft.Azure.DurableTask.Core 2.13.* --> 2.14.*
Microsoft.Azure.DurableTask.AzureStorage 1.14.* --> 1.15.*

Adding Microsoft.Azure.DurableTask.ApplicationInsights v0.1.0