### PR TITLE
Add dotnet isolated release process to release templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-release-template.md
+++ b/.github/ISSUE_TEMPLATE/new-release-template.md
@@ -20,7 +20,7 @@ _Due: <2-3-business-days-before-release>_
 _Due: <2-3-business-days-before-release>_
 - [ ] If there were DTFx.Core changes, check its reference version [here](https://github.com/microsoft/durabletask-dotnet/blob/c838535adb6aedb6671cf193389ce63a6b4a9b24/src/Abstractions/Abstractions.csproj#L10). If updates are required, document the changes in [release notes](https://github.com/microsoft/durabletask-dotnet/blob/c838535adb6aedb6671cf193389ce63a6b4a9b24/src/Abstractions/RELEASENOTES.md).
 - [ ] Check dotnet isolated SDK versions [here](https://github.com/microsoft/durabletask-dotnet/blob/c838535adb6aedb6671cf193389ce63a6b4a9b24/eng/targets/Release.props#L20). If updated, document the changes in the [change logs](https://github.com/microsoft/durabletask-dotnet/blob/c838535adb6aedb6671cf193389ce63a6b4a9b24/CHANGELOG.md).
-- [ ] Run pipeline [Release .Net out-of-proc SDK](https://durabletaskframework.visualstudio.com/Durable%20Task%20Framework%20CI/_build?definitionId=29) to build new package and publish them to the ADO feed for testing.
+- [ ] Run pipeline [Release .Net out-of-proc SDK](https://durabletaskframework.visualstudio.com/Durable%20Task%20Framework%20CI/_build?definitionId=29) to create the new package and publish it to the ADO feed for testing.
 
 **Prep Release (assigned to: )**
 _Due: <2-business-days-before-release>_
@@ -29,8 +29,8 @@ _Due: <2-business-days-before-release>_
 - [ ] Review the [Dependabot vulnerability alerts](https://github.com/Azure/azure-functions-durable-extension/security/dependabot) and address them. Note: code samples / test projects _may_ be excluded from this check.
 - [ ] Add the Durable Functions package to the [ADO test feed](https://dev.azure.com/durabletaskframework/Durable%20Task%20Framework%20CI/_artifacts/feed/durabletask-test).
 - [ ] Check for package size, make sure it's not surprisingly heavier than a previous release.
-- [ ] Update Worker.Extensions.Durabletask references and check current veresion.
-- [ ] Run pipeline [Release .Net Isolated Worker Extension](https://durabletaskframework.visualstudio.com/Durable%20Task%20Framework%20CI/_build?definitionId=30) to build package and add it to ADO for testing.
+- [ ] Update Worker.Extensions.Durabletask references and check current version.
+- [ ] Run pipeline [Release .Net Isolated Worker Extension](https://durabletaskframework.visualstudio.com/Durable%20Task%20Framework%20CI/_build?definitionId=30) to create the new package and add it to the ADO feed for testing.
 - [ ] Merge (**choose create a merge commit, NOT squash merge**) dev into main. Person performing validation must approve PR.
 - [ ] Keep branch `v3.x` updated with branch `dev`. Do not merge PRs that are specific to Durable Functions v2.
 
@@ -50,8 +50,8 @@ _Due: <release-deadline>_
 
 **DotNet Isolated SDK Release Completion: (assigned to:)**
 _Due: <release-deadline>_
-- [ ] Upload .Net isolated SDK packages to NuGet (directly to nuget.org).
-- [ ] Publish release notes for durable-dotnet.
+- [ ] Upload .NET isolated SDK packages to NuGet (directly to nuget.org).
+- [ ] Publish release notes in the durable-dotnet repo.
 
 **Release Completion (assigned to: )**
 _Due: <release-deadline>_
@@ -59,7 +59,7 @@ _Due: <release-deadline>_
 - [ ] Run the [Durable Functions release pipeline](https://dev.azure.com/durabletaskframework/Durable%20Task%20Framework%20CI/_build?definitionId=23) and select `main` as the branch.
 - [ ] Add the Durable Functions package to the [ADO feed](https://dev.azure.com/durabletaskframework/Durable%20Task%20Framework%20CI/_artifacts/feed/durabletask) using [this pipeline](https://dev.azure.com/durabletaskframework/Durable%20Task%20Framework%20CI/_release?_a=releases&view=mine&definitionId=11).
 - [ ] Upload the Durable Functions package to NuGet (directly to nuget.org).
-- [ ] Upload .Net isolated worker extension package to NuGet (directly to nuget.org).
+- [ ] Upload .NET Isolated worker extension package to NuGet (directly to nuget.org).
 - [ ] Create a PR in the [Azure Functions templates repo](https://github.com/Azure/azure-functions-templates) targeting branch `dev` to update all references of "Microsoft.Azure.WebJobs.Extensions.DurableTask" (search for this string in the code) to the latest version.
 - [ ] _if and only if this is a new major release_, Create a PR in the [Azure Functions bundles repo](https://github.com/Azure/azure-functions-extension-bundles) to update bundles to the latest version .
 - [ ] Merge all pending PR docs from `pending_docs.md.`

--- a/.github/ISSUE_TEMPLATE/new-release-template.md
+++ b/.github/ISSUE_TEMPLATE/new-release-template.md
@@ -16,6 +16,12 @@ _Due: <2-3-business-days-before-release>_
 - [ ] Publish DTFx packages to the [ADO feed](https://dev.azure.com/durabletaskframework/Durable%20Task%20Framework%20CI/_artifacts/feed/durabletask) for testing.
 - [ ] Keep branch `azure-storage-v12` updated with branch `main`.
 
+**Prep DotNet Isolated SDK Release: (assigned to:)**
+_Due: <2-3-business-days-before-release>_
+- [ ] If there were DTFx.Core changes, check its reference version [here](https://github.com/microsoft/durabletask-dotnet/blob/c838535adb6aedb6671cf193389ce63a6b4a9b24/src/Abstractions/Abstractions.csproj#L10). If updates are required, document the changes in [release notes](https://github.com/microsoft/durabletask-dotnet/blob/c838535adb6aedb6671cf193389ce63a6b4a9b24/src/Abstractions/RELEASENOTES.md).
+- [ ] Check dotnet isolated SDK versions [here](https://github.com/microsoft/durabletask-dotnet/blob/c838535adb6aedb6671cf193389ce63a6b4a9b24/eng/targets/Release.props#L20). If updated, document the changes in the [change logs](https://github.com/microsoft/durabletask-dotnet/blob/c838535adb6aedb6671cf193389ce63a6b4a9b24/CHANGELOG.md).
+- [ ] Run pipeline [Release .Net out-of-proc SDK](https://durabletaskframework.visualstudio.com/Durable%20Task%20Framework%20CI/_build?definitionId=29) to build new package and publish them to the ADO feed for testing.
+
 **Prep Release (assigned to: )**
 _Due: <2-business-days-before-release>_
 - [ ] Update Durable Functions references (Analyzer? DTFx?) and check current version.
@@ -23,6 +29,8 @@ _Due: <2-business-days-before-release>_
 - [ ] Review the [Dependabot vulnerability alerts](https://github.com/Azure/azure-functions-durable-extension/security/dependabot) and address them. Note: code samples / test projects _may_ be excluded from this check.
 - [ ] Add the Durable Functions package to the [ADO test feed](https://dev.azure.com/durabletaskframework/Durable%20Task%20Framework%20CI/_artifacts/feed/durabletask-test).
 - [ ] Check for package size, make sure it's not surprisingly heavier than a previous release.
+- [ ] Update Worker.Extensions.Durabletask references and check current veresion.
+- [ ] Run pipeline [Release .Net Isolated Worker Extension] to build package and add it to ADO for testing.
 - [ ] Merge (**choose create a merge commit, NOT squash merge**) dev into main. Person performing validation must approve PR.
 - [ ] Keep branch `v3.x` updated with branch `dev`. Do not merge PRs that are specific to Durable Functions v2.
 
@@ -30,6 +38,8 @@ _Due: <2-business-days-before-release>_
 _Due: <1-business-days-before-release>_
 - [ ] Run private performance tests and ensure no regressions. **(assigned to: )**
 - [ ] Smoke test Functions V1, Functions V2, and Functions V3 .NET apps. **(assigned to: )**
+- [ ] Smoke test .NET apps with backend Netherite, MSSQL. **(assigned to: )**
+- [ ] Smoke test .NET isolated apps. **(assigned to: )**
 
 **DTFx Release Completion (assigned to: )**
 _Due: <release-deadline>_
@@ -38,12 +48,18 @@ _Due: <release-deadline>_
 - [ ] Publish release notes for DTFx.
 - [ ] Patch increment DTFx packages that were released (either DT-AzureStorage only or if there were Core changes DT-AzureStorage, DT-Core, and DT-ApplicationInsights)
 
+**DotNet Isolated SDK Release Completion: (assigned to:)**
+_Due: <release-deadline>_
+- [ ] Upload .Net isolated SDK packages to NuGet (directly to nuget.org).
+- [ ] Publish release notes for durable-dotnet.
+
 **Release Completion (assigned to: )**
 _Due: <release-deadline>_
 - [ ] Delete Durable Functions packages from the [ADO test feed](https://dev.azure.com/durabletaskframework/Durable%20Task%20Framework%20CI/_artifacts/feed/durabletask-test).
 - [ ] Run the [Durable Functions release pipeline](https://dev.azure.com/durabletaskframework/Durable%20Task%20Framework%20CI/_build?definitionId=23) and select `main` as the branch.
 - [ ] Add the Durable Functions package to the [ADO feed](https://dev.azure.com/durabletaskframework/Durable%20Task%20Framework%20CI/_artifacts/feed/durabletask) using [this pipeline](https://dev.azure.com/durabletaskframework/Durable%20Task%20Framework%20CI/_release?_a=releases&view=mine&definitionId=11).
 - [ ] Upload the Durable Functions package to NuGet (directly to nuget.org).
+- [ ] Upload .Net isolated worker extension package to NuGet (directly to nuget.org).
 - [ ] Create a PR in the [Azure Functions templates repo](https://github.com/Azure/azure-functions-templates) targeting branch `dev` to update all references of "Microsoft.Azure.WebJobs.Extensions.DurableTask" (search for this string in the code) to the latest version.
 - [ ] _if and only if this is a new major release_, Create a PR in the [Azure Functions bundles repo](https://github.com/Azure/azure-functions-extension-bundles) to update bundles to the latest version .
 - [ ] Merge all pending PR docs from `pending_docs.md.`

--- a/.github/ISSUE_TEMPLATE/new-release-template.md
+++ b/.github/ISSUE_TEMPLATE/new-release-template.md
@@ -24,12 +24,12 @@ _Due: <2-3-business-days-before-release>_
 
 **Prep Release (assigned to: )**
 _Due: <2-business-days-before-release>_
-- [ ] Update Durable Functions references (Analyzer? DTFx?) and check current version.
+- [ ] Update DTFx packages and Analyzer version at WebJobs.Extensions.Durabletask.csproj and check WebJobs.Extensions.Durabletask version.
 - [ ] Locally, run `dotnet list package --vulnerable` to ensure the release is not affected by any vulnerable dependencies.
 - [ ] Review the [Dependabot vulnerability alerts](https://github.com/Azure/azure-functions-durable-extension/security/dependabot) and address them. Note: code samples / test projects _may_ be excluded from this check.
 - [ ] Add the Durable Functions package to the [ADO test feed](https://dev.azure.com/durabletaskframework/Durable%20Task%20Framework%20CI/_artifacts/feed/durabletask-test).
 - [ ] Check for package size, make sure it's not surprisingly heavier than a previous release.
-- [ ] Update Worker.Extensions.Durabletask references and check current version.
+- [ ] Update .NET Isolated SDK version at Worker.Extensions.Durabletask.csproj and check Worker.Extensions.Durabletask version.
 - [ ] Run pipeline [Release .Net Isolated Worker Extension](https://durabletaskframework.visualstudio.com/Durable%20Task%20Framework%20CI/_build?definitionId=30) to create the new package and add it to the ADO feed for testing.
 - [ ] Merge (**choose create a merge commit, NOT squash merge**) dev into main. Person performing validation must approve PR.
 - [ ] Keep branch `v3.x` updated with branch `dev`. Do not merge PRs that are specific to Durable Functions v2.

--- a/.github/ISSUE_TEMPLATE/new-release-template.md
+++ b/.github/ISSUE_TEMPLATE/new-release-template.md
@@ -30,7 +30,7 @@ _Due: <2-business-days-before-release>_
 - [ ] Add the Durable Functions package to the [ADO test feed](https://dev.azure.com/durabletaskframework/Durable%20Task%20Framework%20CI/_artifacts/feed/durabletask-test).
 - [ ] Check for package size, make sure it's not surprisingly heavier than a previous release.
 - [ ] Update Worker.Extensions.Durabletask references and check current veresion.
-- [ ] Run pipeline [Release .Net Isolated Worker Extension] to build package and add it to ADO for testing.
+- [ ] Run pipeline [Release .Net Isolated Worker Extension](https://durabletaskframework.visualstudio.com/Durable%20Task%20Framework%20CI/_build?definitionId=30) to build package and add it to ADO for testing.
 - [ ] Merge (**choose create a merge commit, NOT squash merge**) dev into main. Person performing validation must approve PR.
 - [ ] Keep branch `v3.x` updated with branch `dev`. Do not merge PRs that are specific to Durable Functions v2.
 

--- a/.github/ISSUE_TEMPLATE/new-release-template.md
+++ b/.github/ISSUE_TEMPLATE/new-release-template.md
@@ -24,12 +24,12 @@ _Due: <2-3-business-days-before-release>_
 
 **Prep Release (assigned to: )**
 _Due: <2-business-days-before-release>_
-- [ ] Update DTFx packages and Analyzer version at WebJobs.Extensions.Durabletask.csproj and check WebJobs.Extensions.Durabletask version.
+- [ ] Update DTFx packages and Analyzer versions at WebJobs.Extensions.Durabletask.csproj and check if we need to update the WebJobs.Extensions.Durabletask version.
 - [ ] Locally, run `dotnet list package --vulnerable` to ensure the release is not affected by any vulnerable dependencies.
 - [ ] Review the [Dependabot vulnerability alerts](https://github.com/Azure/azure-functions-durable-extension/security/dependabot) and address them. Note: code samples / test projects _may_ be excluded from this check.
 - [ ] Add the Durable Functions package to the [ADO test feed](https://dev.azure.com/durabletaskframework/Durable%20Task%20Framework%20CI/_artifacts/feed/durabletask-test).
 - [ ] Check for package size, make sure it's not surprisingly heavier than a previous release.
-- [ ] Update .NET Isolated SDK version at Worker.Extensions.Durabletask.csproj and check Worker.Extensions.Durabletask version.
+- [ ] Update .NET Isolated SDK version at Worker.Extensions.Durabletask.csproj and check if we need to update the Worker.Extensions.Durabletask version.
 - [ ] Run pipeline [Release .Net Isolated Worker Extension](https://durabletaskframework.visualstudio.com/Durable%20Task%20Framework%20CI/_build?definitionId=30) to create the new package and add it to the ADO feed for testing.
 - [ ] Merge (**choose create a merge commit, NOT squash merge**) dev into main. Person performing validation must approve PR.
 - [ ] Keep branch `v3.x` updated with branch `dev`. Do not merge PRs that are specific to Durable Functions v2.


### PR DESCRIPTION
<!-- Start the PR description with some context for the change. -->
As titled.

<!-- Make sure to delete the markdown comments and the below sections when squash merging -->
### Issue describing the changes in this PR

resolves #issue_for_this_pr

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)
* [ ] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk
* [ ] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
    * [ ] Otherwise: major or minor version updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
* [ ] My changes **do not** add EventIds to our EventSource logs
    * [ ] Otherwise: Ensure the EventIds are within the supported range in our existing Windows infrastructure. You may validate this with a deployed app's telemetry. You may also extend the range by completing a PR such as [this one](https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files).
* [x] My changes **should** be added to v3.x branch.
    * [ ] Otherwise: This change only applies to Durable Functions v2.x and **will not** be merged to branch v3.x.
