### PR TITLE
Re-add ScheduledStartTime to orchestration scheduling in .NET isolated

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/LocalGrpcListener.cs
+++ b/src/WebJobs.Extensions.DurableTask/LocalGrpcListener.cs
@@ -156,23 +156,24 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 {
                     string instanceId = request.InstanceId ?? Guid.NewGuid().ToString("N");
                     TaskHubClient taskhubClient = new TaskHubClient(this.GetDurabilityProvider(context));
+                    OrchestrationInstance instance;
 
                     // TODO: Ideally, we'd have a single method in the taskhubClient that can handle both scheduled and non-scheduled starts.
                     // TODO: the type of `ScheduledStartTimestamp` is not nullable. Can we change it to `DateTime?` in the proto file?
                     if (request.ScheduledStartTimestamp != null)
                     {
-                        var ins = await taskhubClient.CreateScheduledOrchestrationInstanceAsync(
+                        instance = await taskhubClient.CreateScheduledOrchestrationInstanceAsync(
                             name: request.Name, version: request.Version, instanceId: instanceId, input: Raw(request.Input), startAt: request.ScheduledStartTimestamp.ToDateTime());
                     }
                     else
                     {
-                        await taskhubClient.CreateOrchestrationInstanceAsync(request.Name, request.Version, instanceId, Raw(request.Input));
+                        instance = await taskhubClient.CreateOrchestrationInstanceAsync(request.Name, request.Version, instanceId, Raw(request.Input));
                     }
 
-                    // TODO: should this not inclide the ExecutionId and other elements of the taskhubClient response?
+                    // TODO: should this not include the ExecutionId and other elements of the taskhubClient response?
                     return new P.CreateInstanceResponse
                     {
-                        InstanceId = instanceId,
+                        InstanceId = instance.InstanceId,
                     };
                 }
                 catch (OrchestrationAlreadyExistsException)

--- a/src/WebJobs.Extensions.DurableTask/LocalGrpcListener.cs
+++ b/src/WebJobs.Extensions.DurableTask/LocalGrpcListener.cs
@@ -152,13 +152,33 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
             public async override Task<P.CreateInstanceResponse> StartInstance(P.CreateInstanceRequest request, ServerCallContext context)
             {
+                var instance = new OrchestrationInstance
+                {
+                    InstanceId = request.InstanceId ?? Guid.NewGuid().ToString("N"),
+                    ExecutionId = Guid.NewGuid().ToString(),
+                };
+
+
                 try
                 {
-                    string instanceId = await this.GetClient(context).StartNewAsync(
-                        request.Name, request.InstanceId, Raw(request.Input));
+                        // we don't use a DurableOrchestrationClient here because it doesn't expose a "ScheduledStartTime" property
+                        await this.GetDurabilityProvider(context).CreateTaskOrchestrationAsync(
+                        new TaskMessage
+                        {
+                            Event = new ExecutionStartedEvent(-1, Raw(request.Input))
+                            {
+                                Name = request.Name,
+                                Version = request.Version,
+                                OrchestrationInstance = instance,
+                                ScheduledStartTime = request.ScheduledStartTimestamp?.ToDateTime(),
+                            },
+                            OrchestrationInstance = instance,
+                        },
+                        this.GetStatusesNotToOverride());
+
                     return new P.CreateInstanceResponse
                     {
-                        InstanceId = instanceId,
+                        InstanceId = instance.InstanceId,
                     };
                 }
                 catch (OrchestrationAlreadyExistsException)

--- a/src/WebJobs.Extensions.DurableTask/LocalGrpcListener.cs
+++ b/src/WebJobs.Extensions.DurableTask/LocalGrpcListener.cs
@@ -152,33 +152,27 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
             public async override Task<P.CreateInstanceResponse> StartInstance(P.CreateInstanceRequest request, ServerCallContext context)
             {
-                var instance = new OrchestrationInstance
-                {
-                    InstanceId = request.InstanceId ?? Guid.NewGuid().ToString("N"),
-                    ExecutionId = Guid.NewGuid().ToString(),
-                };
-
-
                 try
                 {
-                        // we don't use a DurableOrchestrationClient here because it doesn't expose a "ScheduledStartTime" property
-                        await this.GetDurabilityProvider(context).CreateTaskOrchestrationAsync(
-                        new TaskMessage
-                        {
-                            Event = new ExecutionStartedEvent(-1, Raw(request.Input))
-                            {
-                                Name = request.Name,
-                                Version = request.Version,
-                                OrchestrationInstance = instance,
-                                ScheduledStartTime = request.ScheduledStartTimestamp?.ToDateTime(),
-                            },
-                            OrchestrationInstance = instance,
-                        },
-                        this.GetStatusesNotToOverride());
+                    string instanceId = request.InstanceId ?? Guid.NewGuid().ToString("N");
+                    TaskHubClient taskhubClient = new TaskHubClient(this.GetDurabilityProvider(context));
 
+                    // TODO: Ideally, we'd have a single method in the taskhubClient that can handle both scheduled and non-scheduled starts.
+                    // TODO: the type of `ScheduledStartTimestamp` is not nullable. Can we change it to `DateTime?` in the proto file?
+                    if (request.ScheduledStartTimestamp != null)
+                    {
+                        var ins = await taskhubClient.CreateScheduledOrchestrationInstanceAsync(
+                            name: request.Name, version: request.Version, instanceId: instanceId, input: Raw(request.Input), startAt: request.ScheduledStartTimestamp.ToDateTime());
+                    }
+                    else
+                    {
+                        await taskhubClient.CreateOrchestrationInstanceAsync(request.Name, request.Version, instanceId, Raw(request.Input));
+                    }
+
+                    // TODO: should this not inclide the ExecutionId and other elements of the taskhubClient response?
                     return new P.CreateInstanceResponse
                     {
-                        InstanceId = instance.InstanceId,
+                        InstanceId = instanceId,
                     };
                 }
                 catch (OrchestrationAlreadyExistsException)
@@ -251,13 +245,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 EntityBackendQueries.EntityQueryResult result = await entityOrchestrationService.EntityBackendQueries!.QueryEntitiesAsync(
                     new EntityBackendQueries.EntityQuery()
                     {
-                         InstanceIdStartsWith = query.InstanceIdStartsWith,
-                         LastModifiedFrom = query.LastModifiedFrom?.ToDateTime(),
-                         LastModifiedTo = query.LastModifiedTo?.ToDateTime(),
-                         IncludeTransient = query.IncludeTransient,
-                         IncludeState = query.IncludeState,
-                         ContinuationToken = query.ContinuationToken,
-                         PageSize = query.PageSize,
+                        InstanceIdStartsWith = query.InstanceIdStartsWith,
+                        LastModifiedFrom = query.LastModifiedFrom?.ToDateTime(),
+                        LastModifiedTo = query.LastModifiedTo?.ToDateTime(),
+                        IncludeTransient = query.IncludeTransient,
+                        IncludeState = query.IncludeState,
+                        ContinuationToken = query.ContinuationToken,
+                        PageSize = query.PageSize,
                     },
                     context.CancellationToken);
 

--- a/test/e2e/Apps/BasicDotNetIsolated/HelloCities.cs
+++ b/test/e2e/Apps/BasicDotNetIsolated/HelloCities.cs
@@ -60,11 +60,11 @@ namespace Microsoft.Azure.Durable.Tests.E2E
             [HttpTrigger(AuthorizationLevel.Anonymous, "get", "post")] HttpRequestData req,
             [DurableClient] DurableTaskClient client,
             FunctionContext executionContext,
-            DateTime ScheduledStartTime)
+            DateTime scheduledStartTime)
         {
             ILogger logger = executionContext.GetLogger("HelloCities_HttpStart");
 
-            var startOptions = new StartOrchestrationOptions(StartAt: ScheduledStartTime);
+            var startOptions = new StartOrchestrationOptions(StartAt: scheduledStartTime);
 
             // Function input comes from the request content.
             string instanceId = await client.ScheduleNewOrchestrationInstanceAsync(

--- a/test/e2e/Apps/BasicDotNetIsolated/HelloCities.cs
+++ b/test/e2e/Apps/BasicDotNetIsolated/HelloCities.cs
@@ -54,5 +54,27 @@ namespace Microsoft.Azure.Durable.Tests.E2E
             // See https://learn.microsoft.com/azure/azure-functions/durable/durable-functions-http-api#start-orchestration
             return await client.CreateCheckStatusResponseAsync(req, instanceId);
         }
+
+        [Function("HelloCities_HttpStart_Scheduled")]
+        public static async Task<HttpResponseData> HttpStartScheduled(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "get", "post")] HttpRequestData req,
+            [DurableClient] DurableTaskClient client,
+            FunctionContext executionContext,
+            DateTime ScheduledStartTime)
+        {
+            ILogger logger = executionContext.GetLogger("HelloCities_HttpStart");
+
+            var startOptions = new StartOrchestrationOptions(StartAt: ScheduledStartTime);
+
+            // Function input comes from the request content.
+            string instanceId = await client.ScheduleNewOrchestrationInstanceAsync(
+                nameof(HelloCities), startOptions);
+
+            logger.LogInformation("Started orchestration with ID = '{instanceId}'.", instanceId);
+
+            // Returns an HTTP 202 response with an instance management payload.
+            // See https://learn.microsoft.com/azure/azure-functions/durable/durable-functions-http-api#start-orchestration
+            return await client.CreateCheckStatusResponseAsync(req, instanceId);
+        }
     }
 }

