### PR TITLE
Revert LocalGrpcListener usage of IDurableClient

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -4,6 +4,8 @@
 
 ### Bug Fixes
 
+- Address input issues when using .NET isolated (#2581)[https://github.com/Azure/azure-functions-durable-extension/issues/2581]
+
 ### Breaking Changes
 
 ### Dependency Updates

--- a/release_notes.md
+++ b/release_notes.md
@@ -4,8 +4,6 @@
 
 ### Bug Fixes
 
-- Fix orchestration input missing [#2577](https://github.com/Azure/azure-functions-durable-extension/issues/2577)
-
 ### Breaking Changes
 
 ### Dependency Updates

--- a/src/WebJobs.Extensions.DurableTask/LocalGrpcListener.cs
+++ b/src/WebJobs.Extensions.DurableTask/LocalGrpcListener.cs
@@ -145,7 +145,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 string? instanceId = null;
                 try
                 {
-                    instanceId = await this.GetClient(context).StartNewAsync(request.Name, request.InstanceId, request.Input);
+                    instanceId = await this.GetClient(context).StartNewAsync(request.Name, request.InstanceId);
                     return new P.CreateInstanceResponse
                     {
                         InstanceId = instanceId,

--- a/src/WebJobs.Extensions.DurableTask/LocalGrpcListener.cs
+++ b/src/WebJobs.Extensions.DurableTask/LocalGrpcListener.cs
@@ -142,50 +142,83 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
             public async override Task<P.CreateInstanceResponse> StartInstance(P.CreateInstanceRequest request, ServerCallContext context)
             {
-                string? instanceId = null;
+                var instance = new OrchestrationInstance
+                {
+                    InstanceId = request.InstanceId ?? Guid.NewGuid().ToString("N"),
+                    ExecutionId = Guid.NewGuid().ToString(),
+                };
+
                 try
                 {
-                    instanceId = await this.GetClient(context).StartNewAsync(request.Name, request.InstanceId);
+                    await this.GetDurabilityProvider(context).CreateTaskOrchestrationAsync(
+                        new TaskMessage
+                        {
+                            Event = new ExecutionStartedEvent(-1, request.Input)
+                            {
+                                Name = request.Name,
+                                Version = request.Version,
+                                OrchestrationInstance = instance,
+                                ScheduledStartTime = request.ScheduledStartTimestamp?.ToDateTime(),
+                            },
+                            OrchestrationInstance = instance,
+                        },
+                        this.GetStatusesNotToOverride());
+
                     return new P.CreateInstanceResponse
                     {
-                        InstanceId = instanceId,
+                        InstanceId = instance.InstanceId,
                     };
                 }
                 catch (InvalidOperationException)
                 {
-                    throw new RpcException(new Status(StatusCode.AlreadyExists, $"An Orchestration instance with the ID {instanceId} already exists."));
+                    throw new RpcException(new Status(StatusCode.AlreadyExists, $"An Orchestration instance with the ID {instance.InstanceId} already exists."));
                 }
             }
 
             public async override Task<P.RaiseEventResponse> RaiseEvent(P.RaiseEventRequest request, ServerCallContext context)
             {
-                await this.GetClient(context).RaiseEventAsync(request.InstanceId, request.Name, request.Input);
+                await this.GetDurabilityProvider(context).SendTaskOrchestrationMessageAsync(
+                    new TaskMessage
+                    {
+                        Event = new EventRaisedEvent(-1, request.Input)
+                        {
+                            Name = request.Name,
+                        },
+                        OrchestrationInstance = new OrchestrationInstance
+                        {
+                            InstanceId = request.InstanceId,
+                        },
+                    });
+
+                // No fields in the response
                 return new P.RaiseEventResponse();
             }
 
             public async override Task<P.TerminateResponse> TerminateInstance(P.TerminateRequest request, ServerCallContext context)
             {
-                await this.GetClient(context).TerminateAsync(request.InstanceId, request.Output);
+                await this.GetDurabilityProvider(context).ForceTerminateTaskOrchestrationAsync(
+                    request.InstanceId,
+                    request.Output);
+
+                // No fields in the response
                 return new P.TerminateResponse();
             }
 
             public async override Task<P.SuspendResponse> SuspendInstance(P.SuspendRequest request, ServerCallContext context)
             {
-                await this.GetClient(context).SuspendAsync(request.InstanceId, request.Reason);
+                await this.GetDurabilityProvider(context).SuspendTaskOrchestrationAsync(request.InstanceId, request.Reason);
                 return new P.SuspendResponse();
             }
 
             public async override Task<P.ResumeResponse> ResumeInstance(P.ResumeRequest request, ServerCallContext context)
             {
-                await this.GetClient(context).ResumeAsync(request.InstanceId, request.Reason);
+                await this.GetDurabilityProvider(context).ResumeTaskOrchestrationAsync(request.InstanceId, request.Reason);
                 return new P.ResumeResponse();
             }
 
             public async override Task<P.RewindInstanceResponse> RewindInstance(P.RewindInstanceRequest request, ServerCallContext context)
             {
-#pragma warning disable CS0618 // Type or member is obsolete
-                await this.GetClient(context).RewindAsync(request.InstanceId, request.Reason);
-#pragma warning restore CS0618 // Type or member is obsolete
+                await this.GetDurabilityProvider(context).RewindAsync(request.InstanceId, request.Reason);
                 return new P.RewindInstanceResponse();
             }
 
@@ -305,21 +338,18 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 };
             }
 
-            private DurableClientAttribute GetAttribute(ServerCallContext context)
+            private DurabilityProvider GetDurabilityProvider(ServerCallContext context)
             {
                 string? taskHub = context.RequestHeaders.GetValue("Durable-TaskHub");
                 string? connectionName = context.RequestHeaders.GetValue("Durable-ConnectionName");
-                return new DurableClientAttribute() { TaskHub = taskHub, ConnectionName = connectionName };
+                var attribute = new DurableClientAttribute() { TaskHub = taskHub, ConnectionName = connectionName };
+                return this.extension.GetDurabilityProvider(attribute);
             }
 
-            private DurabilityProvider GetDurabilityProvider(ServerCallContext context)
+            private OrchestrationStatus[] GetStatusesNotToOverride()
             {
-                return this.extension.GetDurabilityProvider(this.GetAttribute(context));
-            }
-
-            private IDurableClient GetClient(ServerCallContext context)
-            {
-                return this.extension.GetClient(this.GetAttribute(context));
+                OverridableStates overridableStates = this.extension.Options.OverridableExistingInstanceStates;
+                return overridableStates.ToDedupeStatuses();
             }
         }
     }

