### PR TITLE
Rev ooproc SDK pkgs to 1.2.2

### DIFF
--- a/src/Worker.Extensions.DurableTask/Worker.Extensions.DurableTask.csproj
+++ b/src/Worker.Extensions.DurableTask/Worker.Extensions.DurableTask.csproj
@@ -39,8 +39,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Core" Version="1.16.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Abstractions" Version="1.3.0" />
-    <PackageReference Include="Microsoft.DurableTask.Client.Grpc" Version="1.2.1" />
-    <PackageReference Include="Microsoft.DurableTask.Worker.Grpc" Version="1.2.1" />
+    <PackageReference Include="Microsoft.DurableTask.Client.Grpc" Version="1.2.0" />
+    <PackageReference Include="Microsoft.DurableTask.Worker.Grpc" Version="1.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Worker.Extensions.DurableTask/Worker.Extensions.DurableTask.csproj
+++ b/src/Worker.Extensions.DurableTask/Worker.Extensions.DurableTask.csproj
@@ -39,8 +39,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Core" Version="1.16.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Abstractions" Version="1.3.0" />
-    <PackageReference Include="Microsoft.DurableTask.Client.Grpc" Version="1.2.1" />
-    <PackageReference Include="Microsoft.DurableTask.Worker.Grpc" Version="1.2.1" />
+    <PackageReference Include="Microsoft.DurableTask.Client.Grpc" Version="1.2.1-bugfixtest" />
+    <PackageReference Include="Microsoft.DurableTask.Worker.Grpc" Version="1.2.1-bugfixtest" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Worker.Extensions.DurableTask/Worker.Extensions.DurableTask.csproj
+++ b/src/Worker.Extensions.DurableTask/Worker.Extensions.DurableTask.csproj
@@ -39,8 +39,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Core" Version="1.16.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Abstractions" Version="1.3.0" />
-    <PackageReference Include="Microsoft.DurableTask.Client.Grpc" Version="1.2.0" />
-    <PackageReference Include="Microsoft.DurableTask.Worker.Grpc" Version="1.2.0" />
+    <PackageReference Include="Microsoft.DurableTask.Client.Grpc" Version="1.1.1" />
+    <PackageReference Include="Microsoft.DurableTask.Worker.Grpc" Version="1.1.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Worker.Extensions.DurableTask/Worker.Extensions.DurableTask.csproj
+++ b/src/Worker.Extensions.DurableTask/Worker.Extensions.DurableTask.csproj
@@ -32,7 +32,7 @@
     <VersionPrefix>1.1.2</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <AssemblyVersion>$(VersionPrefix).0</AssemblyVersion>
-    <!-- FileVersionRevision is expected to be set by the CI. -->
+    <!-- FileVersionRevision is expected to be set by the CI.  -->
     <FileVersion Condition="'$(FileVersionRevision)' != ''">$(VersionPrefix).$(FileVersionRevision)</FileVersion>
   </PropertyGroup>
   

--- a/src/Worker.Extensions.DurableTask/Worker.Extensions.DurableTask.csproj
+++ b/src/Worker.Extensions.DurableTask/Worker.Extensions.DurableTask.csproj
@@ -39,8 +39,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Core" Version="1.16.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Abstractions" Version="1.3.0" />
-    <PackageReference Include="Microsoft.DurableTask.Client.Grpc" Version="1.1.1" />
-    <PackageReference Include="Microsoft.DurableTask.Worker.Grpc" Version="1.1.1" />
+    <PackageReference Include="Microsoft.DurableTask.Client.Grpc" Version="1.2.1" />
+    <PackageReference Include="Microsoft.DurableTask.Worker.Grpc" Version="1.2.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Worker.Extensions.DurableTask/Worker.Extensions.DurableTask.csproj
+++ b/src/Worker.Extensions.DurableTask/Worker.Extensions.DurableTask.csproj
@@ -39,8 +39,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Core" Version="1.16.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Abstractions" Version="1.3.0" />
-    <PackageReference Include="Microsoft.DurableTask.Client.Grpc" Version="1.2.1-bugfixtest" />
-    <PackageReference Include="Microsoft.DurableTask.Worker.Grpc" Version="1.2.1-bugfixtest" />
+    <PackageReference Include="Microsoft.DurableTask.Client.Grpc" Version="1.2.2" />
+    <PackageReference Include="Microsoft.DurableTask.Worker.Grpc" Version="1.2.2" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Follow up to: https://github.com/Azure/azure-functions-durable-extension/pull/2766 and https://github.com/Azure/azure-functions-durable-extension/pull/2764

Increases:
* Microsoft.DurableTask.Client.Grpc
* Microsoft.DurableTask.Worker.Grpc

to version 1.2.2

I assume this is what's meant by "Update .NET Isolated SDK version at Worker.Extensions.Durabletask.csproj" [here](https://github.com/Azure/azure-functions-durable-extension/issues/2765)