### PR TITLE
Fix handling of entity operation errors for isolated entities

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -10,6 +10,7 @@
 
 - Fix issue with isolated entities: custom deserialization was not working because IServices was not passed along (https://github.com/Azure/azure-functions-durable-extension/pull/2686)
 - Fix issue with `string` activity input having extra quotes (https://github.com/Azure/azure-functions-durable-extension/pull/2708)
+- Fix issue with out-of-proc entity operation errors: success/failure details of individual operations in a batch was not processed correctly (https://github.com/Azure/azure-functions-durable-extension/pull/2752)
 
 ### Breaking Changes
 


### PR DESCRIPTION
The current code is not properly handling failing entity operation batches. Specifically, for failing batches, it was failing all operations indiscriminately, instead of processing the failure details of each operation in the batch and sending them back to the orchestration caller.

This PR fixes the problem by propagating the results of the batch back to the DurableTask middleware pipeline, even if the function failed.

I think this bug could have been caught if the entity tests #2612 were run in CI, as opposed to having to run them manually (I remember these tests all passing last year but they are failing now which alerted me to this problem).
 
### Pull request checklist

* [x] My changes **do not** require documentation changes
* [x] I've added my notes to `release_notes.md`
* [x] My changes **should** be added to v3.x branch.