--- a/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
+++ b/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
@@ -6,7 +6,7 @@
     <RootNamespace>Microsoft.Azure.WebJobs.Extensions.DurableTask</RootNamespace>
     <MajorVersion>2</MajorVersion>
     <MinorVersion>11</MinorVersion>
-    <PatchVersion>1</PatchVersion>
+    <PatchVersion>3</PatchVersion>
     <Version>$(MajorVersion).$(MinorVersion).$(PatchVersion)</Version>
     <FileVersion>$(MajorVersion).$(MinorVersion).$(PatchVersion)</FileVersion>
     <AssemblyVersion>$(MajorVersion).0.0.0</AssemblyVersion>

--- a/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
+++ b/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
@@ -6,7 +6,7 @@
     <RootNamespace>Microsoft.Azure.WebJobs.Extensions.DurableTask</RootNamespace>
     <MajorVersion>2</MajorVersion>
     <MinorVersion>11</MinorVersion>
-    <PatchVersion>2</PatchVersion>
+    <PatchVersion>1</PatchVersion>
     <Version>$(MajorVersion).$(MinorVersion).$(PatchVersion)</Version>
     <FileVersion>$(MajorVersion).$(MinorVersion).$(PatchVersion)</FileVersion>
     <AssemblyVersion>$(MajorVersion).0.0.0</AssemblyVersion>

--- a/test/SmokeTests/OOProcSmokeTests/DotNetIsolated/DotNetIsolated.csproj
+++ b/test/SmokeTests/OOProcSmokeTests/DotNetIsolated/DotNetIsolated.csproj
@@ -9,9 +9,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.18.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.10.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.0.13" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.13.0" OutputItemType="Analyzer" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.7.0" OutputItemType="Analyzer" />
     <PackageReference Include="Microsoft.DurableTask.Generators" Version="1.0.0-preview.1" OutputItemType="Analyzer" />
   </ItemGroup>
 

--- a/test/SmokeTests/OOProcSmokeTests/DotNetIsolated/DotNetIsolated.csproj
+++ b/test/SmokeTests/OOProcSmokeTests/DotNetIsolated/DotNetIsolated.csproj
@@ -9,9 +9,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.10.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.19.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.0.13" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.7.0" OutputItemType="Analyzer" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.14.1" OutputItemType="Analyzer" />
     <PackageReference Include="Microsoft.DurableTask.Generators" Version="1.0.0-preview.1" OutputItemType="Analyzer" />
   </ItemGroup>
 


### PR DESCRIPTION
<!-- Start the PR description with some context for the change. -->

Reverts:
https://github.com/Azure/azure-functions-durable-extension/pull/2578
https://github.com/Azure/azure-functions-durable-extension/pull/2544

<!-- Make sure to delete the markdown comments and the below sections when squash merging -->
### Issue describing the changes in this PR

resolves #2581 

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)
* [x] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk
* [ ] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
    * [x] Otherwise: major or minor version updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
* [x] My changes **do not** add EventIds to our EventSource logs
    * [ ] Otherwise: Ensure the EventIds are within the supported range in our existing Windows infrastructure. You may validate this with a deployed app's telemetry. You may also extend the range by completing a PR such as [this one](https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files).