--- a/test/e2e/Tests/E2ETests.csproj
+++ b/test/e2e/Tests/E2ETests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>

--- a/test/e2e/Tests/Helpers/DurableHelpers.cs
+++ b/test/e2e/Tests/Helpers/DurableHelpers.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Text.Json.Nodes;
+
+namespace Microsoft.Azure.Durable.Tests.DotnetIsolatedE2E;
+
+internal class DurableHelpers
+{
+    internal static string ParseStatusQueryGetUri(HttpResponseMessage invocationStartResponse)
+    {
+        string? responseString = invocationStartResponse.Content?.ReadAsStringAsync().Result;
+        if (string.IsNullOrEmpty(responseString))
+        {
+            return string.Empty;
+        }
+        JsonNode? responseJsonNode = JsonNode.Parse(responseString);
+        if (responseJsonNode == null)
+        {
+            return string.Empty;
+        }
+
+        string? statusQueryGetUri = responseJsonNode["StatusQueryGetUri"]?.GetValue<string>();
+        return statusQueryGetUri ?? string.Empty;
+    }
+    internal static string GetRuntimeStatus(string statusQueryGetUri)
+    {
+        HttpClient client = new HttpClient();
+        var statusQueryResponse = client.GetAsync(statusQueryGetUri);
+
+        string? statusQueryResponseString = statusQueryResponse.Result.Content.ReadAsStringAsync().Result;
+        JsonNode? statusQueryJsonNode = JsonNode.Parse(statusQueryResponseString);
+        if (statusQueryJsonNode == null)
+        {
+            return string.Empty;
+        }
+        return statusQueryJsonNode["runtimeStatus"]?.GetValue<string>() ?? string.Empty;
+    }
+}

