### PR TITLE
Add Injected Durable Client with Identity Based Connection Samples

### DIFF
--- a/samples/durable-client-managed-identity/aspnetcore-app/Controllers/TodoController.cs
+++ b/samples/durable-client-managed-identity/aspnetcore-app/Controllers/TodoController.cs
@@ -1,0 +1,130 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.Azure.WebJobs.Extensions.DurableTask;
+using Microsoft.Azure.WebJobs.Extensions.DurableTask.ContextImplementations;
+using Microsoft.Azure.WebJobs.Extensions.DurableTask.Options;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Newtonsoft.Json;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading.Tasks;
+using TodoApi.Models;
+
+namespace TodoApi.Controllers
+{
+    [Route("api/[controller]")] 
+    [ApiController]
+    public class TodoController : Controller
+    {
+        private readonly TodoContext _context;
+        private readonly IDurableClient _client;
+
+        public TodoController(TodoContext context, IDurableClientFactory clientFactory, IConfiguration configuration)
+        {
+            _context = context;
+
+            if (_context.TodoItems.Count() == 0)
+            {
+                _context.TodoItems.Add(new TodoItem { Name = "Item1" });
+                _context.SaveChanges();
+            }
+
+            _client = clientFactory.CreateClient(new DurableClientOptions
+            {
+                ConnectionName = configuration["MyStorage"],
+                TaskHub = configuration["TaskHub"]
+            });
+        }
+
+        // GET: api/Todo
+        [HttpGet]
+        public async Task<ActionResult<IEnumerable<TodoItem>>> GetTodoItem()
+        {
+            return await _context.TodoItems.ToListAsync();
+        }
+
+        // GET: api/Todo/5
+        [HttpGet("{id}")]
+        public async Task<ActionResult<TodoItem>> GetTodoItem(long id)
+        {
+            var todoItem = await _context.TodoItems.FindAsync(id);
+
+            if (todoItem == null)
+            {
+                return NotFound();
+            }
+
+            return todoItem;
+        }
+
+        // PUT: api/Todo/5
+        // To protect from overposting attacks, please enable the specific properties you want to bind to, for
+        // more details see https://aka.ms/RazorPagesCRUD.
+        [HttpPut("{id}")]
+        public async Task<IActionResult> PutTodoItem(long id, TodoItem todoItem)
+        {
+            if (id != todoItem.Id)
+            {
+                return BadRequest();
+            }
+
+            _context.Entry(todoItem).State = EntityState.Modified;
+
+            try
+            {
+                await _context.SaveChangesAsync();
+            }
+            catch (DbUpdateConcurrencyException)
+            {
+                if (!TodoItemExists(id))
+                {
+                    return NotFound();
+                }
+                else
+                {
+                    throw;
+                }
+            }
+
+            return NoContent();
+        }
+
+        // POST: api/Todo
+        // To protect from overposting attacks, please enable the specific properties you want to bind to, for
+        // more details see https://aka.ms/RazorPagesCRUD.
+        [HttpPost]
+        public async Task<ActionResult<TodoItem>> PostTodoItem(TodoItem todoItem)
+        {
+            _context.TodoItems.Add(todoItem);
+            await _context.SaveChangesAsync();
+
+            string instanceId = await _client.StartNewAsync<string>("SetReminder", todoItem.Name);
+
+            return CreatedAtAction("GetTodoItem", new { id = todoItem.Id }, todoItem);
+        }
+
+        // DELETE: api/Todo/5
+        [HttpDelete("{id}")]
+        public async Task<ActionResult<TodoItem>> DeleteTodoItem(long id)
+        {
+            var todoItem = await _context.TodoItems.FindAsync(id);
+            if (todoItem == null)
+            {
+                return NotFound();
+            }
+
+            _context.TodoItems.Remove(todoItem);
+            await _context.SaveChangesAsync();
+
+            return todoItem;
+        }
+
+        private bool TodoItemExists(long id)
+        {
+            return _context.TodoItems.Any(e => e.Id == id);
+        }
+    }
+}

