### PR TITLE
Allow custom connection string names when using DurableClient

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/DurableTaskJobHostConfigurationExtensions.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskJobHostConfigurationExtensions.cs
@@ -45,8 +45,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             }
 
             serviceCollection.TryAddSingleton<INameResolver, DefaultNameResolver>();
-            serviceCollection.TryAddSingleton<IConnectionInfoResolver, StandardConnectionInfoProvider>();
-            serviceCollection.TryAddSingleton<IStorageAccountProvider, AzureStorageAccountProvider>();
 #if !FUNCTIONS_V1
             serviceCollection.AddAzureClientsCore();
             serviceCollection.TryAddSingleton<ITokenCredentialFactory, AzureCredentialFactory>();


### PR DESCRIPTION
Draft PR to check if CI tests pass.

This PR removes a couple of service registrations, `IConnectionInfoResolver` and `IStorageAccountProvider`, from the `AddDurableClientFactory` method. Before these changes, users were not able to set a custom connection string name when creating a client (example below) since the connection string name would always be set to the default, `Storage`.

``` C#
public ClientFunction(IDurableClientFactory clientFactory, IConfiguration configuration)
{
    _client = clientFactory.CreateClient(new DurableClientOptions
    {
        ConnectionName = "CustomConnection",
        TaskHub = configuration["TaskHub"]
    });
}
```

resolves #issue_for_this_pr

### Pull request checklist

* [ ] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)
* [ ] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk
* [ ] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
    * [ ] Otherwise: major or minor version updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
* [ ] My changes **do not** add EventIds to our EventSource logs
    * [ ] Otherwise: Ensure the EventIds are within the supported range in our existing Windows infrastructure. You may validate this with a deployed app's telemetry. You may also extend the range by completing a PR such as [this one](https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files).
* [ ] My changes **should** be added to v3.x branch.
    * [ ] Otherwise: This change only applies to Durable Functions v2.x and **will not** be merged to branch v3.x.
