### PR TITLE
[WIP] PR to debug transient .NET isolated CI failures

### DIFF
--- a/.github/workflows/smoketest-dotnet-isolated-v4.yml
+++ b/.github/workflows/smoketest-dotnet-isolated-v4.yml
@@ -21,5 +21,5 @@ jobs:
 
       # Validation is blocked on https://github.com/Azure/azure-functions-host/issues/7995
     - name: Run V4 .NET Isolated Smoke Test
-      run: test/SmokeTests/e2e-test.ps1 -DockerfilePath test/SmokeTests/OOProcSmokeTests/DotNetIsolated/Dockerfile -HttpStartPath api/StartHelloCitiesTyped -NoValidation
+      run: test/SmokeTests/e2e-test.ps1 -DockerfilePath test/SmokeTests/OOProcSmokeTests/DotNetIsolated/Dockerfile -HttpStartPath api/StartHelloCitiesTyped
       shell: pwsh

--- a/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Reflection;
+using System.Runtime.Versioning;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -31,10 +32,6 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-
-// debugging
-using System.Reflection;
-using System.Runtime.Versioning;
 
 namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 {

--- a/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
@@ -451,7 +451,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 // This can happen if, for example, a Java user tries to use Durable Functions while targeting V2 or V3 extension bundles
                 // because those bundles target .NET Core 2.2, which doesn't support the gRPC libraries used in the modern out-of-proc implementation.
                 throw new PlatformNotSupportedException(
-                    $"This project type is not supported on this version of the Azure Functions runtime. Please upgrade to Azure Functions V3 or higher. " +
+                    "This project type is not supported on this version of the Azure Functions runtime. Please upgrade to Azure Functions V3 or higher. " +
                     "If you are using a language that supports extension bundles, please use extension bundles V4 or higher. " +
                     "For more information on Azure Functions versions, see https://docs.microsoft.com/azure/azure-functions/functions-versions. " +
                     "For more information on extension bundles, see https://docs.microsoft.com/azure/azure-functions/functions-bindings-register#extension-bundles.");

--- a/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
@@ -32,6 +32,10 @@ using Microsoft.Extensions.Options;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
+// debugging
+using System.Reflection;
+using System.Runtime.Versioning;
+
 namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 {
     /// <summary>
@@ -447,10 +451,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 this.taskHubWorker.AddOrchestrationDispatcherMiddleware(ooprocMiddleware.CallOrchestratorAsync);
                 this.taskHubWorker.AddEntityDispatcherMiddleware(ooprocMiddleware.CallEntityAsync);
 #else
+
+                var targetFramework = Assembly.GetEntryAssembly()?
+                    .GetCustomAttribute<TargetFrameworkAttribute>()?
+                    .FrameworkName;
+
                 // This can happen if, for example, a Java user tries to use Durable Functions while targeting V2 or V3 extension bundles
                 // because those bundles target .NET Core 2.2, which doesn't support the gRPC libraries used in the modern out-of-proc implementation.
                 throw new PlatformNotSupportedException(
-                    "This project type is not supported on this version of the Azure Functions runtime. Please upgrade to Azure Functions V3 or higher. " +
+                    $"{targetFramework}. This project type is not supported on this version of the Azure Functions runtime. Please upgrade to Azure Functions V3 or higher. " +
                     "If you are using a language that supports extension bundles, please use extension bundles V4 or higher. " +
                     "For more information on Azure Functions versions, see https://docs.microsoft.com/azure/azure-functions/functions-versions. " +
                     "For more information on extension bundles, see https://docs.microsoft.com/azure/azure-functions/functions-bindings-register#extension-bundles.");

--- a/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
@@ -9,7 +9,6 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Reflection;
-using System.Runtime.Versioning;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -449,14 +448,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 this.taskHubWorker.AddEntityDispatcherMiddleware(ooprocMiddleware.CallEntityAsync);
 #else
 
-                var targetFramework = Assembly.GetEntryAssembly()?
-                    .GetCustomAttribute<TargetFrameworkAttribute>()?
-                    .FrameworkName;
-
                 // This can happen if, for example, a Java user tries to use Durable Functions while targeting V2 or V3 extension bundles
                 // because those bundles target .NET Core 2.2, which doesn't support the gRPC libraries used in the modern out-of-proc implementation.
                 throw new PlatformNotSupportedException(
-                    $"{targetFramework}. This project type is not supported on this version of the Azure Functions runtime. Please upgrade to Azure Functions V3 or higher. " +
+                    $"This project type is not supported on this version of the Azure Functions runtime. Please upgrade to Azure Functions V3 or higher. " +
                     "If you are using a language that supports extension bundles, please use extension bundles V4 or higher. " +
                     "For more information on Azure Functions versions, see https://docs.microsoft.com/azure/azure-functions/functions-versions. " +
                     "For more information on extension bundles, see https://docs.microsoft.com/azure/azure-functions/functions-bindings-register#extension-bundles.");

--- a/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
@@ -447,7 +447,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 this.taskHubWorker.AddOrchestrationDispatcherMiddleware(ooprocMiddleware.CallOrchestratorAsync);
                 this.taskHubWorker.AddEntityDispatcherMiddleware(ooprocMiddleware.CallEntityAsync);
 #else
-
                 // This can happen if, for example, a Java user tries to use Durable Functions while targeting V2 or V3 extension bundles
                 // because those bundles target .NET Core 2.2, which doesn't support the gRPC libraries used in the modern out-of-proc implementation.
                 throw new PlatformNotSupportedException(

--- a/test/SmokeTests/e2e-test.ps1
+++ b/test/SmokeTests/e2e-test.ps1
@@ -107,6 +107,7 @@ try {
 	$pingUrl = "http://localhost:8080/admin/host/ping"
 	Write-Host "Pinging app at $pingUrl to ensure the host is healthy" -ForegroundColor Yellow
 	Invoke-RestMethod -Method Post -Uri "http://localhost:8080/admin/host/ping"
+	Write-Host "Host is healthy" -ForegroundColor Green
 	Exit-OnError
 
 	if ($NoValidation -eq $false) {

--- a/test/SmokeTests/e2e-test.ps1
+++ b/test/SmokeTests/e2e-test.ps1
@@ -7,7 +7,6 @@ param(
 	[string]$ImageName="dfapp",
 	[string]$ContainerName="app",
 	[switch]$NoSetup=$false,
-	[switch]$NoValidation=$false,
 	[int]$Sleep=30,
   	[switch]$SetupSQLServer=$false,
   	[string]$pw="$env:SA_PASSWORD",
@@ -110,32 +109,30 @@ try {
 	Write-Host "Host is healthy" -ForegroundColor Green
 	Exit-OnError
 
-	if ($NoValidation -eq $false) {
-		# Note that any HTTP protocol errors (e.g. HTTP 4xx or 5xx) will cause an immediate failure
-		$startOrchestrationUri = "http://localhost:8080/$HttpStartPath"
-		Write-Host "Starting a new orchestration instance via POST to $startOrchestrationUri..." -ForegroundColor Yellow
+	# Note that any HTTP protocol errors (e.g. HTTP 4xx or 5xx) will cause an immediate failure
+	$startOrchestrationUri = "http://localhost:8080/$HttpStartPath"
+	Write-Host "Starting a new orchestration instance via POST to $startOrchestrationUri..." -ForegroundColor Yellow
 
-		$result = Invoke-RestMethod -Method Post -Uri $startOrchestrationUri
-		Write-Host "Started orchestration with instance ID '$($result.id)'!" -ForegroundColor Yellow
-		Write-Host "Waiting for orchestration to complete..." -ForegroundColor Yellow
+	$result = Invoke-RestMethod -Method Post -Uri $startOrchestrationUri
+	Write-Host "Started orchestration with instance ID '$($result.id)'!" -ForegroundColor Yellow
+	Write-Host "Waiting for orchestration to complete..." -ForegroundColor Yellow
 
-		$retryCount = 0
-		$success = $false
-		$statusUrl = $result.statusQueryGetUri
+	$retryCount = 0
+	$success = $false
+	$statusUrl = $result.statusQueryGetUri
 
-		while ($retryCount -lt 15) {
-			$result = Invoke-RestMethod -Method Get -Uri $statusUrl
-			$runtimeStatus = $result.runtimeStatus
-			Write-Host "Orchestration is $runtimeStatus" -ForegroundColor Yellow
+	while ($retryCount -lt 15) {
+		$result = Invoke-RestMethod -Method Get -Uri $statusUrl
+		$runtimeStatus = $result.runtimeStatus
+		Write-Host "Orchestration is $runtimeStatus" -ForegroundColor Yellow
 
-			if ($result.runtimeStatus -eq "Completed") {
-				$success = $true
-				break
-			}
-
-			Start-Sleep -Seconds 1
-			$retryCount = $retryCount + 1
+		if ($result.runtimeStatus -eq "Completed") {
+			$success = $true
+			break
 		}
+
+		Start-Sleep -Seconds 1
+		$retryCount = $retryCount + 1
 	}
 
 	if ($success -eq $false) {


### PR DESCRIPTION
As in title. We're getting transient "PlatformNotSupportedExceptions" on the .NET isolated CI. Seems to be because the TFM is not `netcoreapp3.1`, which makes sense for the new / upcoming .net8 split host, but it doesn't explain how this ever worked with the .net6 host