### PR TITLE
Replace ADO tests with GitHub actions

### DIFF
--- a/.github/workflows/validate-build-analyzer.yml
+++ b/.github/workflows/validate-build-analyzer.yml
@@ -1,0 +1,59 @@
+name: Validate Build (analyzer)
+
+on:
+  push:
+    branches:
+      - main
+      - dajusto/run-tests-in-gh-action
+    paths-ignore: [ '**.md' ]
+  pull_request:
+    branches:
+      - main
+    paths-ignore: [ '**.md' ]
+
+env:
+  solution: WebJobs.Extensions.DurableTask.sln
+  config: Release
+  AzureWebJobsStorage: UseDevelopmentStorage=true
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: true
+
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v3
+
+    - name: Set up .NET Core 3.1
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: '3.1.x'
+
+    - name: Set up .NET Core 2.1
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: '2.1.x'
+
+    - name: Restore dependencies
+      run: dotnet restore $solution
+
+    - name: Build
+      run: dotnet build $solution #--configuration $config #--no-restore -p:FileVersionRevision=$GITHUB_RUN_NUMBER -p:ContinuousIntegrationBuild=true
+
+    # Install Azurite
+    - name: Set up Node.js (needed for Azurite)
+      uses: actions/setup-node@v3
+      with:
+        node-version: '18.x' # Azurite requires at least Node 18
+
+    - name: Install Azurite
+      run: npm install -g azurite
+
+    # Run tests
+    - name: Run Analyzer tests
+      run: azurite --silent --blobPort 10000 --queuePort 10001 --tablePort 10002 & dotnet test ./test/WebJobs.Extensions.DurableTask.Analyzers.Test/WebJobs.Extensions.DurableTask.Analyzers.Test.csproj
+

--- a/.github/workflows/validate-build-analyzer.yml
+++ b/.github/workflows/validate-build-analyzer.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - dajusto/run-tests-in-gh-action
     paths-ignore: [ '**.md' ]
   pull_request:
     branches:

--- a/.github/workflows/validate-build-analyzer.yml
+++ b/.github/workflows/validate-build-analyzer.yml
@@ -42,7 +42,7 @@ jobs:
       run: dotnet restore $solution
 
     - name: Build
-      run: dotnet build $solution #--configuration $config #--no-restore -p:FileVersionRevision=$GITHUB_RUN_NUMBER -p:ContinuousIntegrationBuild=true
+      run: dotnet build $solution
 
     # Install Azurite
     - name: Set up Node.js (needed for Azurite)

--- a/.github/workflows/validate-build-e2e.yml
+++ b/.github/workflows/validate-build-e2e.yml
@@ -55,4 +55,4 @@ jobs:
 
     # Run tests
     - name: Run FunctionsV2 tests (only E2E tests)
-      run: azurite --silent --blobPort 10000 --queuePort 10001 --tablePort 10002 & dotnet test ./test/FunctionsV2/WebJobs.Extensions.DurableTask.Tests.V2.csproj  --filter "FullyQualifiedName~Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests.DurableTaskEndToEndTests.*" # --filter "FullyQualifiedName~DurableTaskEndToEndTests.OutputsValidJSONLogs" #--configuration $config --no-build --verbosity normal
+      run: azurite --silent --blobPort 10000 --queuePort 10001 --tablePort 10002 & dotnet test ./test/FunctionsV2/WebJobs.Extensions.DurableTask.Tests.V2.csproj  --filter "FullyQualifiedName~Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests.DurableTaskEndToEndTests" # --filter "FullyQualifiedName~DurableTaskEndToEndTests.OutputsValidJSONLogs" #--configuration $config --no-build --verbosity normal

--- a/.github/workflows/validate-build-e2e.yml
+++ b/.github/workflows/validate-build-e2e.yml
@@ -55,4 +55,5 @@ jobs:
 
     # Run tests
     - name: Run FunctionsV2 tests (only E2E tests)
-      run: azurite --silent --blobPort 10000 --queuePort 10001 --tablePort 10002 & dotnet test ./test/FunctionsV2/WebJobs.Extensions.DurableTask.Tests.V2.csproj  --filter "FullyQualifiedName~Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests.DurableTaskEndToEndTests" # --filter "FullyQualifiedName~DurableTaskEndToEndTests.OutputsValidJSONLogs" #--configuration $config --no-build --verbosity normal
+      run: azurite --silent --blobPort 10000 --queuePort 10001 --tablePort 10002 & dotnet test ./test/FunctionsV2/WebJobs.Extensions.DurableTask.Tests.V2.csproj  
+      --filter "FullyQualifiedName~Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests.DurableTaskEndToEndTests&FullyQualifiedName!~Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests.DurableTaskEndToEndTests.DurableEntity_CleanEntityStorage" # --filter "FullyQualifiedName~DurableTaskEndToEndTests.OutputsValidJSONLogs" #--configuration $config --no-build --verbosity normal

--- a/.github/workflows/validate-build-e2e.yml
+++ b/.github/workflows/validate-build-e2e.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - dajusto/run-tests-in-gh-action
     paths-ignore: [ '**.md' ]
   pull_request:
     branches:

--- a/.github/workflows/validate-build-e2e.yml
+++ b/.github/workflows/validate-build-e2e.yml
@@ -42,7 +42,7 @@ jobs:
       run: dotnet restore $solution
 
     - name: Build
-      run: dotnet build $solution #--configuration $config #--no-restore -p:FileVersionRevision=$GITHUB_RUN_NUMBER -p:ContinuousIntegrationBuild=true
+      run: dotnet build $solution
 
     # Install Azurite
     - name: Set up Node.js (needed for Azurite)

--- a/.github/workflows/validate-build-e2e.yml
+++ b/.github/workflows/validate-build-e2e.yml
@@ -1,4 +1,4 @@
-name: Validate Build (E2E)
+name: Validate Build (E2E tests)
 
 on:
   push:
@@ -54,5 +54,8 @@ jobs:
       run: npm install -g azurite
 
     # Run tests