--- a/samples/durable-client-managed-identity/aspnetcore-app/Program.cs
+++ b/samples/durable-client-managed-identity/aspnetcore-app/Program.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+
+namespace TodoApi
+{
+    public class Program
+    {
+
+        static void Main(string[] args)
+        {
+            CreateHostBuilder(args).Build().Run();
+        }
+
+        public static IHostBuilder CreateHostBuilder(string[] args) =>
+            Host.CreateDefaultBuilder(args)
+                .ConfigureWebHostDefaults(webBuilder =>
+                {
+                    webBuilder.UseStartup<Startup>();
+                });
+    }
+}

--- a/samples/durable-client-managed-identity/aspnetcore-app/README.md
+++ b/samples/durable-client-managed-identity/aspnetcore-app/README.md
@@ -1,0 +1,37 @@
+# ASP.NET Core API To Do List Sample with Identity-Based Connection
+
+This sample is based off of the [To Do List sample](https://github.com/Azure-Samples/dotnet-core-api) in the Azure-Samples repo, and it shows how to use injected Durable Client with ASP.NET Core App and identity based connections. The injected Durable Client in this sample is configured to use a storage connection with the custom name `MyStorage` and client secret application.
+
+
+## To make the sample run, you need to:
+
+1. Create an identity for your Function App in the Azure portal.
+
+2. Grant the following Role-Based Access Control (RBAC) permissions to the identity:
+    - Storage Queue Data Contributor
+    - Storage Blob Data Contributor
+    - Storage Table Data Contributor
+
+3. Link your storage account to your Function App by adding either of these two details to your configuration, which is appsettings.json file in this sample .
+    - accountName
+    - blobServiceUri, queueServiceUri and tableServiceUri
+
+4. Add the required identity information to your Functions App configuration, which is appsettings.json file in this sample.
+    - system-assigned identity: nothing needs to be provided.
+    - user-assigned identity: 
+      - credential: managedidentity
+      - clientId
+    - client secret application:
+      - clientId
+      - ClientSecret
+      - tenantId
+
+
+## Notes
+- The storage connection information must be provided in the format specified in the appsettings.json file.
+- If your storage information is saved in a custom-named JSON file, be sure to add it to your configuration as shown below.
+```csharp            
+this.Configuration = new ConfigurationBuilder()
+                        .AddJsonFile("myjson.json")
+                        .Build();
+```

--- a/samples/durable-client-managed-identity/aspnetcore-app/README.md
+++ b/samples/durable-client-managed-identity/aspnetcore-app/README.md
@@ -1,6 +1,6 @@
 # ASP.NET Core API To Do List Sample with Identity-Based Connection
 
-This sample is based off of the [To Do List sample](https://github.com/Azure-Samples/dotnet-core-api) in the Azure-Samples repo, and it shows how to use injected Durable Client with ASP.NET Core App and identity based connections. The injected Durable Client in this sample is configured to use a storage connection with the custom name `MyStorage` and client secret application.
+This example is adapted from the [To Do List sample](https://github.com/Azure-Samples/dotnet-core-api) in the Azure-Samples repository. It demonstrates an ASP.NET Core application with an injected Durable Client and identity-based connections. In this sample, the Durable Client is configured to use a storage connection with a custom name, `MyStorage`, and is set up to utilize a client secret for authentication.
 
 
 ## To make the sample run, you need to:

--- a/samples/durable-client-managed-identity/aspnetcore-app/Startup.cs
+++ b/samples/durable-client-managed-identity/aspnetcore-app/Startup.cs
@@ -1,0 +1,74 @@
+﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.OpenApi.Models;
+using TodoApi.Models;
+using Microsoft.Azure.WebJobs.Extensions.DurableTask;
+
+namespace TodoApi
+{
+    public class Startup
+    {
+        public Startup(IConfiguration configuration)
+        {
+            Configuration = configuration;
+        }
+
+        public IConfiguration Configuration { get; }
+
+        // This method gets called by the runtime. Use this method to add services to the container.
+        public void ConfigureServices(IServiceCollection services)
+        {
+            // AddDurableClientFactory() registers IDurableClientFactory as a service so the application
+            // can consume it and and call the Durable Client APIs
+            services.AddDurableClientFactory();
+
+            services.AddControllers();
+
+            // Register the Swagger generator, defining 1 or more Swagger documents
+            services.AddSwaggerGen(c =>
+            {
+                c.SwaggerDoc("v1", new OpenApiInfo { Title = "My API", Version = "v1" });
+            });
+
+            services.AddDbContext<TodoContext>(options => options.UseInMemoryDatabase("TodoList"));
+        }
+
+        // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+        {
+            // Enable middleware to serve generated Swagger as a JSON endpoint.
+            app.UseSwagger();
+
+            // Enable middleware to serve swagger-ui (HTML, JS, CSS, etc.),
+            // specifying the Swagger JSON endpoint.
+            app.UseSwaggerUI(c =>
+            {
+                c.SwaggerEndpoint("/swagger/v1/swagger.json", "My API V1");
+            });
+
+            if (env.IsDevelopment())
+            {
+                app.UseDeveloperExceptionPage();
+            }
+
+            //app.UseHttpsRedirection();
+
+            app.UseDefaultFiles();
+
+            app.UseStaticFiles();
+
+            app.UseRouting();
+
+            app.UseAuthorization();
+
+            app.UseEndpoints(endpoints =>
+            {
+                endpoints.MapControllers();
+            });
+        }
+    }
+}

--- a/samples/durable-client-managed-identity/aspnetcore-app/ToDoList.csproj
+++ b/samples/durable-client-managed-identity/aspnetcore-app/ToDoList.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="EntityFramework" Version="6.4.0" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="2.13.4" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="2.13.5" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.1.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.1.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/samples/durable-client-managed-identity/aspnetcore-app/ToDoList.csproj
+++ b/samples/durable-client-managed-identity/aspnetcore-app/ToDoList.csproj
@@ -4,7 +4,6 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
-
   <ItemGroup>
     <PackageReference Include="EntityFramework" Version="6.4.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="2.13.5" />

--- a/samples/durable-client-managed-identity/aspnetcore-app/ToDoList.csproj
+++ b/samples/durable-client-managed-identity/aspnetcore-app/ToDoList.csproj
@@ -1,0 +1,21 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+
+
+  <ItemGroup>
+    <PackageReference Include="EntityFramework" Version="6.4.0" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="2.13.4" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.1.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.1.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.1.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.3" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="5.4.0" />
+    <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.7" />
+  </ItemGroup>
+</Project>

--- a/samples/durable-client-managed-identity/aspnetcore-app/ToDoList.sln
+++ b/samples/durable-client-managed-identity/aspnetcore-app/ToDoList.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30503.244
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ToDoList", "ToDoList.csproj", "{D75105D4-B93A-4A9B-B12E-E8EF0F7E6223}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{D75105D4-B93A-4A9B-B12E-E8EF0F7E6223}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D75105D4-B93A-4A9B-B12E-E8EF0F7E6223}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D75105D4-B93A-4A9B-B12E-E8EF0F7E6223}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D75105D4-B93A-4A9B-B12E-E8EF0F7E6223}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {E7920E27-E4F7-47B7-B1B9-01F8645883CA}
+	EndGlobalSection
+EndGlobal

