### PR TITLE
Rev package versions, update release notes

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -4,14 +4,28 @@
 
 ### New Features
 
-- Updates to take advantage of new core-entity support
-- Support entities for Isolated
+- Support entities for .NET isolated
 
 ### Bug Fixes
-
-- Address input issues when using .NET isolated (#2581)[https://github.com/Azure/azure-functions-durable-extension/issues/2581]
-- No longer fail orchestrations which return before accessing the `TaskOrchestrationContext`.
 
 ### Breaking Changes
 
 ### Dependency Updates
+
+`Microsoft.DurableTask.*` to `1.1.0-preview.1`
+
+## Microsoft.Azure.WebJobs.Extensions.DurableTask v2.12.0-preview.1
+
+### New Features
+
+- Updates to take advantage of new core-entity support
+
+### Bug Fixes
+
+### Breaking Changes
+
+### Dependency Updates
+
+`Microsoft.Azure.DurableTask.Core` to `2.16.0-preview.1`
+`Microsoft.Azure.DurableTask.AzureStorage` to `1.16.0-preview.1`
+

--- a/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
+++ b/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
@@ -7,7 +7,7 @@
     <MajorVersion>2</MajorVersion>
     <MinorVersion>12</MinorVersion>
     <PatchVersion>0</PatchVersion>
-    <Version>$(MajorVersion).$(MinorVersion).$(PatchVersion)-entities-preview.2</Version>
+    <Version>$(MajorVersion).$(MinorVersion).$(PatchVersion)-preview.1</Version>
     <FileVersion>$(MajorVersion).$(MinorVersion).$(PatchVersion)</FileVersion>
     <AssemblyVersion>$(MajorVersion).0.0.0</AssemblyVersion>
     <Company>Microsoft Corporation</Company>
@@ -99,14 +99,14 @@
     <!-- Explicitly pinned transitive dependencies with CVE vulnerabilities.-->
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets" Version="2.2.1" />
     <!-- The gRPC dependencies in this package are not compatible with older frameworks, like .NET Core 2.x -->
-    <PackageReference Include="Microsoft.DurableTask.Grpc" Version="1.1.0-entities-preview.2" />
+    <PackageReference Include="Microsoft.DurableTask.Grpc" Version="1.1.0-preview.1" />
     <PackageReference Include="Grpc.Core" Version="2.46.6" /> <!-- Bring this in until we move to hosted RPC -->
   </ItemGroup>
 
   <!-- Common dependencies across all targets -->
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.DurableTask.Core" Version="2.15.0-entities-preview.2" />
-    <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage" Version="1.16.0-entities-preview.2" />
+    <PackageReference Include="Microsoft.Azure.DurableTask.Core" Version="2.16.0-preview.1" />
+    <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage" Version="1.16.0-preview.1" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers" Version="0.5.*" />
     <!-- Build-time dependencies -->
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.*" PrivateAssets="All" />

--- a/src/Worker.Extensions.DurableTask/AssemblyInfo.cs
+++ b/src/Worker.Extensions.DurableTask/AssemblyInfo.cs
@@ -4,4 +4,4 @@
 using Microsoft.Azure.Functions.Worker.Extensions.Abstractions;
 
 // TODO: Find a way to generate this dynamically at build-time
-[assembly: ExtensionInformation("Microsoft.Azure.WebJobs.Extensions.DurableTask", "2.12.0-entities-preview.2")]
+[assembly: ExtensionInformation("Microsoft.Azure.WebJobs.Extensions.DurableTask", "2.12.0-preview.1")]

--- a/src/Worker.Extensions.DurableTask/Worker.Extensions.DurableTask.csproj
+++ b/src/Worker.Extensions.DurableTask/Worker.Extensions.DurableTask.csproj
@@ -30,17 +30,17 @@
 
     <!-- Version information -->
     <VersionPrefix>1.1.0</VersionPrefix>
-    <VersionSuffix>entities-preview.3</VersionSuffix>
+    <VersionSuffix>preview.1</VersionSuffix>
     <AssemblyVersion>$(VersionPrefix).0</AssemblyVersion>
     <!-- FileVersionRevision is expected to be set by the CI. -->
     <FileVersion Condition="'$(FileVersionRevision)' != ''">$(VersionPrefix).$(FileVersionRevision)</FileVersion>
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Core" Version="1.8.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Abstractions" Version="1.1.0" />
-    <PackageReference Include="Microsoft.DurableTask.Client.Grpc" Version="1.1.0-entities-preview.2" />
-    <PackageReference Include="Microsoft.DurableTask.Worker.Grpc" Version="1.1.0-entities-preview.2" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Core" Version="1.15.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Abstractions" Version="1.3.0" />
+    <PackageReference Include="Microsoft.DurableTask.Client.Grpc" Version="1.1.0-preview.1" />
+    <PackageReference Include="Microsoft.DurableTask.Worker.Grpc" Version="1.1.0-preview.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
<!-- Start the PR description with some context for the change. -->


<!-- Make sure to delete the markdown comments and the below sections when squash merging -->
### Issue describing the changes in this PR

resolves #issue_for_this_pr

### Pull request checklist

* [ ] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)
* [x] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk
* [ ] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
    * [x] Otherwise: major or minor version updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
* [x] My changes **do not** add EventIds to our EventSource logs
    * [ ] Otherwise: Ensure the EventIds are within the supported range in our existing Windows infrastructure. You may validate this with a deployed app's telemetry. You may also extend the range by completing a PR such as [this one](https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files).
* [ ] My changes **should** be added to v3.x branch.
    * [ ] Otherwise: This change only applies to Durable Functions v2.x and **will not** be merged to branch v3.x.
