### PR TITLE
update durability provider class for new core-entities support.

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/AzureStorageDurabilityProvider.cs
+++ b/src/WebJobs.Extensions.DurableTask/AzureStorageDurabilityProvider.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using DurableTask.AzureStorage;
 using DurableTask.AzureStorage.Tracking;
 using DurableTask.Core;
+using DurableTask.Core.Entities;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
@@ -18,6 +19,7 @@ using Newtonsoft.Json.Serialization;
 using Microsoft.Azure.WebJobs.Host.Scale;
 #endif
 using AzureStorage = DurableTask.AzureStorage;
+using DTCore = DurableTask.Core;
 
 namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 {
@@ -52,8 +54,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 });
             this.logger = logger;
         }
-
-        public override bool SupportsEntities => true;
 
         public override bool CheckStatusBeforeRaiseEvent => true;
 
@@ -97,6 +97,29 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
         /// <inheritdoc/>
         public async override Task<string> RetrieveSerializedEntityState(EntityId entityId, JsonSerializerSettings serializerSettings)
+        {
+            EntityBackendQueries entityBackendQueries = (this.serviceClient as IEntityOrchestrationService)?.EntityBackendQueries;
+
+            if (entityBackendQueries != null) // entity queries are natively supported
+            {
+                var entity = await entityBackendQueries.GetEntityAsync(new DTCore.Entities.EntityId(entityId.EntityName, entityId.EntityKey), cancellation: default);
+
+                if (entity == null)
+                {
+                    return null;
+                }
+                else
+                {
+                    return entity.Value.SerializedState;
+                }
+            }
+            else // fall back to old implementation
+            {
+                return await this.LegacyImplementationOfRetrieveSerializedEntityState(entityId, serializerSettings);
+            }
+        }
+
+        async Task<string> LegacyImplementationOfRetrieveSerializedEntityState(EntityId entityId, JsonSerializerSettings serializerSettings)
         {
             var instanceId = EntityId.GetSchedulerIdFromEntityId(entityId);
             IList<OrchestrationState> stateList = await this.serviceClient.GetOrchestrationStateAsync(instanceId, false);

--- a/src/WebJobs.Extensions.DurableTask/AzureStorageDurabilityProvider.cs
+++ b/src/WebJobs.Extensions.DurableTask/AzureStorageDurabilityProvider.cs
@@ -119,7 +119,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             }
         }
 
