### PR TITLE
implement passthrough middleware for entities

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/Bindings/EntityTriggerAttributeBindingProvider.cs
+++ b/src/WebJobs.Extensions.DurableTask/Bindings/EntityTriggerAttributeBindingProvider.cs
@@ -9,6 +9,7 @@ using Microsoft.Azure.WebJobs.Host.Bindings;
 using Microsoft.Azure.WebJobs.Host.Listeners;
 using Microsoft.Azure.WebJobs.Host.Protocols;
 using Microsoft.Azure.WebJobs.Host.Triggers;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
@@ -57,6 +58,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
         private class EntityTriggerBinding : ITriggerBinding
         {
+            private static readonly IReadOnlyDictionary<string, object?> EmptyBindingData = new Dictionary<string, object?>(capacity: 0);
+
             private readonly DurableTaskExtension config;
             private readonly ParameterInfo parameterInfo;
             private readonly FunctionName entityName;
@@ -95,15 +98,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
             public Task<ITriggerData> BindAsync(object value, ValueBindingContext context)
             {
-                var entityContext = (DurableEntityContext)value;
-                Type destinationType = this.parameterInfo.ParameterType;
-
-                object? convertedValue = null;
-                if (destinationType == typeof(IDurableEntityContext))
+                if (value is DurableEntityContext entityContext)
                 {
-                    convertedValue = entityContext;
+                    Type destinationType = this.parameterInfo.ParameterType;
+
+                    object? convertedValue = null;
+                    if (destinationType == typeof(IDurableEntityContext))
+                    {
+                        convertedValue = entityContext;
 #if !FUNCTIONS_V1
-                    ((IDurableEntityContext)value).FunctionBindingContext = context.FunctionContext;
+                        ((IDurableEntityContext)value).FunctionBindingContext = context.FunctionContext;
 #endif
                 }
                 else if (destinationType == typeof(string))
@@ -111,15 +115,35 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     convertedValue = EntityContextToString(entityContext);
                 }
 
-                var inputValueProvider = new ObjectValueProvider(
-                    convertedValue ?? value,
-                    this.parameterInfo.ParameterType);
+                    var inputValueProvider = new ObjectValueProvider(
+                        convertedValue ?? value,
+                        this.parameterInfo.ParameterType);
 
-                var bindingData = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
-                bindingData[this.parameterInfo.Name!] = convertedValue;
+                    var bindingData = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
+                    bindingData[this.parameterInfo.Name!] = convertedValue;
 
-                var triggerData = new TriggerData(inputValueProvider, bindingData);
-                return Task.FromResult<ITriggerData>(triggerData);
+                    var triggerData = new TriggerData(inputValueProvider, bindingData);
+                    return Task.FromResult<ITriggerData>(triggerData);
+                }
+#if FUNCTIONS_V3_OR_GREATER
+                else if (value is RemoteEntityContext remoteContext)
+                {
+                    // Generate a byte array which is the serialized protobuf payload
+                    // https://developers.google.com/protocol-buffers/docs/csharptutorial#parsing_and_serialization
+                    var entityBatchRequest = remoteContext.Request.ToEntityBatchRequest();
+
+                    // We convert the binary payload into a base64 string because that seems to be the most commonly supported
+                    // format for Azure Functions language workers. Attempts to send unencoded byte[] payloads were unsuccessful.
+                    string encodedRequest = ProtobufUtils.Base64Encode(entityBatchRequest);
+                    var contextValueProvider = new ObjectValueProvider(encodedRequest, typeof(string));
+                    var triggerData = new TriggerData(contextValueProvider, EmptyBindingData);
+                    return Task.FromResult<ITriggerData>(triggerData);
+                }
+#endif
+                else
+                {
+                    throw new ArgumentException($"Don't know how to bind to {value?.GetType().Name ?? "null"}.", nameof(value));
+                }
             }
 
             public ParameterDescriptor ToParameterDescriptor()

--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/RemoteEntityContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/RemoteEntityContext.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+#nullable enable
+using System;
+using System.Collections.Generic;
+using DurableTask.Core;
+using DurableTask.Core.Command;
+using DurableTask.Core.Entities.OperationFormat;
+using DurableTask.Core.History;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
+{
+    internal class RemoteEntityContext
+    {
+        public RemoteEntityContext(EntityBatchRequest batchRequest)
+        {
+            this.Request = batchRequest;
+        }
+
+        [JsonProperty("request")]
+        public EntityBatchRequest Request { get; private set; }
+
+        [JsonIgnore]
+        internal EntityBatchResult? Result { get; set; }
+    }
+}

