### PR TITLE
Implement CreateHttpManagementPayload API in Durable Worker Extension

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/Bindings/BindingHelper.cs
+++ b/src/WebJobs.Extensions.DurableTask/Bindings/BindingHelper.cs
@@ -137,7 +137,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             /// This URL is sent by the client binding object to the Durable Worker extension,
             /// allowing the extension to know the host's base URL for constructing management URLs.
             /// </summary>
-            [JsonProperty("HttpBaseUrl")]
+            [JsonProperty("httpBaseUrl")]
             public string? HttpBaseUrl { get; set; }
         }
     }

--- a/src/WebJobs.Extensions.DurableTask/Bindings/BindingHelper.cs
+++ b/src/WebJobs.Extensions.DurableTask/Bindings/BindingHelper.cs
@@ -135,7 +135,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             /// <summary>
             /// The base URL of the Azure Functions host, used in the out-of-proc model.
             /// This URL is sent by the client binding object to the Durable Worker extension,
-            /// allowing the extension to know the host's base URL for constructing complete URLs.
+            /// allowing the extension to know the host's base URL for constructing management URLs.
             /// </summary>
             [JsonProperty("HttpBaseUrl")]
             public string? HttpBaseUrl { get; set; }

--- a/src/WebJobs.Extensions.DurableTask/Bindings/BindingHelper.cs
+++ b/src/WebJobs.Extensions.DurableTask/Bindings/BindingHelper.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     ConnectionName = attr.ConnectionName,
                     RpcBaseUrl = localRpcAddress,
                     RequiredQueryStringParameters = this.config.HttpApiHandler.GetUniversalQueryStrings(),
-                    BaseUrl = this.config.HttpApiHandler.GetBaseUrl(),
+                    HttpBaseUrl = this.config.HttpApiHandler.GetBaseUrl(),
                 });
             }
 
@@ -131,6 +131,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             /// </summary>
             [JsonProperty("rpcBaseUrl")]
             public string? RpcBaseUrl { get; set; }
+
+            /// <summary>
+            /// The base URL of the Azure Functions host, used in the out-of-proc model.
+            /// This URL is sent by the client binding object to the Durable Worker extension,
+            /// allowing the extension to know the host's base URL for constructing complete URLs.
+            /// </summary>
+            [JsonProperty("HttpBaseUrl")]
+            public string? HttpBaseUrl { get; set; }
         }
     }
 }

--- a/src/WebJobs.Extensions.DurableTask/Bindings/BindingHelper.cs
+++ b/src/WebJobs.Extensions.DurableTask/Bindings/BindingHelper.cs
@@ -43,6 +43,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     ConnectionName = attr.ConnectionName,
                     RpcBaseUrl = localRpcAddress,
                     RequiredQueryStringParameters = this.config.HttpApiHandler.GetUniversalQueryStrings(),
+                    BaseUrl = this.config.HttpApiHandler.GetBaseUrl(),
                 });
             }
 

--- a/src/WebJobs.Extensions.DurableTask/HttpManagementPayload.cs
+++ b/src/WebJobs.Extensions.DurableTask/HttpManagementPayload.cs
@@ -3,6 +3,7 @@
 
 using Newtonsoft.Json;
 
+#nullable enable
 namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 {
     /// <summary>
@@ -17,7 +18,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// The ID of the orchestration instance.
         /// </value>
         [JsonProperty("id")]
-        public string Id { get; internal set; }
+        public string? Id { get; internal set; }
 
         /// <summary>
         /// Gets the HTTP GET status query endpoint URL.
@@ -26,7 +27,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// The HTTP URL for fetching the instance status.
         /// </value>
         [JsonProperty("statusQueryGetUri")]
-        public string StatusQueryGetUri { get; internal set; }
+        public string? StatusQueryGetUri { get; internal set; }
 
         /// <summary>
         /// Gets the HTTP POST external event sending endpoint URL.
@@ -35,7 +36,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// The HTTP URL for posting external event notifications.
         /// </value>
         [JsonProperty("sendEventPostUri")]
-        public string SendEventPostUri { get; internal set; }
+        public string? SendEventPostUri { get; internal set; }
 
         /// <summary>
         /// Gets the HTTP POST instance termination endpoint.
@@ -44,7 +45,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// The HTTP URL for posting instance termination commands.
         /// </value>
         [JsonProperty("terminatePostUri")]
-        public string TerminatePostUri { get; internal set; }
+        public string? TerminatePostUri { get; internal set; }
 
         /// <summary>
         /// Gets the HTTP POST instance rewind endpoint.
@@ -53,7 +54,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// The HTTP URL for rewinding orchestration instances.
         /// </value>
         [JsonProperty("rewindPostUri")]
-        public string RewindPostUri { get; internal set; }
+        public string? RewindPostUri { get; internal set; }
 
         /// <summary>
         /// Gets the HTTP DELETE purge instance history by instance ID endpoint.
@@ -62,7 +63,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// The HTTP URL for purging instance history by instance ID.
         /// </value>
         [JsonProperty("purgeHistoryDeleteUri")]
-        public string PurgeHistoryDeleteUri { get; internal set; }
+        public string? PurgeHistoryDeleteUri { get; internal set; }
 
         /// <summary>
         /// Gets the HTTP POST instance restart endpoint.
@@ -71,7 +72,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// The HTTP URL for restarting an orchestration instance.
         /// </value>
         [JsonProperty("restartPostUri")]
-        public string RestartPostUri { get; internal set; }
+        public string? RestartPostUri { get; internal set; }
 
         /// <summary>
         /// Gets the HTTP POST instance suspend endpoint.
@@ -80,7 +81,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// The HTTP URL for suspending an orchestration instance.
         /// </value>
         [JsonProperty("suspendPostUri")]
-        public string SuspendPostUri { get; internal set; }
+        public string? SuspendPostUri { get; internal set; }
 
         /// <summary>
         /// Gets the HTTP POST instance resume endpoint.
@@ -89,6 +90,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// The HTTP URL for resuming an orchestration instance.
         /// </value>
         [JsonProperty("resumePostUri")]
-        public string ResumePostUri { get; internal set; }
+        public string? ResumePostUri { get; internal set; }
     }
 }

