### PR TITLE
update DurableClient to take advantage of native entity queries

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableClient.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableClient.cs
@@ -565,7 +565,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             }
             else
             {
-                return LegacyImplementationOfReadEntityStateAsync(provider, entityId);
+                return await this.LegacyImplementationOfReadEntityStateAsync<T>(provider, entityId);
             }
         }
 

--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableClient.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableClient.cs
@@ -565,11 +565,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             }
             else
             {
-                return await this.LegacyImplementationOfReadEntityStateAsync<T>(provider, entityId);
+                return await this.ReadEntityStateLegacyAsync<T>(provider, entityId);
             }
         }
 
-        private async Task<EntityStateResponse<T>> LegacyImplementationOfReadEntityStateAsync<T>(DurabilityProvider provider, EntityId entityId)
+        private async Task<EntityStateResponse<T>> ReadEntityStateLegacyAsync<T>(DurabilityProvider provider, EntityId entityId)
         {
             string entityState = await provider.RetrieveSerializedEntityState(entityId, this.messageDataConverter.JsonSettings);
 
@@ -662,11 +662,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             }
             else
             {
-                return await this.LegacyImplementationOfListEntitiesAsync(query, cancellationToken);
+                return await this.ListEntitiesLegacyAsync(query, cancellationToken);
             }
         }
 
-        private async Task<EntityQueryResult> LegacyImplementationOfListEntitiesAsync(EntityQuery query, CancellationToken cancellationToken)
+        private async Task<EntityQueryResult> ListEntitiesLegacyAsync(EntityQuery query, CancellationToken cancellationToken)
         {
             var condition = new OrchestrationStatusQueryCondition(query);
             EntityQueryResult entityResult;
@@ -708,11 +708,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             }
             else
             {
-                return await LegacyImplementationOfCleanEntityStorageAsync(removeEmptyEntities, releaseOrphanedLocks, cancellationToken);
+                return await CleanEntityStorageLegacyAsync(removeEmptyEntities, releaseOrphanedLocks, cancellationToken);
             }
         }
 
