### PR TITLE
add vuln check in pipeline and resolve package warnings

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -31,6 +31,7 @@ jobs:
         nugetConfigPath: 'nuget.config'
 
     - task: PowerShell@2
+      displayName: 'Check for vulnerabilities'
       inputs:
         targetType: 'inline'
         script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,6 +30,28 @@ jobs:
         feedsToUse: 'config'
         nugetConfigPath: 'nuget.config'
 
+    - task: PowerShell@2
+      inputs:
+        targetType: 'inline'
+        script: |
+          # Check for vulnerabilities.
+          $logFile = "output.txt"
+          dotnet list package --vulnerable > $logFile
+
+          # report if vulnerabilities are found
+          $report = Get-Content $logFile -Raw
+          $hasNoVulnerabilities = $report | Select-String "has no vulnerable packages given the current sources"
+
+          if ($hasNoVulnerabilities)
+          {
+              Write-Host "No vulnerabilities found"
+          }
+          else {
+              Write-Host "Some dependencies have known vulnerabilities!"
+              Write-Host "Please run `dotnet list package --vulnerable` locally to see the list of reported vulnerabilities"
+              exit 1 # terminate pipeline
+          }
+
     - task: DotNetCoreCLI@2
       inputs:
         command: 'build'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -40,13 +40,10 @@ jobs:
 
           # report if vulnerabilities are found
           $report = Get-Content $logFile -Raw
-          $hasNoVulnerabilities = $report | Select-String "has no vulnerable packages given the current sources"
+          $hasVulnerabilities = $report | Select-String "has the following vulnerable packages"
 
-          if ($hasNoVulnerabilities)
+          if ($hasVulnerabilities)
           {
-              Write-Host "No vulnerabilities found"
-          }
-          else {
               Write-Host "Some dependencies have known vulnerabilities!"
               Write-Host "Please run `dotnet list package --vulnerable` locally to see the list of reported vulnerabilities"
               exit 1 # terminate pipeline

--- a/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
+++ b/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
@@ -67,7 +67,7 @@
     <DocumentationFile>$(AssemblyName).xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="Azure.Identity" Version="1.5.0" />
+    <PackageReference Include="Azure.Identity" Version="1.10.2" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.31" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.WebApiCompatShim" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Routing" Version="2.2.0" />
@@ -88,7 +88,7 @@
     <DefineConstants>$(DefineConstants);FUNCTIONS_V2_OR_GREATER;FUNCTIONS_V3_OR_GREATER</DefineConstants>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
-    <PackageReference Include="Azure.Identity" Version="1.5.0" />
+    <PackageReference Include="Azure.Identity" Version="1.10.2" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.37" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.WebApiCompatShim" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Routing" Version="2.2.0" />

--- a/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
+++ b/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
@@ -49,7 +49,7 @@
     <Compile Include="**/*.cs" Exclude="Auth/*.cs;Correlation/*.cs;**/obj/**/*.cs" />
     <!-- Don't increase below versions without significantly testing on Functions V1!
          Increasing these versions increments some dependencies that have binding redirects in Functions V1. -->
-    <PackageReference Include="Azure.Identity" Version="1.1.1" />
+    <PackageReference Include="Azure.Identity" Version="1.10.2" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="2.3.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="1.0.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="1.0.2" />

--- a/test/SmokeTests/SmokeTestsV1/VSSampleV1.csproj
+++ b/test/SmokeTests/SmokeTestsV1/VSSampleV1.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.30" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="2.3.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">


### PR DESCRIPTION
Added a step in our pipeline to scan for _actionable_ vulnerabilities in our dependencies (i.e vulnerabilities fixed in a new release of the package) and block the PR if any are found.
Also updated our `Azure.Identity` dependency to respond to one such warning. Also updated one of our **sample** dependencies on `Newtonsoft.JSON` for the same reason.