### PR TITLE
Add suspend/resume URIs to createcheckresponse payload

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -1,17 +1,12 @@
 # Release Notes
 
-## Microsoft.Azure.Functions.Worker.Extensions.DurableTask 1.1.1
+## Microsoft.Azure.Functions.Worker.Extensions.DurableTask 1.2.0
 
 ### New Features
 
-- Add `CreateCheckStatusResponseAsync` APIs. (https://github.com/Azure/azure-functions-durable-extension/pull/2722)
+- Add `suspendPostUri` and `resumePostUri` to the list of returned URIs in `CreateCheckStatusResponseAsync`. (https://github.com/Azure/azure-functions-durable-extension/pull/2785)
 
 ### Bug Fixes
-
-- Fix issue with isolated entities: custom deserialization was not working because IServices was not passed along (https://github.com/Azure/azure-functions-durable-extension/pull/2686)
-- Fix issue with `string` activity input having extra quotes (https://github.com/Azure/azure-functions-durable-extension/pull/2708)
-- Fix issue with out-of-proc entity operation errors: success/failure details of individual operations in a batch was not processed correctly (https://github.com/Azure/azure-functions-durable-extension/pull/2752)
-- Fix issues with .NET Isolated out-of-process error parsing (see https://github.com/Azure/azure-functions-durable-extension/issues/2711)
 
 ### Breaking Changes
 
@@ -22,8 +17,6 @@
 ### New Features
 
 ### Bug Fixes
-
-- Fix execution context / log scope leak in token renewal (https://github.com/Azure/azure-functions-durable-extension/pull/2782)
 
 ### Breaking Changes
 

--- a/src/Worker.Extensions.DurableTask/DurableTaskClientExtensions.cs
+++ b/src/Worker.Extensions.DurableTask/DurableTaskClientExtensions.cs
@@ -147,6 +147,8 @@ public static class DurableTaskClientExtensions
             sendEventPostUri = BuildUrl($"{instanceUrl}/raiseEvent/{{eventName}}", commonQueryParameters),
             statusQueryGetUri = BuildUrl(instanceUrl, commonQueryParameters),
             terminatePostUri = BuildUrl($"{instanceUrl}/terminate", "reason={{text}}}", commonQueryParameters),
+            suspendPostUri =  BuildUrl($"{instanceUrl}/suspend", "reason={{text}}}", commonQueryParameters),
+            resumePostUri =  BuildUrl($"{instanceUrl}/resume", "reason={{text}}}", commonQueryParameters)
         };
     }
 

--- a/src/Worker.Extensions.DurableTask/DurableTaskClientExtensions.cs
+++ b/src/Worker.Extensions.DurableTask/DurableTaskClientExtensions.cs
@@ -146,9 +146,9 @@ public static class DurableTaskClientExtensions
             purgeHistoryDeleteUri = BuildUrl(instanceUrl, commonQueryParameters),
             sendEventPostUri = BuildUrl($"{instanceUrl}/raiseEvent/{{eventName}}", commonQueryParameters),
             statusQueryGetUri = BuildUrl(instanceUrl, commonQueryParameters),
-            terminatePostUri = BuildUrl($"{instanceUrl}/terminate", "reason={{text}}}", commonQueryParameters),
-            suspendPostUri =  BuildUrl($"{instanceUrl}/suspend", "reason={{text}}}", commonQueryParameters),
-            resumePostUri =  BuildUrl($"{instanceUrl}/resume", "reason={{text}}}", commonQueryParameters)
+            terminatePostUri = BuildUrl($"{instanceUrl}/terminate", "reason={{text}}", commonQueryParameters),
+            suspendPostUri =  BuildUrl($"{instanceUrl}/suspend", "reason={{text}}", commonQueryParameters),
+            resumePostUri =  BuildUrl($"{instanceUrl}/resume", "reason={{text}}", commonQueryParameters)
         };
     }
 


### PR DESCRIPTION
<!-- Start the PR description with some context for the change. -->
Currently, the `CreateCheckStatusResponseAsync` only returns a subset of the expected URIs: it's missing the ones for suspend/resume.

This PR adds them.

<!-- Make sure to delete the markdown comments and the below sections when squash merging -->
### Issue describing the changes in this PR

resolves N/A

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)
* [x] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk
* [x] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
    * [ ] Otherwise: major or minor version updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
* [x] My changes **do not** add EventIds to our EventSource logs
    * [ ] Otherwise: Ensure the EventIds are within the supported range in our existing Windows infrastructure. You may validate this with a deployed app's telemetry. You may also extend the range by completing a PR such as [this one](https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files).
* [x] My changes **should** be added to v3.x branch.
    * [ ] Otherwise: This change only applies to Durable Functions v2.x and **will not** be merged to branch v3.x.