-        async Task<string> LegacyImplementationOfRetrieveSerializedEntityState(EntityId entityId, JsonSerializerSettings serializerSettings)
+        private async Task<string> LegacyImplementationOfRetrieveSerializedEntityState(EntityId entityId, JsonSerializerSettings serializerSettings)
         {
             var instanceId = EntityId.GetSchedulerIdFromEntityId(entityId);
             IList<OrchestrationState> stateList = await this.serviceClient.GetOrchestrationStateAsync(instanceId, false);

--- a/src/WebJobs.Extensions.DurableTask/AzureStorageDurabilityProviderFactory.cs
+++ b/src/WebJobs.Extensions.DurableTask/AzureStorageDurabilityProviderFactory.cs
@@ -58,6 +58,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             // different defaults for key configuration values.
             int maxConcurrentOrchestratorsDefault = this.inConsumption ? 5 : 10 * Environment.ProcessorCount;
             int maxConcurrentActivitiesDefault = this.inConsumption ? 10 : 10 * Environment.ProcessorCount;
+            int maxConcurrentEntitiesDefault = this.inConsumption ? 10 : 10 * Environment.ProcessorCount;
             int maxEntityOperationBatchSizeDefault = this.inConsumption ? 50 : 5000;
 
             if (this.inConsumption)
@@ -85,6 +86,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             // The following defaults are only applied if the customer did not explicitely set them on `host.json`
             this.options.MaxConcurrentOrchestratorFunctions = this.options.MaxConcurrentOrchestratorFunctions ?? maxConcurrentOrchestratorsDefault;
             this.options.MaxConcurrentActivityFunctions = this.options.MaxConcurrentActivityFunctions ?? maxConcurrentActivitiesDefault;
+            this.options.MaxConcurrentEntityFunctions = this.options.MaxConcurrentEntityFunctions ?? maxConcurrentEntitiesDefault;
             this.options.MaxEntityOperationBatchSize = this.options.MaxEntityOperationBatchSize ?? maxEntityOperationBatchSizeDefault;
 
             // Override the configuration defaults with user-provided values in host.json, if any.
@@ -199,6 +201,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 WorkItemQueueVisibilityTimeout = this.azureStorageOptions.WorkItemQueueVisibilityTimeout,
                 MaxConcurrentTaskOrchestrationWorkItems = this.options.MaxConcurrentOrchestratorFunctions ?? throw new InvalidOperationException($"{nameof(this.options.MaxConcurrentOrchestratorFunctions)} needs a default value"),
                 MaxConcurrentTaskActivityWorkItems = this.options.MaxConcurrentActivityFunctions ?? throw new InvalidOperationException($"{nameof(this.options.MaxConcurrentOrchestratorFunctions)} needs a default value"),
+                MaxConcurrentTaskEntityWorkItems = this.options.MaxConcurrentEntityFunctions ?? throw new InvalidOperationException($"{nameof(this.options.MaxConcurrentEntityFunctions)} needs a default value"),
                 ExtendedSessionsEnabled = this.options.ExtendedSessionsEnabled,
                 ExtendedSessionIdleTimeout = extendedSessionTimeout,
                 MaxQueuePollingInterval = this.azureStorageOptions.MaxQueuePollingInterval,

--- a/src/WebJobs.Extensions.DurableTask/AzureStorageDurabilityProviderFactory.cs
+++ b/src/WebJobs.Extensions.DurableTask/AzureStorageDurabilityProviderFactory.cs
@@ -19,6 +19,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         private readonly AzureStorageOptions azureStorageOptions;
         private readonly INameResolver nameResolver;
         private readonly ILoggerFactory loggerFactory;
+        private readonly bool useSeparateQueriesForEntities;
+        private readonly bool useSeparateQueueForEntityWorkItems;
         private readonly bool inConsumption; // If true, optimize defaults for consumption
         private AzureStorageDurabilityProvider defaultStorageProvider;
 
@@ -69,6 +71,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 {
                     this.azureStorageOptions.ControlQueueBufferThreshold = 128;
                 }
+            }
+
+            WorkerRuntimeType runtimeType = platformInfo.GetWorkerRuntimeType();
+            if (runtimeType == WorkerRuntimeType.DotNetIsolated ||
+                runtimeType == WorkerRuntimeType.Java ||
+                runtimeType == WorkerRuntimeType.Custom)
+            {
+                this.useSeparateQueriesForEntities = true;
+                this.useSeparateQueueForEntityWorkItems = true;
             }
 
             // The following defaults are only applied if the customer did not explicitely set them on `host.json`
@@ -202,6 +213,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 LoggerFactory = this.loggerFactory,
                 UseLegacyPartitionManagement = this.azureStorageOptions.UseLegacyPartitionManagement,
                 UseTablePartitionManagement = this.azureStorageOptions.UseTablePartitionManagement,
+                UseSeparateQueriesForEntities = this.useSeparateQueriesForEntities,
+                UseSeparateQueueForEntityWorkItems = this.useSeparateQueueForEntityWorkItems,
             };
 
             if (this.inConsumption)

--- a/src/WebJobs.Extensions.DurableTask/DurabilityProvider.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurabilityProvider.cs
@@ -6,11 +6,11 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using DurableTask.Core;
+using DurableTask.Core.Entities;
 using DurableTask.Core.History;
 using DurableTask.Core.Query;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-using DurableTask.Core.Entities;
 #if !FUNCTIONS_V1
 using Microsoft.Azure.WebJobs.Host.Scale;
 #endif