--- a/samples/durable-client-managed-identity/aspnetcore-app/appsettings.json
+++ b/samples/durable-client-managed-identity/aspnetcore-app/appsettings.json
@@ -10,8 +10,8 @@
   "TaskHub": "MyTestHub",
   "MyStorage": {
     "accountName": "YourStorageAccountName",
-    "clientId": "ClientSecretApplicationClientId",
-    "clientsecret": "ClientSecretApplicationClientSecret",
-    "tenantId": "ClientSecretApplicationTenantId"
+    "clientId": "<your client id here>",
+    "clientsecret": "<your client secret here>",
+    "tenantId": "<your tenant id here>"
   }
 }

--- a/samples/durable-client-managed-identity/aspnetcore-app/appsettings.json
+++ b/samples/durable-client-managed-identity/aspnetcore-app/appsettings.json
@@ -1,0 +1,17 @@
+﻿{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  },
+  "AllowedHosts": "*",
+  "TaskHub": "MyTestHub",
+  "MyStorage": {
+    "accountName": "YourStorageAccountName",
+    "clientId": "ClientSecretApplicationClientId",
+    "clientsecret": "ClientSecretApplicationClientSecret",
+    "tenantId": "ClientSecretApplicationTenantId"
+  }
+}

--- a/samples/durable-client-managed-identity/functions-app/ClientFunction.cs
+++ b/samples/durable-client-managed-identity/functions-app/ClientFunction.cs
@@ -1,0 +1,52 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Extensions.Http;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using Microsoft.Azure.WebJobs.Extensions.DurableTask;
+using Microsoft.Azure.WebJobs.Extensions.DurableTask.ContextImplementations;
+using Microsoft.Azure.WebJobs.Extensions.DurableTask.Options;
+using Microsoft.Extensions.Configuration;
+
+namespace DurableClientSampleFunctionApp
+{
+    public class ClientFunction
+    {
+        private readonly IDurableClient _client;
+
+        public ClientFunction(IDurableClientFactory clientFactory, IConfiguration configuration)
+        {
+            _client = clientFactory.CreateClient(new DurableClientOptions
+            {
+                ConnectionName = "Storage",
+                TaskHub = configuration["TaskHub"]
+            });
+        }
+
+        [FunctionName("CallHelloSequence")]
+        public async Task<IActionResult> Run(
+            [HttpTrigger(AuthorizationLevel.Function, "get", "post", Route = null)] HttpRequest req,
+            ILogger log)
+        {
+            log.LogInformation("C# HTTP trigger function processed a request.");
+
+            string instanceId = await _client.StartNewAsync("E1_HelloSequence");
+
+            DurableOrchestrationStatus status = await _client.GetStatusAsync(instanceId);
+
+            while (status.RuntimeStatus == OrchestrationRuntimeStatus.Pending ||
+                    status.RuntimeStatus == OrchestrationRuntimeStatus.Running ||
+                    status.RuntimeStatus == OrchestrationRuntimeStatus.ContinuedAsNew)
+            {
+                await Task.Delay(10000);
+                status = await _client.GetStatusAsync(instanceId);
+            }
+
+            return new ObjectResult(status);
+        }
+    }
+}

