### PR TITLE
Merge Latest Changes from dev into v3.x and Dependency Version Upgrades

### DIFF
--- a/.github/workflows/codeQL.yml
+++ b/.github/workflows/codeQL.yml
@@ -1,0 +1,79 @@
+# This workflow generates weekly CodeQL reports for this repo, a security requirements.
+# The workflow is adapted from the following reference: https://github.com/Azure-Samples/azure-functions-python-stream-openai/pull/2/files
+# Generic comments on how to modify these file are left intactfor future maintenance.
+
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ "main", "*" ] # TODO: remove development branch after approval
+  pull_request:
+    branches: [ "main", "*"] # TODO: remove development branch after approval
+  schedule:
+    - cron: '0 0 * * 1' # Weekly Monday run, needed for weekly reports
+  workflow_call: # allows to be invoked as part of a larger workflow
+  workflow_dispatch: # allows for the workflow to run manually see: https://docs.github.com/en/actions/using-workflows/manually-running-a-workflow
+
+env:
+  solution: WebJobs.Extensions.DurableTask.sln
+  config: Release
+
+jobs:
+
+  analyze:
+    name: Analyze
+    runs-on: windows-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ['csharp']
+        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
+        # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
+
+    steps:
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v3
+      with:
+        languages: ${{ matrix.language }}
+        # If you wish to specify custom queries, you can do so here or in a config file.
+        # By default, queries listed here will override any specified in a config file.
+        # Prefix the list here with "+" to use these queries and those in the config file.
+
+        # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
+        # queries: security-extended,security-and-quality
+
+    - uses: actions/checkout@v3
+      with:
+        submodules: true
+
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v3
+
+    - name: Set up .NET Core 2.1
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: '2.1.x'
+
+    - name: Set up .NET Core 3.1
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: '3.1.x'
+
+    - name: Restore dependencies
+      run: dotnet restore $solution
+
+    - name: Build
+      run: dotnet build $solution #--configuration $config #--no-restore -p:FileVersionRevision=$GITHUB_RUN_NUMBER -p:ContinuousIntegrationBuild=true
+
+    # Run CodeQL analysis
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v3
+      with:
+        category: "/language:${{matrix.language}}"

--- a/.github/workflows/smoketest-dotnet-isolated-v4.yml
+++ b/.github/workflows/smoketest-dotnet-isolated-v4.yml
@@ -19,7 +19,79 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-      # Validation is blocked on https://github.com/Azure/azure-functions-host/issues/7995
-    - name: Run V4 .NET Isolated Smoke Test
-      run: test/SmokeTests/e2e-test.ps1 -DockerfilePath test/SmokeTests/OOProcSmokeTests/DotNetIsolated/Dockerfile -HttpStartPath api/StartHelloCitiesTyped -NoValidation
+    # Install .NET versions
+    - name: Set up .NET Core 3.1
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: '3.1.x'
+
+    - name: Set up .NET Core 2.1
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: '2.1.x'
+
+    - name: Set up .NET Core 6.x
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: '6.x'
+
+    - name: Set up .NET Core 8.x
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: '8.x'
+
+    # Install Azurite
+    - name: Set up Node.js (needed for Azurite)
+      uses: actions/setup-node@v3
+      with:
+        node-version: '18.x' # Azurite requires at least Node 18
+
+    - name: Install Azurite
+      run: npm install -g azurite
+
+    - name: Restore WebJobs extension
+      run: dotnet restore $solution
+
+    - name: Build and pack WebJobs extension
+      run: cd ./src/WebJobs.Extensions.DurableTask &&
+        mkdir ./out &&
+        dotnet build -c Release WebJobs.Extensions.DurableTask.csproj --output ./out &&
+        mkdir ~/packages &&
+        dotnet nuget push ./out/Microsoft.Azure.WebJobs.Extensions.DurableTask.*.nupkg --source ~/packages &&
+        dotnet nuget add source ~/packages
+
+    - name: Build .NET Isolated Smoke Test
+      run: cd ./test/SmokeTests/OOProcSmokeTests/DotNetIsolated &&
+        dotnet restore --verbosity normal &&
+        dotnet build -c Release
+
+    - name: Install core tools
+      run: npm i -g azure-functions-core-tools@4 --unsafe-perm true
+  
+    # Run smoke tests
+    # Unlike other smoke tests, the .NET isolated smoke tests run outside of a docker container, but to race conditions
+    # when building the smoke test app in docker, causing the build to fail. This is a temporary workaround until the
+    # root cause is identified and fixed.
+
+    - name: Run smoke tests (Hello Cities)
       shell: pwsh