--- a/src/WebJobs.Extensions.DurableTask/HttpManagementPayload.cs
+++ b/src/WebJobs.Extensions.DurableTask/HttpManagementPayload.cs
@@ -3,7 +3,6 @@
 
 using Newtonsoft.Json;
 
-#nullable enable
 namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 {
     /// <summary>
@@ -18,7 +17,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// The ID of the orchestration instance.
         /// </value>
         [JsonProperty("id")]
-        public string? Id { get; internal set; }
+        public string Id { get; internal set; }
 
         /// <summary>
         /// Gets the HTTP GET status query endpoint URL.
@@ -27,7 +26,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// The HTTP URL for fetching the instance status.
         /// </value>
         [JsonProperty("statusQueryGetUri")]
-        public string? StatusQueryGetUri { get; internal set; }
+        public string StatusQueryGetUri { get; internal set; }
 
         /// <summary>
         /// Gets the HTTP POST external event sending endpoint URL.
@@ -36,7 +35,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// The HTTP URL for posting external event notifications.
         /// </value>
         [JsonProperty("sendEventPostUri")]
-        public string? SendEventPostUri { get; internal set; }
+        public string SendEventPostUri { get; internal set; }
 
         /// <summary>
         /// Gets the HTTP POST instance termination endpoint.
@@ -45,7 +44,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// The HTTP URL for posting instance termination commands.
         /// </value>
         [JsonProperty("terminatePostUri")]
-        public string? TerminatePostUri { get; internal set; }
+        public string TerminatePostUri { get; internal set; }
 
         /// <summary>
         /// Gets the HTTP POST instance rewind endpoint.
@@ -54,7 +53,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// The HTTP URL for rewinding orchestration instances.
         /// </value>
         [JsonProperty("rewindPostUri")]
-        public string? RewindPostUri { get; internal set; }
+        public string RewindPostUri { get; internal set; }
 
         /// <summary>
         /// Gets the HTTP DELETE purge instance history by instance ID endpoint.
@@ -63,7 +62,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// The HTTP URL for purging instance history by instance ID.
         /// </value>
         [JsonProperty("purgeHistoryDeleteUri")]
-        public string? PurgeHistoryDeleteUri { get; internal set; }
+        public string PurgeHistoryDeleteUri { get; internal set; }
 
         /// <summary>
         /// Gets the HTTP POST instance restart endpoint.
@@ -72,7 +71,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// The HTTP URL for restarting an orchestration instance.
         /// </value>
         [JsonProperty("restartPostUri")]
-        public string? RestartPostUri { get; internal set; }
+        public string RestartPostUri { get; internal set; }
 
         /// <summary>
         /// Gets the HTTP POST instance suspend endpoint.
@@ -81,7 +80,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// The HTTP URL for suspending an orchestration instance.
         /// </value>
         [JsonProperty("suspendPostUri")]
-        public string? SuspendPostUri { get; internal set; }
+        public string SuspendPostUri { get; internal set; }
 
         /// <summary>
         /// Gets the HTTP POST instance resume endpoint.
@@ -90,6 +89,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// The HTTP URL for resuming an orchestration instance.
         /// </value>
         [JsonProperty("resumePostUri")]
-        public string? ResumePostUri { get; internal set; }
+        public string ResumePostUri { get; internal set; }
     }
 }

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
@@ -97,7 +97,7 @@
             <summary>
             The base URL of the Azure Functions host, used in the out-of-proc model.
             This URL is sent by the client binding object to the Durable Worker extension,
-            allowing the extension to know the host's base URL for constructing complete URLs.
+            allowing the extension to know the host's base URL for constructing management URLs.
             </summary>
         </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.CleanEntityStorageResult">

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
@@ -93,6 +93,13 @@
             HTTP endpoint. For out-of-proc "v2" (middelware passthrough), this is a gRPC endpoint.
             </summary>
         </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.BindingHelper.OrchestrationClientInputData.HttpBaseUrl">
+            <summary>
+            The base URL of the Azure Functions host, used in the out-of-proc model.
+            This URL is sent by the client binding object to the Durable Worker extension,
+            allowing the extension to know the host's base URL for constructing complete URLs.
+            </summary>
+        </member>
         <member name="T:Microsoft.Azure.WebJobs.Extensions.DurableTask.CleanEntityStorageResult">
             <summary>
             The result of a clean entity storage operation.

--- a/src/Worker.Extensions.DurableTask/DurableTaskClientConverter.cs
+++ b/src/Worker.Extensions.DurableTask/DurableTaskClientConverter.cs
@@ -49,7 +49,7 @@ internal sealed partial class DurableTaskClientConverter : IInputConverter
             }
 
             DurableTaskClient client = this.clientProvider.GetClient(endpoint, inputData?.taskHubName, inputData?.connectionName);