--- a/src/WebJobs.Extensions.DurableTask/DurabilityProvider.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurabilityProvider.cs
@@ -10,6 +10,7 @@ using DurableTask.Core.History;
 using DurableTask.Core.Query;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using DurableTask.Core.Entities;
 #if !FUNCTIONS_V1
 using Microsoft.Azure.WebJobs.Host.Scale;
 #endif
@@ -36,6 +37,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         private readonly string name;
         private readonly IOrchestrationService innerService;
         private readonly IOrchestrationServiceClient innerServiceClient;
+        private readonly IEntityOrchestrationService entityOrchestrationService;
         private readonly string connectionName;
 
         /// <summary>
@@ -52,6 +54,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             this.name = storageProviderName ?? throw new ArgumentNullException(nameof(storageProviderName));
             this.innerService = service ?? throw new ArgumentNullException(nameof(service));
             this.innerServiceClient = serviceClient ?? throw new ArgumentNullException(nameof(serviceClient));
+            this.entityOrchestrationService = service as IEntityOrchestrationService;
             this.connectionName = connectionName ?? throw new ArgumentNullException(connectionName);
         }
 
@@ -64,7 +67,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// <summary>
         /// Specifies whether the durability provider supports Durable Entities.
         /// </summary>
-        public virtual bool SupportsEntities => false;
+        public virtual bool SupportsEntities => this.entityOrchestrationService != null;
 
         /// <summary>
         /// Specifies whether the backend's WaitForOrchestration is implemented without polling.
@@ -100,6 +103,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// Interval time used for long running timers.
         /// </summary>
         public virtual TimeSpan LongRunningTimerIntervalLength { get; set; }
+
+        /// <summary>
+        ///  Returns the entity orchestration service, if this provider supports entities, or null otherwise.
+        /// </summary>
+        public virtual IEntityOrchestrationService EntityOrchestrationService => this.entityOrchestrationService;
 
         /// <summary>
         /// Event source name (e.g. DurableTask-AzureStorage).

--- a/src/WebJobs.Extensions.DurableTask/Options/DurableTaskOptions.cs
+++ b/src/WebJobs.Extensions.DurableTask/Options/DurableTaskOptions.cs
@@ -99,6 +99,18 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         public int? MaxConcurrentOrchestratorFunctions { get; set; } = null;
 
         /// <summary>
+        /// Gets or sets the maximum number of entity functions that can be processed concurrently on a single host instance.
+        /// </summary>
+        /// <remarks>
+        /// Increasing entity function concurrency can result in increased throughput but can
+        /// also increase the total CPU and memory usage on a single worker instance.
+        /// </remarks>
+        /// <value>
+        /// A positive integer configured by the host.
+        /// </value>
+        public int? MaxConcurrentEntityFunctions { get; set; } = null;
+
+        /// <summary>
         /// Gets or sets a value indicating whether to enable the local RPC endpoint managed by this extension.
         /// </summary>
         /// <remarks>
@@ -306,6 +318,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             if (this.MaxConcurrentOrchestratorFunctions <= 0)
             {
                 throw new InvalidOperationException($"{nameof(this.MaxConcurrentOrchestratorFunctions)} must be a positive integer value.");
+            }
+
+            if (this.MaxConcurrentEntityFunctions <= 0)
+            {
+                throw new InvalidOperationException($"{nameof(this.MaxConcurrentEntityFunctions)} must be a positive integer value.");
             }
 
             if (this.MaxEntityOperationBatchSize <= 0)


### PR DESCRIPTION

With new core entity support, storage providers can now support entity queries directly. 
This PR updates the durability providers to reflect this. 

Also, for the Azure Storage durability provider, it configures the new features to be enabled by default in passthrough middleware configurations.

This PR depends on https://github.com/Azure/durabletask/pull/957.

### Pull request checklist

is targeting feature branch `feature/core-entities`.