--- a/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
@@ -439,10 +439,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             {
 #if FUNCTIONS_V3_OR_GREATER
                 // This is a newer, more performant flavor of orchestration/activity middleware that is being
-                // enabled for newer language runtimes. Support for entities in this model is TBD.
+                // enabled for newer language runtimes.
                 var ooprocMiddleware = new OutOfProcMiddleware(this);
                 this.taskHubWorker.AddActivityDispatcherMiddleware(ooprocMiddleware.CallActivityAsync);
                 this.taskHubWorker.AddOrchestrationDispatcherMiddleware(ooprocMiddleware.CallOrchestratorAsync);
+                this.taskHubWorker.AddEntityDispatcherMiddleware(ooprocMiddleware.CallEntityAsync);
 #else
                 // This can happen if, for example, a Java user tries to use Durable Functions while targeting V2 or V3 extension bundles
                 // because those bundles target .NET Core 2.2, which doesn't support the gRPC libraries used in the modern out-of-proc implementation.

--- a/src/WebJobs.Extensions.DurableTask/OutOfProcMiddleware.cs
+++ b/src/WebJobs.Extensions.DurableTask/OutOfProcMiddleware.cs
@@ -335,6 +335,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 functionResult = await functionInfo.Executor.TryExecuteAsync(
                     input,
                     cancellationToken: this.HostLifetimeService.OnStopping);
+
+                if (!functionResult.Succeeded)
+                {
+                    // Shutdown can surface as a completed invocation in a failed state.
+                    // Re-throw so we can abort this invocation.
+                    this.HostLifetimeService.OnStopping.ThrowIfCancellationRequested();
+                }
             }
             catch (Exception hostRuntimeException)
             {

--- a/src/WebJobs.Extensions.DurableTask/ProtobufUtils.cs
+++ b/src/WebJobs.Extensions.DurableTask/ProtobufUtils.cs
@@ -5,10 +5,13 @@
 using System;
 using System.Buffers;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using DurableTask.Core;
 using DurableTask.Core.Command;
+using DurableTask.Core.Entities;
+using DurableTask.Core.Entities.OperationFormat;
 using DurableTask.Core.History;
 using DurableTask.Core.Query;
 using Google.Protobuf;
@@ -428,6 +431,135 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             return new P.PurgeInstancesResponse
             {
                 DeletedInstanceCount = result.DeletedInstanceCount,
+            };
+        }
+
+        /// <summary>
+        /// Converts a <see cref="EntityBatchRequest" /> to <see cref="P.EntityBatchRequest" />.
+        /// </summary>
+        /// <param name="entityBatchRequest">The operation request to convert.</param>
+        /// <returns>The converted operation request.</returns>
+        [return: NotNullIfNotNull("entityBatchRequest")]
+        internal static P.EntityBatchRequest? ToEntityBatchRequest(this EntityBatchRequest? entityBatchRequest)
+        {
+            if (entityBatchRequest == null)
+            {
+                return null;
+            }
+
+            var batchRequest = new P.EntityBatchRequest()
+            {
+                InstanceId = entityBatchRequest.InstanceId,
+                EntityState = entityBatchRequest.EntityState,
+            };
+
+            foreach (var operation in entityBatchRequest.Operations ?? Enumerable.Empty<OperationRequest>())
+            {
+                batchRequest.Operations.Add(operation.ToOperationRequest());
+            }
+
+            return batchRequest;
+        }
+
+        /// <summary>
+        /// Converts a <see cref="OperationRequest" /> to <see cref="P.OperationRequest" />.
+        /// </summary>
+        /// <param name="operationRequest">The operation request to convert.</param>
+        /// <returns>The converted operation request.</returns>
+        [return: NotNullIfNotNull("operationRequest")]
+        internal static P.OperationRequest? ToOperationRequest(this OperationRequest? operationRequest)
+        {
+            if (operationRequest == null)
+            {
+                return null;
+            }
+
+            return new P.OperationRequest()
+            {
+                Operation = operationRequest.Operation,
+                Input = operationRequest.Input,
+                Guid = ByteString.FromStream(new MemoryStream(operationRequest.Id.ToByteArray())),
+            };
+        }
+
+        /// <summary>
+        /// Converts a <see cref="P.EntityBatchResult" /> to a <see cref="OperationBatchResult" />.
+        /// </summary>
+        /// <param name="entityBatchResult">The operation result to convert.</param>
+        /// <returns>The converted operation result.</returns>
+        [return: NotNullIfNotNull("entityBatchResult")]
+        internal static EntityBatchResult? ToEntityBatchResult(this P.EntityBatchResult? entityBatchResult)
+        {
+            if (entityBatchResult == null)
+            {
+                return null;
+            }
+
+            return new EntityBatchResult()
+            {
+                Actions = entityBatchResult.Actions.Select(operationAction => operationAction!.ToOperationAction()).ToList(),
+                EntityState = entityBatchResult.EntityState,
+                Results = entityBatchResult.Results.Select(operationResult => operationResult!.ToOperationResult()).ToList(),
+            };
+        }
+
+        /// <summary>
+        /// Converts a <see cref="P.OperationAction" /> to a <see cref="OperationAction" />.
+        /// </summary>
+        /// <param name="operationAction">The operation action to convert.</param>
+        /// <returns>The converted operation action.</returns>
+        [return: NotNullIfNotNull("operationAction")]
+        internal static OperationAction? ToOperationAction(this P.OperationAction? operationAction)
+        {
+            if (operationAction == null)
+            {
+                return null;
+            }
+
+            switch (operationAction.OperationActionTypeCase)
+            {
+                case P.OperationAction.OperationActionTypeOneofCase.SendSignal:
+
+                    return new SendSignalOperationAction()
+                    {
+                        Name = operationAction.SendSignal.Name,
+                        Input = operationAction.SendSignal.Input,
+                        InstanceId = operationAction.SendSignal.InstanceId,
+                        ScheduledTime = operationAction.SendSignal.HasScheduledTime ? operationAction.SendSignal.ScheduledTime.ToDateTime() : null,
+                    };
+
+                case P.OperationAction.OperationActionTypeOneofCase.StartNewOrchestration:
+
+                    return new StartNewOrchestrationOperationAction()
+                    {
+                        Name = operationAction.StartNewOrchestration.Name,
+                        Input = operationAction.StartNewOrchestration.Input,
+                        InstanceId = operationAction.StartNewOrchestration.InstanceId,
+                        Version = operationAction.StartNewOrchestration.Version,
+                    };
+                default:
+                    throw new NotSupportedException($"Deserialization of {operationAction.OperationActionTypeCase} is not supported.");
+            }
+        }
+
+        /// <summary>
+        /// Converts a <see cref="P.OperationResult" /> to a <see cref="OperationResult" />.
+        /// </summary>
+        /// <param name="operationResult">The operation result to convert.</param>
+        /// <returns>The converted operation result.</returns>
+        [return: NotNullIfNotNull("operationResult")]
+        internal static OperationResult? ToOperationResult(this P.OperationResult? operationResult)
+        {
+            if (operationResult == null)
+            {
+                return null;
+            }
+
+            return new OperationResult()
+            {
+                Result = operationResult.Result,
+                ErrorMessage = operationResult.ErrorCategory,
+                FailureDetails = GetFailureDetails(operationResult.FailureDetails),
             };
         }
     }

--- a/src/WebJobs.Extensions.DurableTask/ProtobufUtils.cs
+++ b/src/WebJobs.Extensions.DurableTask/ProtobufUtils.cs
@@ -478,7 +478,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             {
                 Operation = operationRequest.Operation,
                 Input = operationRequest.Input,
-                Guid = ByteString.FromStream(new MemoryStream(operationRequest.Id.ToByteArray())),
+                RequestId = ByteString.FromStream(new MemoryStream(operationRequest.Id.ToByteArray())),
             };
         }
 


### PR DESCRIPTION
With new core entity support, storage providers can now dispatch entity work items separately, and DT.Core processes them through in a separate dispatcher.

This PR updates the middleware passthrough to reflect this. 

This PR depends on https://github.com/Azure/durabletask/pull/953. 

### Pull request checklist

is targeting feature branch `feature/core-entities`.