-    - name: Run FunctionsV2 tests (only E2E tests)
-      run: azurite --silent --blobPort 10000 --queuePort 10001 --tablePort 10002 & dotnet test ./test/FunctionsV2/WebJobs.Extensions.DurableTask.Tests.V2.csproj  --filter "FullyQualifiedName~Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests.DurableTaskEndToEndTests&FullyQualifiedName!~Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests.DurableTaskEndToEndTests.DurableEntity_CleanEntityStorage" # --filter "FullyQualifiedName~DurableTaskEndToEndTests.OutputsValidJSONLogs" #--configuration $config --no-build --verbosity normal
+    - name: Run FunctionsV2 tests (only DurableEntity_CleanEntityStorage test, which is flaky)
+      run: azurite --silent --blobPort 10000 --queuePort 10001 --tablePort 10002 & dotnet test ./test/FunctionsV2/WebJobs.Extensions.DurableTask.Tests.V2.csproj  --filter "FullyQualifiedName~Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests.DurableTaskEndToEndTests.DurableEntity_CleanEntityStorage"
+
+    - name: Run FunctionsV2 tests (all other E2E tests)
+      run: azurite --silent --blobPort 10000 --queuePort 10001 --tablePort 10002 & dotnet test ./test/FunctionsV2/WebJobs.Extensions.DurableTask.Tests.V2.csproj  --filter "FullyQualifiedName~Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests.DurableTaskEndToEndTests&FullyQualifiedName!~Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests.DurableTaskEndToEndTests.DurableEntity_CleanEntityStorage"

--- a/.github/workflows/validate-build-e2e.yml
+++ b/.github/workflows/validate-build-e2e.yml
@@ -1,0 +1,58 @@
+name: Validate Build (E2E)
+
+on:
+  push:
+    branches:
+      - main
+      - dajusto/run-tests-in-gh-action
+    paths-ignore: [ '**.md' ]
+  pull_request:
+    branches:
+      - main
+    paths-ignore: [ '**.md' ]
+
+env:
+  solution: WebJobs.Extensions.DurableTask.sln
+  config: Release
+  AzureWebJobsStorage: UseDevelopmentStorage=true
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: true
+
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v3
+
+    - name: Set up .NET Core 3.1
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: '3.1.x'
+
+    - name: Set up .NET Core 2.1
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: '2.1.x'
+
+    - name: Restore dependencies
+      run: dotnet restore $solution
+
+    - name: Build
+      run: dotnet build $solution #--configuration $config #--no-restore -p:FileVersionRevision=$GITHUB_RUN_NUMBER -p:ContinuousIntegrationBuild=true
+
+    # Install Azurite
+    - name: Set up Node.js (needed for Azurite)
+      uses: actions/setup-node@v3
+      with:
+        node-version: '18.x' # Azurite requires at least Node 18
+
+    - name: Install Azurite
+      run: npm install -g azurite
+
+    # Run tests
+    - name: Run FunctionsV2 tests (only E2E tests)
+      run: azurite --silent --blobPort 10000 --queuePort 10001 --tablePort 10002 & dotnet test ./test/FunctionsV2/WebJobs.Extensions.DurableTask.Tests.V2.csproj  --filter "FullyQualifiedName~Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests.DurableTaskEndToEndTests.*" # --filter "FullyQualifiedName~DurableTaskEndToEndTests.OutputsValidJSONLogs" #--configuration $config --no-build --verbosity normal

--- a/.github/workflows/validate-build-e2e.yml
+++ b/.github/workflows/validate-build-e2e.yml
@@ -55,5 +55,4 @@ jobs:
 
     # Run tests
     - name: Run FunctionsV2 tests (only E2E tests)
-      run: azurite --silent --blobPort 10000 --queuePort 10001 --tablePort 10002 & dotnet test ./test/FunctionsV2/WebJobs.Extensions.DurableTask.Tests.V2.csproj  
-      --filter "FullyQualifiedName~Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests.DurableTaskEndToEndTests&FullyQualifiedName!~Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests.DurableTaskEndToEndTests.DurableEntity_CleanEntityStorage" # --filter "FullyQualifiedName~DurableTaskEndToEndTests.OutputsValidJSONLogs" #--configuration $config --no-build --verbosity normal
+      run: azurite --silent --blobPort 10000 --queuePort 10001 --tablePort 10002 & dotnet test ./test/FunctionsV2/WebJobs.Extensions.DurableTask.Tests.V2.csproj  --filter "FullyQualifiedName~Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests.DurableTaskEndToEndTests&FullyQualifiedName!~Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests.DurableTaskEndToEndTests.DurableEntity_CleanEntityStorage" # --filter "FullyQualifiedName~DurableTaskEndToEndTests.OutputsValidJSONLogs" #--configuration $config --no-build --verbosity normal

--- a/.github/workflows/validate-build.yml
+++ b/.github/workflows/validate-build.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-      - 'dajusto/add-tests-as-gh-action'
+      - dajusto/run-tests-in-gh-action
     paths-ignore: [ '**.md' ]
   pull_request:
     branches:

--- a/.github/workflows/validate-build.yml
+++ b/.github/workflows/validate-build.yml
@@ -55,4 +55,4 @@ jobs:
 
     # Run tests
     - name: Test FunctionsV2 tests
-      run: azurite --silent --blobPort 10000 --queuePort 10001 --tablePort 10002 & dotnet test ./test/FunctionsV2/WebJobs.Extensions.DurableTask.Tests.V2.csproj   --filter "FullyQualifiedName~DurableTaskEndToEndTests.OutputsValidJSONLogs" #--configuration $config --no-build --verbosity normal
+      run: azurite --silent --blobPort 10000 --queuePort 10001 --tablePort 10002 & dotnet test ./test/FunctionsV2/WebJobs.Extensions.DurableTask.Tests.V2.csproj  # --filter "FullyQualifiedName~DurableTaskEndToEndTests.OutputsValidJSONLogs" #--configuration $config --no-build --verbosity normal

--- a/.github/workflows/validate-build.yml
+++ b/.github/workflows/validate-build.yml
@@ -44,7 +44,8 @@ jobs:
     - name: Build
       run: dotnet build $solution #--configuration $config #--no-restore -p:FileVersionRevision=$GITHUB_RUN_NUMBER -p:ContinuousIntegrationBuild=true
 
-    - name: Set up Node.js
+    # Install Azurite
+    - name: Set up Node.js (needed for Azurite)
       uses: actions/setup-node@v3
       with:
         node-version: '18.x' # Azurite requires at least Node 18
@@ -52,5 +53,6 @@ jobs:
     - name: Install Azurite
       run: npm install -g azurite
 