-            client = new FunctionsDurableTaskClient(client, inputData!.requiredQueryStringParameters, inputData!.baseUrl);
+            client = new FunctionsDurableTaskClient(client, inputData!.requiredQueryStringParameters, inputData!.httpBaseUrl);
             return new ValueTask<ConversionResult>(ConversionResult.Success(client));
         }
         catch (Exception innerException)
@@ -62,5 +62,5 @@ internal sealed partial class DurableTaskClientConverter : IInputConverter
     }
 
     // Serializer is case-sensitive and incoming JSON properties are camel-cased.
-    private record DurableClientInputData(string rpcBaseUrl, string taskHubName, string connectionName, string requiredQueryStringParameters, string baseUrl);
+    private record DurableClientInputData(string rpcBaseUrl, string taskHubName, string connectionName, string requiredQueryStringParameters, string httpBaseUrl);
 }

--- a/src/Worker.Extensions.DurableTask/DurableTaskClientConverter.cs
+++ b/src/Worker.Extensions.DurableTask/DurableTaskClientConverter.cs
@@ -49,7 +49,7 @@ internal sealed partial class DurableTaskClientConverter : IInputConverter
             }
 
             DurableTaskClient client = this.clientProvider.GetClient(endpoint, inputData?.taskHubName, inputData?.connectionName);
-            client = new FunctionsDurableTaskClient(client, inputData!.requiredQueryStringParameters);
+            client = new FunctionsDurableTaskClient(client, inputData!.requiredQueryStringParameters, inputData!.baseUrl);
             return new ValueTask<ConversionResult>(ConversionResult.Success(client));
         }
         catch (Exception innerException)
@@ -62,5 +62,5 @@ internal sealed partial class DurableTaskClientConverter : IInputConverter
     }
 
     // Serializer is case-sensitive and incoming JSON properties are camel-cased.
-    private record DurableClientInputData(string rpcBaseUrl, string taskHubName, string connectionName, string requiredQueryStringParameters);
+    private record DurableClientInputData(string rpcBaseUrl, string taskHubName, string connectionName, string requiredQueryStringParameters, string baseUrl);
 }

--- a/src/Worker.Extensions.DurableTask/DurableTaskClientExtensions.cs
+++ b/src/Worker.Extensions.DurableTask/DurableTaskClientExtensions.cs
@@ -139,14 +139,7 @@ public static class DurableTaskClientExtensions
             throw new ArgumentException("InstanceId cannot be null or empty.", nameof(instanceId));
         }
 
-        try
-        {
-            return SetHeadersAndGetPayload(client, request, null, instanceId);
-        }
-        catch (InvalidOperationException ex)
-        {
-            throw new InvalidOperationException("Failed to create HTTP management payload. " + ex.Message, ex);
-        }
+        return SetHeadersAndGetPayload(client, request, null, instanceId);
     }
 
     private static HttpManagementPayload SetHeadersAndGetPayload(
@@ -181,7 +174,7 @@ public static class DurableTaskClientExtensions
 
         if (baseUrl == null)
         {
-            throw new InvalidOperationException("Base URL is null. Either use Functions bindings or provide an HTTP request to create the HttpPayload.");
+            throw new InvalidOperationException("Failed to create HTTP management payload as base URL is null. Either use Functions bindings or provide an HTTP request to create the HttpPayload.");
         }
         
         bool isFromRequest = request != null;

--- a/src/Worker.Extensions.DurableTask/DurableTaskClientExtensions.cs
+++ b/src/Worker.Extensions.DurableTask/DurableTaskClientExtensions.cs
@@ -129,7 +129,7 @@ public static class DurableTaskClientExtensions
     /// <returns>An object containing instance control URLs.</returns>
     /// <exception cref="ArgumentException">Thrown when instanceId is null or empty.</exception>
     /// <exception cref="InvalidOperationException">Thrown when a valid base URL cannot be determined.</exception>
-    public static object CreateHttpManagementPayload(
+    public static HttpManagementPayload CreateHttpManagementPayload(
         this DurableTaskClient client,
         string instanceId,
         HttpRequestData? request = null)
@@ -149,7 +149,7 @@ public static class DurableTaskClientExtensions
         }
     }
 
-    private static object SetHeadersAndGetPayload(
+    private static HttpManagementPayload SetHeadersAndGetPayload(
         DurableTaskClient client, HttpRequestData? request, HttpResponseData? response, string instanceId)
     {
         static string BuildUrl(string url, params string?[] queryValues)
@@ -198,15 +198,15 @@ public static class DurableTaskClientExtensions
             response.Headers.Add("Content-Type", "application/json");
         }
 
-        return new
+        return new HttpManagementPayload
         {
-            id = instanceId,
-            purgeHistoryDeleteUri = BuildUrl(instanceUrl, commonQueryParameters),
-            sendEventPostUri = BuildUrl($"{instanceUrl}/raiseEvent/{{eventName}}", commonQueryParameters),
-            statusQueryGetUri = BuildUrl(instanceUrl, commonQueryParameters),
-            terminatePostUri = BuildUrl($"{instanceUrl}/terminate", "reason={{text}}", commonQueryParameters),
-            suspendPostUri =  BuildUrl($"{instanceUrl}/suspend", "reason={{text}}", commonQueryParameters),
-            resumePostUri =  BuildUrl($"{instanceUrl}/resume", "reason={{text}}", commonQueryParameters)
+            Id = instanceId,
+            PurgeHistoryDeleteUri = BuildUrl(instanceUrl, commonQueryParameters),
+            SendEventPostUri = BuildUrl($"{instanceUrl}/raiseEvent/{{eventName}}", commonQueryParameters),
+            StatusQueryGetUri = BuildUrl(instanceUrl, commonQueryParameters),
+            TerminatePostUri = BuildUrl($"{instanceUrl}/terminate", "reason={{text}}", commonQueryParameters),
+            SuspendPostUri =  BuildUrl($"{instanceUrl}/suspend", "reason={{text}}", commonQueryParameters),
+            ResumePostUri =  BuildUrl($"{instanceUrl}/resume", "reason={{text}}", commonQueryParameters)
         };
     }
 