-        private async Task<CleanEntityStorageResult> LegacyImplementationOfCleanEntityStorageAsync(bool removeEmptyEntities, bool releaseOrphanedLocks, CancellationToken cancellationToken)
+        private async Task<CleanEntityStorageResult> CleanEntityStorageLegacyAsync(bool removeEmptyEntities, bool releaseOrphanedLocks, CancellationToken cancellationToken)
         {
             DateTime now = DateTime.UtcNow;
             CleanEntityStorageResult finalResult = default;

--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableClient.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableClient.cs
@@ -10,12 +10,14 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using DurableTask.Core;
+using DurableTask.Core.Entities;
 using DurableTask.Core.History;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.WebApiCompatShim;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using DTCore = DurableTask.Core;
 
 namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 {
@@ -549,6 +551,26 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
         private async Task<EntityStateResponse<T>> ReadEntityStateAsync<T>(DurabilityProvider provider, EntityId entityId)
         {
+            if (this.HasNativeEntityQuerySupport(this.durabilityProvider, out var entityBackendQueries))
+            {
+                EntityBackendQueries.EntityMetadata? metaData = await entityBackendQueries.GetEntityAsync(
+                    new DTCore.Entities.EntityId(entityId.EntityName, entityId.EntityKey),
+                    cancellation: default);
+
+                return new EntityStateResponse<T>()
+                {
+                    EntityExists = metaData.HasValue,
+                    EntityState = metaData.HasValue ? this.messageDataConverter.Deserialize<T>(metaData.Value.SerializedState) : default,
+                };
+            }
+            else
+            {
+                return LegacyImplementationOfReadEntityStateAsync(provider, entityId);
+            }
+        }
+
+        private async Task<EntityStateResponse<T>> LegacyImplementationOfReadEntityStateAsync<T>(DurabilityProvider provider, EntityId entityId)
+        {
             string entityState = await provider.RetrieveSerializedEntityState(entityId, this.messageDataConverter.JsonSettings);
 
             return new EntityStateResponse<T>()
@@ -612,6 +634,40 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// <inheritdoc />
         async Task<EntityQueryResult> IDurableEntityClient.ListEntitiesAsync(EntityQuery query, CancellationToken cancellationToken)
         {
+            if (this.HasNativeEntityQuerySupport(this.durabilityProvider, out var entityBackendQueries))
+            {
+                var result = await entityBackendQueries.QueryEntitiesAsync(
+                    new EntityBackendQueries.EntityQuery()
+                    {
+                        InstanceIdStartsWith = query.EntityName != null ? $"${query.EntityName}" : null,
+                        IncludeDeleted = query.IncludeDeleted,
+                        IncludeState = query.FetchState,
+                        LastModifiedFrom = query.LastOperationFrom == DateTime.MinValue ? null : query.LastOperationFrom,
+                        LastModifiedTo = query.LastOperationTo,
+                        PageSize = query.PageSize,
+                        ContinuationToken = query.ContinuationToken,
+                    },
+                    cancellationToken);
+
+                return new EntityQueryResult()
+                {
+                    Entities = result.Results.Select(ConvertEntityMetadata).ToList(),
+                    ContinuationToken = result.ContinuationToken,
+                };
+
+                DurableEntityStatus ConvertEntityMetadata(EntityBackendQueries.EntityMetadata metadata)
+                {
+                    return new DurableEntityStatus(metadata);
+                }
+            }
+            else
+            {
+                return await this.LegacyImplementationOfListEntitiesAsync(query, cancellationToken);
+            }
+        }
+
+        private async Task<EntityQueryResult> LegacyImplementationOfListEntitiesAsync(EntityQuery query, CancellationToken cancellationToken)
+        {
             var condition = new OrchestrationStatusQueryCondition(query);
             EntityQueryResult entityResult;
             Stopwatch stopwatch = new Stopwatch();
@@ -633,6 +689,30 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
         /// <inheritdoc />
         async Task<CleanEntityStorageResult> IDurableEntityClient.CleanEntityStorageAsync(bool removeEmptyEntities, bool releaseOrphanedLocks, CancellationToken cancellationToken)
+        {
+            if (this.HasNativeEntityQuerySupport(this.durabilityProvider, out var entityBackendQueries))
+            {
+                var result = await entityBackendQueries.CleanEntityStorageAsync(
+                    new EntityBackendQueries.CleanEntityStorageRequest()
+                    {
+                        RemoveEmptyEntities = removeEmptyEntities,
+                        ReleaseOrphanedLocks = releaseOrphanedLocks,
+                    },
+                    cancellationToken);
+
+                return new CleanEntityStorageResult()
+                {
+                    NumberOfEmptyEntitiesRemoved = result.EmptyEntitiesRemoved,
+                    NumberOfOrphanedLocksRemoved = result.OrphanedLocksReleased,
+                };
+            }
+            else
+            {
+                return await LegacyImplementationOfCleanEntityStorageAsync(removeEmptyEntities, releaseOrphanedLocks, cancellationToken);
+            }
+        }
+
+        private async Task<CleanEntityStorageResult> LegacyImplementationOfCleanEntityStorageAsync(bool removeEmptyEntities, bool releaseOrphanedLocks, CancellationToken cancellationToken)
         {
             DateTime now = DateTime.UtcNow;
             CleanEntityStorageResult finalResult = default;
@@ -704,6 +784,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             while (condition.ContinuationToken != null);
 
             return finalResult;
+        }
+
+        private bool HasNativeEntityQuerySupport(DurabilityProvider provider, out EntityBackendQueries entityBackendQueries)
+        {
+            entityBackendQueries = provider.EntityOrchestrationService?.EntityBackendQueries;
+            return entityBackendQueries != null;
         }
 
         private async Task<OrchestrationState> GetOrchestrationInstanceStateAsync(string instanceId)

--- a/src/WebJobs.Extensions.DurableTask/DurableEntityStatus.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableEntityStatus.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Runtime.Serialization;
+using DurableTask.Core.Entities;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
@@ -36,6 +37,25 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                         // Just in case the above assumption is ever wrong, fallback to a raw string
                         this.State = state.EntityState;
                     }
+                }
+            }
+        }
+
+        internal DurableEntityStatus(EntityBackendQueries.EntityMetadata metadata)
+        {
+            this.EntityId = new EntityId(metadata.EntityId.Name, metadata.EntityId.Key);
+            this.LastOperationTime = metadata.LastModifiedTime;
+            if (metadata.SerializedState != null)
+            {
+                try
+                {
+                    // Entity state is expected to be JSON-compatible
+                    this.State = JToken.Parse(metadata.SerializedState);
+                }
+                catch (JsonException)
+                {
+                    // Just in case the above assumption is ever wrong, fallback to a raw string
+                    this.State = metadata.SerializedState;
                 }
             }
         }


### PR DESCRIPTION
With new core entity support, storage providers can now support entity queries directly. 
This PR updates the `DurableClient` class to reflect this. 
 
This PR depends on https://github.com/Azure/durabletask/pull/957.

### Pull request checklist

is targeting feature branch `feature/core-entities`.