### PR TITLE
Provide actionable suggestions for when webhooks are not configured

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
+++ b/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
@@ -1242,7 +1242,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         internal Uri GetWebhookUri()
         {
             string errorMessage = "Webhooks are not configured. This may occur if the environment variable `WEBSITE_HOSTNAME` is not set (should be automatically set for Azure Functions). " +
-                "Try setting it to <ip-address>:<port> as the value, where <ip-address>:<port> refers to the address that can be used to reach your function app from outside, or the DNS name of the app.";
+                "Try setting it to the appropiate URI to reach your app. For example: the DNS name of the app, or a value of the form <ip-address>:<port>.";
             return this.webhookUrlProvider?.Invoke() ?? throw new InvalidOperationException(errorMessage);
         }
 

--- a/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
+++ b/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
@@ -1242,7 +1242,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         internal Uri GetWebhookUri()
         {
             string errorMessage = "Webhooks are not configured. This may occur if the environment variable `WEBSITE_HOSTNAME` is not set (should be automatically set for Azure Functions). " +
-             "Set it to <ip-address>:<port> as the value, where <ip-address>:<port> refers to the address that can be used to reach your function app from outside, or the DNS name of the app.";
+                "Try setting it to <ip-address>:<port> as the value, where <ip-address>:<port> refers to the address that can be used to reach your function app from outside, or the DNS name of the app.";
             return this.webhookUrlProvider?.Invoke() ?? throw new InvalidOperationException(errorMessage);
         }
 

--- a/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
+++ b/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
@@ -1241,9 +1241,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
         internal Uri GetWebhookUri()
         {
-            string errorMessage = "Webhooks are not configured. This may occur if the environment variable `WEBSITE_HOSTNAME` is not set (should be automatically set for Azure Functions). "+
+            string errorMessage = "Webhooks are not configured. This may occur if the environment variable `WEBSITE_HOSTNAME` is not set (should be automatically set for Azure Functions). " +
              "Set it to <ip-address>:<port> as the value, where <ip-address>:<port> refers to the address that can be used to reach your function app from outside, or the DNS name of the app.";
-            return this.webhookUrlProvider?.Invoke() ?? throw new InvalidOperationException("Webhooks are not configured");
+            return this.webhookUrlProvider?.Invoke() ?? throw new InvalidOperationException(errorMessage);
         }
 
         internal bool TryGetRpcBaseUrl(out Uri rpcBaseUrl)

--- a/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
+++ b/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
@@ -1241,6 +1241,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
         internal Uri GetWebhookUri()
         {
+            string errorMessage = "Webhooks are not configured. This may occur if the environment variable `WEBSITE_HOSTNAME` is not set (should be automatically set for Azure Functions). "+
+                "Set it to <ip-address>:<port> as the value, where <ip-address>:<port> refers to the address that can be used to reach your function app from outside, or the DNS name of the app.";
             return this.webhookUrlProvider?.Invoke() ?? throw new InvalidOperationException("Webhooks are not configured");
         }
 

--- a/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
+++ b/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
@@ -1242,7 +1242,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         internal Uri GetWebhookUri()
         {
             string errorMessage = "Webhooks are not configured. This may occur if the environment variable `WEBSITE_HOSTNAME` is not set (should be automatically set for Azure Functions). "+
-                "Set it to <ip-address>:<port> as the value, where <ip-address>:<port> refers to the address that can be used to reach your function app from outside, or the DNS name of the app.";
+             "Set it to <ip-address>:<port> as the value, where <ip-address>:<port> refers to the address that can be used to reach your function app from outside, or the DNS name of the app.";
             return this.webhookUrlProvider?.Invoke() ?? throw new InvalidOperationException("Webhooks are not configured");
         }
 

