### PR TITLE
Update dependencies in Worker.Extensions.DurableTask project

### DIFF
--- a/src/Worker.Extensions.DurableTask/AssemblyInfo.cs
+++ b/src/Worker.Extensions.DurableTask/AssemblyInfo.cs
@@ -4,4 +4,4 @@
 using Microsoft.Azure.Functions.Worker.Extensions.Abstractions;
 
 // TODO: Find a way to generate this dynamically at build-time
-[assembly: ExtensionInformation("Microsoft.Azure.WebJobs.Extensions.DurableTask", "2.10.*")]
+[assembly: ExtensionInformation("Microsoft.Azure.WebJobs.Extensions.DurableTask", "2.11.*")]

--- a/src/Worker.Extensions.DurableTask/Worker.Extensions.DurableTask.csproj
+++ b/src/Worker.Extensions.DurableTask/Worker.Extensions.DurableTask.csproj
@@ -29,7 +29,7 @@
     <AssemblyOriginatorKeyFile>..\..\sign.snk</AssemblyOriginatorKeyFile>
 
     <!-- Version information -->
-    <VersionPrefix>1.0.2</VersionPrefix>
+    <VersionPrefix>1.0.3</VersionPrefix>
     <AssemblyVersion>$(VersionPrefix).0</AssemblyVersion>
     <!-- FileVersionRevision is expected to be set by the CI. -->
     <FileVersion Condition="'$(FileVersionRevision)' != ''">$(VersionPrefix).$(FileVersionRevision)</FileVersion>
@@ -38,8 +38,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Core" Version="1.8.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Abstractions" Version="1.1.0" />
-    <PackageReference Include="Microsoft.DurableTask.Client.Grpc" Version="1.0.2" />
-    <PackageReference Include="Microsoft.DurableTask.Worker.Grpc" Version="1.0.2" />
+    <PackageReference Include="Microsoft.DurableTask.Client.Grpc" Version="1.0.3" />
+    <PackageReference Include="Microsoft.DurableTask.Worker.Grpc" Version="1.0.3" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Updating version to 1.0.3

Dependency updates:
Microsoft.Azure.WebJobs.Extensions.DurableTask 2.10.* --> 2.11.*
Microsoft.DurableTask.Worker.Grpc 1.0.2 --> 1.0.3
Microsoft.DurableTask.Client.Grpc 1.0.2 --> 1.0.3