### PR TITLE
Catch ObjectDisposedException in token renewal to prevent app crash

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -1,17 +1,10 @@
 # Release Notes
 
-## Microsoft.Azure.Functions.Worker.Extensions.DurableTask 1.1.1
+## Microsoft.Azure.Functions.Worker.Extensions.DurableTask <version>
 
 ### New Features
 
-- Add `CreateCheckStatusResponseAsync` APIs. (https://github.com/Azure/azure-functions-durable-extension/pull/2722)
-
 ### Bug Fixes
-
-- Fix issue with isolated entities: custom deserialization was not working because IServices was not passed along (https://github.com/Azure/azure-functions-durable-extension/pull/2686)
-- Fix issue with `string` activity input having extra quotes (https://github.com/Azure/azure-functions-durable-extension/pull/2708)
-- Fix issue with out-of-proc entity operation errors: success/failure details of individual operations in a batch was not processed correctly (https://github.com/Azure/azure-functions-durable-extension/pull/2752)
-- Fix issues with .NET Isolated out-of-process error parsing (see https://github.com/Azure/azure-functions-durable-extension/issues/2711)
 
 ### Breaking Changes
 
@@ -22,6 +15,8 @@
 ### New Features
 
 ### Bug Fixes
+
+* Fix crash caused by `ObjectDisposedException` in token renewal code path
 
 ### Breaking Changes
 

--- a/src/WebJobs.Extensions.DurableTask/Auth/AzureCredentialFactory.cs
+++ b/src/WebJobs.Extensions.DurableTask/Auth/AzureCredentialFactory.cs
@@ -143,6 +143,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Auth
             {
                 action();
             }
+            catch (AggregateException ex) when (ex.InnerException is ObjectDisposedException)
+            {
+                // See comment below
+            }
             catch (ObjectDisposedException)
             {
                 // IcM #487363612: This can happen if the host is shutting down or restarting.


### PR DESCRIPTION
This fix comes from a crash dump analysis that was performed as part of ICM #487363612. In this particular case, the customer was using managed identities and there was a crash that occurred when we were writing logs about renewing a token.

```
024-03-20T02:21:16.215224146Z Unhandled exception on 03/20/2024 02:21:16: System.AggregateException: An error occurred while writing to logger(s). (IFeatureCollection has been disposed.
2024-03-20T02:21:16.215272947Z Object name: 'Collection'.)
2024-03-20T02:21:16.215351248Z  ---> System.ObjectDisposedException: IFeatureCollection has been disposed.
2024-03-20T02:21:16.215358648Z Object name: 'Collection'.
2024-03-20T02:21:16.215396648Z    at Microsoft.AspNetCore.Http.Features.FeatureReferences`1.ThrowContextDisposed()
2024-03-20T02:21:16.215401148Z    at Microsoft.AspNetCore.Http.DefaultHttpContext.get_Items()
2024-03-20T02:21:16.216846069Z    at Microsoft.Azure.WebJobs.Script.Extensions.HttpRequestExtensions.GetRequestPropertyOrDefault[TValue](HttpRequest request, String key) in /src/azure-functions-host/src/WebJobs.Script/Extensions/HttpRequestExtensions.cs:line 40
2024-03-20T02:21:16.216867470Z    at Microsoft.Azure.WebJobs.Script.Extensions.HttpRequestExtensions.GetRequestId(HttpRequest request) in /src/azure-functions-host/src/WebJobs.Script/Extensions/HttpRequestExtensions.cs:line 50
2024-03-20T02:21:16.216873470Z    at Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics.SystemLogger.Log[TState](LogLevel logLevel, EventId eventId, TState state, Exception exception, Func`3 formatter) in /src/azure-functions-host/src/WebJobs.Script.WebHost/Diagnostics/SystemLogger.cs:line 150
2024-03-20T02:21:16.216885770Z    at Microsoft.Extensions.Logging.Logger.<Log>g__LoggerLog|12_0[TState](LogLevel logLevel, EventId eventId, ILogger logger, Exception exception, Func`3 formatter, List`1& exceptions, TState& state)
2024-03-20T02:21:16.216891170Z    --- End of inner exception stack trace ---
2024-03-20T02:21:16.216895470Z    at Microsoft.Extensions.Logging.Logger.ThrowLoggingError(List`1 exceptions)
2024-03-20T02:21:16.219139703Z    at Microsoft.Extensions.Logging.Logger.Log[TState](LogLevel logLevel, EventId eventId, TState state, Exception exception, Func`3 formatter)
2024-03-20T02:21:16.219156403Z    at Microsoft.Extensions.Logging.LoggerExtensions.Log(ILogger logger, LogLevel logLevel, EventId eventId, Exception exception, String message, Object[] args)
2024-03-20T02:21:16.219222304Z    at Microsoft.Extensions.Logging.LoggerExtensions.LogInformation(ILogger logger, String message, Object[] args)
2024-03-20T02:21:16.220280119Z    at Microsoft.Azure.WebJobs.Extensions.DurableTask.EndToEndTraceHelper.RetrievingToken(String hubName, String resource) in D:\a\_work\1\s\src\WebJobs.Extensions.DurableTask\EndToEndTraceHelper.cs:line 988
2024-03-20T02:21:16.220302220Z    at Microsoft.Azure.WebJobs.Extensions.DurableTask.Auth.AzureCredentialFactory.OnRenewing(TokenRenewalState state) in D:\a\_work\1\s\src\WebJobs.Extensions.DurableTask\Auth\AzureCredentialFactory.cs:line 118
2024-03-20T02:21:16.220366020Z    at Microsoft.Azure.WebJobs.Extensions.DurableTask.Auth.AzureCredentialFactory.RenewTokenAsync(TokenRenewalState state, CancellationToken cancellationToken) in D:\a\_work\1\s\src\WebJobs.Extensions.DurableTask\Auth\AzureCredentialFactory.cs:line 87
2024-03-20T02:21:16.220479422Z    at Microsoft.WindowsAzure.Storage.Auth.TokenCredential.RenewTokenAsync(Object state)
2024-03-20T02:21:16.220490822Z    at System.Threading.Tasks.Task.<>c.<ThrowAsync>b__128_1(Object state)
2024-03-20T02:21:16.220496122Z    at System.Threading.QueueUserWorkItemCallback.<>c.<.cctor>b__6_0(QueueUserWorkItemCallback quwi)
2024-03-20T02:21:16.220527923Z    at System.Threading.ExecutionContext.RunForThreadPoolUnsafe[TState](ExecutionContext executionContext, Action`1 callback, TState& state)
2024-03-20T02:21:16.220532323Z    at System.Threading.QueueUserWorkItemCallback.Execute()
2024-03-20T02:21:16.220536223Z    at System.Threading.ThreadPoolWorkQueue.Dispatch()
2024-03-20T02:21:16.220547123Z    at System.Threading.PortableThreadPool.WorkerThread.WorkerThreadStart()
2024-03-20T02:21:16.220551423Z    at System.Threading.Thread.StartCallback()
```

Unfortunately, some Kusto logs appear to be missing, which prevents us from narrowing down the exact root cause, but I suspect it's related to a host shutdown, since that's when we typically see these types of `ObjectDisposedException`s occur.

The fix is to wrap the token management calls with try/catch logic to swallow `ObjectDisposedException`, which will prevent the app from crashing.

NOTE: I'm actually not sure if this code applies to the v3.x branch, which has a separate auth mechanism. It might be a fix that's only needed for Durable Functions v2.x, but more investigation may be required.

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)
* [x] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk
* [x] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
    * [ ] Otherwise: major or minor version updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
* [x] My changes **do not** add EventIds to our EventSource logs
    * [ ] Otherwise: Ensure the EventIds are within the supported range in our existing Windows infrastructure. You may validate this with a deployed app's telemetry. You may also extend the range by completing a PR such as [this one](https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files).
* [ ] My changes **should** be added to v3.x branch.
    * [ ] Otherwise: This change only applies to Durable Functions v2.x and **will not** be merged to branch v3.x.