### PR TITLE
Updating OOProc smoke tests

### DIFF
--- a/test/SmokeTests/OOProcSmokeTests/durableJS/DurableFunctionsOrchestratorJS/index.js
+++ b/test/SmokeTests/OOProcSmokeTests/durableJS/DurableFunctionsOrchestratorJS/index.js
@@ -20,7 +20,7 @@ module.exports = df.orchestrator(function* (context) {
     outputs.push(yield context.df.callActivity("Hello", "Seattle"));
     outputs.push(yield context.df.callActivity("Hello", "London"));
     outputs.push(yield context.df.callActivity("Hello", "123"));
-    outputs.push(yield context.df.callActivity("Hello", ["Dubai", "New York", "Vancouver"]));
+    outputs.push(yield context.df.callActivity("PrintArray", ["Dubai", "New York", "Vancouver"]));
     outputs.push(yield context.df.callActivity("PrintObject", city));
 
     return outputs;

--- a/test/SmokeTests/OOProcSmokeTests/durableJS/DurableFunctionsOrchestratorJS/index.js
+++ b/test/SmokeTests/OOProcSmokeTests/durableJS/DurableFunctionsOrchestratorJS/index.js
@@ -13,12 +13,15 @@ const df = require("durable-functions");
 
 module.exports = df.orchestrator(function* (context) {
     const outputs = [];
+    const city = {city:"Paris", country:"France"};
 
     // Replace "Hello" with the name of your Durable Activity Function.
     outputs.push(yield context.df.callActivity("Hello", "Tokyo"));
     outputs.push(yield context.df.callActivity("Hello", "Seattle"));
     outputs.push(yield context.df.callActivity("Hello", "London"));
+    outputs.push(yield context.df.callActivity("Hello", "123"));
+    outputs.push(yield context.df.callActivity("Hello", ["Dubai", "New York", "Vancouver"]));
+    outputs.push(yield context.df.callActivity("PrintObject", city));
 
-    // returns ["Hello Tokyo!", "Hello Seattle!", "Hello London!"]
     return outputs;
 });

--- a/test/SmokeTests/OOProcSmokeTests/durableJS/PrintArray/function.json
+++ b/test/SmokeTests/OOProcSmokeTests/durableJS/PrintArray/function.json
@@ -1,0 +1,9 @@
+{
+  "bindings": [
+    {
+      "name": "array",
+      "type": "activityTrigger",
+      "direction": "in"
+    }
+  ]
+}

--- a/test/SmokeTests/OOProcSmokeTests/durableJS/PrintArray/index.js
+++ b/test/SmokeTests/OOProcSmokeTests/durableJS/PrintArray/index.js
@@ -1,0 +1,14 @@
+/*
+ * This function is not intended to be invoked directly. Instead it will be
+ * triggered by an orchestrator function.
+ * 
+ * Before running this sample, please:
+ * - create a Durable orchestration function
+ * - create a Durable HTTP starter function
+ * - run 'npm install durable-functions' from the wwwroot folder of your
+ *   function app in Kudu
+ */
+
+module.exports = async function (context) {
+    return context.bindings.array.toString();
+};

--- a/test/SmokeTests/OOProcSmokeTests/durableJS/PrintObject/function.json
+++ b/test/SmokeTests/OOProcSmokeTests/durableJS/PrintObject/function.json
@@ -1,0 +1,9 @@
+{
+  "bindings": [
+    {
+      "name": "cities",
+      "type": "activityTrigger",
+      "direction": "in"
+    }
+  ]
+}

--- a/test/SmokeTests/OOProcSmokeTests/durableJS/PrintObject/index.js
+++ b/test/SmokeTests/OOProcSmokeTests/durableJS/PrintObject/index.js
@@ -10,5 +10,5 @@
  */
 
 module.exports = async function (context) {
-    return JSON.stringify(context.bindings.cities);
+    return JSON.stringify(context.bindings.obj);
 };

--- a/test/SmokeTests/OOProcSmokeTests/durableJS/PrintObject/index.js
+++ b/test/SmokeTests/OOProcSmokeTests/durableJS/PrintObject/index.js
@@ -1,0 +1,14 @@
+/*
+ * This function is not intended to be invoked directly. Instead it will be
+ * triggered by an orchestrator function.
+ * 
+ * Before running this sample, please:
+ * - create a Durable orchestration function
+ * - create a Durable HTTP starter function
+ * - run 'npm install durable-functions' from the wwwroot folder of your
+ *   function app in Kudu
+ */
+
+module.exports = async function (context) {
+    return JSON.stringify(context.bindings.cities);
+};


### PR DESCRIPTION
This PR updates OOProc smoke tests to include more use cases for activity inputs like arrays, objects, and integers.