+      run: azurite --silent --blobPort 10000 --queuePort 10001 --tablePort 10002 &
+        cd ./test/SmokeTests/OOProcSmokeTests/DotNetIsolated && func host start --port 7071 &
+        ./test/SmokeTests/OOProcSmokeTests/DotNetIsolated/run-smoke-tests.ps1 -HttpStartPath api/StartHelloCitiesTyped
+
+    - name: Run smoke tests (Process Exit)
+      shell: pwsh
+      run: azurite --silent --blobPort 10000 --queuePort 10001 --tablePort 10002 &
+        ./test/SmokeTests/OOProcSmokeTests/DotNetIsolated/run-smoke-tests.ps1 -HttpStartPath api/durable_HttpStartProcessExitOrchestrator
+
+    - name: Run smoke tests (Timeout)
+      shell: pwsh
+      run: azurite --silent --blobPort 10000 --queuePort 10001 --tablePort 10002 &
+        cd ./test/SmokeTests/OOProcSmokeTests/DotNetIsolated && func host start --port 7071 &
+        ./test/SmokeTests/OOProcSmokeTests/DotNetIsolated/run-smoke-tests.ps1 -HttpStartPath api/durable_HttpStartTimeoutOrchestrator
+
+    - name: Run smoke tests (OOM)
+      shell: pwsh
+      run: azurite --silent --blobPort 10000 --queuePort 10001 --tablePort 10002 &
+        cd ./test/SmokeTests/OOProcSmokeTests/DotNetIsolated && func host start --port 7071 &
+        ./test/SmokeTests/OOProcSmokeTests/DotNetIsolated/run-smoke-tests.ps1 -HttpStartPath api/durable_HttpStartOOMOrchestrator

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,0 +1,37 @@
+<Project>
+  <!-- This is copied from:https://github.com/Azure/azure-functions-host/blob/dev/eng/build/RepositoryInfo.targets -->
+  <!-- The following build target allows us to reconstruct source-link information when building in 1ES -->
+
+  <!--
+    The convention for names of Azure DevOps repositories mirrored from GitHub is "{GitHub org name}.{GitHub repository name}".
+  -->
+  <PropertyGroup>
+    <!-- There are quite a few git repo forms:
+      https://azfunc@dev.azure.com/azfunc/internal/_git/azure.azure-functions-host
+      https://dev.azure.com/azfunc/internal/_git/azure.azure-functions-host
+      https://azfunc.visualstudio.com/internal/_git/azure.azure-functions-host
+      azfunc@vs-ssh.visualstudio.com:v3/azfunc/internal/azure.azure-functions-host
+      git@ssh.dev.azure.com:v3/azfunc/internal/azure.azure-functions-host
+    -->
+    <!-- Set DisableSourceLinkUrlTranslation to true when building a tool for internal use where sources only come from internal URIs -->
+    <DisableSourceLinkUrlTranslation Condition="'$(DisableSourceLinkUrlTranslation)' == ''">false</DisableSourceLinkUrlTranslation>
+    <_TranslateUrlPattern>(https://azfunc%40dev\.azure\.com/azfunc/internal/_git|https://dev\.azure\.com/azfunc/internal/_git|https://azfunc\.visualstudio\.com/internal/_git|azfunc%40vs-ssh\.visualstudio\.com:v3/azfunc/internal|git%40ssh\.dev\.azure\.com:v3/azfunc/internal)/([^/\.]+)\.(.+)</_TranslateUrlPattern>
+    <_TranslateUrlReplacement>https://github.com/$2/$3</_TranslateUrlReplacement>
+  </PropertyGroup>
+
+  <!-- When building from Azure Devops we update SourceLink to point back to the GitHub repo. -->
+  <Target Name="_TranslateAzureDevOpsUrlToGitHubUrl"
+    Condition="'$(DisableSourceLinkUrlTranslation)' == 'false'"
+    DependsOnTargets="$(SourceControlManagerUrlTranslationTargets)"
+    BeforeTargets="SourceControlManagerPublishTranslatedUrls">
+    <PropertyGroup>
+      <ScmRepositoryUrl>$([System.Text.RegularExpressions.Regex]::Replace($(ScmRepositoryUrl), $(_TranslateUrlPattern), $(_TranslateUrlReplacement)))</ScmRepositoryUrl>
+    </PropertyGroup>
+    <ItemGroup>
+      <SourceRoot Update="@(SourceRoot)">
+          <ScmRepositoryUrl>$([System.Text.RegularExpressions.Regex]::Replace(%(SourceRoot.ScmRepositoryUrl), $(_TranslateUrlPattern), $(_TranslateUrlReplacement)))</ScmRepositoryUrl>
+      </SourceRoot>
+    </ItemGroup>
+  </Target>
+
+</Project>

--- a/WebJobs.Extensions.DurableTask.sln
+++ b/WebJobs.Extensions.DurableTask.sln
@@ -18,6 +18,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.editorconfig = .editorconfig
 		azure-pipelines-release-dotnet-isolated.yml = azure-pipelines-release-dotnet-isolated.yml
 		azure-pipelines-release.yml = azure-pipelines-release.yml
+		Directory.Build.targets = Directory.Build.targets
 		nuget.config = nuget.config
 		README.md = README.md
 		release_notes.md = release_notes.md
@@ -94,7 +95,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "PerfTests", "PerfTests", "{
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DFPerfScenariosV4", "test\DFPerfScenarios\DFPerfScenariosV4.csproj", "{FC8AD123-F949-4D21-B817-E5A4BBF7F69B}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Worker.Extensions.DurableTask.Tests", "test\Worker.Extensions.DurableTask.Tests\Worker.Extensions.DurableTask.Tests.csproj", "{76DEC17C-BF6A-498A-8E8A-7D6CB2E03284}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Worker.Extensions.DurableTask.Tests", "test\Worker.Extensions.DurableTask.Tests\Worker.Extensions.DurableTask.Tests.csproj", "{76DEC17C-BF6A-498A-8E8A-7D6CB2E03284}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/eng/ci/official-build.yml
+++ b/eng/ci/official-build.yml
@@ -10,6 +10,17 @@ trigger:
 # CI only, does not trigger on PRs.
 pr: none
 
+schedules:
+# Build nightly to catch any new CVEs and report SDL often.
+# We are also required to generated CodeQL reports weekly, so this
+# helps us meet that.
+- cron: "0 0 * * *"
+  displayName: Nightly Build
+  branches:
+    include:
+    - main
+  always: true
+
 resources:
     repositories:
         - repository: 1es

--- a/eng/ci/official-build.yml
+++ b/eng/ci/official-build.yml
@@ -6,6 +6,7 @@ trigger:
     branches:
         include:
             - main
+            - dev
 
 # CI only, does not trigger on PRs.
 pr: none
@@ -19,6 +20,7 @@ schedules:
   branches:
     include:
     - main
+    - dev
   always: true
 
 resources:

--- a/eng/templates/build.yml
+++ b/eng/templates/build.yml
@@ -46,6 +46,7 @@ jobs:
             solution: '**/WebJobs.Extensions.DurableTask.sln'
             vsVersion: "16.0"
             configuration: Release
+            msbuildArgs: /p:FileVersionRevision=$(Build.BuildId) /p:ContinuousIntegrationBuild=true # these flags make package build deterministic
     
       - template: ci/sign-files.yml@eng
         parameters:

--- a/eng/templates/build.yml
+++ b/eng/templates/build.yml
@@ -54,6 +54,13 @@ jobs:
             pattern: '*DurableTask.dll'
             signType: dll
     
+      - template: ci/sign-files.yml@eng
+        parameters:
+            displayName: Sign assemblies
+            folderPath: 'src/Worker.Extensions.DurableTask/bin/Release'
+            pattern: '*DurableTask.dll'
+            signType: dll
+
       # dotnet pack
       # Packaging needs to be a separate step from build.
       # This will automatically pick up the signed DLLs.
@@ -62,6 +69,19 @@ jobs:
         inputs:
             command: pack
             packagesToPack: 'src/**/WebJobs.Extensions.DurableTask.csproj'
+            configuration: Release
+            packDirectory: $(build.artifactStagingDirectory)
+            nobuild: true
+
+    
+      # dotnet pack
+      # Packaging needs to be a separate step from build.
+      # This will automatically pick up the signed DLLs.
+      - task: DotNetCoreCLI@2
+        displayName: 'dotnet pack Worker.Extensions.DurableTask.csproj'
+        inputs:
+            command: pack
+            packagesToPack: 'src/**/Worker.Extensions.DurableTask.csproj'
             configuration: Release
             packDirectory: $(build.artifactStagingDirectory)
             nobuild: true

--- a/eng/templates/build.yml
+++ b/eng/templates/build.yml
@@ -63,7 +63,7 @@ jobs:
             command: pack
             packagesToPack: 'src/**/WebJobs.Extensions.DurableTask.csproj'
             configuration: Release
-            packDirectory: 'azure-functions-durable-extension'
+            packDirectory: $(build.artifactStagingDirectory)
             nobuild: true
 
       # Remove redundant symbol package(s)

--- a/release_notes.md
+++ b/release_notes.md
@@ -1,22 +1,6 @@
 # Release Notes
 
-## Microsoft.Azure.Functions.Worker.Extensions.DurableTask 1.1.6
-
-### New Features
-
-- Support for new `AllowReplayingTerminalInstances` setting in Azure Storage backend (https://github.com/Azure/durabletask/pull/1159), settable via `host.json`
-
-### Bug Fixes
-
-### Breaking Changes
-
-### Dependency Updates
-
-- Microsoft.DurableTask.Client.Grpc to 1.3.0
-- Microsoft.DurableTask.Worker.Grpc to 1.3.0
-- Microsoft.Azure.WebJobs.Extensions.DurableTask (in host process) to 2.13.6
-
-## Microsoft.Azure.WebJobs.Extensions.DurableTask <version>
+## Microsoft.Azure.Functions.Worker.Extensions.DurableTask (version)
 
 ### New Features
 
@@ -25,3 +9,15 @@
 ### Breaking Changes
 
 ### Dependency Updates
+
+## Microsoft.Azure.WebJobs.Extensions.DurableTask 2.13.7
+
+### New Features
+
+### Bug Fixes
+
+### Breaking Changes
+
+### Dependency Updates
+
+- Microsoft.DurableTask.Grpc to 1.3.0

--- a/release_notes.md
+++ b/release_notes.md
@@ -1,16 +1,20 @@
 # Release Notes
 
-## Microsoft.Azure.Functions.Worker.Extensions.DurableTask 1.2.1
+## Microsoft.Azure.Functions.Worker.Extensions.DurableTask 1.1.6
 
 ### New Features
 
-- Fix regression on `TerminateInstanceAsync` API causing invocations to fail with "unimplemented" exceptions (https://github.com/Azure/azure-functions-durable-extension/pull/2829).
+- Support for new `AllowReplayingTerminalInstances` setting in Azure Storage backend (https://github.com/Azure/durabletask/pull/1159), settable via `host.json`
 
 ### Bug Fixes
 
 ### Breaking Changes
 
 ### Dependency Updates
+
+- Microsoft.DurableTask.Client.Grpc to 1.3.0
+- Microsoft.DurableTask.Worker.Grpc to 1.3.0
+- Microsoft.Azure.WebJobs.Extensions.DurableTask (in host process) to 2.13.6
 
 ## Microsoft.Azure.WebJobs.Extensions.DurableTask <version>
 

--- a/samples/durable-client-managed-identity/aspnetcore-app/ToDoList.csproj
+++ b/samples/durable-client-managed-identity/aspnetcore-app/ToDoList.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="EntityFramework" Version="6.4.0" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="2.13.5" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="2.13.4" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.1.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.1.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/samples/durable-client-managed-identity/functions-app/DurableClientSampleFunctionApp.csproj
+++ b/samples/durable-client-managed-identity/functions-app/DurableClientSampleFunctionApp.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="2.13.5" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="2.13.4" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.7" />
   </ItemGroup>
   <ItemGroup>

--- a/src/WebJobs.Extensions.DurableTask/AzureStorageDurabilityProviderFactory.cs
+++ b/src/WebJobs.Extensions.DurableTask/AzureStorageDurabilityProviderFactory.cs
@@ -217,6 +217,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 UseSeparateQueueForEntityWorkItems = this.useSeparateQueueForEntityWorkItems,
                 EntityMessageReorderWindowInMinutes = this.options.EntityMessageReorderWindowInMinutes,
                 MaxEntityOperationBatchSize = this.options.MaxEntityOperationBatchSize,
+                AllowReplayingTerminalInstances = this.azureStorageOptions.AllowReplayingTerminalInstances,
             };
 
             if (this.inConsumption)

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
@@ -4208,6 +4208,20 @@
             </summary>
             <value>A boolean indicating whether to use the table partition strategy. Defaults to false.</value>
         </member>
+        <member name="P:Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureStorageOptions.AllowReplayingTerminalInstances">
+            <summary>
+            When false, when an orchestrator is in a terminal state (e.g. Completed, Failed, Terminated), events for that orchestrator are discarded.
+            Otherwise, events for a terminal orchestrator induce a replay. This may be used to recompute the state of the orchestrator in the "Instances Table".
+            </summary>
+            <remarks>
+            Transactions across Azure Tables are not possible, so we independently update the "History table" and then the "Instances table"
+            to set the state of the orchestrator.
+            If a crash were to occur between these two updates, the state of the orchestrator in the "Instances table" would be incorrect.
+            By setting this configuration to true, you can recover from these inconsistencies by forcing a replay of the orchestrator in response
+            to a client event like a termination request or an external event, which gives the framework another opportunity to update the state of
+            the orchestrator in the "Instances table". To force a replay after enabling this configuration, just send any external event to the affected instanceId.
+            </remarks>
+        </member>
         <member name="M:Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureStorageOptions.ValidateHubName(System.String)">
             <summary>
             Throws an exception if the provided hub name violates any naming conventions for the storage provider.

--- a/src/WebJobs.Extensions.DurableTask/Options/AzureStorageOptions.cs
+++ b/src/WebJobs.Extensions.DurableTask/Options/AzureStorageOptions.cs
@@ -180,6 +180,20 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         public bool UseTablePartitionManagement { get; set; } = false;
 
         /// <summary>
+        /// When false, when an orchestrator is in a terminal state (e.g. Completed, Failed, Terminated), events for that orchestrator are discarded.
+        /// Otherwise, events for a terminal orchestrator induce a replay. This may be used to recompute the state of the orchestrator in the "Instances Table".
+        /// </summary>
+        /// <remarks>
+        /// Transactions across Azure Tables are not possible, so we independently update the "History table" and then the "Instances table"
+        /// to set the state of the orchestrator.
+        /// If a crash were to occur between these two updates, the state of the orchestrator in the "Instances table" would be incorrect.
+        /// By setting this configuration to true, you can recover from these inconsistencies by forcing a replay of the orchestrator in response
+        /// to a client event like a termination request or an external event, which gives the framework another opportunity to update the state of
+        /// the orchestrator in the "Instances table". To force a replay after enabling this configuration, just send any external event to the affected instanceId.
+        /// </remarks>
+        public bool AllowReplayingTerminalInstances { get; set; } = false;
+
+        /// <summary>
         /// Throws an exception if the provided hub name violates any naming conventions for the storage provider.
         /// </summary>
         public void ValidateHubName(string hubName)

--- a/src/WebJobs.Extensions.DurableTask/OutOfProcMiddleware.cs
+++ b/src/WebJobs.Extensions.DurableTask/OutOfProcMiddleware.cs
@@ -138,10 +138,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
                     byte[] triggerReturnValueBytes = Convert.FromBase64String(triggerReturnValue);
                     P.OrchestratorResponse response = P.OrchestratorResponse.Parser.ParseFrom(triggerReturnValueBytes);
+
+                    // TrySetResult may throw if a platform-level error is encountered (like an out of memory exception).
                     context.SetResult(
                         response.Actions.Select(ProtobufUtils.ToOrchestratorAction),
                         response.CustomStatus);
 
+                    // Here we throw if the orchestrator completed with an application-level error. When we do this,
+                    // the function's result type will be of type `OrchestrationFailureException` which is reserved
+                    // for application-level errors that do not need to be re-tried.
                     context.ThrowIfFailed();
                 },
 #pragma warning restore CS0618 // Type or member is obsolete (not intended for general public use)
@@ -158,6 +163,19 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     // Shutdown can surface as a completed invocation in a failed state.
                     // Re-throw so we can abort this invocation.
                     this.HostLifetimeService.OnStopping.ThrowIfCancellationRequested();
+                }
+
+                // we abort the invocation on "platform level errors" such as:
+                // - a timeout
+                // - an out of memory exception
+                // - a worker process exit
+                if (functionResult.Exception is Host.FunctionTimeoutException
+                    || functionResult.Exception?.InnerException is SessionAbortedException // see RemoteOrchestrationContext.TrySetResultInternal for details on OOM-handling
+                    || (functionResult.Exception?.InnerException?.GetType().ToString().Contains("WorkerProcessExitException") ?? false))
+                {
+                    // TODO: the `WorkerProcessExitException` type is not exposed in our dependencies, it's part of WebJobs.Host.Script.
+                    // Should we add that dependency or should it be exposed in WebJobs.Host?
+                    throw functionResult.Exception;
                 }
             }
             catch (Exception hostRuntimeException)