-    - name: Test DTx.Core
+    # Run tests
+    - name: Test FunctionsV2 tests
       run: azurite --silent --blobPort 10000 --queuePort 10001 --tablePort 10002 & dotnet test ./test/FunctionsV2/WebJobs.Extensions.DurableTask.Tests.V2.csproj   --filter "FullyQualifiedName~DurableTaskEndToEndTests.OutputsValidJSONLogs" #--configuration $config --no-build --verbosity normal

--- a/.github/workflows/validate-build.yml
+++ b/.github/workflows/validate-build.yml
@@ -54,7 +54,7 @@ jobs:
       run: npm install -g azurite
 
     - name: Start Azurite
-      run: azurite --silent &
+      run: azurite --silent --queuePort 10001 &
 
     - name: Test DTx.Core
       run: dotnet test #--configuration $config --no-build --verbosity normal

--- a/.github/workflows/validate-build.yml
+++ b/.github/workflows/validate-build.yml
@@ -53,4 +53,4 @@ jobs:
       run: npm install -g azurite
 
     - name: Test DTx.Core
-      run: azurite --silent --blobPort 10000 --queuePort 10001 --tablePort 10002 & dotnet test ./test/FunctionsV2/WebJobs.Extensions.DurableTask.Tests.V2.csproj --filter "FullyQualifiedName~OutOfProcTests.TestLocalRcpEndpointRuntimeVersion"#--configuration $config --no-build --verbosity normal
+      run: azurite --silent --blobPort 10000 --queuePort 10001 --tablePort 10002 & dotnet test ./test/FunctionsV2/WebJobs.Extensions.DurableTask.Tests.V2.csproj # --filter "FullyQualifiedName~OutOfProcTests.TestLocalRcpEndpointRuntimeVersion" #--configuration $config --no-build --verbosity normal

--- a/.github/workflows/validate-build.yml
+++ b/.github/workflows/validate-build.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Install Azure Storage Emulator
       run: |
         curl -L -o azurestorageemulator.msi "https://download.microsoft.com/download/C/1/9/C1902F99-2183-49E0-BFC8-A7B6E2D8A62E/MicrosoftAzureStorageEmulator.msi"
-        msiexec /i azurestorageemulator.msi /quiet
+        msiexec /i azurestorageemulator.msi
 
     - name: Start Azure Storage Emulator
       shell: cmd

--- a/.github/workflows/validate-build.yml
+++ b/.github/workflows/validate-build.yml
@@ -54,7 +54,7 @@ jobs:
       run: npm install -g azurite
 
     - name: Start Azurite
-      run: azurite --silent --queuePort 10001 &
+      run: azurite --silent --blobPort 10000 --queuePort 10001 --tablePort 10002 &
 
     - name: Test DTx.Core
       run: dotnet test #--configuration $config --no-build --verbosity normal

--- a/.github/workflows/validate-build.yml
+++ b/.github/workflows/validate-build.yml
@@ -53,4 +53,4 @@ jobs:
       run: npm install -g azurite
 
     - name: Test DTx.Core
-      run: azurite --silent --blobPort 10000 --queuePort 10001 --tablePort 10002 & dotnet test ./test/FunctionsV2/WebJobs.Extensions.DurableTask.Tests.V2.csproj  # --filter "FullyQualifiedName~DurableTaskEndToEndTests.DurableEntity_CleanEntityStorage" #--configuration $config --no-build --verbosity normal
+      run: azurite --silent --blobPort 10000 --queuePort 10001 --tablePort 10002 & dotnet test ./test/FunctionsV2/WebJobs.Extensions.DurableTask.Tests.V2.csproj   --filter "FullyQualifiedName~DurableTaskEndToEndTests.OutputsValidJSONLogs" #--configuration $config --no-build --verbosity normal

--- a/.github/workflows/validate-build.yml
+++ b/.github/workflows/validate-build.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - dajusto/run-tests-in-gh-action
     paths-ignore: [ '**.md' ]
   pull_request:
     branches:

--- a/.github/workflows/validate-build.yml
+++ b/.github/workflows/validate-build.yml
@@ -34,7 +34,7 @@ jobs:
       with:
         dotnet-version: '3.1.x'
 
-    - name: Set up .NET Core 321
+    - name: Set up .NET Core 2.1
       uses: actions/setup-dotnet@v3
       with:
         dotnet-version: '2.1.x'

--- a/.github/workflows/validate-build.yml
+++ b/.github/workflows/validate-build.yml
@@ -15,17 +15,17 @@ env:
   solution: WebJobs.Extensions.DurableTask.sln
   config: Release
 
-services:
-  azurite:
-    image: mcr.microsoft.com/azure-storage/azurite
-    ports:
-      - 10000:10000
-      - 10001:10001
-      - 10002:10002
-
 jobs:
   build:
     runs-on: windows-latest
+
+    services:
+      azurite:
+        image: mcr.microsoft.com/azure-storage/azurite
+        ports:
+          - 10000:10000
+          - 10001:10001
+          - 10002:10002
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/validate-build.yml
+++ b/.github/workflows/validate-build.yml
@@ -42,7 +42,7 @@ jobs:
       run: dotnet restore $solution
 
     - name: Build
-      run: dotnet build $solution #--configuration $config #--no-restore -p:FileVersionRevision=$GITHUB_RUN_NUMBER -p:ContinuousIntegrationBuild=true
+      run: dotnet build $solution
 
     # Install Azurite
     - name: Set up Node.js (needed for Azurite)

--- a/.github/workflows/validate-build.yml
+++ b/.github/workflows/validate-build.yml
@@ -19,14 +19,6 @@ jobs:
   build:
     runs-on: windows-latest
 
-    services:
-      azurite:
-        image: mcr.microsoft.com/azure-storage/azurite
-        ports:
-          - 10000:10000
-          - 10001:10001
-          - 10002:10002
-
     steps:
     - uses: actions/checkout@v3
       with:
@@ -40,6 +32,11 @@ jobs:
 
     - name: Build
       run: dotnet build $solution #--configuration $config #--no-restore -p:FileVersionRevision=$GITHUB_RUN_NUMBER -p:ContinuousIntegrationBuild=true
+
+    - name: Run Azurite
+      run: |
+        docker pull mcr.microsoft.com/azure-storage/azurite
+        docker run -d -p 10000:10000 -p 10001:10001 -p 10002:10002 --name azurite mcr.microsoft.com/azure-storage/azurite
 
     - name: Test DTx.Core
       run: dotnet test #--configuration $config --no-build --verbosity normal

