### PR TITLE
Correctly propagate orchestration results of a failed orchestration

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/RemoteOrchestratorContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/RemoteOrchestratorContext.cs
@@ -64,6 +64,20 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             return this.executionResult ?? throw new InvalidOperationException($"The execution result has not yet been set using {nameof(this.SetResult)}.");
         }
 
+        internal bool TryGetOrchestrationErrorDetails(out string details)
+        {
+            if (this.failure != null)
+            {
+                details = this.failure.Message;
+                return true;
+            }
+            else
+            {
+                details = string.Empty;
+                return false;
+            }
+        }
+
         internal void SetResult(IEnumerable<OrchestratorAction> actions, string customStatus)
         {
             var result = new OrchestratorExecutionResult

--- a/src/WebJobs.Extensions.DurableTask/OutOfProcMiddleware.cs
+++ b/src/WebJobs.Extensions.DurableTask/OutOfProcMiddleware.cs
@@ -214,8 +214,31 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                         isReplay: false);
                 }
             }
+            else if (context.TryGetOrchestrationErrorDetails(out string details))
+            {
+                // the function failed because the orchestrator failed.
+
+                orchestratorResult = context.GetResult();
+
+                this.TraceHelper.FunctionFailed(
+                     this.Options.HubName,
+                     functionName.Name,
+                     instance.InstanceId,
+                     details,
+                     FunctionType.Orchestrator,
+                     isReplay: false);
+
+                await this.LifeCycleNotificationHelper.OrchestratorFailedAsync(
+                    this.Options.HubName,
+                    functionName.Name,
+                    instance.InstanceId,
+                    details,
+                    isReplay: false);
+            }
             else
             {
+                // the function failed for some other reason
+
                 string exceptionDetails = functionResult.Exception.ToString();
 
                 this.TraceHelper.FunctionFailed(


### PR DESCRIPTION
As diagnosed in #2743, the current code in `OutOfProcMiddleware.CallOrchestratorAsync` does not correctly propagate the results of a failed orchestration to the backend.  

The problem is that when an orchestrator function fails, the OrchestratorExecutionResult that was constructed by the executor is ignored, and instead an alternate OrchestratorExecutionResult.ForFailure is constructed from the exception returned by the function result. This is a problem because 

1.  the original failure details are lost instead of being persisted in the history.
2.  any orchestrator actions that took place prior to the failure (e.g. sending lock release messages) are ignored.

This PR fixes the problem by propagating the original `OrchestratorExecutionResult` that describes the failure (if there is one).

* [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] I have added all required tests (Unit tests, E2E tests)
* [x] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
* [ ] My changes **should** be added to v3.x branch.
   
