### PR TITLE
Fix custom connection name not working when using IDurableClientFactory -> CreateClient().

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -6,6 +6,8 @@
 
 ### Bug Fixes
 
+- Fix custom connection name not working when using IDurableClientFactory.CreateClient() - contributed by [@hctan](https://github.com/hctan)
+
 ### Breaking Changes
 
 ### Dependency Updates

--- a/src/WebJobs.Extensions.DurableTask/AzureStorageDurabilityProviderFactory.cs
+++ b/src/WebJobs.Extensions.DurableTask/AzureStorageDurabilityProviderFactory.cs
@@ -159,7 +159,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             // Need to check this.defaultStorageProvider != null for external clients that call GetDurabilityProvider(attribute)
             // which never initializes the defaultStorageProvider.
             if (string.Equals(this.defaultSettings?.TaskHubName, settings.TaskHubName, StringComparison.OrdinalIgnoreCase) &&
-                string.Equals(this.defaultSettings?.StorageConnectionString, settings.StorageConnectionString, StringComparison.OrdinalIgnoreCase) &&
+                string.Equals(this.defaultSettings?.StorageAccountDetails?.ConnectionString, settings.StorageAccountDetails?.ConnectionString, StringComparison.OrdinalIgnoreCase) &&
                 this.defaultStorageProvider != null)
             {
                 // It's important that clients use the same AzureStorageOrchestrationService instance

--- a/test/Common/CustomTestStorageAccountProvider.cs
+++ b/test/Common/CustomTestStorageAccountProvider.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System;
 using DurableTask.AzureStorage;
 using Microsoft.WindowsAzure.Storage;
 
@@ -8,18 +9,25 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 {
     internal class CustomTestStorageAccountProvider : IStorageAccountProvider
     {
-        private const string CustomConnectionString = "DefaultEndpointsProtocol=https;AccountName=test;AccountKey=dGVzdA==;EndpointSuffix=core.windows.net";
+        private readonly string customConnectionString;
         private readonly string customConnectionName;
 
         public CustomTestStorageAccountProvider(string connectionName)
         {
             this.customConnectionName = connectionName;
+            this.customConnectionString = $"DefaultEndpointsProtocol=https;AccountName=test;AccountKey={GenerateRandomKey()};EndpointSuffix=core.windows.net";
         }
 
         public CloudStorageAccount GetCloudStorageAccount(string name) =>
-            CloudStorageAccount.Parse(name != this.customConnectionName ? TestHelpers.GetStorageConnectionString() : CustomConnectionString);
+            CloudStorageAccount.Parse(name != this.customConnectionName ? TestHelpers.GetStorageConnectionString() : this.customConnectionString);
 
         public StorageAccountDetails GetStorageAccountDetails(string name) =>
-            new StorageAccountDetails { ConnectionString = name != this.customConnectionName ? TestHelpers.GetStorageConnectionString() : CustomConnectionString };
+            new StorageAccountDetails { ConnectionString = name != this.customConnectionName ? TestHelpers.GetStorageConnectionString() : this.customConnectionString };
+
+        private static string GenerateRandomKey()
+        {
+            string key = Guid.NewGuid().ToString();
+            return Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(key));
+        }
     }
 }

--- a/test/Common/CustomTestStorageAccountProvider.cs
+++ b/test/Common/CustomTestStorageAccountProvider.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using DurableTask.AzureStorage;
+using Microsoft.WindowsAzure.Storage;
+
+namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
+{
+    internal class CustomTestStorageAccountProvider : IStorageAccountProvider
+    {
+        private const string CustomConnectionString = "DefaultEndpointsProtocol=https;AccountName=test;AccountKey=dGVzdA==;EndpointSuffix=core.windows.net";
+        private readonly string customConnectionName;
+
+        public CustomTestStorageAccountProvider(string connectionName)
+        {
+            this.customConnectionName = connectionName;
+        }
+
+        public CloudStorageAccount GetCloudStorageAccount(string name) =>
+            CloudStorageAccount.Parse(name != this.customConnectionName ? TestHelpers.GetStorageConnectionString() : CustomConnectionString);
+
+        public StorageAccountDetails GetStorageAccountDetails(string name) =>
+            new StorageAccountDetails { ConnectionString = name != this.customConnectionName ? TestHelpers.GetStorageConnectionString() : CustomConnectionString };
+    }
+}

--- a/test/FunctionsV2/AzureStorageDurabilityProviderFactoryTests.cs
+++ b/test/FunctionsV2/AzureStorageDurabilityProviderFactoryTests.cs
@@ -154,5 +154,46 @@ namespace WebJobs.Extensions.DurableTask.Tests.V2
 
             Assert.Equal("waws-prod-euapbn1-003:dw0SmallDedicatedWebWorkerRole_hr0HostRole-3-VM-13", settings.WorkerId);
         }
+
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public void CustomConnectionNameIsResolved()
+        {
+            var storageAccountProvider = new CustomTestStorageAccountProvider("CustomConnection");
+            var mockOptions = new OptionsWrapper<DurableTaskOptions>(new DurableTaskOptions());
+            var nameResolver = new Mock<INameResolver>().Object;
+
+            var factory = new AzureStorageDurabilityProviderFactory(
+                mockOptions,
+                storageAccountProvider,
+                nameResolver,
+                NullLoggerFactory.Instance,
+                TestHelpers.GetMockPlatformInformationService());
+
+            factory.GetDurabilityProvider(); // This will initialize the default connection string
+            var provider = factory.GetDurabilityProvider(new DurableClientAttribute() { ConnectionName = "CustomConnection", TaskHub = "TestHubName" });
+
+            Assert.Equal("CustomConnection", provider.ConnectionName);
+        }
+
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public void DefaultConnectionNameIsResolved()
+        {
+            var storageAccountProvider = new CustomTestStorageAccountProvider("CustomConnection");
+            var mockOptions = new OptionsWrapper<DurableTaskOptions>(new DurableTaskOptions());
+            var nameResolver = new Mock<INameResolver>().Object;
+
+            var factory = new AzureStorageDurabilityProviderFactory(
+                mockOptions,
+                storageAccountProvider,
+                nameResolver,
+                NullLoggerFactory.Instance,
+                TestHelpers.GetMockPlatformInformationService());
+
+            var provider = factory.GetDurabilityProvider();
+
+            Assert.Equal("Storage", provider.ConnectionName);
+        }
     }
 }


### PR DESCRIPTION
Fix custom connection name not working when using IDurableClientFactory -> CreateClient(). It always return the default durable client.

<!-- Start the PR description with some context for the change. -->
The issue was caused by checking for StorageConnectionString which is no longer assigned any value (checkout the GetAzureStorageOrchestrationServiceSettings() function where the setting object is configured).
 
The fix is to check connection string in StorageAccountDetails -> ConnectionString instead.   


<!-- Make sure to delete the markdown comments and the below sections when squash merging -->
### Issue describing the changes in this PR

resolves #issue_for_this_pr

### Pull request checklist

* [ ] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)
* [x] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk
* [ ] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
    * [ ] Otherwise: major or minor version updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
* [x] My changes **do not** add EventIds to our EventSource logs
    * [ ] Otherwise: Ensure the EventIds are within the supported range in our existing Windows infrastructure. You may validate this with a deployed app's telemetry. You may also extend the range by completing a PR such as [this one](https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files).
* [x] My changes **should** be added to v3.x branch.
    * [ ] Otherwise: This change only applies to Durable Functions v2.x and **will not** be merged to branch v3.x.
