### PR TITLE
Add HttpRequestData null handling

### DIFF
--- a/src/Worker.Extensions.DurableTask/DurableTaskClientExtensions.cs
+++ b/src/Worker.Extensions.DurableTask/DurableTaskClientExtensions.cs
@@ -56,6 +56,11 @@ public static class DurableTaskClientExtensions
             throw new ArgumentNullException(nameof(client));
         }
 
+        if (request is null)
+        {
+            throw new ArgumentNullException(nameof(request));
+        }
+
         HttpResponseData response = request.CreateResponse(statusCode);
         object payload = SetHeadersAndGetPayload(client, request, response, instanceId);
 
@@ -100,6 +105,11 @@ public static class DurableTaskClientExtensions
         if (client is null)
         {
             throw new ArgumentNullException(nameof(client));
+        }
+
+        if (request is null)
+        {
+            throw new ArgumentNullException(nameof(request));
         }
 
         HttpResponseData response = request.CreateResponse(statusCode);


### PR DESCRIPTION
Add HttpRequestData null handling in CreateCheckStatusResponse.
### Pull request checklist

* [X] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [X] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [X] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)
* [X] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk
* [X] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
    * [ ] Otherwise: major or minor version updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
* [X] My changes **do not** add EventIds to our EventSource logs
    * [ ] Otherwise: Ensure the EventIds are within the supported range in our existing Windows infrastructure. You may validate this with a deployed app's telemetry. You may also extend the range by completing a PR such as [this one](https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files).
* [ ] My changes **should** be added to v3.x branch.
    * [ ] Otherwise: This change only applies to Durable Functions v2.x and **will not** be merged to branch v3.x.