@@ -238,8 +256,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             else
             {
                 // the function failed for some other reason
-
-                string exceptionDetails = functionResult.Exception.ToString();
+                string exceptionDetails = functionResult.Exception?.ToString() ?? "Framework-internal message: exception details could not be extracted";
 
                 this.TraceHelper.FunctionFailed(
                     this.Options.HubName,
@@ -258,7 +275,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
                 orchestratorResult = OrchestratorExecutionResult.ForFailure(
                     message: $"Function '{functionName}' failed with an unhandled exception.",
-                    functionResult.Exception);
+                    functionResult.Exception ?? new Exception($"Function '{functionName}' failed with an unknown unhandled exception"));
             }
 
             // Send the result of the orchestrator function to the DTFx dispatch pipeline.

--- a/src/WebJobs.Extensions.DurableTask/ProtobufUtils.cs
+++ b/src/WebJobs.Extensions.DurableTask/ProtobufUtils.cs
@@ -97,7 +97,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                             },
                         },
                         ScheduledStartTimestamp = startedEvent.ScheduledStartTime == null ? null : Timestamp.FromDateTime(startedEvent.ScheduledStartTime.Value),
-                        CorrelationData = startedEvent.Correlation,
+                        ParentTraceContext = startedEvent.ParentTraceContext == null ? null : new P.TraceContext
+                        {
+                            TraceParent = startedEvent.ParentTraceContext.TraceParent,
+                            TraceState = startedEvent.ParentTraceContext.TraceState,
+                        },
                     };
                     break;
                 case EventType.ExecutionTerminated:

--- a/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
+++ b/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
@@ -51,7 +51,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.11.4" />
+    <PackageReference Include="Azure.Identity" Version="1.13.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.39" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Rpc" Version="3.0.39" />
     <PackageReference Include="Microsoft.Azure.DurableTask.Core" Version="3.0.0" />

--- a/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
+++ b/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
@@ -51,7 +51,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.13.0" />
+    <PackageReference Include="Azure.Identity" Version="1.11.4" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.39" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Rpc" Version="3.0.39" />
     <PackageReference Include="Microsoft.Azure.DurableTask.Core" Version="3.0.0" />

--- a/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
+++ b/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
@@ -6,7 +6,7 @@
     <RootNamespace>Microsoft.Azure.WebJobs.Extensions.DurableTask</RootNamespace>
     <MajorVersion>2</MajorVersion>
     <MinorVersion>13</MinorVersion>
-    <PatchVersion>5</PatchVersion>
+    <PatchVersion>6</PatchVersion>
     <VersionSuffix>$(PackageSuffix)</VersionSuffix>
     <FileVersion>$(MajorVersion).$(MinorVersion).$(PatchVersion)</FileVersion>
     <AssemblyVersion>$(MajorVersion).0.0.0</AssemblyVersion>
@@ -114,7 +114,7 @@
   <!-- Common dependencies across all targets -->
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.DurableTask.Core" Version="2.17.1" />
-    <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage" Version="1.17.4" />
+    <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage" Version="1.17.5" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers" Version="0.5.*" />
     <!-- Build-time dependencies -->
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.*" PrivateAssets="All" />

--- a/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
+++ b/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
@@ -6,7 +6,7 @@
     <RootNamespace>Microsoft.Azure.WebJobs.Extensions.DurableTask</RootNamespace>
     <MajorVersion>2</MajorVersion>
     <MinorVersion>13</MinorVersion>
-    <PatchVersion>4</PatchVersion>
+    <PatchVersion>5</PatchVersion>
     <VersionSuffix>$(PackageSuffix)</VersionSuffix>
     <FileVersion>$(MajorVersion).$(MinorVersion).$(PatchVersion)</FileVersion>
     <AssemblyVersion>$(MajorVersion).0.0.0</AssemblyVersion>
@@ -114,7 +114,7 @@
   <!-- Common dependencies across all targets -->
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.DurableTask.Core" Version="2.17.1" />
-    <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage" Version="1.17.3" />
+    <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage" Version="1.17.4" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers" Version="0.5.*" />
     <!-- Build-time dependencies -->
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.*" PrivateAssets="All" />