--- a/test/Common/HttpApiHandlerTests.cs
+++ b/test/Common/HttpApiHandlerTests.cs
@@ -41,7 +41,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
             var httpApiHandler = new HttpApiHandler(GetTestExtension(options), null);
             var ex = Assert.Throws<InvalidOperationException>(() => httpApiHandler.CreateCheckStatusResponse(new HttpRequestMessage(), string.Empty, null));
-            Assert.Equal("Webhooks are not configured", ex.Message);
+            string errorMessage = "Webhooks are not configured. This may occur if the environment variable `WEBSITE_HOSTNAME` is not set (should be automatically set for Azure Functions). "+
+                "Set it to <ip-address>:<port> as the value, where <ip-address>:<port> refers to the address that can be used to reach your function app from outside, or the DNS name of the app.";
+            Assert.Equal(errorMessage, ex.Message);
         }
 
         [Fact]

--- a/test/Common/HttpApiHandlerTests.cs
+++ b/test/Common/HttpApiHandlerTests.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             var httpApiHandler = new HttpApiHandler(GetTestExtension(options), null);
             var ex = Assert.Throws<InvalidOperationException>(() => httpApiHandler.CreateCheckStatusResponse(new HttpRequestMessage(), string.Empty, null));
             string errorMessage = "Webhooks are not configured. This may occur if the environment variable `WEBSITE_HOSTNAME` is not set (should be automatically set for Azure Functions). " +
-             "Try setting it to <ip-address>:<port> as the value, where <ip-address>:<port> refers to the address that can be used to reach your function app from outside, or the DNS name of the app.";
+            "Try setting it to the appropiate URI to reach your app. For example: the DNS name of the app, or a value of the form <ip-address>:<port>.";
             Assert.Equal(errorMessage, ex.Message);
         }
 

--- a/test/Common/HttpApiHandlerTests.cs
+++ b/test/Common/HttpApiHandlerTests.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             var httpApiHandler = new HttpApiHandler(GetTestExtension(options), null);
             var ex = Assert.Throws<InvalidOperationException>(() => httpApiHandler.CreateCheckStatusResponse(new HttpRequestMessage(), string.Empty, null));
             string errorMessage = "Webhooks are not configured. This may occur if the environment variable `WEBSITE_HOSTNAME` is not set (should be automatically set for Azure Functions). "+
-                "Set it to <ip-address>:<port> as the value, where <ip-address>:<port> refers to the address that can be used to reach your function app from outside, or the DNS name of the app.";
+             "Set it to <ip-address>:<port> as the value, where <ip-address>:<port> refers to the address that can be used to reach your function app from outside, or the DNS name of the app.";
             Assert.Equal(errorMessage, ex.Message);
         }
 

--- a/test/Common/HttpApiHandlerTests.cs
+++ b/test/Common/HttpApiHandlerTests.cs
@@ -41,8 +41,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
             var httpApiHandler = new HttpApiHandler(GetTestExtension(options), null);
             var ex = Assert.Throws<InvalidOperationException>(() => httpApiHandler.CreateCheckStatusResponse(new HttpRequestMessage(), string.Empty, null));
-            string errorMessage = "Webhooks are not configured. This may occur if the environment variable `WEBSITE_HOSTNAME` is not set (should be automatically set for Azure Functions). "+
-             "Set it to <ip-address>:<port> as the value, where <ip-address>:<port> refers to the address that can be used to reach your function app from outside, or the DNS name of the app.";
+            string errorMessage = "Webhooks are not configured. This may occur if the environment variable `WEBSITE_HOSTNAME` is not set (should be automatically set for Azure Functions). " +
+             "Try setting it to <ip-address>:<port> as the value, where <ip-address>:<port> refers to the address that can be used to reach your function app from outside, or the DNS name of the app.";
             Assert.Equal(errorMessage, ex.Message);
         }
 


### PR DESCRIPTION
<!-- Start the PR description with some context for the change. -->

We periodically receive questions about apps failing with the following error "Webhooks are not configured". This often occurs when running in K8s environments.

This PR augments our error message to provide guidance on how to work around this error.