--- a/test/e2e/Tests/Helpers/DurableHelpers.cs
+++ b/test/e2e/Tests/Helpers/DurableHelpers.cs
@@ -7,9 +7,34 @@ namespace Microsoft.Azure.Durable.Tests.DotnetIsolatedE2E;
 
 internal class DurableHelpers
 {
+    static readonly HttpClient _httpClient = new HttpClient();
+
+    internal class OrchestrationStatusDetails
+    {
+        public string RuntimeStatus { get; set; } = string.Empty;
+        public string Input { get; set; } = string.Empty;
+        public string Output { get; set; } = string.Empty;
+        public DateTime CreatedTime { get; set; }
+        public DateTime LastUpdatedTime { get; set; }
+        public OrchestrationStatusDetails(string statusQueryResponse)
+        {
+            JsonNode? statusQueryJsonNode = JsonNode.Parse(statusQueryResponse);
+            if (statusQueryJsonNode == null)
+            {
+                return;
+            }
+            this.RuntimeStatus = statusQueryJsonNode["runtimeStatus"]?.GetValue<string>() ?? string.Empty;
+            this.Input = statusQueryJsonNode["input"]?.ToString() ?? string.Empty;
+            this.Output = statusQueryJsonNode["output"]?.ToString() ?? string.Empty;
+            this.CreatedTime = DateTime.Parse(statusQueryJsonNode["createdTime"]?.GetValue<string>() ?? string.Empty);
+            this.LastUpdatedTime = DateTime.Parse(statusQueryJsonNode["lastUpdatedTime"]?.GetValue<string>() ?? string.Empty);
+        }
+    }
+
     internal static string ParseStatusQueryGetUri(HttpResponseMessage invocationStartResponse)
     {
         string? responseString = invocationStartResponse.Content?.ReadAsStringAsync().Result;
+
         if (string.IsNullOrEmpty(responseString))
         {
             return string.Empty;
@@ -23,17 +48,12 @@ internal class DurableHelpers
         string? statusQueryGetUri = responseJsonNode["StatusQueryGetUri"]?.GetValue<string>();
         return statusQueryGetUri ?? string.Empty;
     }
-    internal static string GetRuntimeStatus(string statusQueryGetUri)
+    internal static OrchestrationStatusDetails GetRunningOrchestrationDetails(string statusQueryGetUri)
     {
-        HttpClient client = new HttpClient();
-        var statusQueryResponse = client.GetAsync(statusQueryGetUri);
+        var statusQueryResponse = _httpClient.GetAsync(statusQueryGetUri);
 
         string? statusQueryResponseString = statusQueryResponse.Result.Content.ReadAsStringAsync().Result;
-        JsonNode? statusQueryJsonNode = JsonNode.Parse(statusQueryResponseString);
-        if (statusQueryJsonNode == null)
-        {
-            return string.Empty;
-        }
-        return statusQueryJsonNode["runtimeStatus"]?.GetValue<string>() ?? string.Empty;
+
+        return new OrchestrationStatusDetails(statusQueryResponseString);
     }
 }

--- a/test/e2e/Tests/Helpers/DurableHelpers.cs
+++ b/test/e2e/Tests/Helpers/DurableHelpers.cs
@@ -26,8 +26,8 @@ internal class DurableHelpers
             this.RuntimeStatus = statusQueryJsonNode["runtimeStatus"]?.GetValue<string>() ?? string.Empty;
             this.Input = statusQueryJsonNode["input"]?.ToString() ?? string.Empty;
             this.Output = statusQueryJsonNode["output"]?.ToString() ?? string.Empty;
-            this.CreatedTime = DateTime.Parse(statusQueryJsonNode["createdTime"]?.GetValue<string>() ?? string.Empty);
-            this.LastUpdatedTime = DateTime.Parse(statusQueryJsonNode["lastUpdatedTime"]?.GetValue<string>() ?? string.Empty);
+            this.CreatedTime = DateTime.Parse(statusQueryJsonNode["createdTime"]?.GetValue<string>() ?? string.Empty).ToUniversalTime();
+            this.LastUpdatedTime = DateTime.Parse(statusQueryJsonNode["lastUpdatedTime"]?.GetValue<string>() ?? string.Empty).ToUniversalTime();
         }
     }
 