--- a/.github/workflows/validate-build.yml
+++ b/.github/workflows/validate-build.yml
@@ -54,5 +54,5 @@ jobs:
       run: npm install -g azurite
 
     # Run tests
-    - name: Test FunctionsV2 tests
-      run: azurite --silent --blobPort 10000 --queuePort 10001 --tablePort 10002 & dotnet test ./test/FunctionsV2/WebJobs.Extensions.DurableTask.Tests.V2.csproj  # --filter "FullyQualifiedName~DurableTaskEndToEndTests.OutputsValidJSONLogs" #--configuration $config --no-build --verbosity normal
+    - name: Run FunctionsV2 tests
+      run: azurite --silent --blobPort 10000 --queuePort 10001 --tablePort 10002 & dotnet test ./test/FunctionsV2/WebJobs.Extensions.DurableTask.Tests.V2.csproj  --filter "FullyQualifiedName!~DurableTaskEndToEndTest.*" # --filter "FullyQualifiedName~DurableTaskEndToEndTests.OutputsValidJSONLogs" #--configuration $config --no-build --verbosity normal

--- a/.github/workflows/validate-build.yml
+++ b/.github/workflows/validate-build.yml
@@ -29,6 +29,17 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
 
+    - name: Install Azure Storage Emulator
+      run: |
+        curl -L -o azurestorageemulator.msi "https://download.microsoft.com/download/C/1/9/C1902F99-2183-49E0-BFC8-A7B6E2D8A62E/MicrosoftAzureStorageEmulator.msi"
+        msiexec /i azurestorageemulator.msi /quiet
+
+    - name: Start Azure Storage Emulator
+      shell: cmd
+      run: |
+        "C:\Program Files (x86)\Microsoft SDKs\Azure\Storage Emulator\AzureStorageEmulator.exe" init
+        "C:\Program Files (x86)\Microsoft SDKs\Azure\Storage Emulator\AzureStorageEmulator.exe" start
+
     - name: Set up .NET Core 3.1
       uses: actions/setup-dotnet@v3
       with:
@@ -52,17 +63,6 @@ jobs:
 
     # - name: Install Azurite
     #   run: npm install -g azurite
-
-    - name: Install Azure Storage Emulator
-      run: |
-        curl -L -o azurestorageemulator.msi "https://download.microsoft.com/download/C/1/9/C1902F99-2183-49E0-BFC8-A7B6E2D8A62E/MicrosoftAzureStorageEmulator.msi"
-        msiexec /i azurestorageemulator.msi /quiet
-
-    - name: Start Azure Storage Emulator
-      run: |
-        "C:\Program Files (x86)\Microsoft SDKs\Azure\Storage Emulator\AzureStorageEmulator.exe" init
-        "C:\Program Files (x86)\Microsoft SDKs\Azure\Storage Emulator\AzureStorageEmulator.exe" start
-
 
     - name: Test DTx.Core
       run: dotnet test #--configuration $config --no-build --verbosity normal

--- a/.github/workflows/validate-build.yml
+++ b/.github/workflows/validate-build.yml
@@ -43,10 +43,16 @@ jobs:
     - name: Build
       run: dotnet build $solution #--configuration $config #--no-restore -p:FileVersionRevision=$GITHUB_RUN_NUMBER -p:ContinuousIntegrationBuild=true
 
-    - name: Run Azurite
-      run: |
-        docker pull mcr.microsoft.com/azure-storage/azurite
-        docker run -d -p 10000:10000 -p 10001:10001 -p 10002:10002 --name azurite mcr.microsoft.com/azure-storage/azurite
+    - name: Set up Node.js
+      uses: actions/setup-node@v3
+      with:
+        node-version: '16.x'
+
+    - name: Install Azurite
+      run: npm install -g azurite
+
+    - name: Start Azurite
+      run: azurite --silent &
 
     - name: Test DTx.Core
       run: dotnet test #--configuration $config --no-build --verbosity normal

--- a/.github/workflows/validate-build.yml
+++ b/.github/workflows/validate-build.yml
@@ -14,6 +14,7 @@ on:
 env:
   solution: WebJobs.Extensions.DurableTask.sln
   config: Release
+  FUNCTIONS_WORKER_RUNTIME: dotnet
 
 jobs:
   build:

--- a/.github/workflows/validate-build.yml
+++ b/.github/workflows/validate-build.yml
@@ -57,3 +57,6 @@ jobs:
     - name: Run FunctionsV2 tests (except E2E tests)
       run: azurite --silent --blobPort 10000 --queuePort 10001 --tablePort 10002 & dotnet test ./test/FunctionsV2/WebJobs.Extensions.DurableTask.Tests.V2.csproj  --filter "FullyQualifiedName!~Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests.DurableTaskEndToEndTests"
 
+    - name: Run Worker Extension tests
+      run: azurite --silent --blobPort 10000 --queuePort 10001 --tablePort 10002 & dotnet test ./test/Worker.Extensions.DurableTask.Tests/Worker.Extensions.DurableTask.Tests.csproj
+

--- a/.github/workflows/validate-build.yml
+++ b/.github/workflows/validate-build.yml
@@ -45,13 +45,24 @@ jobs:
     - name: Build
       run: dotnet build $solution #--configuration $config #--no-restore -p:FileVersionRevision=$GITHUB_RUN_NUMBER -p:ContinuousIntegrationBuild=true
 
-    - name: Set up Node.js
-      uses: actions/setup-node@v3
-      with:
-        node-version: '16.x'
+    # - name: Set up Node.js
+    #   uses: actions/setup-node@v3
+    #   with:
+    #     node-version: '16.x'
 
-    - name: Install Azurite
-      run: npm install -g azurite
+    # - name: Install Azurite
+    #   run: npm install -g azurite
+
+    - name: Install Azure Storage Emulator
+      run: |
+        curl -L -o azurestorageemulator.msi "https://download.microsoft.com/download/C/1/9/C1902F99-2183-49E0-BFC8-A7B6E2D8A62E/MicrosoftAzureStorageEmulator.msi"
+        msiexec /i azurestorageemulator.msi /quiet
+
+    - name: Start Azure Storage Emulator
+      run: |
+        "C:\Program Files (x86)\Microsoft SDKs\Azure\Storage Emulator\AzureStorageEmulator.exe" init
+        "C:\Program Files (x86)\Microsoft SDKs\Azure\Storage Emulator\AzureStorageEmulator.exe" start
+
 
     - name: Test DTx.Core
