### PR TITLE
Default Paritition Manager V3 at Durable Function V3

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/Options/AzureStorageOptions.cs
+++ b/src/WebJobs.Extensions.DurableTask/Options/AzureStorageOptions.cs
@@ -177,7 +177,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// This strategy reduces expected costs for an Azure Storage V2 account.
         /// </summary>
         /// <value>A boolean indicating whether to use the table partition strategy. Defaults to false.</value>
-        public bool UseTablePartitionManagement { get; set; } = false;
+        public bool UseTablePartitionManagement { get; set; } = true;
 
         /// <summary>
         /// Throws an exception if the provided hub name violates any naming conventions for the storage provider.

--- a/test/FunctionsV1/PlatformSpecificHelpers.FunctionsV1.cs
+++ b/test/FunctionsV1/PlatformSpecificHelpers.FunctionsV1.cs
@@ -51,6 +51,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             if (!options.Value.StorageProvider.ContainsKey(nameof(AzureStorageOptions.UseLegacyPartitionManagement)))
             {
                 options.Value.StorageProvider.Add(nameof(AzureStorageOptions.UseLegacyPartitionManagement), true);
+                options.Value.StorageProvider.Add(nameof(AzureStorageOptions.UseTablePartitionManagement), false);
             }
 
             platformInformationService = platformInformationService ?? new DefaultPlatformInformation(nameResolver, loggerFactory);

--- a/test/FunctionsV1/PlatformSpecificHelpers.FunctionsV1.cs
+++ b/test/FunctionsV1/PlatformSpecificHelpers.FunctionsV1.cs
@@ -45,12 +45,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             var loggerFactory = new LoggerFactory();
             loggerFactory.AddProvider(loggerProvider);
 
-            // Unless otherwise specified, use legacy partition management for tests as it makes the task hubs start up faster.
+            // Unless specified, use table partition management for tests as it makes the task hubs start up faster.
             // These tests run on a single task hub workers, so they don't test partition management anyways, and that is tested
             // in the DTFx repo.
-            if (!options.Value.StorageProvider.ContainsKey(nameof(AzureStorageOptions.UseLegacyPartitionManagement)))
+            if (options.Value.StorageProvider.ContainsKey(nameof(AzureStorageOptions.UseLegacyPartitionManagement)))
             {
-                options.Value.StorageProvider.Add(nameof(AzureStorageOptions.UseLegacyPartitionManagement), true);
                 options.Value.StorageProvider.Add(nameof(AzureStorageOptions.UseTablePartitionManagement), false);
             }
 

--- a/test/FunctionsV2/PlatformSpecificHelpers.FunctionsV2.cs
+++ b/test/FunctionsV2/PlatformSpecificHelpers.FunctionsV2.cs
@@ -40,12 +40,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             bool addDurableClientFactory,
             ITypeLocator typeLocator)
         {
-            // Unless otherwise specified, use legacy partition management for tests as it makes the task hubs start up faster.
+            // Unless specified, use table partition management for tests as it makes the task hubs start up faster.
             // These tests run on a single task hub workers, so they don't test partition management anyways, and that is tested
             // in the DTFx repo.
-            if (!options.Value.StorageProvider.ContainsKey(nameof(AzureStorageOptions.UseLegacyPartitionManagement)))
+            if (options.Value.StorageProvider.ContainsKey(nameof(AzureStorageOptions.UseLegacyPartitionManagement)))
             {
-                options.Value.StorageProvider.Add(nameof(AzureStorageOptions.UseLegacyPartitionManagement), true);
                 options.Value.StorageProvider.Add(nameof(AzureStorageOptions.UseTablePartitionManagement), false);
             }
 

--- a/test/FunctionsV2/PlatformSpecificHelpers.FunctionsV2.cs
+++ b/test/FunctionsV2/PlatformSpecificHelpers.FunctionsV2.cs
@@ -46,6 +46,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             if (!options.Value.StorageProvider.ContainsKey(nameof(AzureStorageOptions.UseLegacyPartitionManagement)))
             {
                 options.Value.StorageProvider.Add(nameof(AzureStorageOptions.UseLegacyPartitionManagement), true);
+                options.Value.StorageProvider.Add(nameof(AzureStorageOptions.UseTablePartitionManagement), false);
             }
 
             IHost host = new HostBuilder()


### PR DESCRIPTION
<!-- Start the PR description with some context for the change. -->
As titled.  Default the Partition Manager V3 at DF v3

<!-- Make sure to delete the markdown comments and the below sections when squash merging -->
### Issue describing the changes in this PR

resolves #issue_for_this_pr

### Pull request checklist

* [ ] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)
* [ ] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk
* [ ] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
    * [ ] Otherwise: major or minor version updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
* [ ] My changes **do not** add EventIds to our EventSource logs
    * [ ] Otherwise: Ensure the EventIds are within the supported range in our existing Windows infrastructure. You may validate this with a deployed app's telemetry. You may also extend the range by completing a PR such as [this one](https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files).
* [ ] My changes **should** be added to v3.x branch.
    * [ ] Otherwise: This change only applies to Durable Functions v2.x and **will not** be merged to branch v3.x.