--- a/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
+++ b/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
@@ -54,13 +54,13 @@
     <PackageReference Include="Azure.Identity" Version="1.11.4" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.39" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Rpc" Version="3.0.39" />
-    <PackageReference Include="Microsoft.Azure.DurableTask.Core" Version="2.17.1" />
-    <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage" Version="2.0.0-rc.3" />
+    <PackageReference Include="Microsoft.Azure.DurableTask.Core" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage" Version="2.0.1" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers" Version="0.5.*" />
     <PackageReference Include="Microsoft.Extensions.Azure" Version="1.7.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.WebApiCompatShim" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Azure.DurableTask.ApplicationInsights" Version="0.1.*" />
+    <PackageReference Include="Microsoft.Azure.DurableTask.ApplicationInsights" Version="0.2.*" />
     <!-- The gRPC dependencies in this package are not compatible with older frameworks, like .NET Core 2.x -->
     <PackageReference Include="Microsoft.DurableTask.Grpc" Version="1.3.0" />
     <PackageReference Include="Grpc.Core" Version="2.46.6" /> <!-- Bring this in until we move to hosted RPC -->

--- a/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
+++ b/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
@@ -6,7 +6,7 @@
     <RootNamespace>Microsoft.Azure.WebJobs.Extensions.DurableTask</RootNamespace>
     <MajorVersion>2</MajorVersion>
     <MinorVersion>13</MinorVersion>
-    <PatchVersion>6</PatchVersion>
+    <PatchVersion>7</PatchVersion>
     <VersionSuffix>$(PackageSuffix)</VersionSuffix>
     <FileVersion>$(MajorVersion).$(MinorVersion).$(PatchVersion)</FileVersion>
     <AssemblyVersion>$(MajorVersion).0.0.0</AssemblyVersion>
@@ -107,7 +107,7 @@
     <!-- Explicitly pinned transitive dependencies with CVE vulnerabilities.-->
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets" Version="2.2.1" />
     <!-- The gRPC dependencies in this package are not compatible with older frameworks, like .NET Core 2.x -->
-    <PackageReference Include="Microsoft.DurableTask.Grpc" Version="1.1.0" />
+    <PackageReference Include="Microsoft.DurableTask.Grpc" Version="1.3.0" />
     <PackageReference Include="Grpc.Core" Version="2.46.6" /> <!-- Bring this in until we move to hosted RPC -->
   </ItemGroup>
 

--- a/src/Worker.Extensions.DurableTask/AssemblyInfo.cs
+++ b/src/Worker.Extensions.DurableTask/AssemblyInfo.cs
@@ -5,5 +5,5 @@ using System.Runtime.CompilerServices;
 using Microsoft.Azure.Functions.Worker.Extensions.Abstractions;
 
 // TODO: Find a way to generate this dynamically at build-time
-[assembly: ExtensionInformation("Microsoft.Azure.WebJobs.Extensions.DurableTask", "2.13.5")]
+[assembly: ExtensionInformation("Microsoft.Azure.WebJobs.Extensions.DurableTask", "2.13.6")]
 [assembly: InternalsVisibleTo("Worker.Extensions.DurableTask.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100cd1dabd5a893b40e75dc901fe7293db4a3caf9cd4d3e3ed6178d49cd476969abe74a9e0b7f4a0bb15edca48758155d35a4f05e6e852fff1b319d103b39ba04acbadd278c2753627c95e1f6f6582425374b92f51cca3deb0d2aab9de3ecda7753900a31f70a236f163006beefffe282888f85e3c76d1205ec7dfef7fa472a17b1")]

--- a/src/Worker.Extensions.DurableTask/AssemblyInfo.cs
+++ b/src/Worker.Extensions.DurableTask/AssemblyInfo.cs
@@ -5,5 +5,5 @@ using System.Runtime.CompilerServices;
 using Microsoft.Azure.Functions.Worker.Extensions.Abstractions;
 
 // TODO: Find a way to generate this dynamically at build-time
-[assembly: ExtensionInformation("Microsoft.Azure.WebJobs.Extensions.DurableTask", "2.13.6")]
+[assembly: ExtensionInformation("Microsoft.Azure.WebJobs.Extensions.DurableTask", "2.13.7")]
 [assembly: InternalsVisibleTo("Worker.Extensions.DurableTask.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100cd1dabd5a893b40e75dc901fe7293db4a3caf9cd4d3e3ed6178d49cd476969abe74a9e0b7f4a0bb15edca48758155d35a4f05e6e852fff1b319d103b39ba04acbadd278c2753627c95e1f6f6582425374b92f51cca3deb0d2aab9de3ecda7753900a31f70a236f163006beefffe282888f85e3c76d1205ec7dfef7fa472a17b1")]

--- a/src/Worker.Extensions.DurableTask/AssemblyInfo.cs
+++ b/src/Worker.Extensions.DurableTask/AssemblyInfo.cs
@@ -5,5 +5,5 @@ using System.Runtime.CompilerServices;
 using Microsoft.Azure.Functions.Worker.Extensions.Abstractions;
 
 // TODO: Find a way to generate this dynamically at build-time
-[assembly: ExtensionInformation("Microsoft.Azure.WebJobs.Extensions.DurableTask", "2.13.4")]
+[assembly: ExtensionInformation("Microsoft.Azure.WebJobs.Extensions.DurableTask", "2.13.5")]
 [assembly: InternalsVisibleTo("Worker.Extensions.DurableTask.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100cd1dabd5a893b40e75dc901fe7293db4a3caf9cd4d3e3ed6178d49cd476969abe74a9e0b7f4a0bb15edca48758155d35a4f05e6e852fff1b319d103b39ba04acbadd278c2753627c95e1f6f6582425374b92f51cca3deb0d2aab9de3ecda7753900a31f70a236f163006beefffe282888f85e3c76d1205ec7dfef7fa472a17b1")]

--- a/src/Worker.Extensions.DurableTask/Worker.Extensions.DurableTask.csproj
+++ b/src/Worker.Extensions.DurableTask/Worker.Extensions.DurableTask.csproj
@@ -45,6 +45,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.*" PrivateAssets="All" />
+    <PackageReference Include="System.Text.Json" Version="6.0.10" />
   </ItemGroup>
 
   <!-- Embed the SBOM manifest, which is generated as part of the "official" build -->

--- a/src/Worker.Extensions.DurableTask/Worker.Extensions.DurableTask.csproj
+++ b/src/Worker.Extensions.DurableTask/Worker.Extensions.DurableTask.csproj
@@ -29,7 +29,7 @@
     <AssemblyOriginatorKeyFile>..\..\sign.snk</AssemblyOriginatorKeyFile>
 
     <!-- Version information -->
