### PR TITLE
Entities: Add worker side entity trigger and logic

### DIFF
--- a/src/Worker.Extensions.DurableTask/EntityTriggerAttribute.cs
+++ b/src/Worker.Extensions.DurableTask/EntityTriggerAttribute.cs
@@ -4,12 +4,16 @@
 using System;
 using System.Diagnostics;
 using Microsoft.Azure.Functions.Worker.Extensions.Abstractions;
+using Microsoft.Azure.Functions.Worker.Extensions.DurableTask;
 
 namespace Microsoft.Azure.Functions.Worker;
 
 /// <summary>
 /// Trigger attribute used for durable entity functions.
 /// </summary>
+/// <remarks>
+/// Entity triggers must bind to <see cref="TaskEntityDispatcher"/>.
+/// </remarks>
 [AttributeUsage(AttributeTargets.Parameter)]
 [DebuggerDisplay("{EntityName}")]
 public sealed class EntityTriggerAttribute : TriggerBindingAttribute

--- a/src/Worker.Extensions.DurableTask/EntityTriggerAttribute.cs
+++ b/src/Worker.Extensions.DurableTask/EntityTriggerAttribute.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+using Microsoft.Azure.Functions.Worker.Extensions.Abstractions;
+
+namespace Microsoft.Azure.Functions.Worker;
+
+/// <summary>
+/// Trigger attribute used for durable entity functions.
+/// </summary>
+[AttributeUsage(AttributeTargets.Parameter)]
+[DebuggerDisplay("{EntityName}")]
+public sealed class EntityTriggerAttribute : TriggerBindingAttribute
+{
+    /// <summary>
+    /// Gets or sets the name of the entity function.
+    /// </summary>
+    /// <remarks>
+    /// If not specified, the function name is used as the name of the entity.
+    /// This property supports binding parameters.
+    /// </remarks>
+    /// <value>
+    /// The name of the entity function or <c>null</c> to use the function name.
+    /// </value>
+    public string? EntityName { get; set; }
+}

--- a/src/Worker.Extensions.DurableTask/TaskEntityDispatcher.cs
+++ b/src/Worker.Extensions.DurableTask/TaskEntityDispatcher.cs
@@ -3,15 +3,17 @@
 
 using System;
 using System.Threading.Tasks;
+using Microsoft.DurableTask.Entities;
+using Microsoft.DurableTask.Worker.Grpc;
 using Microsoft.Extensions.DependencyInjection;
 
-namespace Microsoft.Azure.Functions.Worker.Extensions.DurableTask;
+namespace Microsoft.Azure.Functions.Worker;
 
 /// <summary>
 /// Represents a task entity dispatch invocation.
 /// </summary>
 /// <remarks>