--- a/src/Worker.Extensions.DurableTask/DurableTaskClientExtensions.cs
+++ b/src/Worker.Extensions.DurableTask/DurableTaskClientExtensions.cs
@@ -177,8 +177,13 @@ public static class DurableTaskClientExtensions
         // The base URL could be null if:
         // 1. The DurableTaskClient isn't a FunctionsDurableTaskClient (which would have the baseUrl from bindings)
         // 2. There's no valid HttpRequestData provided
-        string? baseUrl = ((request != null) ? request.Url.GetLeftPart(UriPartial.Authority) : GetBaseUrl(client))
-            ?? throw new InvalidOperationException("Base URL is null. Either use Functions bindings or provide an HTTP request to create the HttpPayload.");
+        string? baseUrl = ((request != null) ? request.Url.GetLeftPart(UriPartial.Authority) : GetBaseUrl(client));
+
+        if (baseUrl == null)
+        {
+            throw new InvalidOperationException("Base URL is null. Either use Functions bindings or provide an HTTP request to create the HttpPayload.");
+        }
+        
         bool isFromRequest = request != null;
 
         string formattedInstanceId = Uri.EscapeDataString(instanceId);

--- a/src/Worker.Extensions.DurableTask/DurableTaskClientExtensions.cs
+++ b/src/Worker.Extensions.DurableTask/DurableTaskClientExtensions.cs
@@ -223,6 +223,6 @@ public static class DurableTaskClientExtensions
 
     private static string? GetBaseUrl(DurableTaskClient client)
     {
-        return client is FunctionsDurableTaskClient functions ? functions.BaseUrl : null;
+        return client is FunctionsDurableTaskClient functions ? functions.HttpBaseUrl : null;
     }
 }