-    <VersionPrefix>1.1.6</VersionPrefix>
+    <VersionPrefix>1.1.7</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <AssemblyVersion>$(VersionPrefix).0</AssemblyVersion>
     <!-- FileVersionRevision is expected to be set by the CI.  -->

--- a/src/Worker.Extensions.DurableTask/Worker.Extensions.DurableTask.csproj
+++ b/src/Worker.Extensions.DurableTask/Worker.Extensions.DurableTask.csproj
@@ -29,7 +29,7 @@
     <AssemblyOriginatorKeyFile>..\..\sign.snk</AssemblyOriginatorKeyFile>
 
     <!-- Version information -->
-    <VersionPrefix>1.1.5</VersionPrefix>
+    <VersionPrefix>1.1.6</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <AssemblyVersion>$(VersionPrefix).0</AssemblyVersion>
     <!-- FileVersionRevision is expected to be set by the CI.  -->
@@ -39,8 +39,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Core" Version="1.16.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Abstractions" Version="1.3.0" />
-    <PackageReference Include="Microsoft.DurableTask.Client.Grpc" Version="1.2.4" />
-    <PackageReference Include="Microsoft.DurableTask.Worker.Grpc" Version="1.2.4" />
+    <PackageReference Include="Microsoft.DurableTask.Client.Grpc" Version="1.3.0" />
+    <PackageReference Include="Microsoft.DurableTask.Worker.Grpc" Version="1.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Worker.Extensions.DurableTask/Worker.Extensions.DurableTask.csproj
+++ b/src/Worker.Extensions.DurableTask/Worker.Extensions.DurableTask.csproj
@@ -29,7 +29,7 @@
     <AssemblyOriginatorKeyFile>..\..\sign.snk</AssemblyOriginatorKeyFile>
 
     <!-- Version information -->
-    <VersionPrefix>1.1.4</VersionPrefix>
+    <VersionPrefix>1.1.5</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <AssemblyVersion>$(VersionPrefix).0</AssemblyVersion>
     <!-- FileVersionRevision is expected to be set by the CI.  -->

--- a/test/SmokeTests/OOProcSmokeTests/DotNetIsolated/DotNetIsolated.sln
+++ b/test/SmokeTests/OOProcSmokeTests/DotNetIsolated/DotNetIsolated.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.002.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DotNetIsolated", "DotNetIsolated.csproj", "{B2DBA49D-9D25-46DB-8968-15D5E83B4060}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{B2DBA49D-9D25-46DB-8968-15D5E83B4060}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B2DBA49D-9D25-46DB-8968-15D5E83B4060}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B2DBA49D-9D25-46DB-8968-15D5E83B4060}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B2DBA49D-9D25-46DB-8968-15D5E83B4060}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {0954D7B4-582F-4F85-AE3E-5D503FB07DB1}
+	EndGlobalSection
+EndGlobal

