### PR TITLE
Fail fast if `ExtendedSessionsEnabled` is requested for a non-.NET worker.

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -5,6 +5,7 @@
 ### New Features
 
 - Fix regression on `TerminateInstanceAsync` API causing invocations to fail with "unimplemented" exceptions (https://github.com/Azure/azure-functions-durable-extension/pull/2829).
+- Fail fast if extendedSessionsEnabled set to 'true' for the worker type that doesn't support extended sessions (https://github.com/Azure/azure-functions-durable-extension/pull/2732).
 
 ### Bug Fixes
 

--- a/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
@@ -359,7 +359,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             }
 
             // Throw if any of the configured options are invalid
-            this.Options.Validate(this.nameResolver, this.TraceHelper);
+            this.Options.Validate(this.nameResolver);
 
 #pragma warning disable CS0618 // Type or member is obsolete
 

--- a/src/WebJobs.Extensions.DurableTask/Options/DurableTaskOptions.cs
+++ b/src/WebJobs.Extensions.DurableTask/Options/DurableTaskOptions.cs
@@ -320,12 +320,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 runtimeLanguage != null && // If we don't know from the environment variable, don't assume customer isn't .NET
                 !string.Equals(runtimeLanguage, "dotnet", StringComparison.OrdinalIgnoreCase))
             {
-                traceHelper.ExtensionWarningEvent(
-                    hubName: this.HubName,
-                    functionName: string.Empty,
-                    instanceId: string.Empty,
-                    message: "Durable Functions does not work with extendedSessions = true for non-.NET languages. This value is being set to false instead. See https://docs.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-perf-and-scale#extended-sessions for more details.");
-                this.ExtendedSessionsEnabled = false;
+                throw new InvalidOperationException(
+                    "Durable Functions does not work with ExtendedSessionsEnabled = true for non-.NET languages. " +
+                    "This value is being set to false instead. " +
+                    "See https://docs.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-perf-and-scale#extended-sessions for more details.");
             }
 
             this.Notifications.Validate();

--- a/src/WebJobs.Extensions.DurableTask/Options/DurableTaskOptions.cs
+++ b/src/WebJobs.Extensions.DurableTask/Options/DurableTaskOptions.cs
@@ -321,9 +321,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 !string.Equals(runtimeLanguage, "dotnet", StringComparison.OrdinalIgnoreCase))
             {
                 throw new InvalidOperationException(
-                    "Durable Functions does not work with ExtendedSessionsEnabled = true for non-.NET languages. " +
-                    "This value is being set to false instead. " +
-                    "See https://docs.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-perf-and-scale#extended-sessions for more details.");
+                    "Durable Functions with extendedSessionsEnabled set to 'true' is only supported when using the in-process .NET worker. Please remove the setting or change it to 'false'." +
+                    "See https://docs.microsoft.com/azure/azure-functions/durable/durable-functions-perf-and-scale#extended-sessions for more details.");
             }
 
             this.Notifications.Validate();

--- a/src/WebJobs.Extensions.DurableTask/Options/DurableTaskOptions.cs
+++ b/src/WebJobs.Extensions.DurableTask/Options/DurableTaskOptions.cs
@@ -302,7 +302,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             traceHelper.TraceConfiguration(this.HubName, configurationJson.ToString(Formatting.None));
         }
 
-        internal void Validate(INameResolver environmentVariableResolver, EndToEndTraceHelper traceHelper)
+        internal void Validate(INameResolver environmentVariableResolver)
         {
             if (string.IsNullOrEmpty(this.HubName))
             {

--- a/test/Common/DurableTaskEndToEndTests.cs
+++ b/test/Common/DurableTaskEndToEndTests.cs
@@ -5577,16 +5577,26 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 { "FUNCTIONS_WORKER_RUNTIME", "node" },
             });
 
-            using (var host = TestHelpers.GetJobHostWithOptions(
-                this.loggerProvider,
-                durableTaskOptions,
-                nameResolver: nameResolver))
-            {
-                await host.StartAsync();
-                await host.StopAsync();
-            }
 
-            Assert.False(durableTaskOptions.ExtendedSessionsEnabled);
+            InvalidOperationException exception =
+                await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+                {
+                    using (var host = TestHelpers.GetJobHostWithOptions(
+                        this.loggerProvider,
+                        durableTaskOptions,
+                        nameResolver: nameResolver))
+                    {
+                        await host.StartAsync();
+                        await host.StopAsync();
+                    }
+                });
+
+            Assert.NotNull(exception);
+            Assert.StartsWith(
+                "Durable Functions with extendedSessionsEnabled set to 'true' is only supported when using",
+                exception.Message,
+                StringComparison.OrdinalIgnoreCase
+            )
         }
 
         [Fact]

