### PR TITLE
Call EnsureLegalAccess from EntityFeature in dotnet-isolated

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -1,5 +1,7 @@
 # Release Notes
 
+## Microsoft.Azure.Functions.Worker.Extensions.DurableTask v1.1.0-preview.1
+
 ### New Features
 
 - Updates to take advantage of new core-entity support
@@ -8,6 +10,7 @@
 ### Bug Fixes
 
 - Address input issues when using .NET isolated (#2581)[https://github.com/Azure/azure-functions-durable-extension/issues/2581]
+- No longer fail orchestrations which return before accessing the `TaskOrchestrationContext`.
 
 ### Breaking Changes
 

--- a/src/Worker.Extensions.DurableTask/FunctionsOrchestrationContext.EntityFeature.cs
+++ b/src/Worker.Extensions.DurableTask/FunctionsOrchestrationContext.EntityFeature.cs
@@ -1,0 +1,58 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading.Tasks;
+using Microsoft.DurableTask.Entities;
+
+namespace Microsoft.Azure.Functions.Worker.Extensions.DurableTask;
+
+internal sealed partial class FunctionsOrchestrationContext
+{
+    private class EntityFeature : TaskOrchestrationEntityFeature
+    {
+        private readonly FunctionsOrchestrationContext parent;
+        private readonly TaskOrchestrationEntityFeature inner;
+
+        public EntityFeature(FunctionsOrchestrationContext parent, TaskOrchestrationEntityFeature inner)
+        {
+            this.parent = parent;
+            this.inner = inner;
+        }
+
+        public override Task<TResult> CallEntityAsync<TResult>(
+            EntityInstanceId id, string operationName, object? input = null, CallEntityOptions? options = null)
+        {
+            this.parent.ThrowIfIllegalAccess();
+            return this.inner.CallEntityAsync<TResult>(id, operationName, input, options);
+        }
+
+        public override Task CallEntityAsync(
+            EntityInstanceId id, string operationName, object? input = null, CallEntityOptions? options = null)
+        {
+            this.parent.ThrowIfIllegalAccess();
+            return this.inner.CallEntityAsync(id, operationName, input, options);
+        }
+
+        public override Task SignalEntityAsync(
+            EntityInstanceId id, string operationName, object? input = null, SignalEntityOptions? options = null)
+        {
+            this.parent.ThrowIfIllegalAccess();
+            return this.inner.SignalEntityAsync(id, operationName, input, options);
+        }
+
+        public override bool InCriticalSection([NotNullWhen(true)] out IReadOnlyList<EntityInstanceId>? entityIds)
+        {
+            this.parent.ThrowIfIllegalAccess();
+            return this.inner.InCriticalSection(out entityIds);
+        }
+
+        public override Task<IAsyncDisposable> LockEntitiesAsync(IEnumerable<EntityInstanceId> entityIds)
+        {
+            this.parent.ThrowIfIllegalAccess();
+            return this.inner.LockEntitiesAsync(entityIds);
+        }
+    }
+}

--- a/src/Worker.Extensions.DurableTask/FunctionsOrchestrationContext.EntityFeature.cs
+++ b/src/Worker.Extensions.DurableTask/FunctionsOrchestrationContext.EntityFeature.cs
@@ -25,33 +25,33 @@ internal sealed partial class FunctionsOrchestrationContext
         public override Task<TResult> CallEntityAsync<TResult>(
             EntityInstanceId id, string operationName, object? input = null, CallEntityOptions? options = null)
         {
-            this.parent.ThrowIfIllegalAccess();
+            this.parent.EnsureLegalAccess();
             return this.inner.CallEntityAsync<TResult>(id, operationName, input, options);
         }
 
         public override Task CallEntityAsync(
             EntityInstanceId id, string operationName, object? input = null, CallEntityOptions? options = null)
         {
-            this.parent.ThrowIfIllegalAccess();
+            this.parent.EnsureLegalAccess();
             return this.inner.CallEntityAsync(id, operationName, input, options);
         }
 
         public override Task SignalEntityAsync(
             EntityInstanceId id, string operationName, object? input = null, SignalEntityOptions? options = null)
         {
-            this.parent.ThrowIfIllegalAccess();
+            this.parent.EnsureLegalAccess();
             return this.inner.SignalEntityAsync(id, operationName, input, options);
         }
 
         public override bool InCriticalSection([NotNullWhen(true)] out IReadOnlyList<EntityInstanceId>? entityIds)
         {
-            this.parent.ThrowIfIllegalAccess();
+            this.parent.EnsureLegalAccess();
             return this.inner.InCriticalSection(out entityIds);
         }
 
         public override Task<IAsyncDisposable> LockEntitiesAsync(IEnumerable<EntityInstanceId> entityIds)
         {
-            this.parent.ThrowIfIllegalAccess();
+            this.parent.EnsureLegalAccess();
             return this.inner.LockEntitiesAsync(entityIds);
         }
     }

