### PR TITLE
Update Pull Request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -22,4 +22,4 @@ resolves #issue_for_this_pr
 * [ ] My changes **do not** add EventIds to our EventSource logs
     * [ ] Otherwise: Ensure the EventIds are within the supported range in our existing Windows infrastructure. You may validate this with a deployed app's telemetry. You may also extend the range by completing a PR such as [this one](https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files).
 * [ ] My changes **should** be added to v3.x branch.
-    * [ ] Otherwise: This change is only applies to Durable Functions v2.x and **will not** be merged to branch v3.x.
+    * [ ] Otherwise: This change only applies to Durable Functions v2.x and **will not** be merged to branch v3.x.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -21,5 +21,5 @@ resolves #issue_for_this_pr
     * [ ] Otherwise: major or minor version updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
 * [ ] My changes **do not** add EventIds to our EventSource logs
     * [ ] Otherwise: Ensure the EventIds are within the supported range in our existing Windows infrastructure. You may validate this with a deployed app's telemetry. You may also extend the range by completing a PR such as [this one](https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files).
-* [ ] My changes **should** be added to v3.x branch.
-      * [ ] Otherwise: This change is only applies to Durable Functions v2.x and **will not** be merged to branch v3.x.
+* [ ] My changes **should** be added to v3.x branch. Otherwise: This change is only applies to Durable Functions v2.x and **will not** be merged to branch v3.x.
+    * [ ] Otherwise: This change is only applies to Durable Functions v2.x and **will not** be merged to branch v3.x.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -21,3 +21,5 @@ resolves #issue_for_this_pr
     * [ ] Otherwise: major or minor version updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
 * [ ] My changes **do not** add EventIds to our EventSource logs
     * [ ] Otherwise: Ensure the EventIds are within the supported range in our existing Windows infrastructure. You may validate this with a deployed app's telemetry. You may also extend the range by completing a PR such as [this one](https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files).
+* [ ] My changes **should** be added to v3.x branch.
+      * [ ] Otherwise: This change is only applies to Durable Functions v2.x and **will not** be merged to branch v3.x.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -21,5 +21,5 @@ resolves #issue_for_this_pr
     * [ ] Otherwise: major or minor version updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
 * [ ] My changes **do not** add EventIds to our EventSource logs
     * [ ] Otherwise: Ensure the EventIds are within the supported range in our existing Windows infrastructure. You may validate this with a deployed app's telemetry. You may also extend the range by completing a PR such as [this one](https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files).
-* [ ] My changes **should** be added to v3.x branch. Otherwise: This change is only applies to Durable Functions v2.x and **will not** be merged to branch v3.x.
+* [ ] My changes **should** be added to v3.x branch.
     * [ ] Otherwise: This change is only applies to Durable Functions v2.x and **will not** be merged to branch v3.x.


### PR DESCRIPTION
<!-- Start the PR description with some context for the change. -->
Since there is a new branch `v3.x` for preview Durable Functions V3, it needs to be updated with the branch `dev`. Thus add a new check item for it. 

Once the branch v3.x becomes the new dev, this new-added check item can be deleted. 


<!-- Make sure to delete the markdown comments and the below sections when squash merging -->
### Issue describing the changes in this PR

resolves #issue_for_this_pr

### Pull request checklist

* [ ] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)
* [ ] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk
* [ ] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
    * [ ] Otherwise: major or minor version updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
* [ ] My changes **do not** add EventIds to our EventSource logs
    * [ ] Otherwise: Ensure the EventIds are within the supported range in our existing Windows infrastructure. You may validate this with a deployed app's telemetry. You may also extend the range by completing a PR such as [this one](https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files).