### PR TITLE
Add CreateCheckStatusResponseAsync APIs

### DIFF
--- a/test/SmokeTests/OOProcSmokeTests/DotNetIsolated/DirectInput.cs
+++ b/test/SmokeTests/OOProcSmokeTests/DotNetIsolated/DirectInput.cs
@@ -51,18 +51,18 @@ public static class DirectInput
     }
 
     [Function(ActivityName)]
-    public static string Activity([ActivityTrigger] MyInput input, FunctionContext executionContext)
+    public static string Activity([ActivityTrigger] string input, FunctionContext executionContext)
     {
         ILogger logger = executionContext.GetLogger(ActivityName);
         logger.LogInformation("Received input {input}", input);
-        return $"{input.PropA}, {input.PropB}";
+        return input;
     }
 
     private static async Task<string> InputOrchestrationImpl(
         TaskOrchestrationContext context, MyInput input, FunctionContext functionContext)
     {
-        string result = await context.CallActivityAsync<string>(ActivityName, input) + ", ";
-        result += await context.CallActivityAsync<string>(ActivityName, new MyInput(functionContext.FunctionId, 1, true));
+        string result = await context.CallActivityAsync<string>(ActivityName) + ", ";
+        result += await context.CallActivityAsync<string>(ActivityName);
         return result;
     }
 


### PR DESCRIPTION
<!-- Start the PR description with some context for the change. -->

With AspNetCore support via extension in dotnet isolated, customers are unable to use our `CreateCheckStatusResponse` APIs due to synchronous IO not being allowed by default. While we don't want to add direct AspNetCore support at this time (would require bringing in that extension package, which is a no-go for us without our own separate package). We can in the short term add `CreateCheckStatusResponseAsync` which will fix the no-sync IO issue.

<!-- Make sure to delete the markdown comments and the below sections when squash merging -->
### Issue describing the changes in this PR

resolves #2717

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)
* [x] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk
* [x] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
    * [ ] Otherwise: major or minor version updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
* [x] My changes **do not** add EventIds to our EventSource logs
    * [ ] Otherwise: Ensure the EventIds are within the supported range in our existing Windows infrastructure. You may validate this with a deployed app's telemetry. You may also extend the range by completing a PR such as [this one](https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files).
* [ ] My changes **should** be added to v3.x branch.
    * [x] Otherwise: This change only applies to Durable Functions v2.x and **will not** be merged to branch v3.x.