--- a/src/Worker.Extensions.DurableTask/FunctionsDurableTaskClient.cs
+++ b/src/Worker.Extensions.DurableTask/FunctionsDurableTaskClient.cs
@@ -17,15 +17,16 @@ internal sealed class FunctionsDurableTaskClient : DurableTaskClient
 {
     private readonly DurableTaskClient inner;
 
-    public FunctionsDurableTaskClient(DurableTaskClient inner, string? queryString)
+    public FunctionsDurableTaskClient(DurableTaskClient inner, string? queryString, string? baseUrl)
         : base(inner.Name)
     {
         this.inner = inner;
         this.QueryString = queryString;
+        this.BaseUrl = baseUrl;
     }
 
     public string? QueryString { get; }
-
+    public string? BaseUrl { get; }
     public override DurableEntityClient Entities => this.inner.Entities;
 
     public override ValueTask DisposeAsync()

--- a/src/Worker.Extensions.DurableTask/FunctionsDurableTaskClient.cs
+++ b/src/Worker.Extensions.DurableTask/FunctionsDurableTaskClient.cs
@@ -17,16 +17,16 @@ internal sealed class FunctionsDurableTaskClient : DurableTaskClient
 {
     private readonly DurableTaskClient inner;
 
-    public FunctionsDurableTaskClient(DurableTaskClient inner, string? queryString, string? baseUrl)
+    public FunctionsDurableTaskClient(DurableTaskClient inner, string? queryString, string? httpBaseUrl)
         : base(inner.Name)
     {
         this.inner = inner;
         this.QueryString = queryString;
-        this.BaseUrl = baseUrl;
+        this.HttpBaseUrl = httpBaseUrl;
     }
 
     public string? QueryString { get; }
-    public string? BaseUrl { get; }
+    public string? HttpBaseUrl { get; }
     public override DurableEntityClient Entities => this.inner.Entities;
 
     public override ValueTask DisposeAsync()

--- a/src/Worker.Extensions.DurableTask/HttpManagementPayload.cs
+++ b/src/Worker.Extensions.DurableTask/HttpManagementPayload.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
+// This is a copy of: https://github.com/Azure/azure-functions-durable-extension/blob/dev/src/WebJobs.Extensions.DurableTask/HttpManagementPayload.cs
 
 using System;
 using System.Collections.Generic;

--- a/src/Worker.Extensions.DurableTask/HttpManagementPayload.cs
+++ b/src/Worker.Extensions.DurableTask/HttpManagementPayload.cs
@@ -1,0 +1,96 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Newtonsoft.Json;
+
+namespace Microsoft.Azure.Functions.Worker;
+
+/// <summary>
+/// Data structure containing status, terminate and send external event HTTP endpoints.
+/// </summary>
+public class HttpManagementPayload
+{
+    /// <summary>
+    /// Gets the ID of the orchestration instance.
+    /// </summary>
+    /// <value>
+    /// The ID of the orchestration instance.
+    /// </value>
+    [JsonProperty("id")]
+    public string Id { get; internal set; }
+
+    /// <summary>
+    /// Gets the HTTP GET status query endpoint URL.
+    /// </summary>
+    /// <value>
+    /// The HTTP URL for fetching the instance status.
+    /// </value>
+    [JsonProperty("statusQueryGetUri")]
+    public string StatusQueryGetUri { get; internal set; }
+
+    /// <summary>
+    /// Gets the HTTP POST external event sending endpoint URL.
+    /// </summary>
+    /// <value>
+    /// The HTTP URL for posting external event notifications.
+    /// </value>
+    [JsonProperty("sendEventPostUri")]
+    public string SendEventPostUri { get; internal set; }
+
+    /// <summary>
+    /// Gets the HTTP POST instance termination endpoint.
+    /// </summary>
+    /// <value>
+    /// The HTTP URL for posting instance termination commands.
+    /// </value>
+    [JsonProperty("terminatePostUri")]
+    public string TerminatePostUri { get; internal set; }
+
+    /// <summary>
+    /// Gets the HTTP POST instance rewind endpoint.
+    /// </summary>
+    /// <value>
+    /// The HTTP URL for rewinding orchestration instances.
+    /// </value>
+    [JsonProperty("rewindPostUri")]
+    public string RewindPostUri { get; internal set; }
+
+    /// <summary>
+    /// Gets the HTTP DELETE purge instance history by instance ID endpoint.
+    /// </summary>
+    /// <value>
+    /// The HTTP URL for purging instance history by instance ID.
+    /// </value>
+    [JsonProperty("purgeHistoryDeleteUri")]
+    public string PurgeHistoryDeleteUri { get; internal set; }
+
+    /// <summary>
+    /// Gets the HTTP POST instance restart endpoint.
+    /// </summary>
+    /// <value>
+    /// The HTTP URL for restarting an orchestration instance.
+    /// </value>
+    [JsonProperty("restartPostUri")]
+    public string RestartPostUri { get; internal set; }
+
+    /// <summary>
+    /// Gets the HTTP POST instance suspend endpoint.
+    /// </summary>
+    /// <value>
+    /// The HTTP URL for suspending an orchestration instance.
+    /// </value>
+    [JsonProperty("suspendPostUri")]
+    public string SuspendPostUri { get; internal set; }
+
+    /// <summary>
+    /// Gets the HTTP POST instance resume endpoint.
+    /// </summary>
+    /// <value>
+    /// The HTTP URL for resuming an orchestration instance.
+    /// </value>
+    [JsonProperty("resumePostUri")]
+    public string ResumePostUri { get; internal set; }
+}

--- a/src/Worker.Extensions.DurableTask/HttpManagementPayload.cs
+++ b/src/Worker.Extensions.DurableTask/HttpManagementPayload.cs
@@ -20,7 +20,7 @@ public class HttpManagementPayload
     /// The ID of the orchestration instance.
     /// </value>
     [JsonProperty("id")]
-    public string Id { get; internal set; }
+    public string? Id { get; internal set; }
 
     /// <summary>
     /// Gets the HTTP GET status query endpoint URL.
@@ -29,7 +29,7 @@ public class HttpManagementPayload
     /// The HTTP URL for fetching the instance status.
     /// </value>
     [JsonProperty("statusQueryGetUri")]
-    public string StatusQueryGetUri { get; internal set; }
+    public string? StatusQueryGetUri { get; internal set; }
 
     /// <summary>
     /// Gets the HTTP POST external event sending endpoint URL.
@@ -38,7 +38,7 @@ public class HttpManagementPayload
     /// The HTTP URL for posting external event notifications.
     /// </value>
     [JsonProperty("sendEventPostUri")]
-    public string SendEventPostUri { get; internal set; }
+    public string? SendEventPostUri { get; internal set; }
 
     /// <summary>
     /// Gets the HTTP POST instance termination endpoint.
@@ -47,7 +47,7 @@ public class HttpManagementPayload
     /// The HTTP URL for posting instance termination commands.
     /// </value>
     [JsonProperty("terminatePostUri")]
-    public string TerminatePostUri { get; internal set; }
+    public string? TerminatePostUri { get; internal set; }
 
     /// <summary>
     /// Gets the HTTP POST instance rewind endpoint.
@@ -56,7 +56,7 @@ public class HttpManagementPayload
     /// The HTTP URL for rewinding orchestration instances.
     /// </value>
     [JsonProperty("rewindPostUri")]
-    public string RewindPostUri { get; internal set; }
+    public string? RewindPostUri { get; internal set; }
 
     /// <summary>
     /// Gets the HTTP DELETE purge instance history by instance ID endpoint.
@@ -65,7 +65,7 @@ public class HttpManagementPayload
     /// The HTTP URL for purging instance history by instance ID.
     /// </value>
     [JsonProperty("purgeHistoryDeleteUri")]
-    public string PurgeHistoryDeleteUri { get; internal set; }
+    public string? PurgeHistoryDeleteUri { get; internal set; }
 
     /// <summary>
     /// Gets the HTTP POST instance restart endpoint.
@@ -74,7 +74,7 @@ public class HttpManagementPayload
     /// The HTTP URL for restarting an orchestration instance.
     /// </value>
     [JsonProperty("restartPostUri")]
-    public string RestartPostUri { get; internal set; }
+    public string? RestartPostUri { get; internal set; }
 
     /// <summary>
     /// Gets the HTTP POST instance suspend endpoint.
@@ -83,7 +83,7 @@ public class HttpManagementPayload
     /// The HTTP URL for suspending an orchestration instance.
     /// </value>
     [JsonProperty("suspendPostUri")]
-    public string SuspendPostUri { get; internal set; }
+    public string? SuspendPostUri { get; internal set; }
 
     /// <summary>
     /// Gets the HTTP POST instance resume endpoint.
@@ -92,5 +92,5 @@ public class HttpManagementPayload
     /// The HTTP URL for resuming an orchestration instance.
     /// </value>
     [JsonProperty("resumePostUri")]
-    public string ResumePostUri { get; internal set; }
+    public string? ResumePostUri { get; internal set; }
 }

--- a/test/Worker.Extensions.DurableTask.Tests/FunctionsDurableTaskClientTests.cs
+++ b/test/Worker.Extensions.DurableTask.Tests/FunctionsDurableTaskClientTests.cs
@@ -91,13 +91,13 @@ namespace Microsoft.Azure.Functions.Worker.Tests
 
         private static void AssertHttpManagementPayload(dynamic payload, string BaseUrl, string instanceId)
         {
-            Assert.Equal(instanceId, payload.id);
-            Assert.Equal($"{BaseUrl}/instances/{instanceId}", payload.purgeHistoryDeleteUri);
-            Assert.Equal($"{BaseUrl}/instances/{instanceId}/raiseEvent/{{eventName}}", payload.sendEventPostUri);
-            Assert.Equal($"{BaseUrl}/instances/{instanceId}", payload.statusQueryGetUri);
-            Assert.Equal($"{BaseUrl}/instances/{instanceId}/terminate?reason={{{{text}}}}", payload.terminatePostUri);
-            Assert.Equal($"{BaseUrl}/instances/{instanceId}/suspend?reason={{{{text}}}}", payload.suspendPostUri);
-            Assert.Equal($"{BaseUrl}/instances/{instanceId}/resume?reason={{{{text}}}}", payload.resumePostUri);
+            Assert.Equal(instanceId, payload.Id);
+            Assert.Equal($"{BaseUrl}/instances/{instanceId}", payload.PurgeHistoryDeleteUri);
+            Assert.Equal($"{BaseUrl}/instances/{instanceId}/raiseEvent/{{eventName}}", payload.SendEventPostUri);
+            Assert.Equal($"{BaseUrl}/instances/{instanceId}", payload.StatusQueryGetUri);
+            Assert.Equal($"{BaseUrl}/instances/{instanceId}/terminate?reason={{{{text}}}}", payload.TerminatePostUri);
+            Assert.Equal($"{BaseUrl}/instances/{instanceId}/suspend?reason={{{{text}}}}", payload.SuspendPostUri);
+            Assert.Equal($"{BaseUrl}/instances/{instanceId}/resume?reason={{{{text}}}}", payload.ResumePostUri);
         }
     }
 }