--- a/samples/durable-client-managed-identity/functions-app/ClientFunction.cs
+++ b/samples/durable-client-managed-identity/functions-app/ClientFunction.cs
@@ -22,7 +22,7 @@ namespace DurableClientSampleFunctionApp
         {
             _client = clientFactory.CreateClient(new DurableClientOptions
             {
-                ConnectionName = "Storage",
+                ConnectionName = "ClientStorage",
                 TaskHub = configuration["TaskHub"]
             });
         }

--- a/samples/durable-client-managed-identity/functions-app/DurableClientSampleFunctionApp.csproj
+++ b/samples/durable-client-managed-identity/functions-app/DurableClientSampleFunctionApp.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="2.13.4" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="2.13.5" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.7" />
   </ItemGroup>
   <ItemGroup>

--- a/samples/durable-client-managed-identity/functions-app/DurableClientSampleFunctionApp.csproj
+++ b/samples/durable-client-managed-identity/functions-app/DurableClientSampleFunctionApp.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <AzureFunctionsVersion>v3</AzureFunctionsVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="2.13.4" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.7" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Update="host.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="local.settings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>Never</CopyToPublishDirectory>
+    </None>
+  </ItemGroup>
+</Project>

--- a/samples/durable-client-managed-identity/functions-app/README.md
+++ b/samples/durable-client-managed-identity/functions-app/README.md
@@ -1,6 +1,7 @@
 # Azure Function App with Durable Function and Identity-Based Connection
 
