### PR TITLE
Turn Kestrel and AspNetCore into a framework dependency

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
+++ b/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
@@ -99,6 +99,8 @@
     <PackageReference Include="Azure.Identity" Version="1.11.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.37" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.WebApiCompatShim" Version="2.2.0" />
+	<!-- To access Kestrel, use metapackage and leverage framework dependency on AspNetCore.
+	This allows us to avoid dependency on outdated Kestrel packages from NuGet, which may have CVEs-->
 	<PackageReference Include="Microsoft.AspNetCore.App" />
 	<PackageReference Include="Microsoft.Extensions.Azure" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="2.2.0" />

--- a/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
+++ b/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
@@ -100,7 +100,7 @@
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.37" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.WebApiCompatShim" Version="2.2.0" />
     <!-- To access Kestrel, use metapackage and leverage framework dependency on AspNetCore.
-    This allows us to avoid dependency on outdated Kestrel packages from NuGet, which may have CVEs-->
+    This allows us to avoid taking dependency on outdated Kestrel packages from NuGet, which may have CVEs-->
     <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.Extensions.Azure" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="2.2.0" />

--- a/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
+++ b/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
@@ -99,9 +99,9 @@
     <PackageReference Include="Azure.Identity" Version="1.11.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.37" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.WebApiCompatShim" Version="2.2.0" />
-	<!-- To access Kestrel, use metapackage and leverage framework dependency on AspNetCore.
-	This allows us to avoid dependency on outdated Kestrel packages from NuGet, which may have CVEs-->
-	<PackageReference Include="Microsoft.AspNetCore.App" />
+    <!-- To access Kestrel, use metapackage and leverage framework dependency on AspNetCore.
+    This allows us to avoid dependency on outdated Kestrel packages from NuGet, which may have CVEs-->
+    <PackageReference Include="Microsoft.AspNetCore.App" />
 	<PackageReference Include="Microsoft.Extensions.Azure" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="2.2.0" />
     <PackageReference Include="Microsoft.Azure.DurableTask.ApplicationInsights" Version="0.1.*" />

--- a/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
+++ b/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
@@ -99,13 +99,10 @@
     <PackageReference Include="Azure.Identity" Version="1.11.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.37" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.WebApiCompatShim" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Routing" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Azure" Version="1.1.1" />
+	<PackageReference Include="Microsoft.AspNetCore.App" />
+	<PackageReference Include="Microsoft.Extensions.Azure" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="2.2.0" />
     <PackageReference Include="Microsoft.Azure.DurableTask.ApplicationInsights" Version="0.1.*" />
-    <!-- Explicitly pinned transitive dependencies with CVE vulnerabilities.-->
-    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets" Version="2.2.1" />
     <!-- The gRPC dependencies in this package are not compatible with older frameworks, like .NET Core 2.x -->
     <PackageReference Include="Microsoft.DurableTask.Grpc" Version="1.1.0" />
     <PackageReference Include="Grpc.Core" Version="2.46.6" /> <!-- Bring this in until we move to hosted RPC -->

--- a/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
+++ b/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
@@ -102,7 +102,7 @@
     <!-- To access Kestrel, use metapackage and leverage framework dependency on AspNetCore.
     This allows us to avoid dependency on outdated Kestrel packages from NuGet, which may have CVEs-->
     <PackageReference Include="Microsoft.AspNetCore.App" />
-	<PackageReference Include="Microsoft.Extensions.Azure" Version="1.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Azure" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="2.2.0" />
     <PackageReference Include="Microsoft.Azure.DurableTask.ApplicationInsights" Version="0.1.*" />
     <!-- The gRPC dependencies in this package are not compatible with older frameworks, like .NET Core 2.x -->


### PR DESCRIPTION
<!-- Start the PR description with some context for the change. -->
AspNetCore comes bundled with .NET. As a result, we don't need an explicit package dependency on Kestrel or other AspNetCore packages in the extension. On the contrary, since the NuGet packages for AspNetCore have not been updated in a while, this may lead up to CVEs being flagged for the extension. This PR is an attempt at turning those AspNetCore dependencies into framework dependencies, so that we simply load them from the .NET installation on the machine, just like the Azure Functions Host itself.

Note that this is in response to a customer IcM reporting CVEs in our Kestrel dependency (v2.2.0). Seems the Kestrel package on NuGet is no longer being updated, so this seems like "the only path forward" if we want to appease that request. I may be wrong about that, please let me know. As I know this is a big change, I won't merge until there's an agreement.
