### PR TITLE
Switch to Microsoft.DurableTask.Grpc

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableClient.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableClient.cs
@@ -710,7 +710,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             }
             else
             {
-                return await CleanEntityStorageLegacyAsync(removeEmptyEntities, releaseOrphanedLocks, cancellationToken);
+                return await this.CleanEntityStorageLegacyAsync(removeEmptyEntities, releaseOrphanedLocks, cancellationToken);
             }
         }
 

--- a/src/WebJobs.Extensions.DurableTask/LocalGrpcListener.cs
+++ b/src/WebJobs.Extensions.DurableTask/LocalGrpcListener.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using DurableTask.Core;
@@ -208,7 +207,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     request.Input,
                     EntityMessageEvent.GetCappedScheduledTime(
                         DateTime.UtcNow,
-                        entityOrchestrationService.EntityBackendProperties.MaximumSignalDelayTime,
+                        entityOrchestrationService.EntityBackendProperties!.MaximumSignalDelayTime,
                         request.ScheduledTime?.ToDateTime()));
 
                 await durabilityProvider.SendTaskOrchestrationMessageAsync(eventToSend.AsTaskMessage());
@@ -221,7 +220,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             {
                 this.CheckEntitySupport(context, out var durabilityProvider, out var entityOrchestrationService);
 
-                EntityBackendQueries.EntityMetadata? metaData = await entityOrchestrationService.EntityBackendQueries.GetEntityAsync(
+                EntityBackendQueries.EntityMetadata? metaData = await entityOrchestrationService.EntityBackendQueries!.GetEntityAsync(
                     DTCore.Entities.EntityId.FromString(request.InstanceId),
                     request.IncludeState,
                     includeDeleted: false,
@@ -239,7 +238,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 this.CheckEntitySupport(context, out var durabilityProvider, out var entityOrchestrationService);
 
                 P.EntityQuery query = request.Query;
-                EntityBackendQueries.EntityQueryResult result = await entityOrchestrationService.EntityBackendQueries.QueryEntitiesAsync(
+                EntityBackendQueries.EntityQueryResult result = await entityOrchestrationService.EntityBackendQueries!.QueryEntitiesAsync(
                     new EntityBackendQueries.EntityQuery()
                     {
                          InstanceIdStartsWith = query.InstanceIdStartsWith,
@@ -269,7 +268,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             {
                 this.CheckEntitySupport(context, out var durabilityProvider, out var entityOrchestrationService);
 
-                EntityBackendQueries.CleanEntityStorageResult result = await entityOrchestrationService.EntityBackendQueries.CleanEntityStorageAsync(
+                EntityBackendQueries.CleanEntityStorageResult result = await entityOrchestrationService.EntityBackendQueries!.CleanEntityStorageAsync(
                     new EntityBackendQueries.CleanEntityStorageRequest()
                     {
                         RemoveEmptyEntities = request.RemoveEmptyEntities,
@@ -447,10 +446,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             private void CheckEntitySupport(ServerCallContext context, out DurabilityProvider durabilityProvider, out IEntityOrchestrationService entityOrchestrationService)
             {
                 durabilityProvider = this.GetDurabilityProvider(context);
-                entityOrchestrationService = durabilityProvider as IEntityOrchestrationService;
+                entityOrchestrationService = durabilityProvider;
                 if (entityOrchestrationService?.EntityBackendProperties == null)
                 {
-                    throw new NotSupportedException($"The provider '{durabilityProvider.GetType().Name}' does not support entities.");
+                    throw new NotSupportedException($"The provider '{durabilityProvider.GetBackendInfo()}' does not support entities.");
                 }
             }
 

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
@@ -2026,6 +2026,18 @@
         <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurabilityProvider.MaxConcurrentTaskActivityWorkItems">
             <inheritdoc/>
         </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurabilityProvider.DurableTask#Core#Entities#IEntityOrchestrationService#EntityBackendProperties">
+            <inheritdoc/>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurabilityProvider.DurableTask#Core#Entities#IEntityOrchestrationService#EntityBackendQueries">
+            <inheritdoc/>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurabilityProvider.DurableTask#Core#Entities#IEntityOrchestrationService#LockNextOrchestrationWorkItemAsync(System.TimeSpan,System.Threading.CancellationToken)">
+            <inheritdoc/>
+        </member>
+        <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurabilityProvider.DurableTask#Core#Entities#IEntityOrchestrationService#LockNextEntityWorkItemAsync(System.TimeSpan,System.Threading.CancellationToken)">
+            <inheritdoc/>
+        </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurabilityProvider.AbandonTaskActivityWorkItemAsync(DurableTask.Core.TaskActivityWorkItem)">
             <inheritdoc/>
         </member>
@@ -4283,6 +4295,18 @@
             <summary>
             Gets or sets the maximum number of orchestrator functions that can be processed concurrently on a single host instance.
             </summary>
+            <value>
+            A positive integer configured by the host.
+            </value>
+        </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskOptions.MaxConcurrentEntityFunctions">
+            <summary>
+            Gets or sets the maximum number of entity functions that can be processed concurrently on a single host instance.
+            </summary>
+            <remarks>
+            Increasing entity function concurrency can result in increased throughput but can
+            also increase the total CPU and memory usage on a single worker instance.
+            </remarks>
             <value>
             A positive integer configured by the host.
             </value>

--- a/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
+++ b/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
@@ -99,7 +99,7 @@
     <!-- Explicitly pinned transitive dependencies with CVE vulnerabilities.-->
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets" Version="2.2.1" />
     <!-- The gRPC dependencies in this package are not compatible with older frameworks, like .NET Core 2.x -->
-    <PackageReference Include="Microsoft.DurableTask.Sidecar.Protobuf" Version="1.0.0" />
+    <PackageReference Include="Microsoft.DurableTask.Grpc" Version="1.1.0-entities-preview.1" />
   </ItemGroup>
 
   <!-- Common dependencies across all targets -->


### PR DESCRIPTION
<!-- Start the PR description with some context for the change. -->

This PR does two things:

1. Fixes nullability and stylecop warnings
2. Switches from Microsoft.DurableTask.Protobuf to Microsoft.DurableTask.Grpc for the proto definitions. The later was made so that the microsoft/durabletask-grpc could directly control its own packaging/release without needing to go through the proto repo.

<!-- Make sure to delete the markdown comments and the below sections when squash merging -->
### Issue describing the changes in this PR

resolves #issue_for_this_pr

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)
* [x] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk
* [x] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
    * [ ] Otherwise: major or minor version updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
* [x] My changes **do not** add EventIds to our EventSource logs
    * [ ] Otherwise: Ensure the EventIds are within the supported range in our existing Windows infrastructure. You may validate this with a deployed app's telemetry. You may also extend the range by completing a PR such as [this one](https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files).
* [x] My changes **should** be added to v3.x branch.
    * [ ] Otherwise: This change only applies to Durable Functions v2.x and **will not** be merged to branch v3.x.