--- a/test/e2e/Tests/Tests/HelloCitiesTest.cs
+++ b/test/e2e/Tests/Tests/HelloCitiesTest.cs
@@ -40,7 +40,7 @@ public class HttpEndToEndTests
     [InlineData("HelloCities_HttpStart_Scheduled", -5, HttpStatusCode.Accepted)]
     public async Task ScheduledStartTests(string functionName, int startDelaySeconds, HttpStatusCode expectedStatusCode)
     {
-        var testStartTime = DateTime.Now;
+        var testStartTime = DateTime.UtcNow;
         var scheduledStartTime = testStartTime + TimeSpan.FromSeconds(startDelaySeconds);
         string urlQueryString = $"?ScheduledStartTime={scheduledStartTime.ToString("o")}";
 
@@ -52,7 +52,7 @@ public class HttpEndToEndTests
         Assert.Equal(expectedStatusCode, response.StatusCode);
 
         var orchestrationDetails = DurableHelpers.GetRunningOrchestrationDetails(statusQueryGetUri);
-        while (DateTime.Now < scheduledStartTime)
+        while (DateTime.UtcNow < scheduledStartTime)
         {
             _output.WriteLine($"Test scheduled for {scheduledStartTime}, current time {DateTime.Now}");
             orchestrationDetails = DurableHelpers.GetRunningOrchestrationDetails(statusQueryGetUri);

--- a/test/e2e/Tests/Tests/HelloCitiesTest.cs
+++ b/test/e2e/Tests/Tests/HelloCitiesTest.cs
@@ -7,7 +7,7 @@ using Xunit.Abstractions;
 
 namespace Microsoft.Azure.Durable.Tests.DotnetIsolatedE2E;
 
-[Collection(Constants.FunctionAppCollectionName )]
+[Collection(Constants.FunctionAppCollectionName)]
 public class HttpEndToEndTests
 {
     private readonly FunctionAppFixture _fixture;
@@ -19,17 +19,34 @@ public class HttpEndToEndTests
     }
 
     [Theory]
-    [InlineData("HelloCities_HttpStart", "", HttpStatusCode.Accepted, "")]
-    public async Task HttpTriggerTests(string functionName, string queryString, HttpStatusCode expectedStatusCode, string expectedMessage)
+    [InlineData("HelloCities_HttpStart", HttpStatusCode.Accepted)]
+    public async Task HttpTriggerTests(string functionName, HttpStatusCode expectedStatusCode)
     {
-        using HttpResponseMessage response = await HttpHelpers.InvokeHttpTrigger(functionName, queryString);
+        using HttpResponseMessage response = await HttpHelpers.InvokeHttpTrigger(functionName, "");
         string actualMessage = await response.Content.ReadAsStringAsync();
 
         Assert.Equal(expectedStatusCode, response.StatusCode);
+        Assert.False(string.IsNullOrEmpty(actualMessage));
+    }
 
-        if (!string.IsNullOrEmpty(expectedMessage))
-        {
-            Assert.False(string.IsNullOrEmpty(actualMessage));
-        }
+    [Theory]
+    [InlineData("HelloCities_HttpStart_Scheduled", HttpStatusCode.Accepted)]
+    public async Task ScheduledStartTests(string functionName, HttpStatusCode expectedStatusCode)
+    {
+        var scheduledStartDate = DateTime.Now + TimeSpan.FromSeconds(10);
+
+        using HttpResponseMessage response = await HttpHelpers.InvokeHttpTrigger(functionName, $"?ScheduledStartTime={scheduledStartDate.ToString("o")}");
+        string actualMessage = await response.Content.ReadAsStringAsync();
+
+        string statusQueryGetUri = DurableHelpers.ParseStatusQueryGetUri(response);
+
+        Assert.Equal(expectedStatusCode, response.StatusCode);
+
+        string startRuntimeStatus = DurableHelpers.GetRuntimeStatus(statusQueryGetUri);
+        Assert.Equal("Pending", startRuntimeStatus);
+        Thread.Sleep(11000);
+
+        string endRuntimeStatus = DurableHelpers.GetRuntimeStatus(statusQueryGetUri);
+        Assert.Equal("Completed", endRuntimeStatus);
     }
 }

--- a/test/e2e/Tests/Tests/HelloCitiesTest.cs
+++ b/test/e2e/Tests/Tests/HelloCitiesTest.cs
@@ -11,42 +11,62 @@ namespace Microsoft.Azure.Durable.Tests.DotnetIsolatedE2E;
 public class HttpEndToEndTests
 {
     private readonly FunctionAppFixture _fixture;
+    private readonly ITestOutputHelper _output;
 
     public HttpEndToEndTests(FunctionAppFixture fixture, ITestOutputHelper testOutputHelper)
     {
         _fixture = fixture;
         _fixture.TestLogs.UseTestLogger(testOutputHelper);
+        _output = testOutputHelper;
     }
 
     [Theory]
-    [InlineData("HelloCities_HttpStart", HttpStatusCode.Accepted)]
-    public async Task HttpTriggerTests(string functionName, HttpStatusCode expectedStatusCode)
+    [InlineData("HelloCities_HttpStart", HttpStatusCode.Accepted, "Hello Tokyo!")]
+    public async Task HttpTriggerTests(string functionName, HttpStatusCode expectedStatusCode, string partialExpectedOutput)
     {
         using HttpResponseMessage response = await HttpHelpers.InvokeHttpTrigger(functionName, "");
         string actualMessage = await response.Content.ReadAsStringAsync();
 
         Assert.Equal(expectedStatusCode, response.StatusCode);
-        Assert.False(string.IsNullOrEmpty(actualMessage));
+        string statusQueryGetUri = DurableHelpers.ParseStatusQueryGetUri(response);
+        Thread.Sleep(1000);
+        var orchestrationDetails = DurableHelpers.GetRunningOrchestrationDetails(statusQueryGetUri);
+        Assert.Equal("Completed", orchestrationDetails.RuntimeStatus);
+        Assert.Contains(partialExpectedOutput, orchestrationDetails.Output);
     }
 
     [Theory]
-    [InlineData("HelloCities_HttpStart_Scheduled", HttpStatusCode.Accepted)]
-    public async Task ScheduledStartTests(string functionName, HttpStatusCode expectedStatusCode)
+    [InlineData("HelloCities_HttpStart_Scheduled", 5, HttpStatusCode.Accepted)]
+    [InlineData("HelloCities_HttpStart_Scheduled", -5, HttpStatusCode.Accepted)]
+    public async Task ScheduledStartTests(string functionName, int startDelaySeconds, HttpStatusCode expectedStatusCode)
     {
-        var scheduledStartDate = DateTime.Now + TimeSpan.FromSeconds(10);
+        var testStartTime = DateTime.Now;
+        var scheduledStartTime = testStartTime + TimeSpan.FromSeconds(startDelaySeconds);
+        string urlQueryString = $"?ScheduledStartTime={scheduledStartTime.ToString("o")}";
 
-        using HttpResponseMessage response = await HttpHelpers.InvokeHttpTrigger(functionName, $"?ScheduledStartTime={scheduledStartDate.ToString("o")}");
+        using HttpResponseMessage response = await HttpHelpers.InvokeHttpTrigger(functionName, urlQueryString);
         string actualMessage = await response.Content.ReadAsStringAsync();
 
         string statusQueryGetUri = DurableHelpers.ParseStatusQueryGetUri(response);
 
         Assert.Equal(expectedStatusCode, response.StatusCode);
 
-        string startRuntimeStatus = DurableHelpers.GetRuntimeStatus(statusQueryGetUri);
-        Assert.Equal("Pending", startRuntimeStatus);
-        Thread.Sleep(11000);
+        var orchestrationDetails = DurableHelpers.GetRunningOrchestrationDetails(statusQueryGetUri);
+        while (DateTime.Now < scheduledStartTime)
+        {
+            _output.WriteLine($"Test scheduled for {scheduledStartTime}, current time {DateTime.Now}");
+            orchestrationDetails = DurableHelpers.GetRunningOrchestrationDetails(statusQueryGetUri);
+            Assert.Equal("Pending", orchestrationDetails.RuntimeStatus);
+            Thread.Sleep(3000);
+        }
 
-        string endRuntimeStatus = DurableHelpers.GetRuntimeStatus(statusQueryGetUri);
-        Assert.Equal("Completed", endRuntimeStatus);
+        // Give a small amount of time for the orchestration to complete, even if scheduled to run immediately
+        Thread.Sleep(1000);
+        _output.WriteLine($"Test scheduled for {scheduledStartTime}, current time {DateTime.Now}, looking for completed");
+
+        var finalOrchestrationDetails = DurableHelpers.GetRunningOrchestrationDetails(statusQueryGetUri);
+        Assert.Equal("Completed", finalOrchestrationDetails.RuntimeStatus);
+
+        Assert.True(finalOrchestrationDetails.LastUpdatedTime > scheduledStartTime);
     }
 }


### PR DESCRIPTION
<!-- Start the PR description with some context for the change. -->
Follow up to:
https://github.com/Azure/azure-functions-durable-extension/pull/2634
https://github.com/Azure/azure-functions-durable-extension/pull/2544#issuecomment-1688579724

Fixes: https://github.com/microsoft/durabletask-dotnet/issues/256

When refactoring the localGrpcListener (used by .NET isolated and Java) to use an IDurableClient (necessary for Distributed Tracing), we accidentally dropped the ability to set an orchestrator's "fireAt" time. This PR adds that back.

Since the IDurableClient does not expose functionality for scheduled orchestrators, this PR constructs the `TaskHubClient`, which does expose that functionality. It also leaves a few "TODO" comments to simplify the implementation in the future.
 
 **Sitll pending:**
 * Manual E2E test
 * Inclusion of distributed tracing regression test
 * Inclusion of test of scheduled orchestrations test.
 
<!-- Make sure to delete the markdown comments and the below sections when squash merging -->
### Issue describing the changes in this PR

resolves https://github.com/microsoft/durabletask-dotnet/issues/256


### Pull request checklist

* [ ] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)
* [ ] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk
* [ ] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
    * [ ] Otherwise: major or minor version updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
* [ ] My changes **do not** add EventIds to our EventSource logs
    * [ ] Otherwise: Ensure the EventIds are within the supported range in our existing Windows infrastructure. You may validate this with a deployed app's telemetry. You may also extend the range by completing a PR such as [this one](https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files).
* [ ] My changes **should** be added to v3.x branch.
    * [ ] Otherwise: This change only applies to Durable Functions v2.x and **will not** be merged to branch v3.x.
