### PR TITLE
Override new "base" Terminate API

### DIFF
--- a/WebJobs.Extensions.DurableTask.sln
+++ b/WebJobs.Extensions.DurableTask.sln
@@ -94,6 +94,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "PerfTests", "PerfTests", "{
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DFPerfScenariosV4", "test\DFPerfScenarios\DFPerfScenariosV4.csproj", "{FC8AD123-F949-4D21-B817-E5A4BBF7F69B}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Worker.Extensions.DurableTask.Tests", "test\Worker.Extensions.DurableTask.Tests\Worker.Extensions.DurableTask.Tests.csproj", "{76DEC17C-BF6A-498A-8E8A-7D6CB2E03284}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -178,6 +180,10 @@ Global
 		{FC8AD123-F949-4D21-B817-E5A4BBF7F69B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FC8AD123-F949-4D21-B817-E5A4BBF7F69B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{FC8AD123-F949-4D21-B817-E5A4BBF7F69B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{76DEC17C-BF6A-498A-8E8A-7D6CB2E03284}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{76DEC17C-BF6A-498A-8E8A-7D6CB2E03284}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{76DEC17C-BF6A-498A-8E8A-7D6CB2E03284}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{76DEC17C-BF6A-498A-8E8A-7D6CB2E03284}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -211,6 +217,7 @@ Global
 		{65F904AA-0F6F-48CB-BE19-593B7D68152A} = {7387E723-E153-4B7A-B105-8C67BFBD48CF}
 		{7387E723-E153-4B7A-B105-8C67BFBD48CF} = {78BCF152-C22C-408F-9FB1-0F8C99B154B5}
 		{FC8AD123-F949-4D21-B817-E5A4BBF7F69B} = {7387E723-E153-4B7A-B105-8C67BFBD48CF}
+		{76DEC17C-BF6A-498A-8E8A-7D6CB2E03284} = {78BCF152-C22C-408F-9FB1-0F8C99B154B5}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {5E9AC327-DE18-41A5-A55D-E44CB4281943}

--- a/release_notes.md
+++ b/release_notes.md
@@ -1,11 +1,10 @@
 # Release Notes
 
-## Microsoft.Azure.Functions.Worker.Extensions.DurableTask 1.2.0
+## Microsoft.Azure.Functions.Worker.Extensions.DurableTask 1.2.1
 
 ### New Features
 
-- Add `suspendPostUri` and `resumePostUri` to the list of returned URIs in `CreateCheckStatusResponseAsync`. (https://github.com/Azure/azure-functions-durable-extension/pull/2785)
-- Fix `NotSupportedException` when calling `PurgeAllInstancesAsync` and `PurgeInstanceAsync`
+- Fix regression on `TerminateInstanceAsync` API causing invocations to fail with "unimplemented" exceptions (https://github.com/Azure/azure-functions-durable-extension/pull/2829).
 
 ### Bug Fixes
 

--- a/src/Worker.Extensions.DurableTask/AssemblyInfo.cs
+++ b/src/Worker.Extensions.DurableTask/AssemblyInfo.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System.Runtime.CompilerServices;
 using Microsoft.Azure.Functions.Worker.Extensions.Abstractions;
 
 // TODO: Find a way to generate this dynamically at build-time
 [assembly: ExtensionInformation("Microsoft.Azure.WebJobs.Extensions.DurableTask", "2.13.3")]
+[assembly: InternalsVisibleTo("Worker.Extensions.DurableTask.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100cd1dabd5a893b40e75dc901fe7293db4a3caf9cd4d3e3ed6178d49cd476969abe74a9e0b7f4a0bb15edca48758155d35a4f05e6e852fff1b319d103b39ba04acbadd278c2753627c95e1f6f6582425374b92f51cca3deb0d2aab9de3ecda7753900a31f70a236f163006beefffe282888f85e3c76d1205ec7dfef7fa472a17b1")]

--- a/src/Worker.Extensions.DurableTask/FunctionsDurableTaskClient.cs
+++ b/src/Worker.Extensions.DurableTask/FunctionsDurableTaskClient.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.DurableTask;

--- a/src/Worker.Extensions.DurableTask/FunctionsDurableTaskClient.cs
+++ b/src/Worker.Extensions.DurableTask/FunctionsDurableTaskClient.cs
@@ -85,7 +85,7 @@ internal sealed class FunctionsDurableTaskClient : DurableTaskClient
     }
 
     public override Task TerminateInstanceAsync(
-    string instanceId, TerminateInstanceOptions? options = null, CancellationToken cancellation = default)
+        string instanceId, TerminateInstanceOptions? options = null, CancellationToken cancellation = default)
     {
         object? output = options?.Output;
         return this.inner.TerminateInstanceAsync(instanceId, output: output, cancellation);

--- a/src/Worker.Extensions.DurableTask/FunctionsDurableTaskClient.cs
+++ b/src/Worker.Extensions.DurableTask/FunctionsDurableTaskClient.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.DurableTask;
@@ -87,8 +88,7 @@ internal sealed class FunctionsDurableTaskClient : DurableTaskClient
     public override Task TerminateInstanceAsync(
         string instanceId, TerminateInstanceOptions? options = null, CancellationToken cancellation = default)
     {
-        object? output = options?.Output;
-        return this.inner.TerminateInstanceAsync(instanceId, output: output, cancellation);
+        return this.inner.TerminateInstanceAsync(instanceId, options, cancellation);
     }
 
     public override Task<OrchestrationMetadata> WaitForInstanceCompletionAsync(

--- a/src/Worker.Extensions.DurableTask/FunctionsDurableTaskClient.cs
+++ b/src/Worker.Extensions.DurableTask/FunctionsDurableTaskClient.cs
@@ -85,9 +85,10 @@ internal sealed class FunctionsDurableTaskClient : DurableTaskClient
     }
 
     public override Task TerminateInstanceAsync(
-        string instanceId, object? output = null, CancellationToken cancellation = default)
+    string instanceId, TerminateInstanceOptions? options = null, CancellationToken cancellation = default)
     {
-        return this.inner.TerminateInstanceAsync(instanceId, output, cancellation);
+        object? output = options?.Output;
+        return this.inner.TerminateInstanceAsync(instanceId, output: output, cancellation);
     }
 
     public override Task<OrchestrationMetadata> WaitForInstanceCompletionAsync(

--- a/src/Worker.Extensions.DurableTask/HTTP/HttpMethodConverter.cs
+++ b/src/Worker.Extensions.DurableTask/HTTP/HttpMethodConverter.cs
@@ -20,7 +20,8 @@ internal class HttpMethodConverter : JsonConverter<HttpMethod>
         Type objectType,
         JsonSerializerOptions options)
     {
-        return new HttpMethod(reader.GetString());
+        string readerString = reader.GetString() ?? string.Empty;
+        return new HttpMethod(readerString);
     }
 
     public override void Write(

--- a/test/Worker.Extensions.DurableTask.Tests/FunctionsDurableTaskClientTests.cs
+++ b/test/Worker.Extensions.DurableTask.Tests/FunctionsDurableTaskClientTests.cs
@@ -1,0 +1,56 @@
+using Microsoft.DurableTask.Client;
+using Microsoft.DurableTask.Client.Grpc;
+using Moq;
+
+namespace Microsoft.Azure.Functions.Worker.Tests
+{
+    /// <summary>
+    /// Unit tests for <see cref="FunctionsDurableTaskClient />.
+    /// </summary>
+    public class FunctionsDurableTaskClientTests
+    {
+        private FunctionsDurableTaskClient GetTestFunctionsDurableTaskClient()
+        {
+            // construct mock client
+
+            // The DurableTaskClient demands a string parameter in it's constructor, so we pass it in
+            string clientName = string.Empty;
+            Mock<DurableTaskClient> durableClientMock = new(clientName);
+
+            Task completedTask = Task.CompletedTask;
+            durableClientMock.Setup(x => x.TerminateInstanceAsync(It.IsAny<string>(), It.IsAny<TerminateInstanceOptions>(), It.IsAny<CancellationToken>())).Returns(completedTask);
+
+            DurableTaskClient durableClient = durableClientMock.Object;
+            FunctionsDurableTaskClient client = new FunctionsDurableTaskClient(durableClient, queryString: null);
+            return client;
+        }
+
+        /// <summary>
+        /// Test that the `TerminateInstnaceAsync` can be invoked without exceptions.
+        /// Exceptions are a risk since we inherit from an abstract class where default implementations are not provided.
+        /// </summary>
+        [Fact]
+        public async void TerminateDoesNotThrow()
+        {
+            FunctionsDurableTaskClient client = GetTestFunctionsDurableTaskClient();
+
+            string instanceId = string.Empty;
+            object output = string.Empty;
+            TerminateInstanceOptions options = new TerminateInstanceOptions();
+            CancellationToken token = CancellationToken.None;
+
+            // call terminate API with every possible parameter combination
+            // if we don't encounter any unimplemented exceptions from the abstract class,
+            // then the test passes
+
+            await client.TerminateInstanceAsync(instanceId, token);
+
+            await client.TerminateInstanceAsync(instanceId, output);
+            await client.TerminateInstanceAsync(instanceId, output, token);
+
+            await client.TerminateInstanceAsync(instanceId);
+            await client.TerminateInstanceAsync(instanceId, options);
+            await client.TerminateInstanceAsync(instanceId, options, token);
+        }
+    }
+}

--- a/test/Worker.Extensions.DurableTask.Tests/FunctionsDurableTaskClientTests.cs
+++ b/test/Worker.Extensions.DurableTask.Tests/FunctionsDurableTaskClientTests.cs
@@ -18,7 +18,8 @@ namespace Microsoft.Azure.Functions.Worker.Tests
             Mock<DurableTaskClient> durableClientMock = new(clientName);
 
             Task completedTask = Task.CompletedTask;
-            durableClientMock.Setup(x => x.TerminateInstanceAsync(It.IsAny<string>(), It.IsAny<TerminateInstanceOptions>(), It.IsAny<CancellationToken>())).Returns(completedTask);
+            durableClientMock.Setup(x => x.TerminateInstanceAsync(
+                It.IsAny<string>(), It.IsAny<TerminateInstanceOptions>(), It.IsAny<CancellationToken>())).Returns(completedTask);
 
             DurableTaskClient durableClient = durableClientMock.Object;
             FunctionsDurableTaskClient client = new FunctionsDurableTaskClient(durableClient, queryString: null);

--- a/test/Worker.Extensions.DurableTask.Tests/Worker.Extensions.DurableTask.Tests.csproj
+++ b/test/Worker.Extensions.DurableTask.Tests/Worker.Extensions.DurableTask.Tests.csproj
@@ -1,0 +1,29 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+
+	<!-- Sign assembly so it can reference internal components of the Worker Extension package -->
+	<SignAssembly>true</SignAssembly>
+	<AssemblyOriginatorKeyFile>..\..\sign.snk</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+	<PackageReference Include="Moq" Version="4.7.145" />
+	<ProjectReference Include="..\..\src\Worker.Extensions.DurableTask\Worker.Extensions.DurableTask.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/test/Worker.Extensions.DurableTask.Tests/Worker.Extensions.DurableTask.Tests.csproj
+++ b/test/Worker.Extensions.DurableTask.Tests/Worker.Extensions.DurableTask.Tests.csproj
@@ -18,8 +18,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="xunit" Version="2.5.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
-	<PackageReference Include="Moq" Version="4.7.145" />
-	<ProjectReference Include="..\..\src\Worker.Extensions.DurableTask\Worker.Extensions.DurableTask.csproj" />
+    <PackageReference Include="Moq" Version="4.7.145" />
+    <ProjectReference Include="..\..\src\Worker.Extensions.DurableTask\Worker.Extensions.DurableTask.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Worker.Extensions.DurableTask.Tests/Worker.Extensions.DurableTask.Tests.csproj
+++ b/test/Worker.Extensions.DurableTask.Tests/Worker.Extensions.DurableTask.Tests.csproj
@@ -8,9 +8,9 @@
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
 
-	<!-- Sign assembly so it can reference internal components of the Worker Extension package -->
-	<SignAssembly>true</SignAssembly>
-	<AssemblyOriginatorKeyFile>..\..\sign.snk</AssemblyOriginatorKeyFile>
+    <!-- Sign assembly so it can reference internal components of the Worker Extension package -->
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>..\..\sign.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
<!-- Start the PR description with some context for the change. -->
Follow up to: https://github.com/Azure/azure-functions-durable-extension/pull/2802

The PR above made the `FunctionsDurableTaskClient` override new overloads from `DurableTaskClient` which were causing issues as reported here: https://github.com/microsoft/durabletask-dotnet/issues/282#issuecomment-2114590648

Seems we missed the `TerminateInstanceAsync` API in the PR above, so this PR adds it.

This PR also adds what appears to be the first set of unit tests for the .NET isolated worker extension. In it, we're testing against this particular exception: that the `TerminateInstanceAsync` API can be invoked without triggering exceptions. I tested with and without the code change and confirmed that the test is fails without the change, and passes with it.

**Note:** the new test project I added won't run as part of the CI automatically. I think to do that, I need to create a new ADO pipeline. Given that we're migrating our CI to a different ADO organization, now may not be the right time to add it either, so I'd like to do that in a different PR.

<!-- Make sure to delete the markdown comments and the below sections when squash merging -->
### Issue describing the changes in this PR

resolves https://github.com/microsoft/durabletask-dotnet/issues/282#issuecomment-2114590648

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)
* [x] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk
* [x] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
    * [ ] Otherwise: major or minor version updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
* [x] My changes **do not** add EventIds to our EventSource logs
    * [ ] Otherwise: Ensure the EventIds are within the supported range in our existing Windows infrastructure. You may validate this with a deployed app's telemetry. You may also extend the range by completing a PR such as [this one](https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files).
* [x] My changes **should** be added to v3.x branch.
    * [ ] Otherwise: This change only applies to Durable Functions v2.x and **will not** be merged to branch v3.x.