-/// This type is used to aid in dispatching a <see cref="EntityTriggerAttribute"/> to the operation reciever object.
+/// This type is used to aid in dispatching a <see cref="EntityTriggerAttribute"/> to the operation receiver object.
 /// </remarks>
 public sealed class TaskEntityDispatcher
 {
@@ -35,7 +37,7 @@ public sealed class TaskEntityDispatcher
     {
         if (entity == null)
         {
-            throw ArgumentNullException(nameof(entity));
+            throw new ArgumentNullException(nameof(entity));
         }
 
         this.Result = await GrpcEntityRunner.LoadAndRunAsync(this.request, entity);
@@ -44,12 +46,12 @@ public sealed class TaskEntityDispatcher
     /// <summary>
     /// <para>Dispatches the entity trigger to an instance of the provided <typeparamref name="T"/>.</para>
     /// <para>
-    /// If <typeparamref name="T"/> is <see cref="ITaskEntity"/>, it will be activated from <see cref="IServiceProvider"/>
-    /// and then be dispatched to.
+    /// If <typeparamref name="T"/> is a <see cref="ITaskEntity"/>, it will be activated from
+    /// <see cref="IServiceProvider"/> and then be dispatched to.
     /// </para>
     /// <para>
-    /// If <typeparamref name="T"/> is not <see cref="ITaskEntity"/>, it is assumed the type represents the entity state
-    /// and it will be deserialized and dispatched directly to the state.
+    /// If <typeparamref name="T"/> is not <see cref="ITaskEntity"/>, it is assumed the <typeparamref name="T"/>
+    /// represents the entity state and it will be deserialized and dispatched directly to the state.
     /// </para>
     /// </summary>
     /// <typeparam name="T">The type to dispatch to.</typeparam>
@@ -67,6 +69,6 @@ public sealed class TaskEntityDispatcher
 
     private class StateEntity<T> : TaskEntity<T>
     {
-        public override AllowStateDispatch => true;
+        public override bool AllowStateDispatch => true;
     }
 }

--- a/src/Worker.Extensions.DurableTask/TaskEntityDispatcher.cs
+++ b/src/Worker.Extensions.DurableTask/TaskEntityDispatcher.cs
@@ -1,0 +1,69 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.Azure.Functions.Worker.Extensions.DurableTask;
+
+/// <summary>
+/// Represents a task entity dispatch invocation.
+/// </summary>
+public sealed class TaskEntityDispatcher
+{
+    private readonly string request;
+    private readonly IServiceProvider services;
+
+    internal TaskEntityDispatcher(string request, IServiceProvider services)
+    {
+        this.request = request;
+        this.services = services;
+    }
+
+    internal string Result { get; private set; } = string.Empty;
+
+    /// <summary>
+    /// Dispatches this entity trigger to the provided <see cref="ITaskEntity"/>.
+    /// </summary>
+    /// <param name="entity">The task entity to dispatch to.</param>
+    /// <returns>A task that completes when the dispatch has finished.</returns>
+    public async Task DispatchAsync(ITaskEntity entity)
+    {
+        if (entity == null)
+        {
+            throw ArgumentNullException(nameof(entity));
+        }
+
+        this.Result = await GrpcEntityRunner.LoadAndRunAsync(this.request, entity);
+    }
+
+    /// <summary>
+    /// <para>Dispatches the entity trigger to an instance of the provided <typeparamref name="T"/>.</para>
+    /// <para>
+    /// If <typeparamref name="T"/> is <see cref="ITaskEntity"/>, it will be activated from <see cref="IServiceProvider"/>
+    /// and then be ran.
+    /// </para>
+    /// <para>
+    /// If <typeparamref name="T"/> is not <see cref="ITaskEntity"/>, it is assumed the type represents the entity state
+    /// and it will be deserialized and dispatched directly to the state.
+    /// </para>
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <returns></returns>
+    public Task DispatchAsync<T>()
+    {
+        if (typeof(ITaskEntity).IsAssignableFrom(typeof(T)))
+        {
+            ITaskEntity entity = (ITaskEntity)ActivatorUtilities.GetServiceOrCreateInstance<T>(this.services);
+            return this.DispatchAsync(entity);
+        }
+
+        return this.DispatchAsync(new StateEntity<T>());
+    }
+
+    private class StateEntity<T> : TaskEntity<T>
+    {
+        public override AllowStateDispatch => true;
+    }
+}

--- a/src/Worker.Extensions.DurableTask/TaskEntityDispatcher.cs
+++ b/src/Worker.Extensions.DurableTask/TaskEntityDispatcher.cs
@@ -10,6 +10,9 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.DurableTask;
 /// <summary>
 /// Represents a task entity dispatch invocation.
 /// </summary>
+/// <remarks>
+/// This type is used to aid in dispatching a <see cref="EntityTriggerAttribute"/> to the operation reciever object.
+/// </remarks>
 public sealed class TaskEntityDispatcher
 {
     private readonly string request;
@@ -42,15 +45,15 @@ public sealed class TaskEntityDispatcher
     /// <para>Dispatches the entity trigger to an instance of the provided <typeparamref name="T"/>.</para>
     /// <para>
     /// If <typeparamref name="T"/> is <see cref="ITaskEntity"/>, it will be activated from <see cref="IServiceProvider"/>
-    /// and then be ran.
+    /// and then be dispatched to.
     /// </para>
     /// <para>
     /// If <typeparamref name="T"/> is not <see cref="ITaskEntity"/>, it is assumed the type represents the entity state
     /// and it will be deserialized and dispatched directly to the state.
     /// </para>
     /// </summary>
-    /// <typeparam name="T"></typeparam>
-    /// <returns></returns>
+    /// <typeparam name="T">The type to dispatch to.</typeparam>
+    /// <returns>A task that completes when the dispatch has finished.</returns>
     public Task DispatchAsync<T>()
     {
         if (typeof(ITaskEntity).IsAssignableFrom(typeof(T)))


### PR DESCRIPTION
<!-- Start the PR description with some context for the change. -->

Adds the dotnet isolated worker side trigger and logic to allow for entity invocation. Many APIs are stubbed out to what we expect the final dependencies to look like.

<!-- Make sure to delete the markdown comments and the below sections when squash merging -->
### Issue describing the changes in this PR

resolves https://github.com/microsoft/durabletask-dotnet/issues/188

### Pull request checklist

* [ ] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)
* [ ] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk
* [ ] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
    * [ ] Otherwise: major or minor version updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
* [ ] My changes **do not** add EventIds to our EventSource logs
    * [ ] Otherwise: Ensure the EventIds are within the supported range in our existing Windows infrastructure. You may validate this with a deployed app's telemetry. You may also extend the range by completing a PR such as [this one](https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files).