--- a/test/Worker.Extensions.DurableTask.Tests/FunctionsDurableTaskClientTests.cs
+++ b/test/Worker.Extensions.DurableTask.Tests/FunctionsDurableTaskClientTests.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Azure.Functions.Worker.Tests
             FunctionsDurableTaskClient client = this.GetTestFunctionsDurableTaskClient(BaseUrl);
             string instanceId = "testInstanceIdWithHostBaseUrl";
 
-            dynamic payload = client.CreateHttpManagementPayload(instanceId);
+            HttpManagementPayload payload = client.CreateHttpManagementPayload(instanceId);
 
             AssertHttpManagementPayload(payload, BaseUrl, instanceId);
         }
@@ -84,12 +84,12 @@ namespace Microsoft.Azure.Functions.Worker.Tests
             var mockHttpRequestData = new Mock<HttpRequestData>(mockFunctionContext.Object);
             mockHttpRequestData.SetupGet(r => r.Url).Returns(new Uri(requestUrl));
 
-            dynamic payload = client.CreateHttpManagementPayload(instanceId, mockHttpRequestData.Object);
+            HttpManagementPayload payload = client.CreateHttpManagementPayload(instanceId, mockHttpRequestData.Object);
 
             AssertHttpManagementPayload(payload, "http://localhost:7075/runtime/webhooks/durabletask", instanceId);
         }
 
-        private static void AssertHttpManagementPayload(dynamic payload, string BaseUrl, string instanceId)
+        private static void AssertHttpManagementPayload(HttpManagementPayload payload, string BaseUrl, string instanceId)
         {
             Assert.Equal(instanceId, payload.Id);
             Assert.Equal($"{BaseUrl}/instances/{instanceId}", payload.PurgeHistoryDeleteUri);

--- a/test/Worker.Extensions.DurableTask.Tests/FunctionsDurableTaskClientTests.cs
+++ b/test/Worker.Extensions.DurableTask.Tests/FunctionsDurableTaskClientTests.cs
@@ -1,7 +1,5 @@
-using System.Security.Claims;
 using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.DurableTask.Client;
-using Microsoft.DurableTask.Client.Grpc;
 using Moq;
 
 namespace Microsoft.Azure.Functions.Worker.Tests
@@ -24,7 +22,7 @@ namespace Microsoft.Azure.Functions.Worker.Tests
                 It.IsAny<string>(), It.IsAny<TerminateInstanceOptions>(), It.IsAny<CancellationToken>())).Returns(completedTask);
 
             DurableTaskClient durableClient = durableClientMock.Object;