-This project demonstrates an Azure Function App that invokes a Durable Function through a Durable Client using dependency injection and identity-based connection. Both the function host and the injected Durable Client are configured to use a storage connection with the default name `Storage`.
+This project demonstrates an Azure Function App that invokes a Durable Function through a Durable Client using dependency injection and identity-based connection. In the sample, the function is set up to utilize a storage connection named `Storage` by default. Meanwhile, the integrated Durable Client is set to use a storage connection that is specifically named `ClientStorage`.
+
 
 ## To make the sample run, you need to:
 
@@ -29,5 +30,5 @@ This project demonstrates an Azure Function App that invokes a Durable Function 
 ## Notes
 
 - The Azure Functions runtime requires a storage account to start, with the default connection name `Storage`.
-- For Durable Functions initiated by the Durable Client to run successfully, both the Durable Client and the Functions runtime must use the same storage account. If you need to use a custom storage connection name for the Durable Client, ensure you also update the Azure Functions runtime to use this custom name.
+- When injecting a Durable Client, it also requires a storage account, with the same default connection name `Storage`. However, you can use a custom connection name for a separate storage account as runtime for the durable client. For example, in this sample we use custom name `ClientStorage`.~ 
 

--- a/samples/durable-client-managed-identity/functions-app/README.md
+++ b/samples/durable-client-managed-identity/functions-app/README.md
@@ -30,5 +30,5 @@ This project demonstrates an Azure Function App that invokes a Durable Function 
 ## Notes
 
 - The Azure Functions runtime requires a storage account to start, with the default connection name `Storage`.
-- The Durable Client injected also requires a storage account, with the same default connection name `Storage`. However, you can use a custom connection name for a separate storage account as runtime for the durable client. For example, in this sample we use custom name `ClientStorage`.~ 
+- The Durable Client injected also requires a storage account, with the same default connection name `Storage`. However, you can use a custom connection name for a separate storage account as runtime for the durable client. For example, in this sample we use custom name `ClientStorage`.
 

--- a/samples/durable-client-managed-identity/functions-app/README.md
+++ b/samples/durable-client-managed-identity/functions-app/README.md
@@ -1,0 +1,33 @@
+# Azure Function App with Durable Function and Identity-Based Connection
+
+This project demonstrates an Azure Function App that invokes a Durable Function through a Durable Client using dependency injection and identity-based connection. Both the function host and the injected Durable Client are configured to use a storage connection with the default name `Storage`.
+
+## To make the sample run, you need to:
+
+1. Create an identity for your Function App in the Azure portal.
+
+2. Grant the following Role-Based Access Control (RBAC) permissions to the identity:
+    - Storage Queue Data Contributor
+    - Storage Blob Data Contributor
+    - Storage Table Data Contributor
+
+3. Link your storage account to your Function App by adding either of these two details to your `local.settings.json` file (for local development) or as environment variables in your Function App settings in Azure.
+    - AzureWebJobsStorage__accountName
+    - AzureWebJobsStorage__blobServiceUri, AzureWebJobsStorage__queueServiceUri and AzureWebJobsStorage__tableServiceUri
+
+4. Add the required identity information to your Functions App configuration.
+    - system-assigned identity: nothing needs to be provided.
+    - user-assigned identity: 
+      - AzureWebJobsStorage__credential: managedidentity
+      - AzureWebJobsStorage__clientId
+    - client secret application:
+      - AzureWebJobsStorage__clientId
+      - AzureWebJobsStorage__ClientSecret
+      - AzureWebJobsStorage__tenantId
+
+
+## Notes
+
+- The Azure Functions runtime requires a storage account to start, with the default connection name `Storage`.
+- For Durable Functions initiated by the Durable Client to run successfully, both the Durable Client and the Functions runtime must use the same storage account. If you need to use a custom storage connection name for the Durable Client, ensure you also update the Azure Functions runtime to use this custom name.
+

