### PR TITLE
automatically generate version suffixes

### DIFF
--- a/azure-pipelines-release-nightly.yml
+++ b/azure-pipelines-release-nightly.yml
@@ -17,18 +17,14 @@ pool:
     - ImageOverride -equals MMS2022TLS
 
 variables:
-  PackageSuffix: ''
+
+  - name: PackageSuffix
+    ${{ if ne(variables['Build.SourceBranchName'], 'dev') }}:
+      value: 'ci.$(Build.BuildNumber)' # the "ci" section is to denote this payload is automatically released by the CI
+    ${{ else }}:
+      value: ''
 
 steps:
-
-- task: PowerShell@2
-  displayName: 'Populate PackageSuffix'
-  inputs:
-    targetType: 'inline'
-    script: |
-      # the "ci" section is to denote this payload is automatically released by the CI
-      $versionSuffix = "ci.$(Build.BuildNumber)""
-      Write-Host "##vso[task.setvariable variable=PackageSuffix;]$versionSuffix"
 
 # Configure all the .NET SDK versions we need
 - task: UseDotNet@2

--- a/azure-pipelines-release-nightly.yml
+++ b/azure-pipelines-release-nightly.yml
@@ -16,7 +16,19 @@ pool:
   demands:
     - ImageOverride -equals MMS2022TLS
 
+variables:
+  PackageSuffix: ''
+
 steps:
+
+- task: PowerShell@2
+  displayName: 'Populate PackageSuffix'
+  inputs:
+    targetType: 'inline'
+    script: |
+      # the "ci" section is to denote this payload is automatically released by the CI
+      $versionSuffix = ".ci.$(Build.BuildNumber)""
+      Write-Host "##vso[task.setvariable variable=PackageSuffix;]$versionSuffix"
 
 # Configure all the .NET SDK versions we need
 - task: UseDotNet@2

--- a/azure-pipelines-release-nightly.yml
+++ b/azure-pipelines-release-nightly.yml
@@ -27,7 +27,7 @@ steps:
     targetType: 'inline'
     script: |
       # the "ci" section is to denote this payload is automatically released by the CI
-      $versionSuffix = ".ci.$(Build.BuildNumber)""
+      $versionSuffix = "ci.$(Build.BuildNumber)""
       Write-Host "##vso[task.setvariable variable=PackageSuffix;]$versionSuffix"
 
 # Configure all the .NET SDK versions we need

--- a/azure-pipelines-release-nightly.yml
+++ b/azure-pipelines-release-nightly.yml
@@ -19,11 +19,7 @@ pool:
 variables:
 
   - name: PackageSuffix
-    ${{ if ne(variables['Build.SourceBranchName'], 'dev') }}:
       value: 'ci.$(Build.BuildNumber)' # the "ci" section is to denote this payload is automatically released by the CI
-    ${{ else }}:
-      value: ''
-
 steps:
 
 # Configure all the .NET SDK versions we need

--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -6,7 +6,23 @@ pool:
   demands:
     - ImageOverride -equals MMS2022TLS
 
+variables:
+  PackageSuffix: ''
+
 steps:
+
+- task: PowerShell@2
+  displayName: 'Populate PackageSuffix iff source branch is not dev'
+  inputs:
+    targetType: 'inline'
+    script: |
+      # if source branch is not `dev` then we're generating a release based on a feature branch
+      # In that case, we populate the environment variable "PackageSuffix" accordingly
+      if($Env:BUILD_SOURCEBRANCHNAME -ne 'dev'){
+        # the "pr" section is to denote this code is a candidate to be PR'ed
+        $versionSuffix = "pr.$(Build.BuildNumber)"
+        Write-Host "##vso[task.setvariable variable=PackageSuffix;]$versionSuffix"
+      }
 
 # Configure all the .NET SDK versions we need
 - task: UseDotNet@2

--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -7,22 +7,17 @@ pool:
     - ImageOverride -equals MMS2022TLS
 
 variables:
-  PackageSuffix: ''
+
+  - name: PackageSuffix
+    # if source branch is not `dev` then we're generating a release based on a feature branch
+    # In that case, we populate the environment variable "PackageSuffix" accordingly
+    ${{ if ne(variables['Build.SourceBranchName'], 'dev') }}:
+      value: 'pr.$(Build.BuildNumber)' # the "pr" section is to denote this code is a candidate to be PR'ed
+    ${{ else }}:
+      value: ''
+
 
 steps:
-
-- task: PowerShell@2
-  displayName: 'Populate PackageSuffix iff source branch is not dev'
-  inputs:
-    targetType: 'inline'
-    script: |
-      # if source branch is not `dev` then we're generating a release based on a feature branch
-      # In that case, we populate the environment variable "PackageSuffix" accordingly
-      if($Env:BUILD_SOURCEBRANCHNAME -ne 'dev'){
-        # the "pr" section is to denote this code is a candidate to be PR'ed
-        $versionSuffix = "pr.$(Build.BuildNumber)"
-        Write-Host "##vso[task.setvariable variable=PackageSuffix;]$versionSuffix"
-      }
 
 # Configure all the .NET SDK versions we need
 - task: UseDotNet@2

--- a/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
+++ b/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
@@ -7,8 +7,6 @@
     <MajorVersion>2</MajorVersion>
     <MinorVersion>13</MinorVersion>
     <PatchVersion>1</PatchVersion>
-    <Version>$(MajorVersion).$(MinorVersion).$(PatchVersion)</Version>
-    <FileVersion>$(MajorVersion).$(MinorVersion).$(PatchVersion)</FileVersion>
     <AssemblyVersion>$(MajorVersion).0.0.0</AssemblyVersion>
     <Company>Microsoft Corporation</Company>
     <LangVersion>9.0</LangVersion>
@@ -20,6 +18,16 @@
     <!-- See https://github.com/Azure/azure-functions-durable-extension/issues/1433 -->
     <NoWarn>NU5125;SA0001</NoWarn>
   </PropertyGroup>
+
+  <PropertyGroup Condition="$(VersionSuffix) == ''">
+    <Version>$(MajorVersion).$(MinorVersion).$(PatchVersion)</Version>
+    <FileVersion>$(MajorVersion).$(MinorVersion).$(PatchVersion)</FileVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition="$(VersionSuffix) != ''">
+    <Version>$(MajorVersion).$(MinorVersion).$(PatchVersion)-$(VersionSuffix)</Version>
+    <FileVersion>$(MajorVersion).$(MinorVersion).$(PatchVersion)-$(VersionSuffix)</FileVersion>
+  </PropertyGroup>
+
 
   <!-- NuGet Publishing Metadata -->
   <PropertyGroup>

--- a/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
+++ b/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
@@ -7,6 +7,8 @@
     <MajorVersion>2</MajorVersion>
     <MinorVersion>13</MinorVersion>
     <PatchVersion>1</PatchVersion>
+    <VersionSuffix>$(PackageSuffix)</VersionSuffix>
+    <FileVersion>$(MajorVersion).$(MinorVersion).$(PatchVersion)</FileVersion>
     <AssemblyVersion>$(MajorVersion).0.0.0</AssemblyVersion>
     <Company>Microsoft Corporation</Company>
     <LangVersion>9.0</LangVersion>
@@ -21,11 +23,9 @@
 
   <PropertyGroup Condition="$(VersionSuffix) == ''">
     <Version>$(MajorVersion).$(MinorVersion).$(PatchVersion)</Version>
-    <FileVersion>$(MajorVersion).$(MinorVersion).$(PatchVersion)</FileVersion>
   </PropertyGroup>
   <PropertyGroup Condition="$(VersionSuffix) != ''">
     <Version>$(MajorVersion).$(MinorVersion).$(PatchVersion)-$(VersionSuffix)</Version>
-    <FileVersion>$(MajorVersion).$(MinorVersion).$(PatchVersion)-$(VersionSuffix)</FileVersion>
   </PropertyGroup>
 
 


### PR DESCRIPTION
Replaces: https://github.com/Azure/azure-functions-durable-extension/pull/2707

When making a private extension release, we manually add a version suffix to the package so that it can be distinguished from an official release.

This PR automates that process in 2 ways:

(1) the CI automatically adds a version suffix when the standard/manual release pipeline is triggered in a feature branch. The version suffix will be `-pr.<yyyymmdd.<buildRev>>` where `<buildRev>` is an integer that increases every time the pipeline is triggered on a given day.
(2) the CI automatically adds a version suffix when the nightly release pipeline is triggered. The version suffix will be `-ci.<yyyymmdd.<buildRev>>` where `<buildRev>` is an integer that increases every time the pipeline is triggered on a given day.