-            FunctionsDurableTaskClient client = new FunctionsDurableTaskClient(durableClient, queryString: null, baseUrl: baseUrl);
+            FunctionsDurableTaskClient client = new FunctionsDurableTaskClient(durableClient, queryString: null, httpBaseUrl: baseUrl);
             return client;
         }
 
@@ -62,7 +60,7 @@ namespace Microsoft.Azure.Functions.Worker.Tests
         [Fact]
         public void CreateHttpManagementPayload_WithBaseUrl()
         {
-            string BaseUrl = "http://localhost:7071/runtime/webhooks/durabletask";
+            const string BaseUrl = "http://localhost:7071/runtime/webhooks/durabletask";
             FunctionsDurableTaskClient client = this.GetTestFunctionsDurableTaskClient(BaseUrl);
             string instanceId = "testInstanceIdWithHostBaseUrl";
 
@@ -77,13 +75,16 @@ namespace Microsoft.Azure.Functions.Worker.Tests
         [Fact]
         public void CreateHttpManagementPayload_WithHttpRequestData()
         {
-            string requestUrl = "http://localhost:7075/orchestrators/E1_HelloSequence";
+            const string requestUrl = "http://localhost:7075/orchestrators/E1_HelloSequence";
             FunctionsDurableTaskClient client = this.GetTestFunctionsDurableTaskClient();
             string instanceId = "testInstanceIdWithRequest";
-            var context = new TestFunctionContext();
-            var request = new TestHttpRequestData(context, new Uri(requestUrl));
 
-            dynamic payload = client.CreateHttpManagementPayload(instanceId, request);
+            // Create mock HttpRequestData object.
+            var mockFunctionContext = new Mock<FunctionContext>();
+            var mockHttpRequestData = new Mock<HttpRequestData>(mockFunctionContext.Object);
+            mockHttpRequestData.SetupGet(r => r.Url).Returns(new Uri(requestUrl));
+
+            dynamic payload = client.CreateHttpManagementPayload(instanceId, mockHttpRequestData.Object);
 
             AssertHttpManagementPayload(payload, "http://localhost:7075/runtime/webhooks/durabletask", instanceId);
         }
@@ -98,50 +99,5 @@ namespace Microsoft.Azure.Functions.Worker.Tests
             Assert.Equal($"{BaseUrl}/instances/{instanceId}/suspend?reason={{{{text}}}}", payload.suspendPostUri);
             Assert.Equal($"{BaseUrl}/instances/{instanceId}/resume?reason={{{{text}}}}", payload.resumePostUri);
         }
-    }
-
-    /// <summary>
-    /// A minimal implementation of FunctionContext for testing purposes.
-    /// It's used to create a TestHttpRequestData instance, which requires a FunctionContext.
-    /// </summary>
-    public class TestFunctionContext : FunctionContext
-    {
-        public override string InvocationId => throw new NotImplementedException();
-        public override string FunctionId => throw new NotImplementedException();
-        public override TraceContext TraceContext => throw new NotImplementedException();
-        public override BindingContext BindingContext => throw new NotImplementedException();
-        public override RetryContext RetryContext => throw new NotImplementedException();
-        public override IServiceProvider InstanceServices { get; set; } = new EmptyServiceProvider();
-        public override FunctionDefinition FunctionDefinition => throw new NotImplementedException();
-        public override IDictionary<object, object> Items { get; set; } = new Dictionary<object, object>();
-        public override IInvocationFeatures Features => throw new NotImplementedException();
-    }
-
-    /// <summary>
-    /// A minimal implementation of IServiceProvider for testing purposes.
-    /// </summary>
-    public class EmptyServiceProvider : IServiceProvider
-    {
-        public object GetService(Type serviceType) => null;
-    }
-
-    // <summary>
-    /// A test implementation of HttpRequestData used for unit testing.
-    /// This class allows us to create instances of HttpRequestData, which is normally abstract.
-    /// </summary>
-    public class TestHttpRequestData : HttpRequestData
-    {
-        public TestHttpRequestData(FunctionContext functionContext, Uri url) : base(functionContext)
-        {
-            Url = url;
-        }
-
-        public override Stream Body => throw new NotImplementedException();
-        public override HttpHeadersCollection Headers => throw new NotImplementedException();
-        public override IReadOnlyCollection<IHttpCookie> Cookies => throw new NotImplementedException();
-        public override Uri Url { get; }
-        public override IEnumerable<ClaimsIdentity> Identities => throw new NotImplementedException();
-        public override string Method => throw new NotImplementedException();
-        public override HttpResponseData CreateResponse() => throw new NotImplementedException();
     }
 }

--- a/test/Worker.Extensions.DurableTask.Tests/FunctionsDurableTaskClientTests.cs
+++ b/test/Worker.Extensions.DurableTask.Tests/FunctionsDurableTaskClientTests.cs
@@ -1,3 +1,4 @@
+using System.Security.Claims;
 using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.DurableTask.Client;
 using Microsoft.DurableTask.Client.Grpc;