-      run: azurite --blobPort 10000 --queuePort 10001 --tablePort 10002 & dotnet test #--configuration $config --no-build --verbosity normal
+      run: dotnet test #--configuration $config --no-build --verbosity normal

--- a/.github/workflows/validate-build.yml
+++ b/.github/workflows/validate-build.yml
@@ -54,4 +54,4 @@ jobs:
       run: npm install -g azurite
 
     - name: Test DTx.Core
-      run: azurite --silent --blobPort 10000 --queuePort 10001 --tablePort 10002 & dotnet test ./test/FunctionsV2/WebJobs.Extensions.DurableTask.Tests.V2.csproj #--configuration $config --no-build --verbosity normal
+      run: azurite --silent --blobPort 10000 --queuePort 10001 --tablePort 10002 & dotnet test ./test/FunctionsV2/WebJobs.Extensions.DurableTask.Tests.V2.csproj --filter "FullyQualifiedName~OutOfProcTests.TestLocalRcpEndpointRuntimeVersion"#--configuration $config --no-build --verbosity normal

--- a/.github/workflows/validate-build.yml
+++ b/.github/workflows/validate-build.yml
@@ -47,10 +47,10 @@ jobs:
     - name: Set up Node.js
       uses: actions/setup-node@v3
       with:
-        node-version: '16.x'
+        node-version: '18.x' # Azurite requires at least Node 18
 
     - name: Install Azurite
       run: npm install -g azurite
 
     - name: Test DTx.Core
-      run: azurite --silent --blobPort 10000 --queuePort 10001 --tablePort 10002 & dotnet test ./test/FunctionsV2/WebJobs.Extensions.DurableTask.Tests.V2.csproj  --filter "FullyQualifiedName~DurableTaskEndToEndTests.DurableEntity_CleanEntityStorage" #--configuration $config --no-build --verbosity normal
+      run: azurite --silent --blobPort 10000 --queuePort 10001 --tablePort 10002 & dotnet test ./test/FunctionsV2/WebJobs.Extensions.DurableTask.Tests.V2.csproj  # --filter "FullyQualifiedName~DurableTaskEndToEndTests.DurableEntity_CleanEntityStorage" #--configuration $config --no-build --verbosity normal

--- a/.github/workflows/validate-build.yml
+++ b/.github/workflows/validate-build.yml
@@ -54,5 +54,6 @@ jobs:
       run: npm install -g azurite
 
     # Run tests
-    - name: Run FunctionsV2 tests
+    - name: Run FunctionsV2 tests (except E2E tests)
       run: azurite --silent --blobPort 10000 --queuePort 10001 --tablePort 10002 & dotnet test ./test/FunctionsV2/WebJobs.Extensions.DurableTask.Tests.V2.csproj  --filter "FullyQualifiedName!~Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests.DurableTaskEndToEndTests.*" # --filter "FullyQualifiedName~DurableTaskEndToEndTests.OutputsValidJSONLogs" #--configuration $config --no-build --verbosity normal
+

--- a/.github/workflows/validate-build.yml
+++ b/.github/workflows/validate-build.yml
@@ -54,4 +54,4 @@ jobs:
       run: npm install -g azurite
 
     - name: Test DTx.Core
-      run: azurite --blobPort 10000 --queuePort 10001 --tablePort 10002 & dotnet test ./test/FunctionsV2/WebJobs.Extensions.DurableTask.Tests.V2.csproj #--configuration $config --no-build --verbosity normal
+      run: azurite --silent --blobPort 10000 --queuePort 10001 --tablePort 10002 & dotnet test ./test/FunctionsV2/WebJobs.Extensions.DurableTask.Tests.V2.csproj #--configuration $config --no-build --verbosity normal

--- a/.github/workflows/validate-build.yml
+++ b/.github/workflows/validate-build.yml
@@ -14,7 +14,6 @@ on:
 env:
   solution: WebJobs.Extensions.DurableTask.sln
   config: Release
-  FUNCTIONS_WORKER_RUNTIME: dotnet
   AzureWebJobsStorage: UseDevelopmentStorage=true
 
 jobs:

--- a/.github/workflows/validate-build.yml
+++ b/.github/workflows/validate-build.yml
@@ -15,6 +15,7 @@ env:
   solution: WebJobs.Extensions.DurableTask.sln
   config: Release
   FUNCTIONS_WORKER_RUNTIME: dotnet
+  AzureWebJobsStorage: UseDevelopmentStorage=true
 
 jobs:
   build:

--- a/.github/workflows/validate-build.yml
+++ b/.github/workflows/validate-build.yml
@@ -27,6 +27,11 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
 
+    - name: Set up .NET Core 3.1
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: '3.1.x'
+
     - name: Restore dependencies
       run: dotnet restore $solution
 

--- a/.github/workflows/validate-build.yml
+++ b/.github/workflows/validate-build.yml
@@ -55,5 +55,5 @@ jobs:
 
     # Run tests
     - name: Run FunctionsV2 tests (except E2E tests)
-      run: azurite --silent --blobPort 10000 --queuePort 10001 --tablePort 10002 & dotnet test ./test/FunctionsV2/WebJobs.Extensions.DurableTask.Tests.V2.csproj  --filter "FullyQualifiedName!~Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests.DurableTaskEndToEndTests.*" # --filter "FullyQualifiedName~DurableTaskEndToEndTests.OutputsValidJSONLogs" #--configuration $config --no-build --verbosity normal
+      run: azurite --silent --blobPort 10000 --queuePort 10001 --tablePort 10002 & dotnet test ./test/FunctionsV2/WebJobs.Extensions.DurableTask.Tests.V2.csproj  --filter "FullyQualifiedName!~Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests.DurableTaskEndToEndTests" # --filter "FullyQualifiedName~DurableTaskEndToEndTests.OutputsValidJSONLogs" #--configuration $config --no-build --verbosity normal
 

--- a/.github/workflows/validate-build.yml
+++ b/.github/workflows/validate-build.yml
@@ -53,4 +53,4 @@ jobs:
       run: npm install -g azurite
 
     - name: Test DTx.Core
