### PR TITLE
Update ActivityInputConverter for Activities with FunctionContext-only parameters

### DIFF
--- a/src/Worker.Extensions.DurableTask/ActivityInputConverter.cs
+++ b/src/Worker.Extensions.DurableTask/ActivityInputConverter.cs
@@ -25,6 +25,13 @@ internal class ActivityInputConverter : IInputConverter
             throw new ArgumentNullException(nameof(context));
         }
 
+        // Special handling for FunctionContext
+        // This addresses cases where the activity function has only FunctionContext as a parameter.
+        if (context.TargetType == typeof(FunctionContext))
+        {
+            return new(ConversionResult.Success(context.FunctionContext));
+        }
+
         if (context.Source is null)
         {
             return new(ConversionResult.Success(null));

--- a/src/Worker.Extensions.DurableTask/ActivityInputConverter.cs
+++ b/src/Worker.Extensions.DurableTask/ActivityInputConverter.cs
@@ -29,7 +29,7 @@ internal class ActivityInputConverter : IInputConverter
         // This addresses cases where the activity function has only FunctionContext as a parameter.
         if (context.TargetType == typeof(FunctionContext))
         {
-            return new(ConversionResult.Success(context.FunctionContext));
+            return new(ConversionResult.Unhandled());
         }
 
         if (context.Source is null)

--- a/src/Worker.Extensions.DurableTask/ActivityTriggerAttribute.cs
+++ b/src/Worker.Extensions.DurableTask/ActivityTriggerAttribute.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Azure.Functions.Worker;
 [AttributeUsage(AttributeTargets.Parameter)]
 [DebuggerDisplay("{Activity}")]
 [InputConverter(typeof(ActivityInputConverter))]
-[ConverterFallbackBehavior(ConverterFallbackBehavior.Disallow)]
+[ConverterFallbackBehavior(ConverterFallbackBehavior.Allow)]
 public sealed class ActivityTriggerAttribute : TriggerBindingAttribute
 {
     /// <summary>


### PR DESCRIPTION
Fix issue #2741 

When activity functions with only one parameter, the FunctionContext, would incorrectly have the FunctionContext set to null after ConvertAsync() at ActivityInputConverter. That's because the ContextConverter handles the `source` as null and `TargetType` as FunctionContext. This PR adds a specific case in the ActivityInputConverter to address this issue.




### Pull request checklist

* [ ] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)
* [ ] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk
* [ ] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
    * [ ] Otherwise: major or minor version updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
* [ ] My changes **do not** add EventIds to our EventSource logs
    * [ ] Otherwise: Ensure the EventIds are within the supported range in our existing Windows infrastructure. You may validate this with a deployed app's telemetry. You may also extend the range by completing a PR such as [this one](https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files).
* [x] My changes **should** be added to v3.x branch.
    * [ ] Otherwise: This change only applies to Durable Functions v2.x and **will not** be merged to branch v3.x.
