### PR TITLE
Change 'durabletask-extension.official' to `durable-extension.official' in publish pipeline

### DIFF
--- a/eng/ci/publish.yml
+++ b/eng/ci/publish.yml
@@ -22,7 +22,7 @@ resources:
 
     pipelines:
     - pipeline: officialPipeline # Reference to the pipeline to be used as an artifact source
-      source: 'durabletask-extension.official'
+      source: 'durable-extension.official'
 
 extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1es


### PR DESCRIPTION
As in title. The current CI had a typo (yet another one :( ), which prevented the publishing pipeline from passing validation. Hoping this is the last of it.