### PR TITLE
Suppress execution context from token renewal

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -23,6 +23,8 @@
 
 ### Bug Fixes
 
+- Fix execution context / log scope leak in token renewal (https://github.com/Azure/azure-functions-durable-extension/pull/2782)
+
 ### Breaking Changes
 
 ### Dependency Updates

--- a/src/WebJobs.Extensions.DurableTask/Auth/AzureCredentialFactory.cs
+++ b/src/WebJobs.Extensions.DurableTask/Auth/AzureCredentialFactory.cs
@@ -72,6 +72,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Auth
                 RefreshOffset = tokenRefreshOffset,
             };
 
+            // The token credential will make background callbacks to renew the token.
+            // We suppress async flow to avoid logging scope from being captured as we do not know
+            // where this will be called from first.
+            using AsyncFlowControl flowControl = System.Threading.ExecutionContext.SuppressFlow();
             return new AppAuthTokenCredential(
                 value.Token,
                 (o, t) => this.RenewTokenAsync((TokenRenewalState)o, t),


### PR DESCRIPTION
<!-- Start the PR description with some context for the change. -->

Suppress execution context from the background token renewal operations. The renewal uses the logger, and so we will capture whatever current log scope is present, leaking that scope into this background thread. This is both a small memory leak and potential object disposed failure (the log scope or its contents may be disposed at any point).

<!-- Make sure to delete the markdown comments and the below sections when squash merging -->
### Issue describing the changes in this PR

resolves #issue_for_this_pr

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)
* [x] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk
* [x] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
    * [ ] Otherwise: major or minor version updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
* [x] My changes **do not** add EventIds to our EventSource logs
    * [ ] Otherwise: Ensure the EventIds are within the supported range in our existing Windows infrastructure. You may validate this with a deployed app's telemetry. You may also extend the range by completing a PR such as [this one](https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files).
* [x] My changes **should** be added to v3.x branch.
    * [ ] Otherwise: This change only applies to Durable Functions v2.x and **will not** be merged to branch v3.x.