--- a/src/Worker.Extensions.DurableTask/FunctionsOrchestrationContext.cs
+++ b/src/Worker.Extensions.DurableTask/FunctionsOrchestrationContext.cs
@@ -36,6 +36,8 @@ internal sealed partial class FunctionsOrchestrationContext : TaskOrchestrationC
         this.LoggerFactory = functionContext.InstanceServices.GetRequiredService<ILoggerFactory>();
     }
 
+    public bool IsAccessed { get; private set; }
+
     public override TaskName Name => this.innerContext.Name;
 
     public override string InstanceId => this.innerContext.InstanceId;
@@ -53,7 +55,7 @@ internal sealed partial class FunctionsOrchestrationContext : TaskOrchestrationC
 
     public override T GetInput<T>()
     {
-        this.ThrowIfIllegalAccess();
+        this.EnsureLegalAccess();
 
         object? input = this.innerContext.GetInput<object>();
         if (input is T typed)
@@ -71,50 +73,50 @@ internal sealed partial class FunctionsOrchestrationContext : TaskOrchestrationC
 
     public override Guid NewGuid()
     {
-        this.ThrowIfIllegalAccess();
+        this.EnsureLegalAccess();
         return this.innerContext.NewGuid();
     }
 
     public override Task<T> CallActivityAsync<T>(TaskName name, object? input = null, TaskOptions? options = null)
     {
-        this.ThrowIfIllegalAccess();
+        this.EnsureLegalAccess();
         return this.innerContext.CallActivityAsync<T>(name, input, options);
     }
 
     public override Task<TResult> CallSubOrchestratorAsync<TResult>(
         TaskName orchestratorName, object? input = null, TaskOptions? options = null)
     {
-        this.ThrowIfIllegalAccess();
+        this.EnsureLegalAccess();
         return this.innerContext.CallSubOrchestratorAsync<TResult>(orchestratorName, input, options);
     }
 
     public override void ContinueAsNew(object? newInput = null, bool preserveUnprocessedEvents = true)
     {
-        this.ThrowIfIllegalAccess();
+        this.EnsureLegalAccess();
         this.innerContext.ContinueAsNew(newInput, preserveUnprocessedEvents);
     }
 
     public override Task CreateTimer(DateTime fireAt, CancellationToken cancellationToken)
     {
-        this.ThrowIfIllegalAccess();
+        this.EnsureLegalAccess();
         return this.innerContext.CreateTimer(fireAt, cancellationToken);
     }
 
     public override void SetCustomStatus(object? customStatus)
     {
-        this.ThrowIfIllegalAccess();
+        this.EnsureLegalAccess();
         this.innerContext.SetCustomStatus(customStatus);
     }
 
     public override void SendEvent(string instanceId, string eventName, object payload)
     {
-        this.ThrowIfIllegalAccess();
+        this.EnsureLegalAccess();
         this.innerContext.SendEvent(instanceId, eventName, payload);
     }
 
     public override Task<T> WaitForExternalEvent<T>(string eventName, CancellationToken cancellationToken = default)
     {
-        this.ThrowIfIllegalAccess();
+        this.EnsureLegalAccess();
         return this.innerContext.WaitForExternalEvent<T>(eventName, cancellationToken);
     }
 
@@ -138,5 +140,14 @@ internal sealed partial class FunctionsOrchestrationContext : TaskOrchestrationC
                 throw;
             }
         }
