### PR TITLE
Add ActivityInputConverter

### DIFF
--- a/src/Worker.Extensions.DurableTask/ActivityInputConverter.cs
+++ b/src/Worker.Extensions.DurableTask/ActivityInputConverter.cs
@@ -25,6 +25,11 @@ internal class ActivityInputConverter : IInputConverter
             throw new ArgumentNullException(nameof(context));
         }
 
+        if (context.Source is null)
+        {
+            return new(ConversionResult.Success(null));
+        }
+
         if (context.Source is not string source)
         {
             throw new InvalidOperationException($"Expected converter source to be a string, received {context.Source?.GetType()}.");

--- a/src/Worker.Extensions.DurableTask/ActivityInputConverter.cs
+++ b/src/Worker.Extensions.DurableTask/ActivityInputConverter.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.Azure.Functions.Worker.Converters;
+using Microsoft.DurableTask.Worker;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.Azure.Functions.Worker.Extensions.DurableTask;
+
+internal class ActivityInputConverter : IInputConverter
+{
+    private readonly DurableTaskWorkerOptions options;
+
+    public ActivityInputConverter(IOptions<DurableTaskWorkerOptions> options)
+    {
+        this.options = options?.Value ?? throw new ArgumentNullException(nameof(options));
+    }
+
+    public ValueTask<ConversionResult> ConvertAsync(ConverterContext context)
+    {
+        if (context is null)
+        {
+            throw new ArgumentNullException(nameof(context));
+        }
+
+        if (context.Source is not string source)
+        {
+            throw new InvalidOperationException($"Expected converter source to be a string, received {context.Source?.GetType()}.");
+        }
+
+        object? value = this.options.DataConverter.Deserialize(source, context.TargetType);
+        return new(ConversionResult.Success(value));
+    }
+}

--- a/src/Worker.Extensions.DurableTask/ActivityTriggerAttribute.cs
+++ b/src/Worker.Extensions.DurableTask/ActivityTriggerAttribute.cs
@@ -3,7 +3,9 @@
 
 using System;
 using System.Diagnostics;
+using Microsoft.Azure.Functions.Worker.Converters;
 using Microsoft.Azure.Functions.Worker.Extensions.Abstractions;
+using Microsoft.Azure.Functions.Worker.Extensions.DurableTask;
 
 namespace Microsoft.Azure.Functions.Worker;
 
@@ -12,6 +14,8 @@ namespace Microsoft.Azure.Functions.Worker;
 /// </summary>
 [AttributeUsage(AttributeTargets.Parameter)]
 [DebuggerDisplay("{Activity}")]
+[InputConverter(typeof(ActivityInputConverter))]
+[ConverterFallbackBehavior(ConverterFallbackBehavior.Disallow)]
 public sealed class ActivityTriggerAttribute : TriggerBindingAttribute
 {
     /// <summary>

--- a/src/Worker.Extensions.DurableTask/DurableClientAttribute.cs
+++ b/src/Worker.Extensions.DurableTask/DurableClientAttribute.cs
@@ -1,13 +1,17 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using Microsoft.Azure.Functions.Worker.Converters;
 using Microsoft.Azure.Functions.Worker.Extensions.Abstractions;
+using Microsoft.Azure.Functions.Worker.Extensions.DurableTask;
 
 namespace Microsoft.Azure.Functions.Worker;
 
 /// <summary>
 /// Azure Functions attribute for binding a function parameter to a Durable Task client object.
 /// </summary>
+[InputConverter(typeof(DurableTaskClientConverter))]
+[ConverterFallbackBehavior(ConverterFallbackBehavior.Disallow)]
 public sealed class DurableClientAttribute : InputBindingAttribute
 {
     /// <summary>

--- a/src/Worker.Extensions.DurableTask/DurableTaskExtensionStartup.cs
+++ b/src/Worker.Extensions.DurableTask/DurableTaskExtensionStartup.cs
@@ -58,7 +58,6 @@ public sealed class DurableTaskExtensionStartup : WorkerExtensionStartup
 
         applicationBuilder.Services.Configure<WorkerOptions>(o =>
         {
-            o.InputConverters.RegisterAt<DurableTaskClientConverter>(0);
             o.InputConverters.Register<OrchestrationInputConverter>();
         });
 

--- a/src/Worker.Extensions.DurableTask/HTTP/HttpHeadersConverter.cs
+++ b/src/Worker.Extensions.DurableTask/HTTP/HttpHeadersConverter.cs
@@ -28,7 +28,7 @@ internal class HttpHeadersConverter : JsonConverter<IDictionary<string, StringVa
         var valueList = new List<string>();
         while (reader.Read() && reader.TokenType != JsonTokenType.EndObject)
         {
-            string? propertyName = reader.GetString();
+            string propertyName = reader.GetString()!;
 
             reader.Read();
 
@@ -42,7 +42,7 @@ internal class HttpHeadersConverter : JsonConverter<IDictionary<string, StringVa
             {
                 while (reader.Read() && reader.TokenType != JsonTokenType.EndArray)
                 {
-                    valueList.Add(reader.GetString());
+                    valueList.Add(reader.GetString()!);
                 }
 
                 values = new StringValues(valueList.ToArray());
@@ -62,8 +62,7 @@ internal class HttpHeadersConverter : JsonConverter<IDictionary<string, StringVa
     {
         writer.WriteStartObject();
 
-        var headers = (IDictionary<string, StringValues>)value;
-        foreach (var pair in headers)
+        foreach (KeyValuePair<string, StringValues> pair in value)
         {
             if (pair.Value.Count == 1)
             {

--- a/src/Worker.Extensions.DurableTask/Worker.Extensions.DurableTask.csproj
+++ b/src/Worker.Extensions.DurableTask/Worker.Extensions.DurableTask.csproj
@@ -37,7 +37,7 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Core" Version="1.15.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Core" Version="1.16.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Abstractions" Version="1.3.0" />
     <PackageReference Include="Microsoft.DurableTask.Client.Grpc" Version="1.1.0" />
     <PackageReference Include="Microsoft.DurableTask.Worker.Grpc" Version="1.1.0" />


### PR DESCRIPTION
<!-- Start the PR description with some context for the change. -->

This PR adds an explicit `ActivityInputConverter` to work around the default Functions converter we were relying on.  Specifically, the default converter special cases a few types (such as string) which we do not want. Adding this converter also has the added benefit of ensuring consistency between orchestrations and activity deserialization.

Another change is to register `DurableTaskClientConverter` directly on `DurableClientAttribute` via `InputConverterAttribute` (this was not available when we first wrote this converter).

<!-- Make sure to delete the markdown comments and the below sections when squash merging -->
### Issue describing the changes in this PR

resolves #2674

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)
* [x] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk
* [x] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
    * [ ] Otherwise: major or minor version updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
* [x] My changes **do not** add EventIds to our EventSource logs
    * [ ] Otherwise: Ensure the EventIds are within the supported range in our existing Windows infrastructure. You may validate this with a deployed app's telemetry. You may also extend the range by completing a PR such as [this one](https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files).
* [x] My changes **should** be added to v3.x branch.
    * [ ] Otherwise: This change only applies to Durable Functions v2.x and **will not** be merged to branch v3.x.
