### PR TITLE
Expose OOP invocation errors

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -1,6 +1,6 @@
 # Release Notes
 
-## Microsoft.Azure.Functions.Worker.Extensions.DurableTask v1.1.0-preview.2
+## Microsoft.Azure.Functions.Worker.Extensions.DurableTask <version>
 
 ### New Features
 
@@ -10,20 +10,15 @@
 
 ### Dependency Updates
 
-`Microsoft.DurableTask.*` to `1.1.0-preview.2`
-
-## Microsoft.Azure.WebJobs.Extensions.DurableTask v2.12.0-preview.1
+## Microsoft.Azure.WebJobs.Extensions.DurableTask <version>
 
 ### New Features
 
-- Updates to take advantage of new core-entity support
-
 ### Bug Fixes
+
+- Fix failed orchestration/entities not showing up as function invocation failures.
 
 ### Breaking Changes
 
 ### Dependency Updates
-
-`Microsoft.Azure.DurableTask.Core` to `2.16.0-preview.2`
-`Microsoft.Azure.DurableTask.AzureStorage` to `1.16.0-preview.2`
 

--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/RemoteEntityContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/RemoteEntityContext.cs
@@ -3,10 +3,8 @@
 #nullable enable
 using System;
 using System.Collections.Generic;
-using System.Reflection;
 using DurableTask.Core.Entities;
 using DurableTask.Core.Entities.OperationFormat;
-using DurableTask.Core.Exceptions;
 using Newtonsoft.Json;
 
 namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
@@ -24,7 +22,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         [JsonIgnore]
         internal EntityBatchResult? Result { get; set; }
 
-        internal void EnsureSuccess()
+        internal void ThrowIfFailed()
         {
             if (this.Result == null)
             {

--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/RemoteEntityContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/RemoteEntityContext.cs
@@ -3,6 +3,8 @@
 #nullable enable
 using System;
 using System.Collections.Generic;
+using System.Reflection;
+using DurableTask.Core.Entities;
 using DurableTask.Core.Entities.OperationFormat;
 using DurableTask.Core.Exceptions;
 using Newtonsoft.Json;
@@ -31,8 +33,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
             if (this.Result.FailureDetails is { } f)
             {
-                // TODO: use an entity specific exception type.
-                throw new OrchestrationFailureException(f.ErrorMessage);
+                throw new EntityFailureException(f.ErrorMessage);
             }
 
             List<Exception>? errors = null;
@@ -43,7 +44,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     if (result.FailureDetails is { } failure)
                     {
                         errors ??= new List<Exception>();
-                        errors.Add(new OrchestrationFailureException(failure.ErrorMessage));
+                        errors.Add(new EntityFailureException(failure.ErrorMessage));
                     }
                 }
             }

--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/RemoteOrchestratorContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/RemoteOrchestratorContext.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         [JsonIgnore]
         internal TaskOrchestrationEntityParameters? EntityParameters { get; private set; }
 
-        internal void EnsureSuccess()
+        internal void ThrowIfFailed()
         {
             if (this.failure != null)
             {

--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/RemoteOrchestratorContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/RemoteOrchestratorContext.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using DurableTask.Core;
 using DurableTask.Core.Command;
 using DurableTask.Core.Entities;
+using DurableTask.Core.Exceptions;
 using DurableTask.Core.History;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -17,6 +18,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         private readonly OrchestrationRuntimeState runtimeState;
 
         private OrchestratorExecutionResult? executionResult;
+
+        private Exception? failure;
 
         public RemoteOrchestratorContext(OrchestrationRuntimeState runtimeState, TaskOrchestrationEntityParameters? entityParameters)
         {
@@ -47,6 +50,19 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
         [JsonIgnore]
         internal TaskOrchestrationEntityParameters? EntityParameters { get; private set; }
+
+        internal void EnsureSuccess()
+        {
+            if (this.failure != null)
+            {
+                throw this.failure;
+            }
+        }
+
+        internal OrchestratorExecutionResult GetResult()
+        {
+            return this.executionResult ?? throw new InvalidOperationException($"The execution result has not yet been set using {nameof(this.SetResult)}.");
+        }
 
         internal void SetResult(IEnumerable<OrchestratorAction> actions, string customStatus)
         {
@@ -107,16 +123,24 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     this.OrchestratorCompleted = true;
                     this.SerializedOutput = completeAction.Result;
                     this.ContinuedAsNew = completeAction.OrchestrationStatus == OrchestrationStatus.ContinuedAsNew;
+
+                    if (completeAction.OrchestrationStatus == OrchestrationStatus.Failed)
+                    {
+                        string message = completeAction switch
+                        {
+                            { FailureDetails: { } f } => f.ErrorMessage,
+                            { Result: { } r } => r,
+                            _ => "Exception occurred during orchestration execution.",
+                        };
+
+                        this.failure = new OrchestrationFailureException(message);
+                    }
+
                     break;
                 }
             }
 
             this.executionResult = result;
-        }
-
-        internal OrchestratorExecutionResult GetResult()
-        {
-            return this.executionResult ?? throw new InvalidOperationException($"The execution result has not yet been set using {nameof(this.SetResult)}.");
         }
     }
 }

