### PR TITLE
Cache TokenCredential

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/AzureStorageAccountProvider.cs
+++ b/src/WebJobs.Extensions.DurableTask/AzureStorageAccountProvider.cs
@@ -49,6 +49,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             AzureStorageAccountOptions account = connectionInfo.Get<AzureStorageAccountOptions>();
             if (account != null)
             {
+                // To avoid memory leaks, we cache the TokenCredential, which can be retrieved using a `key`
+                // There are two ways of generating the key, corresponding to the two setting sets that can be used to set up System-assigned Identities (see: https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-configure-durable-functions-with-credentials#add-managed-identity-configuration-in-the-azure-portal)
                 string key = !string.IsNullOrEmpty(account.AccountName) ? account.AccountName : account.BlobServiceUri.ToString();
 
                 TokenCredential credential = this.cachedTokenCredentials.GetOrAdd(

--- a/src/WebJobs.Extensions.DurableTask/AzureStorageAccountProvider.cs
+++ b/src/WebJobs.Extensions.DurableTask/AzureStorageAccountProvider.cs
@@ -49,8 +49,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             AzureStorageAccountOptions account = connectionInfo.Get<AzureStorageAccountOptions>();
             if (account != null)
             {
+                string key = !string.IsNullOrEmpty(account.AccountName) ? account.AccountName : account.BlobServiceUri.ToString();
+
                 TokenCredential credential = this.cachedTokenCredentials.GetOrAdd(
-                    account.AccountName,
+                    key,
                     attr => this.credentialFactory.Create(connectionInfo));
 
                 return new StorageAccountDetails

--- a/src/WebJobs.Extensions.DurableTask/AzureStorageAccountProvider.cs
+++ b/src/WebJobs.Extensions.DurableTask/AzureStorageAccountProvider.cs
@@ -2,10 +2,10 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
+using System.Collections.Concurrent;
 using DurableTask.AzureStorage;
 using Microsoft.Azure.WebJobs.Extensions.DurableTask.Options;
 using Microsoft.Extensions.Configuration;
-using System.Collections.Concurrent;
 
 #if !FUNCTIONS_V1
 using Microsoft.Azure.WebJobs.Extensions.DurableTask.Auth;

--- a/src/WebJobs.Extensions.DurableTask/AzureStorageAccountProvider.cs
+++ b/src/WebJobs.Extensions.DurableTask/AzureStorageAccountProvider.cs
@@ -49,12 +49,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             AzureStorageAccountOptions account = connectionInfo.Get<AzureStorageAccountOptions>();
             if (account != null)
             {
-                // To avoid memory leaks, we cache the TokenCredential, which can be retrieved using a `key`
-                // There are two ways of generating the key, corresponding to the two setting sets that can be used to set up System-assigned Identities (see: https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-configure-durable-functions-with-credentials#add-managed-identity-configuration-in-the-azure-portal)
-                string key = !string.IsNullOrEmpty(account.AccountName) ? account.AccountName : account.BlobServiceUri.ToString();
-
                 TokenCredential credential = this.cachedTokenCredentials.GetOrAdd(
-                    key,
+                    connectionName,
                     attr => this.credentialFactory.Create(connectionInfo));
 
                 return new StorageAccountDetails

--- a/test/Common/AzureStorageAccountProviderTests.cs
+++ b/test/Common/AzureStorageAccountProviderTests.cs
@@ -80,11 +80,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             Assert.Equal(options.TableServiceUri, actual.TableServiceUri);
 
             // Get CloudStorageAccount
-            CloudStorageAccount acount = actual.ToCloudStorageAccount();
-            Assert.Same(actual.StorageCredentials, acount.Credentials);
-            Assert.Equal(options.BlobServiceUri, acount.BlobEndpoint);
-            Assert.Equal(options.QueueServiceUri, acount.QueueEndpoint);
-            Assert.Equal(options.TableServiceUri, acount.TableEndpoint);
+            CloudStorageAccount account = actual.ToCloudStorageAccount();
+            Assert.Same(actual.StorageCredentials, account.Credentials);
+            Assert.Equal(options.BlobServiceUri, account.BlobEndpoint);
+            Assert.Equal(options.QueueServiceUri, account.QueueEndpoint);
+            Assert.Equal(options.TableServiceUri, account.TableEndpoint);
         }
 
         [Fact]


### PR DESCRIPTION
This PR caches `TokenCredential` to resolve a memory issue that has been reported when managed identity is enabled. With these changes, we only create the `TokenCredential` object once instead of every time that `GetStorageAccountDetails()` is called. This also means that `TokenRenewalState` is also created once.

These changes were verified by enabling managed identity locally using [these instructions](https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-configure-durable-functions-with-credentials#configure-your-app-to-use-client-secret-credentials) and measuring the memory in VS with and without the changes in this PR.

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)
* [x] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk
* [x] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
    * [ ] Otherwise: major or minor version updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
* [x] My changes **do not** add EventIds to our EventSource logs
    * [ ] Otherwise: Ensure the EventIds are within the supported range in our existing Windows infrastructure. You may validate this with a deployed app's telemetry. You may also extend the range by completing a PR such as [this one](https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files).
* [ ] My changes **should** be added to v3.x branch.
    * [x] Otherwise: This change only applies to Durable Functions v2.x and **will not** be merged to branch v3.x.
