### PR TITLE
Fix orchestration input

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -4,6 +4,8 @@
 
 ### Bug Fixes
 
+- Fix orchestration input missing [#2577](https://github.com/Azure/azure-functions-durable-extension/issues/2577)
+
 ### Breaking Changes
 
 ### Dependency Updates

--- a/src/WebJobs.Extensions.DurableTask/LocalGrpcListener.cs
+++ b/src/WebJobs.Extensions.DurableTask/LocalGrpcListener.cs
@@ -145,7 +145,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 string? instanceId = null;
                 try
                 {
-                    instanceId = await this.GetClient(context).StartNewAsync(request.Name, request.InstanceId);
+                    instanceId = await this.GetClient(context).StartNewAsync(request.Name, request.InstanceId, request.Input);
                     return new P.CreateInstanceResponse
                     {
                         InstanceId = instanceId,

--- a/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
+++ b/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
@@ -6,7 +6,7 @@
     <RootNamespace>Microsoft.Azure.WebJobs.Extensions.DurableTask</RootNamespace>
     <MajorVersion>2</MajorVersion>
     <MinorVersion>11</MinorVersion>
-    <PatchVersion>1</PatchVersion>
+    <PatchVersion>2</PatchVersion>
     <Version>$(MajorVersion).$(MinorVersion).$(PatchVersion)</Version>
     <FileVersion>$(MajorVersion).$(MinorVersion).$(PatchVersion)</FileVersion>
     <AssemblyVersion>$(MajorVersion).0.0.0</AssemblyVersion>


### PR DESCRIPTION
<!-- Start the PR description with some context for the change. -->

An argument was missed when converting to using Durable client for starting new orchestrations.

<!-- Make sure to delete the markdown comments and the below sections when squash merging -->
### Issue describing the changes in this PR

resolves #2577

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)
* [x] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk
* [ ] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
    * [x] Otherwise: major or minor version updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
* [x] My changes **do not** add EventIds to our EventSource logs
    * [ ] Otherwise: Ensure the EventIds are within the supported range in our existing Windows infrastructure. You may validate this with a deployed app's telemetry. You may also extend the range by completing a PR such as [this one](https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files).