### PR TITLE
.NET out-of-proc error parsing fixes

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -11,6 +11,7 @@
 - Fix issue with isolated entities: custom deserialization was not working because IServices was not passed along (https://github.com/Azure/azure-functions-durable-extension/pull/2686)
 - Fix issue with `string` activity input having extra quotes (https://github.com/Azure/azure-functions-durable-extension/pull/2708)
 - Fix issue with out-of-proc entity operation errors: success/failure details of individual operations in a batch was not processed correctly (https://github.com/Azure/azure-functions-durable-extension/pull/2752)
+- Fix issues with .NET Isolated out-of-process error parsing (see https://github.com/Azure/azure-functions-durable-extension/issues/2711)
 
 ### Breaking Changes
 

--- a/src/WebJobs.Extensions.DurableTask/OutOfProcMiddleware.cs
+++ b/src/WebJobs.Extensions.DurableTask/OutOfProcMiddleware.cs
@@ -655,23 +655,40 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             [NotNullWhen(true)] out string? exceptionType,
             [NotNullWhen(true)] out string? exceptionMessage)
         {
-            // Example exception messages:
+            // In certain situations, like when the .NET Isolated worker is configured with
+            // WorkerOptions.EnableUserCodeException = true, the exception message we get from the .NET Isoalted
+            // worker looks like this:
+            // "Exception of type 'ExceptionSerialization.Function+UnknownException' was thrown."
+            const string startMarker = "Exception of type '";
+            const string endMarker = "' was thrown.";
+            if (exception.StartsWith(startMarker) && exception.EndsWith(endMarker))
+            {
+                exceptionType = exception[startMarker.Length..^endMarker.Length];
+                exceptionMessage = string.Empty;
+                return true;
+            }
+
+            // The following are the more common cases that we expect to see, which will be common across a
+            // variety of language workers:
             // .NET   : System.ApplicationException: Kah-BOOOOM!!
             // Java   : SQLServerException: Invalid column name 'status'.
             // Python : ResourceNotFoundError: The specified blob does not exist. RequestId:8d5a2c9b-b01e-006f-33df-3f7a2e000000 Time:2022-03-25T00:31:24.2003327Z ErrorCode:BlobNotFound Error:None
             // Node   : SyntaxError: Unexpected token N in JSON at position 12768
 
-            // From the above examples, they all follow the same pattern of {ExceptionType}: {Message}
+            // From the above examples, they all follow the same pattern of {ExceptionType}: {Message}.
+            // However, some exception types override the ToString() method and do something custom, in which
+            // case the message may not be in the expected format. In such cases we won't be able to distinguish
+            // the exception type.
             string delimeter = ": ";
             int endExceptionType = exception.IndexOf(delimeter);
             if (endExceptionType < 0)
             {
                 exceptionType = null;
-                exceptionMessage = null;
+                exceptionMessage = exception;
                 return false;
             }
 
-            exceptionType = exception[..endExceptionType];
+            exceptionType = exception[..endExceptionType].TrimEnd();
 
             // The .NET Isolated language worker strangely includes the stack trace in the exception message.
             // To avoid bloating the payload with redundant information, we only consider the first line.
@@ -679,7 +696,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             int endMessage = exception.IndexOf('\n', startMessage);
             if (endMessage < 0)
             {
-                exceptionMessage = exception[startMessage..];
+                exceptionMessage = exception[startMessage..].TrimEnd();
             }
             else
             {

--- a/src/WebJobs.Extensions.DurableTask/OutOfProcMiddleware.cs
+++ b/src/WebJobs.Extensions.DurableTask/OutOfProcMiddleware.cs
@@ -656,7 +656,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             [NotNullWhen(true)] out string? exceptionMessage)
         {
             // In certain situations, like when the .NET Isolated worker is configured with
-            // WorkerOptions.EnableUserCodeException = true, the exception message we get from the .NET Isoalted
+            // WorkerOptions.EnableUserCodeException = true, the exception message we get from the .NET Isolated
             // worker looks like this:
             // "Exception of type 'ExceptionSerialization.Function+UnknownException' was thrown."
             const string startMarker = "Exception of type '";


### PR DESCRIPTION
Resolves https://github.com/Azure/azure-functions-durable-extension/issues/2711

There were a few edge cases that weren't being handled correctly when dealing with activity exceptions in .NET out-of-proc. The edge cases included:

- Cases when customers override `Exception.ToString()` and change the exception message formatting
- Cases when customers enable `WorkerOptions.EnableUserCodeException`

In the above cases, what we receive from the .NET Isolated worker changes from what we expect, resulting in exception information missing when customers try to handle exceptions in their orchestrator function code. The changes in this PR are meant to cover these corner cases and provide users with more accurate exception information.

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)
* [ ] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [x] Otherwise: That work is being tracked here: (not required per-se but definitely related: https://github.com/microsoft/durabletask-dotnet/pull/273)
* [x] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
    * [ ] Otherwise: major or minor version updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
* [x] My changes **do not** add EventIds to our EventSource logs
    * [ ] Otherwise: Ensure the EventIds are within the supported range in our existing Windows infrastructure. You may validate this with a deployed app's telemetry. You may also extend the range by completing a PR such as [this one](https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files).
* [x] My changes **should** be added to v3.x branch.
    * [ ] Otherwise: This change only applies to Durable Functions v2.x and **will not** be merged to branch v3.x.
