### PR TITLE
Update Microsoft.DurableTask.Grpc to latest version

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -1,22 +1,6 @@
 # Release Notes
 
-## Microsoft.Azure.Functions.Worker.Extensions.DurableTask 1.1.6
-
-### New Features
-
-- Support for new `AllowReplayingTerminalInstances` setting in Azure Storage backend (https://github.com/Azure/durabletask/pull/1159), settable via `host.json`
-
-### Bug Fixes
-
-### Breaking Changes
-
-### Dependency Updates
-
-- Microsoft.DurableTask.Client.Grpc to 1.3.0
-- Microsoft.DurableTask.Worker.Grpc to 1.3.0
-- Microsoft.Azure.WebJobs.Extensions.DurableTask (in host process) to 2.13.6
-
-## Microsoft.Azure.WebJobs.Extensions.DurableTask <version>
+## Microsoft.Azure.Functions.Worker.Extensions.DurableTask (version)
 
 ### New Features
 
@@ -25,3 +9,15 @@
 ### Breaking Changes
 
 ### Dependency Updates
+
+## Microsoft.Azure.WebJobs.Extensions.DurableTask 2.13.7
+
+### New Features
+
+### Bug Fixes
+
+### Breaking Changes
+
+### Dependency Updates
+
+- Microsoft.DurableTask.Grpc to 1.3.0

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
@@ -4208,6 +4208,20 @@
             </summary>
             <value>A boolean indicating whether to use the table partition strategy. Defaults to false.</value>
         </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureStorageOptions.AllowReplayingTerminalInstances">
+            <summary>
+            When false, when an orchestrator is in a terminal state (e.g. Completed, Failed, Terminated), events for that orchestrator are discarded.
+            Otherwise, events for a terminal orchestrator induce a replay. This may be used to recompute the state of the orchestrator in the "Instances Table".
+            </summary>
+            <remarks>
+            Transactions across Azure Tables are not possible, so we independently update the "History table" and then the "Instances table"
+            to set the state of the orchestrator.
+            If a crash were to occur between these two updates, the state of the orchestrator in the "Instances table" would be incorrect.
+            By setting this configuration to true, you can recover from these inconsistencies by forcing a replay of the orchestrator in response
+            to a client event like a termination request or an external event, which gives the framework another opportunity to update the state of
+            the orchestrator in the "Instances table". To force a replay after enabling this configuration, just send any external event to the affected instanceId.
+            </remarks>
+        </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureStorageOptions.ValidateHubName(System.String)">
             <summary>
             Throws an exception if the provided hub name violates any naming conventions for the storage provider.

--- a/src/WebJobs.Extensions.DurableTask/ProtobufUtils.cs
+++ b/src/WebJobs.Extensions.DurableTask/ProtobufUtils.cs
@@ -97,7 +97,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                             },
                         },
                         ScheduledStartTimestamp = startedEvent.ScheduledStartTime == null ? null : Timestamp.FromDateTime(startedEvent.ScheduledStartTime.Value),
-                        CorrelationData = startedEvent.Correlation,
+                        ParentTraceContext = startedEvent.ParentTraceContext == null ? null : new P.TraceContext
+                        {
+                            TraceParent = startedEvent.ParentTraceContext.TraceParent,
+                            TraceState = startedEvent.ParentTraceContext.TraceState,
+                        },
                     };
                     break;
                 case EventType.ExecutionTerminated:

--- a/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
+++ b/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
@@ -137,8 +137,4 @@
     </Content>
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="LocalNuGet" Version="1.0.0" PrivateAssets="All" />
-  </ItemGroup>
-
 </Project>

--- a/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
+++ b/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
@@ -6,7 +6,7 @@
     <RootNamespace>Microsoft.Azure.WebJobs.Extensions.DurableTask</RootNamespace>
     <MajorVersion>2</MajorVersion>
     <MinorVersion>13</MinorVersion>
-    <PatchVersion>6</PatchVersion>
+    <PatchVersion>7</PatchVersion>
     <VersionSuffix>$(PackageSuffix)</VersionSuffix>
     <FileVersion>$(MajorVersion).$(MinorVersion).$(PatchVersion)</FileVersion>
     <AssemblyVersion>$(MajorVersion).0.0.0</AssemblyVersion>