-      run: azurite --silent --blobPort 10000 --queuePort 10001 --tablePort 10002 & dotnet test ./test/FunctionsV2/WebJobs.Extensions.DurableTask.Tests.V2.csproj # --filter "FullyQualifiedName~OutOfProcTests.TestLocalRcpEndpointRuntimeVersion" #--configuration $config --no-build --verbosity normal
+      run: azurite --silent --blobPort 10000 --queuePort 10001 --tablePort 10002 & dotnet test ./test/FunctionsV2/WebJobs.Extensions.DurableTask.Tests.V2.csproj  --filter "FullyQualifiedName~DurableTaskEndToEndTests.DurableEntity_CleanEntityStorage" #--configuration $config --no-build --verbosity normal

--- a/.github/workflows/validate-build.yml
+++ b/.github/workflows/validate-build.yml
@@ -55,4 +55,4 @@ jobs:
 
     # Run tests
     - name: Run FunctionsV2 tests
-      run: azurite --silent --blobPort 10000 --queuePort 10001 --tablePort 10002 & dotnet test ./test/FunctionsV2/WebJobs.Extensions.DurableTask.Tests.V2.csproj  --filter "FullyQualifiedName!~DurableTaskEndToEndTest.*" # --filter "FullyQualifiedName~DurableTaskEndToEndTests.OutputsValidJSONLogs" #--configuration $config --no-build --verbosity normal
+      run: azurite --silent --blobPort 10000 --queuePort 10001 --tablePort 10002 & dotnet test ./test/FunctionsV2/WebJobs.Extensions.DurableTask.Tests.V2.csproj  --filter "FullyQualifiedName!~Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests.DurableTaskEndToEndTests.*" # --filter "FullyQualifiedName~DurableTaskEndToEndTests.OutputsValidJSONLogs" #--configuration $config --no-build --verbosity normal

--- a/.github/workflows/validate-build.yml
+++ b/.github/workflows/validate-build.yml
@@ -1,0 +1,31 @@
+name: Validate Build
+
+on:
+  push:
+    branches:
+      - main
+      - 'dajusto/add-tests-as-gh-action'
+    paths-ignore: [ '**.md' ]
+  pull_request:
+    branches:
+      - main
+    paths-ignore: [ '**.md' ]
+
+env:
+  solution: WebJobs.Extensions.DurableTask.sln
+  config: Release
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: true
+
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v3
+
+    - name: Restore dependencies
+      run: dotnet restore $solution

--- a/.github/workflows/validate-build.yml
+++ b/.github/workflows/validate-build.yml
@@ -32,6 +32,11 @@ jobs:
       with:
         dotnet-version: '3.1.x'
 
+    - name: Set up .NET Core 321
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: '2.1.x'
+
     - name: Restore dependencies
       run: dotnet restore $solution
 

--- a/.github/workflows/validate-build.yml
+++ b/.github/workflows/validate-build.yml
@@ -29,17 +29,6 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
 
-    - name: Install Azure Storage Emulator
-      run: |
-        curl -L -o azurestorageemulator.msi "https://download.microsoft.com/download/C/1/9/C1902F99-2183-49E0-BFC8-A7B6E2D8A62E/MicrosoftAzureStorageEmulator.msi"
-        msiexec /i azurestorageemulator.msi
-
-    - name: Start Azure Storage Emulator
-      shell: cmd
-      run: |
-        "C:\Program Files (x86)\Microsoft SDKs\Azure\Storage Emulator\AzureStorageEmulator.exe" init
-        "C:\Program Files (x86)\Microsoft SDKs\Azure\Storage Emulator\AzureStorageEmulator.exe" start
-
     - name: Set up .NET Core 3.1
       uses: actions/setup-dotnet@v3
       with:
@@ -56,13 +45,13 @@ jobs:
     - name: Build
       run: dotnet build $solution #--configuration $config #--no-restore -p:FileVersionRevision=$GITHUB_RUN_NUMBER -p:ContinuousIntegrationBuild=true
 
-    # - name: Set up Node.js
-    #   uses: actions/setup-node@v3
-    #   with:
-    #     node-version: '16.x'
+    - name: Set up Node.js
+      uses: actions/setup-node@v3
+      with:
+        node-version: '16.x'
 
-    # - name: Install Azurite
-    #   run: npm install -g azurite
+    - name: Install Azurite
+      run: npm install -g azurite
 
     - name: Test DTx.Core
-      run: dotnet test #--configuration $config --no-build --verbosity normal
+      run: azurite --blobPort 10000 --queuePort 10001 --tablePort 10002 & dotnet test ./test/FunctionsV2/WebJobs.Extensions.DurableTask.Tests.V2.csproj #--configuration $config --no-build --verbosity normal

--- a/.github/workflows/validate-build.yml
+++ b/.github/workflows/validate-build.yml
@@ -53,8 +53,5 @@ jobs:
     - name: Install Azurite
       run: npm install -g azurite
 
-    - name: Start Azurite
-      run: azurite --silent --blobPort 10000 --queuePort 10001 --tablePort 10002 &
-
     - name: Test DTx.Core
-      run: dotnet test #--configuration $config --no-build --verbosity normal
+      run: azurite --blobPort 10000 --queuePort 10001 --tablePort 10002 & dotnet test #--configuration $config --no-build --verbosity normal

--- a/.github/workflows/validate-build.yml
+++ b/.github/workflows/validate-build.yml
@@ -1,4 +1,4 @@
-name: Validate Build
+name: Validate Build (except E2E tests)
 
 on:
   push:
@@ -55,5 +55,5 @@ jobs:
 
     # Run tests
     - name: Run FunctionsV2 tests (except E2E tests)
-      run: azurite --silent --blobPort 10000 --queuePort 10001 --tablePort 10002 & dotnet test ./test/FunctionsV2/WebJobs.Extensions.DurableTask.Tests.V2.csproj  --filter "FullyQualifiedName!~Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests.DurableTaskEndToEndTests" # --filter "FullyQualifiedName~DurableTaskEndToEndTests.OutputsValidJSONLogs" #--configuration $config --no-build --verbosity normal
+      run: azurite --silent --blobPort 10000 --queuePort 10001 --tablePort 10002 & dotnet test ./test/FunctionsV2/WebJobs.Extensions.DurableTask.Tests.V2.csproj  --filter "FullyQualifiedName!~Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests.DurableTaskEndToEndTests"
 

