### PR TITLE
Add MSBuild step to auto-generate the .NET worker's AssemblyInfo based on the webjobs extension's version.

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
+++ b/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
@@ -138,6 +138,9 @@
   </ItemGroup>
 
 
+	<!-- The "AssemblyInfo.cs" file for the .NET isolated worker extension needs to be kept up to date with the
+	WebJobs extension version. This pre-build task re-generates that AssemblyInfo file based on this csproj's
+	Version tag.-->
 	<Target Name="GenerateTextFileOnBuild" BeforeTargets="BeforeBuild">
 		<ItemGroup>
 			<FileContent 

--- a/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
+++ b/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
@@ -137,4 +137,22 @@
     </Content>
   </ItemGroup>
 
+
+	<Target Name="GenerateTextFileOnBuild" BeforeTargets="BeforeBuild">
+		<ItemGroup>
+			<FileContent 
+				Include=
+'// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Microsoft.Azure.Functions.Worker.Extensions.Abstractions%3B
+[assembly: ExtensionInformation("Microsoft.Azure.WebJobs.Extensions.DurableTask", "$(Version)")]' />
+		</ItemGroup>
+		<WriteLinesToFile
+		  File="..\Worker.Extensions.DurableTask\AssemblyInfo.cs"
+		  Lines="@(FileContent)"
+		  Overwrite="true"
+		  Encoding="UTF-8" />
+	</Target>
+
 </Project>

--- a/src/Worker.Extensions.DurableTask/AssemblyInfo.cs
+++ b/src/Worker.Extensions.DurableTask/AssemblyInfo.cs
@@ -2,6 +2,4 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using Microsoft.Azure.Functions.Worker.Extensions.Abstractions;
-
-// TODO: Find a way to generate this dynamically at build-time
 [assembly: ExtensionInformation("Microsoft.Azure.WebJobs.Extensions.DurableTask", "2.13.2")]


### PR DESCRIPTION
Another step in the effort to minimize our release burden. This adds a "before build" step to the webjobs extension that re-generates the AssemblyInfo file of the `Worker.Extensions.DurableTask` project, so that it is kept up to date with the "Version" tag of the WebJobs extension.