### PR TITLE
Add dev to list of CodeQL branches

### DIFF
--- a/eng/ci/official-build.yml
+++ b/eng/ci/official-build.yml
@@ -6,6 +6,7 @@ trigger:
     branches:
         include:
             - main
+            - dev
 
 # CI only, does not trigger on PRs.
 pr: none
@@ -19,6 +20,7 @@ schedules:
   branches:
     include:
     - main
+    - dev
   always: true
 
 resources:


### PR DESCRIPTION
This PR adds `dev` to the list of branches we run codeQL over. This will ensure we catch regressions in the `dev` branch, which is one of our main merge targets