--- a/.github/workflows/validate-build.yml
+++ b/.github/workflows/validate-build.yml
@@ -15,6 +15,14 @@ env:
   solution: WebJobs.Extensions.DurableTask.sln
   config: Release
 
+services:
+  azurite:
+    image: mcr.microsoft.com/azure-storage/azurite
+    ports:
+      - 10000:10000
+      - 10001:10001
+      - 10002:10002
+
 jobs:
   build:
     runs-on: windows-latest
@@ -29,3 +37,9 @@ jobs:
 
     - name: Restore dependencies
       run: dotnet restore $solution
+
+    - name: Build
+      run: dotnet build $solution #--configuration $config #--no-restore -p:FileVersionRevision=$GITHUB_RUN_NUMBER -p:ContinuousIntegrationBuild=true
+
+    - name: Test DTx.Core
+      run: dotnet test #--configuration $config --no-build --verbosity normal

--- a/src/WebJobs.Extensions.DurableTask.Analyzers/WebJobs.Extensions.DurableTask.Analyzers.csproj
+++ b/src/WebJobs.Extensions.DurableTask.Analyzers/WebJobs.Extensions.DurableTask.Analyzers.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+	<NoWarn>RS1026</NoWarn> <!-- Disable 'Enable concurrent execution' warning until we investigate if it's safe to enable-->
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/WebJobs.Extensions.DurableTask.Analyzers/WebJobs.Extensions.DurableTask.Analyzers.csproj
+++ b/src/WebJobs.Extensions.DurableTask.Analyzers/WebJobs.Extensions.DurableTask.Analyzers.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-	<NoWarn>RS1026</NoWarn> <!-- Disable 'Enable concurrent execution' warning until we investigate if it's safe to enable-->
+    <NoWarn>RS1026</NoWarn> <!-- Disable 'Enable concurrent execution' warning until we investigate if it's safe to enable-->
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
+++ b/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
@@ -57,7 +57,7 @@
     <Compile Include="**/*.cs" Exclude="Auth/*.cs;Correlation/*.cs;**/obj/**/*.cs" />
     <!-- Don't increase below versions without significantly testing on Functions V1!
          Increasing these versions increments some dependencies that have binding redirects in Functions V1. -->
-    <PackageReference Include="Azure.Identity" Version="1.1.1" />
+    <PackageReference Include="Azure.Identity" Version="1.1.1" NoWarn="NU1902"/> <!-- Added NoWarn as this dependency cannot be dropped due to Functions V1-->
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="2.3.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="1.0.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="1.0.2" />

--- a/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
+++ b/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
@@ -57,7 +57,7 @@
     <Compile Include="**/*.cs" Exclude="Auth/*.cs;Correlation/*.cs;**/obj/**/*.cs" />
     <!-- Don't increase below versions without significantly testing on Functions V1!
          Increasing these versions increments some dependencies that have binding redirects in Functions V1. -->
-    <PackageReference Include="Azure.Identity" Version="1.1.1" NoWarn="NU1902"/> <!-- Added NoWarn as this dependency cannot be dropped due to Functions V1-->
+    <PackageReference Include="Azure.Identity" Version="1.1.1" NoWarn="NU1902,NU1903"/> <!-- Added NoWarn as this dependency cannot be dropped due to Functions V1-->
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="2.3.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="1.0.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="1.0.2" />

--- a/test/Common/DurableTaskEndToEndTests.cs
+++ b/test/Common/DurableTaskEndToEndTests.cs
@@ -4299,7 +4299,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         }
 
         /// <summary>
-        /// Test which validates that entity state deserialization
+        /// Test which validates that entity state deserialization.
         /// </summary>
         [Theory]
         [InlineData(true)]

--- a/test/Common/DurableTaskEndToEndTests.cs
+++ b/test/Common/DurableTaskEndToEndTests.cs
@@ -746,6 +746,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 conditionDescription: "Log file exists",
                 timeout: TimeSpan.FromSeconds(30));
 