--- a/src/WebJobs.Extensions.DurableTask/Exceptions/EntityFailureException.cs
+++ b/src/WebJobs.Extensions.DurableTask/Exceptions/EntityFailureException.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+
+// TODO: move to DurableTask.Core if needed.
+namespace DurableTask.Core.Entities
+{
+    internal class EntityFailureException : Exception
+    {
+        public EntityFailureException(string message)
+            : base(message)
+        {
+        }
+    }
+}

--- a/src/WebJobs.Extensions.DurableTask/OutOfProcMiddleware.cs
+++ b/src/WebJobs.Extensions.DurableTask/OutOfProcMiddleware.cs
@@ -142,7 +142,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                         response.Actions.Select(ProtobufUtils.ToOrchestratorAction),
                         response.CustomStatus);
 
-                    context.EnsureSuccess();
+                    context.ThrowIfFailed();
                 },
 #pragma warning restore CS0618 // Type or member is obsolete (not intended for general public use)
             };
@@ -331,7 +331,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     P.EntityBatchResult response = P.EntityBatchResult.Parser.ParseFrom(triggerReturnValueBytes);
                     context.Result = response.ToEntityBatchResult();
 
-                    context.EnsureSuccess();
+                    context.ThrowIfFailed();
 #pragma warning restore CS0618 // Type or member is obsolete (not intended for general public use)
                 },
             };

--- a/src/WebJobs.Extensions.DurableTask/OutOfProcMiddleware.cs
+++ b/src/WebJobs.Extensions.DurableTask/OutOfProcMiddleware.cs
@@ -14,7 +14,7 @@ using DurableTask.Core.Exceptions;
 using DurableTask.Core.History;
 using DurableTask.Core.Middleware;
 using Microsoft.Azure.WebJobs.Host.Executors;
-using Newtonsoft.Json;
+using P = Microsoft.DurableTask.Protobuf;
 
 namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 {
@@ -137,10 +137,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     }
 
                     byte[] triggerReturnValueBytes = Convert.FromBase64String(triggerReturnValue);
-                    var response = Microsoft.DurableTask.Protobuf.OrchestratorResponse.Parser.ParseFrom(triggerReturnValueBytes);
+                    P.OrchestratorResponse response = P.OrchestratorResponse.Parser.ParseFrom(triggerReturnValueBytes);
                     context.SetResult(
                         response.Actions.Select(ProtobufUtils.ToOrchestratorAction),
                         response.CustomStatus);
+
+                    context.EnsureSuccess();
                 },
 #pragma warning restore CS0618 // Type or member is obsolete (not intended for general public use)
             };
@@ -326,9 +328,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     }
 
                     byte[] triggerReturnValueBytes = Convert.FromBase64String(triggerReturnValue);
-                    var response = Microsoft.DurableTask.Protobuf.EntityBatchResult.Parser.ParseFrom(triggerReturnValueBytes);
+                    P.EntityBatchResult response = P.EntityBatchResult.Parser.ParseFrom(triggerReturnValueBytes);
                     context.Result = response.ToEntityBatchResult();
 
+                    context.EnsureSuccess();
 #pragma warning restore CS0618 // Type or member is obsolete (not intended for general public use)
                 },
             };


### PR DESCRIPTION
<!-- Start the PR description with some context for the change. -->

This PR fixes an issue with failed orchestrations and entities not showing up as "failed" in telemetry.

<!-- Make sure to delete the markdown comments and the below sections when squash merging -->
### Issue describing the changes in this PR

resolves #2595

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)
* [x] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk
* [x] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
    * [ ] Otherwise: major or minor version updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
* [x] My changes **do not** add EventIds to our EventSource logs
    * [ ] Otherwise: Ensure the EventIds are within the supported range in our existing Windows infrastructure. You may validate this with a deployed app's telemetry. You may also extend the range by completing a PR such as [this one](https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files).
* [x] My changes **should** be added to v3.x branch.
    * [ ] Otherwise: This change only applies to Durable Functions v2.x and **will not** be merged to branch v3.x.