--- a/test/Common/DurableTaskEndToEndTests.cs
+++ b/test/Common/DurableTaskEndToEndTests.cs
@@ -5592,7 +5592,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 { "FUNCTIONS_WORKER_RUNTIME", "node" },
             });
 
-
             InvalidOperationException exception =
                 await Assert.ThrowsAsync<InvalidOperationException>(async () =>
                 {
@@ -5610,8 +5609,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             Assert.StartsWith(
                 "Durable Functions with extendedSessionsEnabled set to 'true' is only supported when using",
                 exception.Message,
-                StringComparison.OrdinalIgnoreCase
-            );
+                StringComparison.OrdinalIgnoreCase);
         }
 
         [Fact]

--- a/test/Common/DurableTaskEndToEndTests.cs
+++ b/test/Common/DurableTaskEndToEndTests.cs
@@ -5611,7 +5611,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 "Durable Functions with extendedSessionsEnabled set to 'true' is only supported when using",
                 exception.Message,
                 StringComparison.OrdinalIgnoreCase
-            )
+            );
         }
 
         [Fact]

--- a/test/SmokeTests/e2e-test.ps1
+++ b/test/SmokeTests/e2e-test.ps1
@@ -31,7 +31,7 @@ $AzuriteVersion = "3.26.0"
 if ($NoSetup -eq $false) {
 	# Build the docker image first, since that's the most critical step
 	Write-Host "Building sample app Docker container from '$DockerfilePath'..." -ForegroundColor Yellow
-	docker build -f $DockerfilePath -t $ImageName --progress plain $PSScriptRoot/../../
+	docker build --pull --no-cache -f $DockerfilePath -t $ImageName --progress plain $PSScriptRoot/../../
 	Exit-OnError
 
 	# Next, download and start the Azurite emulator Docker image

--- a/test/SmokeTests/e2e-test.ps1
+++ b/test/SmokeTests/e2e-test.ps1
@@ -31,7 +31,7 @@ $AzuriteVersion = "3.26.0"
 if ($NoSetup -eq $false) {
 	# Build the docker image first, since that's the most critical step
 	Write-Host "Building sample app Docker container from '$DockerfilePath'..." -ForegroundColor Yellow
-	docker build -f $DockerfilePath -t $ImageName --progress plain $PSScriptRoot/../../
+	docker build --pull -f $DockerfilePath -t $ImageName --progress plain $PSScriptRoot/../../
 	Exit-OnError
 
 	# Next, download and start the Azurite emulator Docker image


### PR DESCRIPTION
## Problem

If you set `extendedSessionsEnabled` to true for Python durable function, it fails to complete orchestrations. Although the control queues are properly processed and the history tables are written accordingly, Python worker only triggers the orchestration once and never replays it.

Excerpt from host.json:

```json
{
  "extensions": {
     "durableTask": {
      "hubName": "TaskHub3",
      "extendedSessionsEnabled": true
      "extendedSessionIdleTimeoutInSeconds": 600
     }
  }
```

Excerpt from the logs:

```
[2024-01-26T13:29:09.316Z] Durable Functions does not work with extendedSessions = true for non-.NET languages. This value is being set to false instead. See https://docs.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-perf-and-scale#extended-sessions for more details.. InstanceId: . Function: . HubName: TaskHub2. AppName: . SlotName: . ExtensionVersion: 2.12.0. SequenceNumber: 0.
```

Related issue about this parameter I've found via github search: https://github.com/briandunnington/briandunnington.github.com/blob/97f5a9cca08b41654c07d3552e8ede184ae1b8e4/_posts/durable_functions_an_eventstarted_event_is_required.md?plain=1#L61

## Solution

The current code emits the warning and overwrites the option value to false. However, it seems like the framework reads the "old" option value before that, e.g. in the `InitializeForFunctionsV1I()` During execution, at least part of the framework logic still assumes that the extended sessions are on. 

A more simple and reliable approach is to just disallow this option value for non-dotnet workers and fail when it's provided.

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)
* [x] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk
* [x] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
    * [ ] Otherwise: major or minor version updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
* [x] My changes **do not** add EventIds to our EventSource logs
    * [ ] Otherwise: Ensure the EventIds are within the supported range in our existing Windows infrastructure. You may validate this with a deployed app's telemetry. You may also extend the range by completing a PR such as [this one](https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files).
* [x] My changes **should** be added to v3.x branch.
    * [ ] Otherwise: This change only applies to Durable Functions v2.x and **will not** be merged to branch v3.x.