+    }
+
+    /// <summary>
+    /// Throws if accessed by a non-orchestrator thread or marks the current object as accessed successfully.
+    /// </summary>
+    private void EnsureLegalAccess()
+    {
+        this.ThrowIfIllegalAccess();
+        this.IsAccessed = true;
     }
 }

--- a/src/Worker.Extensions.DurableTask/FunctionsOrchestrationContext.cs
+++ b/src/Worker.Extensions.DurableTask/FunctionsOrchestrationContext.cs
@@ -23,6 +23,7 @@ internal sealed partial class FunctionsOrchestrationContext : TaskOrchestrationC
     private readonly DurableTaskWorkerOptions options;
 
     private InputConverter? inputConverter;
+    private EntityFeature? entities;
 
     public FunctionsOrchestrationContext(TaskOrchestrationContext innerContext, FunctionContext functionContext)
     {
@@ -47,7 +48,8 @@ internal sealed partial class FunctionsOrchestrationContext : TaskOrchestrationC
 
     protected override ILoggerFactory LoggerFactory { get; }
 
-    public override TaskOrchestrationEntityFeature Entities => this.innerContext.Entities;
+    public override TaskOrchestrationEntityFeature Entities =>
+        this.entities ??= new EntityFeature(this, this.innerContext.Entities);
 
     public override T GetInput<T>()
     {

--- a/src/Worker.Extensions.DurableTask/FunctionsOrchestrationContext.cs
+++ b/src/Worker.Extensions.DurableTask/FunctionsOrchestrationContext.cs
@@ -35,8 +35,6 @@ internal sealed partial class FunctionsOrchestrationContext : TaskOrchestrationC
         this.LoggerFactory = functionContext.InstanceServices.GetRequiredService<ILoggerFactory>();
     }
 
-    public bool IsAccessed { get; private set; }
-
     public override TaskName Name => this.innerContext.Name;
 
     public override string InstanceId => this.innerContext.InstanceId;
@@ -53,7 +51,7 @@ internal sealed partial class FunctionsOrchestrationContext : TaskOrchestrationC
 
     public override T GetInput<T>()
     {
-        this.EnsureLegalAccess();
+        this.ThrowIfIllegalAccess();
 
         object? input = this.innerContext.GetInput<object>();
         if (input is T typed)
@@ -71,60 +69,51 @@ internal sealed partial class FunctionsOrchestrationContext : TaskOrchestrationC
 
     public override Guid NewGuid()
     {
-        this.EnsureLegalAccess();
+        this.ThrowIfIllegalAccess();
         return this.innerContext.NewGuid();
     }
 
     public override Task<T> CallActivityAsync<T>(TaskName name, object? input = null, TaskOptions? options = null)
     {
-        this.EnsureLegalAccess();
+        this.ThrowIfIllegalAccess();
         return this.innerContext.CallActivityAsync<T>(name, input, options);
     }
 
     public override Task<TResult> CallSubOrchestratorAsync<TResult>(
         TaskName orchestratorName, object? input = null, TaskOptions? options = null)
     {
-        this.EnsureLegalAccess();
+        this.ThrowIfIllegalAccess();
         return this.innerContext.CallSubOrchestratorAsync<TResult>(orchestratorName, input, options);
     }
 
     public override void ContinueAsNew(object? newInput = null, bool preserveUnprocessedEvents = true)
     {
-        this.EnsureLegalAccess();
+        this.ThrowIfIllegalAccess();
         this.innerContext.ContinueAsNew(newInput, preserveUnprocessedEvents);
     }
 
     public override Task CreateTimer(DateTime fireAt, CancellationToken cancellationToken)
     {
-        this.EnsureLegalAccess();
+        this.ThrowIfIllegalAccess();
         return this.innerContext.CreateTimer(fireAt, cancellationToken);
     }
 
     public override void SetCustomStatus(object? customStatus)
     {
-        this.EnsureLegalAccess();
+        this.ThrowIfIllegalAccess();
         this.innerContext.SetCustomStatus(customStatus);
     }
 
     public override void SendEvent(string instanceId, string eventName, object payload)
     {
-        this.EnsureLegalAccess();
+        this.ThrowIfIllegalAccess();
         this.innerContext.SendEvent(instanceId, eventName, payload);
     }
 
     public override Task<T> WaitForExternalEvent<T>(string eventName, CancellationToken cancellationToken = default)
     {
-        this.EnsureLegalAccess();
-        return this.innerContext.WaitForExternalEvent<T>(eventName, cancellationToken);
-    }
-
-    /// <summary>
-    /// Throws if accessed by a non-orchestrator thread or marks the current object as accessed successfully.
-    /// </summary>
-    private void EnsureLegalAccess()
-    {
         this.ThrowIfIllegalAccess();
-        this.IsAccessed = true;
+        return this.innerContext.WaitForExternalEvent<T>(eventName, cancellationToken);
     }
 
     internal void ThrowIfIllegalAccess()

--- a/src/Worker.Extensions.DurableTask/FunctionsOrchestrator.cs
+++ b/src/Worker.Extensions.DurableTask/FunctionsOrchestrator.cs
@@ -58,14 +58,6 @@ internal class FunctionsOrchestrator : ITaskOrchestrator
         FunctionsOrchestrationContext orchestrationContext)
     {
         Task orchestratorTask = next(functionContext);
-        if (!orchestratorTask.IsCompleted && !orchestrationContext.IsAccessed)
-        {
-            // If the middleware returns before the orchestrator function's context object was accessed and before
-            // it completes its execution, then we know that either some middleware component went async or that the
-            // orchestrator function did some illegal await as its very first action.
-            throw new InvalidOperationException(Constants.IllegalAwaitErrorMessage);
-        }
-
         await orchestratorTask;
 
         // This will throw if either the orchestrator performed an illegal await or if some middleware ahead of this

--- a/src/Worker.Extensions.DurableTask/FunctionsOrchestrator.cs
+++ b/src/Worker.Extensions.DurableTask/FunctionsOrchestrator.cs
@@ -58,6 +58,14 @@ internal class FunctionsOrchestrator : ITaskOrchestrator
         FunctionsOrchestrationContext orchestrationContext)
     {
         Task orchestratorTask = next(functionContext);
+        if (!orchestratorTask.IsCompleted && !orchestrationContext.IsAccessed)
+        {
+            // If the middleware returns before the orchestrator function's context object was accessed and before
+            // it completes its execution, then we know that either some middleware component went async or that the
+            // orchestrator function did some illegal await as its very first action.
+            throw new InvalidOperationException(Constants.IllegalAwaitErrorMessage);
+        }
+
         await orchestratorTask;
 
         // This will throw if either the orchestrator performed an illegal await or if some middleware ahead of this

--- a/src/Worker.Extensions.DurableTask/OrchestrationInputConverter.cs
+++ b/src/Worker.Extensions.DurableTask/OrchestrationInputConverter.cs
@@ -61,7 +61,7 @@ internal class OrchestrationInputConverter : IInputConverter
         // 3. The TargetType matches our cached type.
         // If these are met, then we assume this parameter is the orchestration input.
         if (context.Source is null
-            && context.FunctionContext.Items.TryGetValue(OrchestrationInputKey, out object value)
+            && context.FunctionContext.Items.TryGetValue(OrchestrationInputKey, out object? value)
             && context.TargetType == value?.GetType())
         {
             // Remove this from the items so we bind this only once.

--- a/src/Worker.Extensions.DurableTask/TaskEntityDispatcher.cs
+++ b/src/Worker.Extensions.DurableTask/TaskEntityDispatcher.cs
@@ -89,7 +89,7 @@ public sealed class TaskEntityDispatcher
 
     private class DelegateEntity : ITaskEntity
     {
-        readonly Func<TaskEntityOperation, ValueTask<object?>> handler;
+        private readonly Func<TaskEntityOperation, ValueTask<object?>> handler;
 
         public DelegateEntity(Func<TaskEntityOperation, ValueTask<object?>> handler)
         {

--- a/src/Worker.Extensions.DurableTask/Worker.Extensions.DurableTask.csproj
+++ b/src/Worker.Extensions.DurableTask/Worker.Extensions.DurableTask.csproj
@@ -30,7 +30,7 @@
 
     <!-- Version information -->
     <VersionPrefix>1.1.0</VersionPrefix>
-    <VersionSuffix>entities-preview.2</VersionSuffix>
+    <VersionSuffix>entities-preview.3</VersionSuffix>
     <AssemblyVersion>$(VersionPrefix).0</AssemblyVersion>
     <!-- FileVersionRevision is expected to be set by the CI. -->
     <FileVersion Condition="'$(FileVersionRevision)' != ''">$(VersionPrefix).$(FileVersionRevision)</FileVersion>

--- a/test/SmokeTests/OOProcSmokeTests/DotNetIsolated/Counter.cs
+++ b/test/SmokeTests/OOProcSmokeTests/DotNetIsolated/Counter.cs
@@ -103,7 +103,14 @@ public static class CounterTest
 
         logger.LogInformation($"Reading state of {entityId}...");
         var response = await client.Entities.GetEntityAsync(entityId, includeState: true);
-        logger.LogInformation($"Read state of {entityId}: {response?.SerializedState ?? "(null: entity does not exist)"}");
+        if (response?.IncludesState ?? false)
+        {
+            logger.LogInformation("Entity does not exist.");
+        }
+        else
+        {
+            logger.LogInformation("Entity state is: {State}", response!.State.Value);
+        }
 
         if (response == null)
         {
@@ -111,7 +118,7 @@ public static class CounterTest
         }
         else
         {
-            int currentValue = response.ReadStateAs<Counter>()!.CurrentValue;
+            int currentValue = response.State.ReadAs<Counter>()!.CurrentValue;
             var httpResponse = request.CreateResponse(System.Net.HttpStatusCode.OK);
             httpResponse.Headers.Add("Content-Type", "text/plain; charset=utf-8");
             httpResponse.WriteString($"{currentValue}\n");

--- a/test/SmokeTests/OOProcSmokeTests/DotNetIsolated/DotNetIsolated.csproj
+++ b/test/SmokeTests/OOProcSmokeTests/DotNetIsolated/DotNetIsolated.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.19.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.0.13" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.14.1" OutputItemType="Analyzer" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.16.0-preview2" OutputItemType="Analyzer" />
     <PackageReference Include="Microsoft.DurableTask.Generators" Version="1.0.0-preview.1" OutputItemType="Analyzer" />
   </ItemGroup>
 


### PR DESCRIPTION
<!-- Start the PR description with some context for the change. -->

Removes a check that asserts the `TaskOrchestrationContext` was accessed. It does not add much value and instead causes issues:

1. As we add extensions / extra functionality to the `TaskOrchestrationContext`, we have to ensure everything is wrapped to make the `IsAccessed=true` call. This is cumbersome.
2. An orchestration could validly have 0 work off the context and be purely computational based on its inputs, we should not block this.
    1. e.g: an orchestration could follow a branch that based on the input it decides there is 0 work to be done and just returns.

<!-- Make sure to delete the markdown comments and the below sections when squash merging -->
### Issue describing the changes in this PR

resolves #issue_for_this_pr

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)
* [x] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk
* [x] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
    * [ ] Otherwise: major or minor version updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
* [x] My changes **do not** add EventIds to our EventSource logs
    * [ ] Otherwise: Ensure the EventIds are within the supported range in our existing Windows infrastructure. You may validate this with a deployed app's telemetry. You may also extend the range by completing a PR such as [this one](https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files).
* [ ] My changes **should** be added to v3.x branch.
    * [ ] Otherwise: This change only applies to Durable Functions v2.x and **will not** be merged to branch v3.x.
