### PR TITLE
Fix unintentional input unwrapping for OOP workers

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -1,6 +1,6 @@
 # Release Notes
 
-## Microsoft.Azure.Functions.Worker.Extensions.DurableTask v1.1.0-preview.2
+## Microsoft.Azure.Functions.Worker.Extensions.DurableTask <version>
 
 ### New Features
 
@@ -10,20 +10,14 @@
 
 ### Dependency Updates
 
-`Microsoft.DurableTask.*` to `1.1.0-preview.2`
-
-## Microsoft.Azure.WebJobs.Extensions.DurableTask v2.12.0-preview.1
+## Microsoft.Azure.WebJobs.Extensions.DurableTask <version>
 
 ### New Features
 
-- Updates to take advantage of new core-entity support
-
 ### Bug Fixes
+
+- Fix issue where json token input (not a json object) was unwrapped before sending to an out-of-proc worker. This could then lead to deserialization issues as the wrapping quotes were missing.
 
 ### Breaking Changes
 
 ### Dependency Updates
-
-`Microsoft.Azure.DurableTask.Core` to `2.16.0-preview.2`
-`Microsoft.Azure.DurableTask.AzureStorage` to `1.16.0-preview.2`
-

--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableActivityContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableActivityContext.cs
@@ -15,19 +15,18 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         DurableActivityContextBase // for v1 legacy compatibility.
 #pragma warning restore 618
     {
-        private readonly bool isOutOfProc;
         private readonly string functionName;
         private readonly string serializedInput;
         private readonly string instanceId;
         private readonly MessagePayloadDataConverter messageDataConverter;
         private readonly bool inputsAreArrays;
+        private readonly bool rawInput;
 
         private JToken parsedJsonInput;
         private string serializedOutput;
 
         internal DurableActivityContext(DurableTaskExtension config, string instanceId, string serializedInput, string functionName)
         {
-            this.isOutOfProc = config.PlatformInformationService.GetWorkerRuntimeType() != WorkerRuntimeType.DotNet;
             this.messageDataConverter = config.MessageDataConverter;
             this.instanceId = instanceId;
             this.serializedInput = serializedInput;
@@ -37,6 +36,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             this.inputsAreArrays =
                 config.OutOfProcProtocol == OutOfProcOrchestrationProtocol.OrchestratorShim ||
                 config.PlatformInformationService.GetWorkerRuntimeType() == WorkerRuntimeType.DotNetIsolated;
+
+            // Do not manipulate JSON input when using middleware passthrough.
+            this.rawInput = config.OutOfProcProtocol == OutOfProcOrchestrationProtocol.MiddlewarePassthrough;
         }
 
         /// <inheritdoc />
@@ -118,7 +120,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 return null;
             }
 
-            if (!this.isOutOfProc && jToken is JValue value)
+            if (!this.rawInput && jToken is JValue value)
             {
                 return value.ToObject(destinationType);
             }
@@ -130,7 +132,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             // MessagePayloadDataConverter to throw an exception. This is a workaround for that case. All other
             // inputs with destination System.String (in-proc: JSON and not JSON; out-of-proc: not-JSON) inputs with
             // destination System.String should cast to JValues and be handled above.)
-            if (this.isOutOfProc)
+            if (this.rawInput)
             {
                 return serializedValue;
             }


### PR DESCRIPTION
<!-- Start the PR description with some context for the change. -->

This PR fixes an issue where when dispatching JToken values to an out-of-proc worker, we would unwrap the serialized contents, thus causing serialization to fail.

<!-- Make sure to delete the markdown comments and the below sections when squash merging -->
### Issue describing the changes in this PR

resolves #2504, https://github.com/microsoft/durabletask-dotnet/issues/199

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)
* [ ] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk
* [x] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
    * [ ] Otherwise: major or minor version updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
* [x] My changes **do not** add EventIds to our EventSource logs
    * [ ] Otherwise: Ensure the EventIds are within the supported range in our existing Windows infrastructure. You may validate this with a deployed app's telemetry. You may also extend the range by completing a PR such as [this one](https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files).
* [x] My changes **should** be added to v3.x branch.
    * [ ] Otherwise: This change only applies to Durable Functions v2.x and **will not** be merged to branch v3.x.