--- a/samples/durable-client-managed-identity/functions-app/README.md
+++ b/samples/durable-client-managed-identity/functions-app/README.md
@@ -30,5 +30,5 @@ This project demonstrates an Azure Function App that invokes a Durable Function 
 ## Notes
 
 - The Azure Functions runtime requires a storage account to start, with the default connection name `Storage`.
-- When injecting a Durable Client, it also requires a storage account, with the same default connection name `Storage`. However, you can use a custom connection name for a separate storage account as runtime for the durable client. For example, in this sample we use custom name `ClientStorage`.~ 
+- The Durable Client injected also requires a storage account, with the same default connection name `Storage`. However, you can use a custom connection name for a separate storage account as runtime for the durable client. For example, in this sample we use custom name `ClientStorage`.~ 
 

--- a/samples/durable-client-managed-identity/functions-app/Startup.cs
+++ b/samples/durable-client-managed-identity/functions-app/Startup.cs
@@ -1,0 +1,17 @@
+﻿using Microsoft.Azure.Functions.Extensions.DependencyInjection;
+using Microsoft.Azure.WebJobs.Extensions.DurableTask;
+
+[assembly: FunctionsStartup(typeof(DurableClientSampleFunctionApp.Startup))]
+
+namespace DurableClientSampleFunctionApp
+{
+    public class Startup : FunctionsStartup
+    {
+        public override void Configure(IFunctionsHostBuilder builder)
+        {
+            // AddDurableClientFactory() registers IDurableClientFactory as a service so the application
+            // can consume it and and call the Durable Client APIs
+            builder.Services.AddDurableClientFactory();
+        }
+    }
+}

--- a/samples/durable-client-managed-identity/functions-app/host.json
+++ b/samples/durable-client-managed-identity/functions-app/host.json
@@ -1,0 +1,11 @@
+{
+    "version": "2.0",
+    "logging": {
+        "applicationInsights": {
+            "samplingExcludedTypes": "Request",
+            "samplingSettings": {
+                "isEnabled": true
+            }
+        }
+    }
+}

--- a/samples/durable-client-managed-identity/functions-app/local.settings.json
+++ b/samples/durable-client-managed-identity/functions-app/local.settings.json
@@ -1,0 +1,8 @@
+{
+  "IsEncrypted": false,
+  "Values": {
+    "AzureWebJobsStorage__accountName": "YourIdentityLinkedStorageName",
+    "FUNCTIONS_WORKER_RUNTIME": "dotnet",
+    "TaskHub": "mytesthub"
+  }
+}

--- a/samples/durable-client-managed-identity/functions-app/local.settings.json
+++ b/samples/durable-client-managed-identity/functions-app/local.settings.json
@@ -1,7 +1,8 @@
 {
   "IsEncrypted": false,
   "Values": {
-    "AzureWebJobsStorage__accountName": "YourIdentityLinkedStorageName",
+    "AzureWebJobsStorage__accountName": "<your identity linked storage account name for functions runtime>",
+    "ClientStorage__accountName": "<your identity linked storage account name for durable client>", 
     "FUNCTIONS_WORKER_RUNTIME": "dotnet",
     "TaskHub": "mytesthub"
   }


### PR DESCRIPTION
<!-- Start the PR description with some context for the change. -->


<!-- Make sure to delete the markdown comments and the below sections when squash merging -->
### Issue describing the changes in this PR

Add samples showing how to use external durable client with identity based connection. 

### Pull request checklist

* [ ] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)
* [ ] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk
* [ ] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
    * [ ] Otherwise: major or minor version updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
* [ ] My changes **do not** add EventIds to our EventSource logs
    * [ ] Otherwise: Ensure the EventIds are within the supported range in our existing Windows infrastructure. You may validate this with a deployed app's telemetry. You may also extend the range by completing a PR such as [this one](https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files).
* [ ] My changes **should** be added to v3.x branch.
    * [ ] Otherwise: This change only applies to Durable Functions v2.x and **will not** be merged to branch v3.x.
