### PR TITLE
Produce better error message when backend does not support entities

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/LocalGrpcListener.cs
+++ b/src/WebJobs.Extensions.DurableTask/LocalGrpcListener.cs
@@ -449,7 +449,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 entityOrchestrationService = durabilityProvider;
                 if (entityOrchestrationService?.EntityBackendProperties == null)
                 {
-                    throw new NotSupportedException($"The provider '{durabilityProvider.GetBackendInfo()}' does not support entities.");
+                    throw new RpcException(new Grpc.Core.Status(
+                        Grpc.Core.StatusCode.Unimplemented,
+                        $"Missing entity support for storage backend '{durabilityProvider.GetBackendInfo()}'. Entity support" +
+                        $" may have not been implemented yet, or the selected package version is too old."));
                 }
             }
 


### PR DESCRIPTION
Previously, when calling entity client functions on a backend that does not support entities, a `NotSupportedException` was thrown. Unfortunately, the details of that exception are lost after returning to the gRPC caller context.

To fix that, we instead throw an RpcException, whose details are well visible to the caller.


### Pull request checklist

tracked in feature branch.