+            // add a minute wait to ensure logs are fully written
+            await Task.Delay(TimeSpan.FromMinutes(1));
+
             await TestHelpers.WaitUntilTrue(
                 predicate: () =>
                 {

--- a/test/Common/TestDurableClient.cs
+++ b/test/Common/TestDurableClient.cs
@@ -182,7 +182,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         {
             if (timeout == null)
             {
-                timeout = Debugger.IsAttached ? TimeSpan.FromMinutes(5) : TimeSpan.FromSeconds(30);
+                timeout = Debugger.IsAttached ? TimeSpan.FromMinutes(5) : TimeSpan.FromMinutes(1);
             }
 
             Stopwatch sw = Stopwatch.StartNew();

--- a/test/Common/TestHelpers.cs
+++ b/test/Common/TestHelpers.cs
@@ -12,8 +12,8 @@ using System.Threading.Tasks;
 using DurableTask.AzureStorage;
 using Microsoft.ApplicationInsights.Channel;
 #if !FUNCTIONS_V1
-using Microsoft.Extensions.Hosting;
 using Microsoft.Azure.WebJobs.Host.Scale;
+using Microsoft.Extensions.Hosting;
 #endif
 using Microsoft.Azure.WebJobs.Host.TestCommon;
 using Microsoft.Extensions.Logging;

--- a/test/FunctionsV2/CorrelationEndToEndTests.cs
+++ b/test/FunctionsV2/CorrelationEndToEndTests.cs
@@ -234,7 +234,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         [InlineData(false, true, true)]
         [InlineData(true, true, false)]
         [InlineData(true, true, true)]
-        public async void TelemetryClientSetup_AppInsights_Warnings(bool instrumentationKeyIsSet, bool connStringIsSet, bool extendedSessions)
+        public void TelemetryClientSetup_AppInsights_Warnings(bool instrumentationKeyIsSet, bool connStringIsSet, bool extendedSessions)
         {
             TraceOptions traceOptions = new TraceOptions()
             {
@@ -258,11 +258,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             }
             else if (instrumentationKeyIsSet)
             {
-                mockNameResolver = GetNameResolverMock(new[] { (instKeyEnvVarName, environmentVariableValue), (connStringEnvVarName, String.Empty) });
+                mockNameResolver = GetNameResolverMock(new[] { (instKeyEnvVarName, environmentVariableValue), (connStringEnvVarName, string.Empty) });
             }
             else if (connStringIsSet)
             {
-                mockNameResolver = GetNameResolverMock(new[] { (instKeyEnvVarName, String.Empty), (connStringEnvVarName, connStringValue) });
+                mockNameResolver = GetNameResolverMock(new[] { (instKeyEnvVarName, string.Empty), (connStringEnvVarName, connStringValue) });
             }
 
             using (var host = TestHelpers.GetJobHost(

--- a/test/FunctionsV2/CorrelationEndToEndTests.cs
+++ b/test/FunctionsV2/CorrelationEndToEndTests.cs
@@ -405,14 +405,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             var result = new List<OperationTelemetry>();
             if (current.Count != 0)
             {
-                /*foreach (var some in current)
-                {
-                    if (parent.Id == some.Context.Operation.ParentId)
-                    {
-                        Console.WriteLine("match");
-                    }
-                }*/
-
                 IOrderedEnumerable<OperationTelemetry> nexts = current.Where(p => p.Context.Operation.ParentId == parent.Id).OrderBy(p => p.Timestamp.Ticks);
                 foreach (OperationTelemetry next in nexts)
                 {

--- a/test/FunctionsV2/CorrelationEndToEndTests.cs
+++ b/test/FunctionsV2/CorrelationEndToEndTests.cs
@@ -405,13 +405,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             var result = new List<OperationTelemetry>();
             if (current.Count != 0)
             {
-                foreach (var some in current)
+                /*foreach (var some in current)
                 {
                     if (parent.Id == some.Context.Operation.ParentId)
                     {
                         Console.WriteLine("match");
                     }
-                }
+                }*/
 
                 IOrderedEnumerable<OperationTelemetry> nexts = current.Where(p => p.Context.Operation.ParentId == parent.Id).OrderBy(p => p.Timestamp.Ticks);
                 foreach (OperationTelemetry next in nexts)

--- a/test/FunctionsV2/OutOfProcTests.cs
+++ b/test/FunctionsV2/OutOfProcTests.cs
@@ -367,6 +367,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             {
                 await host.StartAsync();
 
+#pragma warning disable SYSLIB0014 // Type or member is obsolete
                 using (var client = new WebClient())
                 {
                     string jsonString = client.DownloadString("http://localhost:17071/durabletask/instances");
@@ -374,6 +375,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                     // The result is expected to be an empty array
                     JArray array = JArray.Parse(jsonString);
                 }
+#pragma warning restore SYSLIB0014 // Type or member is obsolete
 
                 await host.StopAsync();
             }

--- a/test/FunctionsV2/OutOfProcTests.cs
+++ b/test/FunctionsV2/OutOfProcTests.cs
@@ -342,9 +342,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 // Validate if we opened local RPC endpoint by looking at log statements.
                 var logger = this.loggerProvider.CreatedLoggers.Single(l => l.Category == TestHelpers.LogCategory);
                 var logMessages = logger.LogMessages.ToList();
+
+                Assert.True(logMessages.Count > 0, "No log messages found.");
+
                 bool enabledRpcEndpoint = logMessages.Any(msg => msg.Level == Microsoft.Extensions.Logging.LogLevel.Information && msg.FormattedMessage.StartsWith($"Opened local {expectedProtocol} endpoint:"));
 
-                Assert.Equal(enabledExpected, enabledRpcEndpoint);
+                Assert.Equal(enabledExpected, enabledRpcEndpoint, );
 
                 await host.StopAsync();
             }

--- a/test/FunctionsV2/OutOfProcTests.cs
+++ b/test/FunctionsV2/OutOfProcTests.cs
@@ -344,10 +344,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 var logMessages = logger.LogMessages.ToList();
 
                 Assert.True(logMessages.Count > 0, "No log messages found.");
+                Console.WriteLine(logMessages);
 
                 bool enabledRpcEndpoint = logMessages.Any(msg => msg.Level == Microsoft.Extensions.Logging.LogLevel.Information && msg.FormattedMessage.StartsWith($"Opened local {expectedProtocol} endpoint:"));
 
-                Assert.Equal(enabledExpected, enabledRpcEndpoint, );
+                Assert.Equal(enabledExpected, enabledRpcEndpoint);
 
                 await host.StopAsync();
             }

--- a/test/FunctionsV2/OutOfProcTests.cs
+++ b/test/FunctionsV2/OutOfProcTests.cs
@@ -343,9 +343,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 var logger = this.loggerProvider.CreatedLoggers.Single(l => l.Category == TestHelpers.LogCategory);
                 var logMessages = logger.LogMessages.ToList();
 
-                Assert.True(logMessages.Count > 0, "No log messages found.");
-                Console.WriteLine(logMessages);
-
                 bool enabledRpcEndpoint = logMessages.Any(msg => msg.Level == Microsoft.Extensions.Logging.LogLevel.Information && msg.FormattedMessage.StartsWith($"Opened local {expectedProtocol} endpoint:"));
 
                 Assert.Equal(enabledExpected, enabledRpcEndpoint);

--- a/test/FunctionsV2/PlatformSpecificHelpers.FunctionsV2.cs
+++ b/test/FunctionsV2/PlatformSpecificHelpers.FunctionsV2.cs
@@ -230,7 +230,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
         internal class FunctionsV2HostWrapper : ITestHost
         {
-            internal readonly IHost InnerHost;
             private readonly JobHost innerWebJobsHost;
             private readonly DurableTaskOptions options;
             private readonly INameResolver nameResolver;
@@ -254,6 +253,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 this.innerWebJobsHost = (JobHost)this.InnerHost.Services.GetService<IJobHost>();
                 this.options = options.Value;
             }
+
+            internal IHost InnerHost { get; private set; }
 
             public Task CallAsync(string methodName, IDictionary<string, object> args)
                 => this.innerWebJobsHost.CallAsync(methodName, args);

--- a/test/SmokeTests/SmokeTestsV1/VSSampleV1.csproj
+++ b/test/SmokeTests/SmokeTestsV1/VSSampleV1.csproj
@@ -10,7 +10,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.30" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="2.3.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">


### PR DESCRIPTION
As part of our 1ES migration - we're replacing our ADO unit, integration, and end to tests with GitHub actions that use Azurite as a backing Azure Storage store. This PR does just that: it creates 3 new GitHub actions - one for the analyzer tests, one for the E2E tests, and another for the remaining tests.

Finally, this PR also resolve a myriad of build warnings, for clean up sake.