@@ -107,7 +107,7 @@
     <!-- Explicitly pinned transitive dependencies with CVE vulnerabilities.-->
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets" Version="2.2.1" />
     <!-- The gRPC dependencies in this package are not compatible with older frameworks, like .NET Core 2.x -->
-    <PackageReference Include="Microsoft.DurableTask.Grpc" Version="1.1.0" />
+    <PackageReference Include="Microsoft.DurableTask.Grpc" Version="1.3.0" />
     <PackageReference Include="Grpc.Core" Version="2.46.6" /> <!-- Bring this in until we move to hosted RPC -->
   </ItemGroup>
 
@@ -135,6 +135,10 @@
       <Pack>true</Pack>
       <PackagePath>content/SBOM</PackagePath>
     </Content>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="LocalNuGet" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>

--- a/src/Worker.Extensions.DurableTask/AssemblyInfo.cs
+++ b/src/Worker.Extensions.DurableTask/AssemblyInfo.cs
@@ -5,5 +5,5 @@ using System.Runtime.CompilerServices;
 using Microsoft.Azure.Functions.Worker.Extensions.Abstractions;
 
 // TODO: Find a way to generate this dynamically at build-time
-[assembly: ExtensionInformation("Microsoft.Azure.WebJobs.Extensions.DurableTask", "2.13.6")]
+[assembly: ExtensionInformation("Microsoft.Azure.WebJobs.Extensions.DurableTask", "2.13.7")]
 [assembly: InternalsVisibleTo("Worker.Extensions.DurableTask.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100cd1dabd5a893b40e75dc901fe7293db4a3caf9cd4d3e3ed6178d49cd476969abe74a9e0b7f4a0bb15edca48758155d35a4f05e6e852fff1b319d103b39ba04acbadd278c2753627c95e1f6f6582425374b92f51cca3deb0d2aab9de3ecda7753900a31f70a236f163006beefffe282888f85e3c76d1205ec7dfef7fa472a17b1")]

--- a/src/Worker.Extensions.DurableTask/Worker.Extensions.DurableTask.csproj
+++ b/src/Worker.Extensions.DurableTask/Worker.Extensions.DurableTask.csproj
@@ -29,7 +29,7 @@
     <AssemblyOriginatorKeyFile>..\..\sign.snk</AssemblyOriginatorKeyFile>
 
     <!-- Version information -->
-    <VersionPrefix>1.1.6</VersionPrefix>
+    <VersionPrefix>1.1.7</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <AssemblyVersion>$(VersionPrefix).0</AssemblyVersion>
     <!-- FileVersionRevision is expected to be set by the CI.  -->


### PR DESCRIPTION
This change updates the Microsoft.DurableTask.Grpc package to the latest version (1.3.0). This is important because there was a breaking change in an earlier version of this package, making the extension incompatible with certain backend extensions. This change will fix the incompatibility.

This PR also updates the versions in the `WebJobs.Extensions.DurableTask` and `Functions.Worker.Extensions.DurableTask` projects.

<!-- Make sure to delete the markdown comments and the below sections when squash merging -->
### Issue describing the changes in this PR

Without this fix, it's possible for certain backends to run into a `MissingMethodException` on `set_CorrelationData` since that property was removed in a previous version of the `Microsoft.DurableTask.Grpc` package. This PR removes the dependency on that missing property and replaces it with the modern (TraceV2) variant. This only impacts .NET Isolated and Java. There's no impact to other stacks.

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)
* [x] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk
* [ ] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
    * [x] Otherwise: major or minor version updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
* [x] My changes **do not** add EventIds to our EventSource logs
    * [ ] Otherwise: Ensure the EventIds are within the supported range in our existing Windows infrastructure. You may validate this with a deployed app's telemetry. You may also extend the range by completing a PR such as [this one](https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files).
* [x] My changes **should** be added to v3.x branch.
    * [ ] Otherwise: This change only applies to Durable Functions v2.x and **will not** be merged to branch v3.x.
