### PR TITLE
Add a nightly release pipeline

### DIFF
--- a/azure-pipelines-release-nightly.yml
+++ b/azure-pipelines-release-nightly.yml
@@ -7,7 +7,7 @@ schedules:
   displayName: Daily midnight build
   branches:
     include:
-    - dev
+    - dajusto/add-nightly-release
 
 trigger: none
 pr: none

--- a/azure-pipelines-release-nightly.yml
+++ b/azure-pipelines-release-nightly.yml
@@ -1,13 +1,12 @@
-# This is a copy of azure-pieplines-release.yml except that it triggers nightly.
+# This is a copy of azure-pipelines-release.yml except that it triggers nightly.
 # We want a copy so we can distinguish between nightly artifacts (which may trigger nightly perf tests) and artifacts built on-demand
 
-# YAML file in the main branch
 schedules:
-- cron: '0 0 * * *'
-  displayName: Daily midnight build
+- cron: '0 8 * * *'
+  displayName: Daily midnight (PDT) build
   branches:
     include:
-    - dajusto/add-nightly-release
+    - dev
 
 trigger: none
 pr: none

--- a/azure-pipelines-release-nightly.yml
+++ b/azure-pipelines-release-nightly.yml
@@ -7,7 +7,7 @@ schedules:
   displayName: Daily midnight build
   branches:
     include:
-    - main
+    - dev
 
 trigger: none
 pr: none