--- a/test/SmokeTests/OOProcSmokeTests/DotNetIsolated/FaultyOrchestrators.cs
+++ b/test/SmokeTests/OOProcSmokeTests/DotNetIsolated/FaultyOrchestrators.cs
@@ -1,0 +1,165 @@
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
+using Microsoft.DurableTask;
+using Microsoft.DurableTask.Client;
+using Microsoft.Extensions.Logging;
+using System;
+
+namespace FaultOrchestrators
+{
+    public static class FaultyOrchestrators
+    {
+        [Function(nameof(OOMOrchestrator))]
+        public static Task OOMOrchestrator(
+            [OrchestrationTrigger] TaskOrchestrationContext context)
+        {
+            // this orchestrator is not deterministic, on purpose.
+            // we use the non-determinism to force an OOM exception on only the first replay
+            
+            // check if a file named "replayEvidence" exists in source code directory, create it if it does not.
+            // From experience, this code runs in `<sourceCodePath>/bin/output/`, so we store the file two directories above.
+            // We do this because the /bin/output/ directory gets overridden during the build process, which happens automatically
+            // when `func host start` is re-invoked.
+            string evidenceFile = System.IO.Path.Combine(System.IO.Directory.GetCurrentDirectory(), "..", "..", "replayEvidence");
+            bool isTheFirstReplay = !System.IO.File.Exists(evidenceFile);
+            if (isTheFirstReplay)
+            {
+                System.IO.File.Create(evidenceFile).Close();
+
+                // force the process to run out of memory
+                List<byte[]> data = new List<byte[]>();
+
+                for (int i = 0; i < 10000000; i++)
+                {
+                    data.Add(new byte[1024 * 1024 * 1024]);
+                }
+
+                // we expect the code to never reach this statement, it should OOM.
+                // we throw just in case the code does not time out. This should fail the test
+                throw new Exception("this should never be reached");
+            }
+            else {
+                // if it's not the first replay, delete the evidence file and return
+                System.IO.File.Delete(evidenceFile);
+                return Task.CompletedTask;
+            }
+        }
+        
+        [Function(nameof(ProcessExitOrchestrator))]
+        public static Task ProcessExitOrchestrator(
+            [OrchestrationTrigger] TaskOrchestrationContext context)
+        {
+            // this orchestrator is not deterministic, on purpose.
+            // we use the non-determinism to force a sudden process exit on only the first replay
+            
+            // check if a file named "replayEvidence" exists in source code directory, create it if it does not.
+            // From experience, this code runs in `<sourceCodePath>/bin/output/`, so we store the file two directories above.
+            // We do this because the /bin/output/ directory gets overridden during the build process, which happens automatically
+            // when `func host start` is re-invoked.
+            string evidenceFile = System.IO.Path.Combine(System.IO.Directory.GetCurrentDirectory(), "..", "..", "replayEvidence");
+            bool isTheFirstReplay = !System.IO.File.Exists(evidenceFile);
+            if (isTheFirstReplay)
+            {
+                System.IO.File.Create(evidenceFile).Close();
+
+                // force sudden crash
+                Environment.FailFast("Simulating crash!");
+                throw new Exception("this should never be reached");
+            }
+            else {
+                // if it's not the first replay, delete the evidence file and return
+                System.IO.File.Delete(evidenceFile);
+                return Task.CompletedTask;
+            }
+        }
+
+        [Function(nameof(TimeoutOrchestrator))]
+        public static Task TimeoutOrchestrator(
+            [OrchestrationTrigger] TaskOrchestrationContext context)
+        {
+            // this orchestrator is not deterministic, on purpose.
+            // we use the non-determinism to force a timeout on only the first replay
+            
+            // check if a file named "replayEvidence" exists in source code directory, create it if it does not.
+            // From experience, this code runs in `<sourceCodePath>/bin/output/`, so we store the file two directories above.
+            // We do this because the /bin/output/ directory gets overridden during the build process, which happens automatically
+            // when `func host start` is re-invoked.
+            string evidenceFile = System.IO.Path.Combine(System.IO.Directory.GetCurrentDirectory(), "..", "..", "replayEvidence");
+            bool isTheFirstReplay = !System.IO.File.Exists(evidenceFile);
+
+            if (isTheFirstReplay)
+            {
+                System.IO.File.Create(evidenceFile).Close();
+                
+                // force the process to timeout after a 1 minute wait
+                System.Threading.Thread.Sleep(TimeSpan.FromMinutes(1));
+                
+                // we expect the code to never reach this statement, it should time out.
+                // we throw just in case the code does not time out. This should fail the test
+                throw new Exception("this should never be reached");
+            }
+            else {
+                // if it's not the first replay, delete the evidence file and return
+                System.IO.File.Delete(evidenceFile);
+                return Task.CompletedTask;
+            }
+        }
+
+        [Function("durable_HttpStartOOMOrchestrator")]
+        public static async Task<HttpResponseData> HttpStartOOMOrchestrator(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "get", "post")] HttpRequestData req,
+            [DurableClient] DurableTaskClient client,
+            FunctionContext executionContext)
+        {
+            ILogger logger = executionContext.GetLogger("durable_HttpStartOOMOrchestrator");
+
+            // Function input comes from the request content.
+            string instanceId = await client.ScheduleNewOrchestrationInstanceAsync(
+                nameof(OOMOrchestrator));
+
+            logger.LogInformation("Started orchestration with ID = '{instanceId}'.", instanceId);
+
+            // Returns an HTTP 202 response with an instance management payload.
+            // See https://learn.microsoft.com/azure/azure-functions/durable/durable-functions-http-api#start-orchestration
+            return await client.CreateCheckStatusResponseAsync(req, instanceId);
+        }
+
+        [Function("durable_HttpStartProcessExitOrchestrator")]
+        public static async Task<HttpResponseData> HttpStartProcessExitOrchestrator(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "get", "post")] HttpRequestData req,
+            [DurableClient] DurableTaskClient client,
+            FunctionContext executionContext)
+        {
+            ILogger logger = executionContext.GetLogger("durable_HttpStartProcessExitOrchestrator");
+
+            // Function input comes from the request content.
+            string instanceId = await client.ScheduleNewOrchestrationInstanceAsync(
+                nameof(ProcessExitOrchestrator));
+
+            logger.LogInformation("Started orchestration with ID = '{instanceId}'.", instanceId);
+
+            // Returns an HTTP 202 response with an instance management payload.
+            // See https://learn.microsoft.com/azure/azure-functions/durable/durable-functions-http-api#start-orchestration
+            return await client.CreateCheckStatusResponseAsync(req, instanceId);
+        }
+
+        [Function("durable_HttpStartTimeoutOrchestrator")]
+        public static async Task<HttpResponseData> HttpStartTimeoutOrchestrator(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "get", "post")] HttpRequestData req,
+            [DurableClient] DurableTaskClient client,
+            FunctionContext executionContext)
+        {
+            ILogger logger = executionContext.GetLogger("durable_HttpStartTimeoutOrchestrator");
+
+            // Function input comes from the request content.
+            string instanceId = await client.ScheduleNewOrchestrationInstanceAsync(
+                nameof(TimeoutOrchestrator));
+
+            logger.LogInformation("Started orchestration with ID = '{instanceId}'.", instanceId);
+
+            // Returns an HTTP 202 response with an instance management payload.
+            // See https://learn.microsoft.com/azure/azure-functions/durable/durable-functions-http-api#start-orchestration
+            return await client.CreateCheckStatusResponseAsync(req, instanceId);
+        }
+    }
+}

--- a/test/SmokeTests/OOProcSmokeTests/DotNetIsolated/host.json
+++ b/test/SmokeTests/OOProcSmokeTests/DotNetIsolated/host.json
@@ -7,5 +7,14 @@
         "excludedTypes": "Request"
       }
     }
-  }
+  },
+  "extensions": {
+    "durableTask": {
+      "storageProvider": {
+        "maxQueuePollingInterval": "00:00:01",
+        "controlQueueVisibilityTimeout": "00:01:00"
+      }
+    }
+  },
+  "functionTimeout": "00:00:30"
 }