@@ -10,7 +11,7 @@ namespace Microsoft.Azure.Functions.Worker.Tests
     /// </summary>
     public class FunctionsDurableTaskClientTests
     {
-        private FunctionsDurableTaskClient GetTestFunctionsDurableTaskClient(string baseUrl = null)
+        private FunctionsDurableTaskClient GetTestFunctionsDurableTaskClient(string? baseUrl = null)
         {
             // construct mock client
 
@@ -59,15 +60,32 @@ namespace Microsoft.Azure.Functions.Worker.Tests
         /// Test that the `CreateHttpManagementPayload` method returns the expected payload structure without HttpRequestData.
         /// </summary>
         [Fact]
-        public void CreateHttpManagementPayload_WithBaseUrl_ReturnsExpectedStructure()
+        public void CreateHttpManagementPayload_WithBaseUrl()
         {
             string BaseUrl = "http://localhost:7071/runtime/webhooks/durabletask";
             FunctionsDurableTaskClient client = this.GetTestFunctionsDurableTaskClient(BaseUrl);
-            string instanceId = "testInstanceId";
+            string instanceId = "testInstanceIdWithHostBaseUrl";
 
             dynamic payload = client.CreateHttpManagementPayload(instanceId);
 
             AssertHttpManagementPayload(payload, BaseUrl, instanceId);
+        }
+
+        /// <summary>
+        /// Test that the `CreateHttpManagementPayload` method returns the expected payload structure with HttpRequestData.
+        /// </summary>
+        [Fact]
+        public void CreateHttpManagementPayload_WithHttpRequestData()
+        {
+            string requestUrl = "http://localhost:7075/orchestrators/E1_HelloSequence";
+            FunctionsDurableTaskClient client = this.GetTestFunctionsDurableTaskClient();
+            string instanceId = "testInstanceIdWithRequest";
+            var context = new TestFunctionContext();
+            var request = new TestHttpRequestData(context, new Uri(requestUrl));
+
+            dynamic payload = client.CreateHttpManagementPayload(instanceId, request);
+
+            AssertHttpManagementPayload(payload, "http://localhost:7075/runtime/webhooks/durabletask", instanceId);
         }
 
         private static void AssertHttpManagementPayload(dynamic payload, string BaseUrl, string instanceId)
@@ -80,5 +98,50 @@ namespace Microsoft.Azure.Functions.Worker.Tests
             Assert.Equal($"{BaseUrl}/instances/{instanceId}/suspend?reason={{{{text}}}}", payload.suspendPostUri);
             Assert.Equal($"{BaseUrl}/instances/{instanceId}/resume?reason={{{{text}}}}", payload.resumePostUri);
         }
+    }
+
+    /// <summary>
+    /// A minimal implementation of FunctionContext for testing purposes.
+    /// It's used to create a TestHttpRequestData instance, which requires a FunctionContext.
+    /// </summary>
+    public class TestFunctionContext : FunctionContext
+    {
+        public override string InvocationId => throw new NotImplementedException();
+        public override string FunctionId => throw new NotImplementedException();
+        public override TraceContext TraceContext => throw new NotImplementedException();
+        public override BindingContext BindingContext => throw new NotImplementedException();
+        public override RetryContext RetryContext => throw new NotImplementedException();
+        public override IServiceProvider InstanceServices { get; set; } = new EmptyServiceProvider();
+        public override FunctionDefinition FunctionDefinition => throw new NotImplementedException();
+        public override IDictionary<object, object> Items { get; set; } = new Dictionary<object, object>();
+        public override IInvocationFeatures Features => throw new NotImplementedException();
+    }
+
+    /// <summary>
+    /// A minimal implementation of IServiceProvider for testing purposes.
+    /// </summary>
+    public class EmptyServiceProvider : IServiceProvider
+    {
+        public object GetService(Type serviceType) => null;
+    }
+
+    // <summary>
+    /// A test implementation of HttpRequestData used for unit testing.
+    /// This class allows us to create instances of HttpRequestData, which is normally abstract.
+    /// </summary>
+    public class TestHttpRequestData : HttpRequestData
+    {
+        public TestHttpRequestData(FunctionContext functionContext, Uri url) : base(functionContext)
+        {
+            Url = url;
+        }
+
+        public override Stream Body => throw new NotImplementedException();
+        public override HttpHeadersCollection Headers => throw new NotImplementedException();
+        public override IReadOnlyCollection<IHttpCookie> Cookies => throw new NotImplementedException();
+        public override Uri Url { get; }
+        public override IEnumerable<ClaimsIdentity> Identities => throw new NotImplementedException();
+        public override string Method => throw new NotImplementedException();
+        public override HttpResponseData CreateResponse() => throw new NotImplementedException();
     }
 }


### PR DESCRIPTION
<!-- Start the PR description with some context for the change. -->


<!-- Make sure to delete the markdown comments and the below sections when squash merging -->
### Issue describing the changes in this PR

Fix issue #2810 

This PR adds the implementation of the CreateHttpManagementPayload API in the Durable Worker Extension. The implementation works as follows:

- If an HttpRequestData object is provided, the HTTP management payload is created using the base URL derived from this request data.
- If no HttpRequestData is available, the base URL is obtained from the Functions Host configuration, which is sent and converted by DurableTaskClient.

### Pull request checklist

* [ ] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)
* [ ] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk
* [ ] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
    * [ ] Otherwise: major or minor version updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
* [ ] My changes **do not** add EventIds to our EventSource logs
    * [ ] Otherwise: Ensure the EventIds are within the supported range in our existing Windows infrastructure. You may validate this with a deployed app's telemetry. You may also extend the range by completing a PR such as [this one](https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files).
* [ ] My changes **should** be added to v3.x branch.
    * [ ] Otherwise: This change only applies to Durable Functions v2.x and **will not** be merged to branch v3.x.
