### PR TITLE
[For private package] Add Entity Telemetry in exchange of EventGridNotification logs

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/EtwEventSource.cs
+++ b/src/WebJobs.Extensions.DurableTask/EtwEventSource.cs
@@ -175,7 +175,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             bool IsReplay,
             long LatencyMs)
         {
-            this.WriteEvent(210, TaskHub, AppName, SlotName, FunctionName, FunctionState, InstanceId, Details, StatusCode, Reason, FunctionType, ExtensionVersion, IsReplay, LatencyMs);
+            this.WriteEvent(233, TaskHub, AppName, SlotName, FunctionName, FunctionState, InstanceId, Details, StatusCode, Reason, FunctionType, ExtensionVersion, IsReplay, LatencyMs);
         }
 
         [Event(234, Level = EventLevel.Error, Version = 3)]
@@ -194,7 +194,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             bool IsReplay,
             long LatencyMs)
         {
-            this.WriteEvent(211, TaskHub, AppName, SlotName, FunctionName, FunctionState, InstanceId, Details, StatusCode, Reason, FunctionType, ExtensionVersion, IsReplay, LatencyMs);
+            this.WriteEvent(234, TaskHub, AppName, SlotName, FunctionName, FunctionState, InstanceId, Details, StatusCode, Reason, FunctionType, ExtensionVersion, IsReplay, LatencyMs);
         }
 
         [Event(212, Level = EventLevel.Error)]

--- a/src/WebJobs.Extensions.DurableTask/EtwEventSource.cs
+++ b/src/WebJobs.Extensions.DurableTask/EtwEventSource.cs
@@ -536,7 +536,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             string ExtensionVersion,
             bool IsReplay)
         {
-            this.WriteEvent(233, TaskHub, AppName, SlotName, FunctionName, InstanceId, EventsReceived, OperationsInBatch, OperationsExecuted, OutOfOrderMessages, QueuedMessages, UserStateSize, Sources, Destinations, LockedBy, Suspended, TraceFlags, FunctionType, ExtensionVersion, IsReplay);
+            this.WriteEvent(210, TaskHub, AppName, SlotName, FunctionName, InstanceId, EventsReceived, OperationsInBatch, OperationsExecuted, OutOfOrderMessages, QueuedMessages, UserStateSize, Sources, Destinations, LockedBy, Suspended, TraceFlags, FunctionType, ExtensionVersion, IsReplay);
         }
 
         [Event(211, Level = EventLevel.Error, Version = 4)]
@@ -551,7 +551,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             string FunctionType,
             string ExtensionVersion)
         {
-            this.WriteEvent(234, TaskHub, AppName, SlotName, FunctionName, InstanceId, TraceFlags, Details, FunctionType, ExtensionVersion);
+            this.WriteEvent(211, TaskHub, AppName, SlotName, FunctionName, InstanceId, TraceFlags, Details, FunctionType, ExtensionVersion);
         }
 
 #pragma warning restore SA1313 // Parameter names should begin with lower-case letter

--- a/src/WebJobs.Extensions.DurableTask/EtwEventSource.cs
+++ b/src/WebJobs.Extensions.DurableTask/EtwEventSource.cs
@@ -159,7 +159,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             this.WriteEvent(209, TaskHub, AppName, SlotName, FunctionName, InstanceId, Reason, FunctionType, ExtensionVersion, IsReplay);
         }
 
-        [Event(210, Level = EventLevel.Informational, Version = 3)]
+        [Event(233, Level = EventLevel.Informational, Version = 3)]
         public void EventGridNotificationCompleted(
             string TaskHub,
             string AppName,
@@ -178,7 +178,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             this.WriteEvent(210, TaskHub, AppName, SlotName, FunctionName, FunctionState, InstanceId, Details, StatusCode, Reason, FunctionType, ExtensionVersion, IsReplay, LatencyMs);
         }
 
-        [Event(211, Level = EventLevel.Error, Version = 3)]
+        [Event(234, Level = EventLevel.Error, Version = 3)]
         public void EventGridNotificationFailed(
             string TaskHub,
             string AppName,
@@ -514,7 +514,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             this.WriteEvent(232, TaskHub, AppName, SlotName, FunctionName, InstanceId, Reason, FunctionType, ExtensionVersion, IsReplay);
         }
 
-        [Event(233, Level = EventLevel.Informational, Version = 4)]
+        [Event(210, Level = EventLevel.Informational, Version = 4)]
         public void EntityBatchCompleted(
             string TaskHub,
             string AppName,
@@ -539,7 +539,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             this.WriteEvent(233, TaskHub, AppName, SlotName, FunctionName, InstanceId, EventsReceived, OperationsInBatch, OperationsExecuted, OutOfOrderMessages, QueuedMessages, UserStateSize, Sources, Destinations, LockedBy, Suspended, TraceFlags, FunctionType, ExtensionVersion, IsReplay);
         }
 
-        [Event(234, Level = EventLevel.Error, Version = 4)]
+        [Event(211, Level = EventLevel.Error, Version = 4)]
         public void EntityBatchFailed(
             string TaskHub,
             string AppName,

--- a/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
+++ b/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
@@ -7,7 +7,7 @@
     <MajorVersion>2</MajorVersion>
     <MinorVersion>11</MinorVersion>
     <PatchVersion>4</PatchVersion>
-    <Version>$(MajorVersion).$(MinorVersion).$(PatchVersion)-entity-logs-1</Version>
+    <Version>$(MajorVersion).$(MinorVersion).$(PatchVersion)-entity-logs-2</Version>
     <FileVersion>$(MajorVersion).$(MinorVersion).$(PatchVersion)</FileVersion>
     <AssemblyVersion>$(MajorVersion).0.0.0</AssemblyVersion>
     <Company>Microsoft Corporation</Company>

--- a/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
+++ b/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
@@ -6,8 +6,8 @@
     <RootNamespace>Microsoft.Azure.WebJobs.Extensions.DurableTask</RootNamespace>
     <MajorVersion>2</MajorVersion>
     <MinorVersion>11</MinorVersion>
-    <PatchVersion>3</PatchVersion>
-    <Version>$(MajorVersion).$(MinorVersion).$(PatchVersion)</Version>
+    <PatchVersion>4</PatchVersion>
+    <Version>$(MajorVersion).$(MinorVersion).$(PatchVersion)-entity-logs-1</Version>
     <FileVersion>$(MajorVersion).$(MinorVersion).$(PatchVersion)</FileVersion>
     <AssemblyVersion>$(MajorVersion).0.0.0</AssemblyVersion>
     <Company>Microsoft Corporation</Company>


### PR DESCRIPTION
For private package only. IcM is = 423004777

As per [this](https://github.com/Azure/azure-functions-durable-extension/pull/2390#issuecomment-1516808217) comment, the EventIds for some of our entity telemetry is not showing up in our telemetry yet.

This draft PR is a hack that swaps the ETW EventIds of EventGridNotifications for the Entity ETW events. That should suffice to let these critical logs surface to our Kusto server for investigation's sake.