--- a/azure-pipelines-release-nightly.yml
+++ b/azure-pipelines-release-nightly.yml
@@ -1,0 +1,177 @@
+# This is a copy of azure-pieplines-release.yml except that it triggers nightly.
+# We want a copy so we can distinguish between nightly artifacts (which may trigger nightly perf tests) and artifacts built on-demand
+
+# YAML file in the main branch
+schedules:
+- cron: '0 0 * * *'
+  displayName: Daily midnight build
+  branches:
+    include:
+    - main
+
+trigger: none
+pr: none
+
+pool:
+  name: '1ES-Hosted-DurableTaskFramework'
+  demands:
+    - ImageOverride -equals MMS2022TLS
+
+steps:
+
+# Configure all the .NET SDK versions we need
+- task: UseDotNet@2
+  displayName: 'Use the .NET Core 2.1 SDK (required for build signing)'
+  inputs:
+    packageType: 'sdk'
+    version: '2.1.x'
+
+- task: UseDotNet@2
+  displayName: 'Use the .NET Core 3.1 SDK'
+  inputs:
+    packageType: 'sdk'
+    version: '3.1.x'
+
+- task: UseDotNet@2
+  displayName: 'Use the .NET 6 SDK'
+  inputs:
+    packageType: 'sdk'
+    version: '6.0.x'
+
+# Use NuGet
+- task: NuGetToolInstaller@1
+  displayName: 'Use NuGet '
+
+# dotnet restore
+- task: DotNetCoreCLI@2
+  displayName: 'dotnet restore'
+  inputs:
+    command: restore
+    projects: '**/**/*.csproj'
+    feedsToUse: config
+    nugetConfigPath: 'nuget.config'
+
+# Build durable-extension
+- task: VSBuild@1
+  displayName: 'Build Durable Extension'
+  inputs:
+    solution: '**/WebJobs.Extensions.DurableTask.sln'
+    vsVersion: "16.0"
+    configuration: Release
+
+# Authenticode sign all the DLLs with the Microsoft certificate.
+- task: EsrpCodeSigning@1
+  inputs:
+    ConnectedServiceName: 'ESRP Service'
+    FolderPath: 'src/WebJobs.Extensions.DurableTask/bin/Release'
+    Pattern: '*DurableTask.dll'
+    signConfigType: 'inlineSignParams'
+    inlineOperation: |
+      [    
+          {
+            "KeyCode": "CP-230012",
+            "OperationCode": "SigntoolSign",
+            "Parameters": {
+              "OpusName": "Microsoft",
+              "OpusInfo": "http://www.microsoft.com",
+              "FileDigest": "/fd \"SHA256\"",
+              "PageHash": "/NPH",
+              "TimeStamp": "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
+            },
+            "ToolName": "sign",
+            "ToolVersion": "1.0"
+          },
+          {
+            "KeyCode": "CP-230012",
+            "OperationCode": "SigntoolVerify",
+            "Parameters": {},
+            "ToolName": "sign",
+            "ToolVersion": "1.0"
+          }
+      ]
+    SessionTimeout: '60'
+    MaxConcurrency: '50'
+    MaxRetryAttempts: '5'
+
+# SBOM generator task for additional supply chain protection
+- task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
+  displayName: 'Manifest Generator '
+  inputs:
+    BuildDropPath: '$(System.DefaultWorkingDirectory)'
+
+# dotnet pack
+# Packaging needs to be a separate step from build.
+# This will automatically pick up the signed DLLs.
+- task: DotNetCoreCLI@2
+  displayName: 'dotnet pack WebJobs.Extensions.DurableTask.csproj'
+  inputs:
+    command: pack
+    packagesToPack: 'src/**/WebJobs.Extensions.DurableTask.csproj'
+    configuration: Release
+    packDirectory: 'azure-functions-durable-extension'
+    nobuild: true
+
+# Remove redundant symbol package(s)
+- script: |
+   echo *** Searching for .symbols.nupkg files to delete...
+   dir /s /b *.symbols.nupkg
+   
+   echo *** Deleting .symbols.nupkg files...
+   del /S /Q *.symbols.nupkg
+   
+   echo *** Listing remaining packages
+   dir /s /b *.nupkg
+  displayName: 'Remove Redundant Symbols Package(s)'
+  continueOnError: true
+
+# Digitally sign all the nuget packages with the Microsoft certificate.
+# This appears to be an in-place signing job, which is convenient.
+- task: EsrpCodeSigning@1
+  inputs:
+    ConnectedServiceName: 'ESRP Service'
+    FolderPath: '$(System.DefaultWorkingDirectory)'
+    Pattern: '*.nupkg'
+    signConfigType: 'inlineSignParams'
+    inlineOperation: |
+      [    
+          {
+            "KeyCode": "CP-401405",
+            "OperationCode": "NuGetSign",
+            "Parameters": {},
+            "ToolName": "sign",
+            "ToolVersion": "1.0"
+          },
+          {
+            "KeyCode": "CP-401405",
+            "OperationCode": "NuGetVerify",
+            "Parameters": {},
+            "ToolName": "sign",
+            "ToolVersion": "1.0"
+          }
+      ]
+    SessionTimeout: '60'
+    MaxConcurrency: '50'
+    MaxRetryAttempts: '5'
+
+# zip .NET in-proc perf tests
+- task: DotNetCoreCLI@2
+  displayName: 'Zip .NET in-proc perf tests'
+  inputs:
+    command: 'publish'
+    publishWebProjects: false
+    projects: '$(System.DefaultWorkingDirectory)/test/PerfTests/DFPerfTests/**/*.csproj'
+    arguments: '-o $(System.DefaultWorkingDirectory)/test/PerfTests/DFPerfTests/Output'
+    zipAfterPublish: true
+    modifyOutputPath: true
+
+# Move zip'ed .NET in-proc perf tests to the ADO publishing directory
+- task: CopyFiles@2
+  inputs:
+    SourceFolder: '$(System.DefaultWorkingDirectory)/test/PerfTests/DFPerfTests/Output/'
+    Contents: '**'
+    TargetFolder: '$(System.DefaultWorkingDirectory)/azure-functions-durable-extension/'
+
+# Make the nuget packages available for download in the ADO portal UI
+- publish: '$(System.DefaultWorkingDirectory)/azure-functions-durable-extension'
+  displayName: 'Publish nuget packages to Artifacts'
+  artifact: PackageOutput


### PR DESCRIPTION
This is a follow up to: https://github.com/Azure/azure-functions-durable-extension/pull/2694

In this PR, I make a copy of the "Release Extension 2.x" pipeline that triggers **nightly** **iff** there's any new code merged in `dev`. If we incorporate this pipeline, we should be able to create automation that runs e2e perf tests on the same night as new code is merged into the `dev` branch. That should help us catch performance regressions faster.

Additionally, this also paves the way for potentially created a nightly package on ADO, which may have its own servicing wins. That said, this PR is primarily for E2E testing automation.  