### PR TITLE
Clear NuGet security warnings

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -2,6 +2,7 @@
 
 <configuration>
   <packageSources>
+    </clear>
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
     <add key="AzureFunctionsTempStaging" value="https://pkgs.dev.azure.com/azfunc/e6a70c92-4128-439f-8012-382fe78d6396/_packaging/AzureFunctionsTempStaging/nuget/v3/index.json" />
     <add key="durabletask" value="https://pkgs.dev.azure.com/durabletaskframework/734e7913-2fab-4624-a174-bc57fe96f95d/_packaging/durabletask/nuget/v3/index.json" />

--- a/test/SmokeTests/OOProcSmokeTests/durableJS/Nuget.config
+++ b/test/SmokeTests/OOProcSmokeTests/durableJS/Nuget.config
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <packageSources>
+        </clear>
+        <add key="nuget.org" value="https://api.nuget.org/v3/index.json"/>
         <add key="local" value="." />
-        <add key="azure_app_service" value="https://www.myget.org/F/azure-appservice/api/v2" />
         <add key="durabletask" value="https://pkgs.dev.azure.com/durabletaskframework/734e7913-2fab-4624-a174-bc57fe96f95d/_packaging/durabletask/nuget/v3/index.json" />
     </packageSources>
 </configuration>

--- a/test/SmokeTests/OOProcSmokeTests/durableJava/Nuget.config
+++ b/test/SmokeTests/OOProcSmokeTests/durableJava/Nuget.config
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <packageSources>
+        </clear>
+        <add key="nuget.org" value="https://api.nuget.org/v3/index.json"/>
         <add key="local" value="." />
-        <add key="azure_app_service" value="https://www.myget.org/F/azure-appservice/api/v2" />
         <add key="durabletask" value="https://pkgs.dev.azure.com/durabletaskframework/734e7913-2fab-4624-a174-bc57fe96f95d/_packaging/durabletask/nuget/v3/index.json" />
     </packageSources>
 </configuration>

--- a/test/SmokeTests/OOProcSmokeTests/durablePy/Nuget.config
+++ b/test/SmokeTests/OOProcSmokeTests/durablePy/Nuget.config
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <packageSources>
+        </clear>
+        <add key="nuget.org" value="https://api.nuget.org/v3/index.json"/>
         <add key="local" value="." />
-        <add key="azure_app_service" value="https://www.myget.org/F/azure-appservice/api/v2" />
         <add key="durabletask" value="https://pkgs.dev.azure.com/durabletaskframework/734e7913-2fab-4624-a174-bc57fe96f95d/_packaging/durabletask/nuget/v3/index.json" />
     </packageSources>
 </configuration>

--- a/test/TimeoutTests/Python/Nuget.config
+++ b/test/TimeoutTests/Python/Nuget.config
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <packageSources>
+        </clear>
+        <add key="nuget.org" value="https://api.nuget.org/v3/index.json"/>
         <add key="local" value="." />
-        <add key="azure_app_service" value="https://www.myget.org/F/azure-appservice/api/v2" />
         <add key="durabletask" value="https://pkgs.dev.azure.com/durabletaskframework/734e7913-2fab-4624-a174-bc57fe96f95d/_packaging/durabletask/nuget/v3/index.json" />
     </packageSources>
 </configuration>


### PR DESCRIPTION
<!-- Start the PR description with some context for the change. -->
As part of the 1ES migration, we have new supply chain requirements around our repo's nuget.config files.

In particular, we're getting errors due to use MyGet. This PR removes our MyGet usage. It also addresses warnings regarding missing <clear/> statements.