--- a/test/SmokeTests/OOProcSmokeTests/DotNetIsolated/run-smoke-tests.ps1
+++ b/test/SmokeTests/OOProcSmokeTests/DotNetIsolated/run-smoke-tests.ps1
@@ -1,0 +1,119 @@
+# This is a simple test runner to validate the .NET isolated smoke tests.
+# It supercedes the usual e2e-tests.ps1 script for the .NET isolated scenario because building the snmoke test app
+# on the docker image is unreliable. For more details, see: https://github.com/Azure/azure-functions-host/issues/7995
+
+# This script is designed specifically to test cases where the isolated worker process experiences a platform failure:
+# timeouts, OOMs, etc. For that reason, it is careful to check that the Functions Host is running and healthy at regular
+# intervals. This makes these tests run more slowly than other test categories.
+
+param(
+	[Parameter(Mandatory=$true)]
+	[string]$HttpStartPath
+)
+
+$retryCount = 0;
+$statusUrl = $null;
+$success = $false;
+$haveManuallyRestartedHost = $false;
+
+Do {
+    $testIsRunning = $true;
+
+    # Start the functions host if it's not running already.
+    # Then give it up to 1 minute to start up. 
+    # This is a long wait, but from experience the CI can be slow to start up the host, especially after a platform-error.
+    $isFunctionsHostRunning = (Get-Process -Name func -ErrorAction SilentlyContinue)
+    if ($isFunctionsHostRunning -eq $null) {
+        Write-Host "Starting the Functions host..." -ForegroundColor Yellow
+
+        # The '&' operator is used to run the command in the background
+        cd ./test/SmokeTests/OOProcSmokeTests/DotNetIsolated && func host start --port 7071 &       
+        Write-Host "Waiting for the Functions host to start up..." -ForegroundColor Yellow
+        Start-Sleep -Seconds 60
+    }
+
+    
+    try {
+        # Make sure the Functions runtime is up and running
+        $pingUrl = "http://localhost:7071/admin/host/ping"
+        Write-Host "Pinging app at $pingUrl to ensure the host is healthy" -ForegroundColor Yellow
+        Invoke-RestMethod -Method Post -Uri "http://localhost:7071/admin/host/ping"
+        Write-Host "Host is healthy!" -ForegroundColor Green
+
+        # Start orchestrator if it hasn't been started yet
+        if ($statusUrl -eq $null){
+            $startOrchestrationUri = "http://localhost:7071/$HttpStartPath"
+            Write-Host "Starting a new orchestration instance via POST to $startOrchestrationUri..." -ForegroundColor Yellow
+
+            $result = Invoke-RestMethod -Method Post -Uri $startOrchestrationUri
+            Write-Host "Started orchestration with instance ID '$($result.id)'!" -ForegroundColor Yellow
+            Write-Host "Waiting for orchestration to complete..." -ForegroundColor Yellow
+
+            $statusUrl = $result.statusQueryGetUri
+            
+            # sleep for a bit to give the orchestrator a chance to start,
+            # then loop once more in case the orchestrator ran quickly, made the host unhealthy,
+            # and the functions host needs to be restarted
+            Start-Sleep -Seconds 5
+            continue;
+        }
+
+        # Check the orchestrator status
+        $result = Invoke-RestMethod -Method Get -Uri $statusUrl
+        $runtimeStatus = $result.runtimeStatus
+        Write-Host "Orchestration is $runtimeStatus" -ForegroundColor Yellow
+        Write-Host $result
+
+        if ($result.runtimeStatus -eq "Completed") {
+            $success = $true
+            $testIsRunning = $false
+            break
+        }
+        if ($result.runtimeStatus -eq "Failed") {
+            $success = $false
+            $testIsRunning = $false
+            break
+        }
+
+        # If the orchestrator did not complete yet, wait for a bit before checking again
+        Start-Sleep -Seconds 2
+        $retryCount = $retryCount + 1
+
+    } catch {
+        # we expect to enter this 'catch' block if any of our HTTP requests to the host fail.
+        # Some failures observed during development include:
+        # - The host is not running/was restarting/was killed
+        # - The host is running but not healthy (OOMs may cause this), so it needs to be forcibly restarted
+        Write-Host "An error occurred:" -ForegroundColor Red
+        Write-Host $_ -ForegroundColor Red
+
+        # When testing for platform errors, we want to make sure the Functions host is healthy and ready to take requests.
+        # The Host can get into bad states (for example, in an OOM-inducing test) where it does not self-heal.
+        # For these cases, we manually restart the host to ensure it is in a good state. We only do this once per test.
+        if ($haveManuallyRestartedHost -eq $false) {
+            
+            # We stop the host process and wait for a bit before checking if it is running again.
+            Write-Host "Restarting the Functions host..." -ForegroundColor Yellow
+            Stop-Process -Name "func" -Force
+            Start-Sleep -Seconds 5
+            
+            # Log whether the process kill succeeded
+            $haveManuallyRestartedHost = $true
+            $isFunctionsHostRunning = ((Get-Process -Name func -ErrorAction SilentlyContinue) -eq $null)
+            Write-Host "Host process killed: $isFunctionsHostRunning" -ForegroundColor Yellow
+  
+            # the beginning of the loop will restart the host
+            continue
+        }
+
+        # Rethrow the original exception
+        throw
+    }
+
+} while (($testIsRunning -eq $true) -and ($retryCount -lt 65))
+
+if ($success -eq $false) {
+    throw "Orchestration failed or did not compete in time! :("
+}
+
+Write-Host "Success!" -ForegroundColor Green

--- a/test/SmokeTests/e2e-test.ps1
+++ b/test/SmokeTests/e2e-test.ps1
@@ -26,7 +26,7 @@ function Exit-OnError() {
 }
 
 $ErrorActionPreference = "Stop"
-$AzuriteVersion = "3.26.0"
+$AzuriteVersion = "3.32.0"
 
 if ($NoSetup -eq $false) {
 	# Build the docker image first, since that's the most critical step

--- a/test/SmokeTests/e2e-test.ps1
+++ b/test/SmokeTests/e2e-test.ps1
@@ -65,7 +65,7 @@ if ($NoSetup -eq $false) {
 
 	 	# Create the database with strict binary collation
 		Write-Host "Creating '$dbname' database with '$collation' collation" -ForegroundColor DarkYellow
-		docker exec -d mssql-server /opt/mssql-tools/bin/sqlcmd -S . -U sa -P "$pw" -Q "CREATE DATABASE [$dbname] COLLATE $collation"
+		docker exec -d mssql-server /opt/mssql-tools18/bin/sqlcmd -S . -U sa -P "$pw" -Q "CREATE DATABASE [$dbname] COLLATE $collation"
 		Exit-OnError
 
   		# Wait for database to be ready

--- a/tools/triageHelper/function_app.py
+++ b/tools/triageHelper/function_app.py
@@ -12,6 +12,7 @@ REPOS = [
     "Azure/azure-functions-durable-extension",
     "Azure/azure-functions-durable-js",
     "Azure/azure-functions-durable-python",
+    "Azure/azure-functions-durable-powershell",
     powershell_worker_repo,
     "microsoft/durabletask-java",
     "microsoft/durabletask-dotnet",
@@ -40,7 +41,6 @@ def get_triage_issues(repository):
     'labels': label, 
 }
 
-    payload_str = urllib.parse.urlencode(payload, safe=':+')
     # Define the GitHub API endpoint
     api_endpoint = f"https://api.github.com/repos/{repository}/issues"
     query_str1 = "?labels=Needs%3A%20Triage%20%3Amag%3A"


### PR DESCRIPTION
<!-- Start the PR description with some context for the change. -->


<!-- Make sure to delete the markdown comments and the below sections when squash merging -->
### Issue describing the changes in this PR

- Synced the v3.x branch with the latest updates from the dev branch.
- Updated DTFx dependencies:

    DTFx.Core from 2.17.1 to 3.0.0
    DTFx.ApplicationInsights from 0.1.* to 0.2.*
    DTFx.AzureStorage from 2.0.0-rc.3 to 2.0.1



### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)
* [ ] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk
* [ ] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
    * [ ] Otherwise: major or minor version updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
* [ ] My changes **do not** add EventIds to our EventSource logs
    * [ ] Otherwise: Ensure the EventIds are within the supported range in our existing Windows infrastructure. You may validate this with a deployed app's telemetry. You may also extend the range by completing a PR such as [this one](https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files).
* [ ] My changes **should** be added to v3.x branch.
    * [ ] Otherwise: This change only applies to Durable Functions v2.x and **will not** be merged to branch v3.x.
