### PR TITLE
Refactor entity cleanup test to make it less flakey

### DIFF
--- a/test/Common/DurableTaskEndToEndTests.cs
+++ b/test/Common/DurableTaskEndToEndTests.cs
@@ -5104,6 +5104,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 // run an orchestration B that queues behind A for the lock (and thus gets stuck)
                 TestDurableClient clientB = await host.StartOrchestratorAsync(nameof(TestOrchestrations.LockThenFailReplay), (orphanedEntityId, false), this.output, orchestrationB);
 
+                await Task.Delay(TimeSpan.FromMinutes(1)); // wait for a stable entity executionID, needed until https://github.com/Azure/durabletask/pull/1128 is merged
+
                 // remove release orphaned lock to unblock orchestration B
                 // Note: do NOT remove empty entities yet: we want to keep the empty entity so it can unblock orchestration B
                 response = await client.InnerClient.CleanEntityStorageAsync(removeEmptyEntities: false, releaseOrphanedLocks: true, CancellationToken.None);

--- a/test/Common/DurableTaskEndToEndTests.cs
+++ b/test/Common/DurableTaskEndToEndTests.cs
@@ -5109,8 +5109,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 // remove release orphaned lock to unblock orchestration B
                 // Note: do NOT remove empty entities yet: we want to keep the empty entity so it can unblock orchestration B
                 response = await client.InnerClient.CleanEntityStorageAsync(removeEmptyEntities: false, releaseOrphanedLocks: true, CancellationToken.None);
-                Assert.Equal(0, response.NumberOfEmptyEntitiesRemoved);
                 Assert.Equal(1, response.NumberOfOrphanedLocksRemoved);
+                Assert.Equal(0, response.NumberOfEmptyEntitiesRemoved);
 
                 // wait for orchestration B to complete, now that the lock has been released
                 status = await clientB.WaitForCompletionAsync(this.output);

--- a/test/Common/HttpApiHandlerTests.cs
+++ b/test/Common/HttpApiHandlerTests.cs
@@ -411,14 +411,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                     TaskHub = TestConstants.TaskHub,
                     ConnectionName = TestConstants.ConnectionName,
                 },
-                TimeSpan.FromSeconds(10),
+                TimeSpan.FromSeconds(15),
                 TimeSpan.FromSeconds(3));
             stopwatch.Stop();
             Assert.Equal(HttpStatusCode.OK, httpResponseMessage.StatusCode);
             var content = await httpResponseMessage.Content.ReadAsStringAsync();
             var value = JsonConvert.DeserializeObject<string>(content);
             Assert.Equal("Hello Tokyo!", value);
-            Assert.True(stopwatch.Elapsed < TimeSpan.FromSeconds(10));
+            Assert.True(stopwatch.Elapsed < TimeSpan.FromSeconds(15));
         }
 
         [Fact]


### PR DESCRIPTION
The `DurableEntity_CleanEntityStorage` test has been extremely flakey ever since our migration to GitHub actions.
The test works broadly as follows.
It sets up 2 orchestrators: "A" and "B".
(1) Orchestrator "A" takes a lock on Entity "E", and completes without releasing that lock.
(2) Orchestrator "B" tries to take a lock on "E", and gets stuck until "E"'s current locking by A is forcibly broken.
(3) The test sends a "release orphaned locks" request to "E" so that "B" may obtain the lock and compete.
(4) The test waits for "B" to complete, then performs some assertions.

The test would often fail on step (4), because "B" would fail to receive the lock. The reason for this is that step (3) had a race condition. When sending a "release orphaned locks" external event to "E", that external event is sent with the entity's executionID, which may change if the entity is mid-processing (after every processed batch, and entity calls continue as new, changing it's executionID). Therefore, in many cases entity "E" would receive a "release orphaned locks" event with an older executionID, and therefore discard that event, keeping it itself locked, and leading the test to failure.

To put it another way, with concrete values, this is the race condition that caused the test to fail:
(0) Entity currently has instanceID "123" with executionID "A"
(1) Client sends "fix orphaned locks" message to entity instanceId "123" with executionID "A"
(2) Entity processes receives some request (not the fix orphaned locks message) and processes it. Therefore, it calls continue-as-new and changes it executionID to "B".
(3) Entity receives "Fix orphaned locks" message but it's for the wrong executionID. Therefore, it discards that message.
(4) Entity remains locked, the test fails
 
This PR makes the test more resilient to this by waiting some time before sending the "release orphaned locks" request. This will ensure that the entity's executionID is stable (that it won't change) by the time we send the request, so that the test may succeed.