### PR TITLE
Run official build nightly

### DIFF
--- a/eng/ci/official-build.yml
+++ b/eng/ci/official-build.yml
@@ -10,6 +10,17 @@ trigger:
 # CI only, does not trigger on PRs.
 pr: none
 
+schedules:
+# Build nightly to catch any new CVEs and report SDL often.
+# We are also required to generated CodeQL reports weekly, so this
+# helps us meet that.
+- cron: "0 0 * * *"
+  displayName: Nightly Build
+  branches:
+    include:
+    - main
+  always: true
+
 resources:
     repositories:
         - repository: 1es


### PR DESCRIPTION
As in title, needed for 1ES integration.
May need to cherry-pick this to the v2 branch