### PR TITLE
Rev WebJobs Extension to 2.13.6, Rev DTFx.AS dependency to 1.17.5, make 1ES build deterministic, increase CI Azurite version

### DIFF
--- a/eng/templates/build.yml
+++ b/eng/templates/build.yml
@@ -46,6 +46,7 @@ jobs:
             solution: '**/WebJobs.Extensions.DurableTask.sln'
             vsVersion: "16.0"
             configuration: Release
+            msbuildArgs: /p:FileVersionRevision=$(Build.BuildId) /p:ContinuousIntegrationBuild=true # these flags make package build deterministic
     
       - template: ci/sign-files.yml@eng
         parameters:

--- a/src/WebJobs.Extensions.DurableTask/AzureStorageDurabilityProviderFactory.cs
+++ b/src/WebJobs.Extensions.DurableTask/AzureStorageDurabilityProviderFactory.cs
@@ -217,6 +217,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 UseSeparateQueueForEntityWorkItems = this.useSeparateQueueForEntityWorkItems,
                 EntityMessageReorderWindowInMinutes = this.options.EntityMessageReorderWindowInMinutes,
                 MaxEntityOperationBatchSize = this.options.MaxEntityOperationBatchSize,
+                AllowReplayingTerminalInstances = this.azureStorageOptions.AllowReplayingTerminalInstances,
             };
 
             if (this.inConsumption)

--- a/src/WebJobs.Extensions.DurableTask/Options/AzureStorageOptions.cs
+++ b/src/WebJobs.Extensions.DurableTask/Options/AzureStorageOptions.cs
@@ -180,6 +180,20 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         public bool UseTablePartitionManagement { get; set; } = false;
 
         /// <summary>
+        /// When false, when an orchestrator is in a terminal state (e.g. Completed, Failed, Terminated), events for that orchestrator are discarded.
+        /// Otherwise, events for a terminal orchestrator induce a replay. This may be used to recompute the state of the orchestrator in the "Instances Table".
+        /// </summary>
+        /// <remarks>
+        /// Transactions across Azure Tables are not possible, so we independently update the "History table" and then the "Instances table"
+        /// to set the state of the orchestrator.
+        /// If a crash were to occur between these two updates, the state of the orchestrator in the "Instances table" would be incorrect.
+        /// By setting this configuration to true, you can recover from these inconsistencies by forcing a replay of the orchestrator in response
+        /// to a client event like a termination request or an external event, which gives the framework another opportunity to update the state of
+        /// the orchestrator in the "Instances table". To force a replay after enabling this configuration, just send any external event to the affected instanceId.
+        /// </remarks>
+        public bool AllowReplayingTerminalInstances { get; set; } = false;
+
+        /// <summary>
         /// Throws an exception if the provided hub name violates any naming conventions for the storage provider.
         /// </summary>
         public void ValidateHubName(string hubName)

--- a/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
+++ b/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
@@ -6,7 +6,7 @@
     <RootNamespace>Microsoft.Azure.WebJobs.Extensions.DurableTask</RootNamespace>
     <MajorVersion>2</MajorVersion>
     <MinorVersion>13</MinorVersion>
-    <PatchVersion>5</PatchVersion>
+    <PatchVersion>6</PatchVersion>
     <VersionSuffix>$(PackageSuffix)</VersionSuffix>
     <FileVersion>$(MajorVersion).$(MinorVersion).$(PatchVersion)</FileVersion>
     <AssemblyVersion>$(MajorVersion).0.0.0</AssemblyVersion>

--- a/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
+++ b/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
@@ -114,7 +114,7 @@
   <!-- Common dependencies across all targets -->
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.DurableTask.Core" Version="2.17.1" />
-    <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage" Version="1.17.4" />
+    <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage" Version="1.17.5" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers" Version="0.5.*" />
     <!-- Build-time dependencies -->
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.*" PrivateAssets="All" />

--- a/test/SmokeTests/e2e-test.ps1
+++ b/test/SmokeTests/e2e-test.ps1
@@ -26,7 +26,7 @@ function Exit-OnError() {
 }
 
 $ErrorActionPreference = "Stop"
-$AzuriteVersion = "3.26.0"
+$AzuriteVersion = "3.32.0"
 
 if ($NoSetup -eq $false) {
 	# Build the docker image first, since that's the most critical step


### PR DESCRIPTION
This PR was opened primarily to increase the WebJobs extension version to 2.13.6, and increase the DTFx.AS dependency to 1.17.5, which allows us to support the upcoming `AllowReplayingTerminalInstances` DTFx property.

However, the CI revealed two more problems:
(1) The Azurite version used in our tests was out of date, creating issues. So we've increased the Azurite version from 3.26 to 3.32.
(2) The 1ES build of the WebJobs extension was being flagged as non-deterministic. I added the determinism flags (`/p:FileVersionRevision=$(Build.BuildId) /p:ContinuousIntegrationBuild=true`) in our offficial build yml, which we already use in [DTFx](https://github.com/Azure/durabletask/blob/ed3ece34ba4a22b6945388acf3972e1440ea8881/eng/templates/build.yml#L47) and other packages.