### PR TITLE
Make durable client registration idempotent.

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -1,12 +1,14 @@
 # Release Notes
 
-## Microsoft.Azure.Functions.Worker.Extensions.DurableTask 1.2.1
+## Microsoft.Azure.Functions.Worker.Extensions.DurableTask <version>
 
 ### New Features
 
-- Fix regression on `TerminateInstanceAsync` API causing invocations to fail with "unimplemented" exceptions (https://github.com/Azure/azure-functions-durable-extension/pull/2829).
+- Added an `IFunctionsWorkerApplicationBuilder.ConfigureDurableExtension()` extension method for cases where auto-registration does not work (no source gen running). (#2950)
 
 ### Bug Fixes
+
+- Made durable extension for isolated worker configuration idempotent, allowing multiple calls safely. (#2950)
 
 ### Breaking Changes
 

--- a/src/Worker.Extensions.DurableTask/DurableTaskExtensionStartup.cs
+++ b/src/Worker.Extensions.DurableTask/DurableTaskExtensionStartup.cs
@@ -1,20 +1,8 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System;
-using Azure.Core.Serialization;
 using Microsoft.Azure.Functions.Worker.Core;
 using Microsoft.Azure.Functions.Worker.Extensions.DurableTask;
-using Microsoft.DurableTask;
-using Microsoft.DurableTask.Client;
-using Microsoft.DurableTask.Converters;
-using Microsoft.DurableTask.Worker;
-using Microsoft.DurableTask.Worker.Shims;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
-using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 
 [assembly: WorkerExtensionStartup(typeof(DurableTaskExtensionStartup))]
 
@@ -28,49 +16,6 @@ public sealed class DurableTaskExtensionStartup : WorkerExtensionStartup
     /// <inheritdoc/>
     public override void Configure(IFunctionsWorkerApplicationBuilder applicationBuilder)
     {
-        applicationBuilder.Services.AddSingleton<FunctionsDurableClientProvider>();
-        applicationBuilder.Services.AddOptions<DurableTaskClientOptions>()
-            .Configure(options => options.EnableEntitySupport = true)
-            .PostConfigure<IServiceProvider>((opt, sp) =>
-            {
-                if (GetConverter(sp) is DataConverter converter)
-                {
-                    opt.DataConverter = converter;
-                }
-            });
-
-        applicationBuilder.Services.AddOptions<DurableTaskWorkerOptions>()
-            .Configure(options => options.EnableEntitySupport = true)
-            .PostConfigure<IServiceProvider>((opt, sp) =>
-            {
-                if (GetConverter(sp) is DataConverter converter)
-                {
-                    opt.DataConverter = converter;
-                }
-            });
-
-        applicationBuilder.Services.TryAddSingleton(sp =>
-        {
-            DurableTaskWorkerOptions options = sp.GetRequiredService<IOptions<DurableTaskWorkerOptions>>().Value;
-            ILoggerFactory factory = sp.GetRequiredService<ILoggerFactory>();
-            return new DurableTaskShimFactory(options, factory); // For GrpcOrchestrationRunner
-        });
-
-        applicationBuilder.Services.Configure<WorkerOptions>(o =>
-        {
-            o.InputConverters.Register<OrchestrationInputConverter>();
-        });
-
-        applicationBuilder.UseMiddleware<DurableTaskFunctionsMiddleware>();
-    }
-
-    private static DataConverter? GetConverter(IServiceProvider services)
-    {
-        // We intentionally do not consider a DataConverter in the DI provider, or if one was already set. This is to
-        // ensure serialization is consistent with the rest of Azure Functions. This is particularly important because
-        // TaskActivity bindings use ObjectSerializer directly for the time being. Due to this, allowing DataConverter
-        // to be set separately from ObjectSerializer would give an inconsistent serialization solution.
-        WorkerOptions? worker = services.GetRequiredService<IOptions<WorkerOptions>>()?.Value;
-        return worker?.Serializer is not null ? new ObjectConverterShim(worker.Serializer) : null;
+        applicationBuilder.ConfigureDurableExtension();
     }
 }

--- a/src/Worker.Extensions.DurableTask/FunctionsWorkerApplicationBuilderExtensions.cs
+++ b/src/Worker.Extensions.DurableTask/FunctionsWorkerApplicationBuilderExtensions.cs
@@ -1,0 +1,125 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using Azure.Core.Serialization;
+using Microsoft.Azure.Functions.Worker.Core;
+using Microsoft.Azure.Functions.Worker.Extensions.DurableTask;
+using Microsoft.DurableTask;
+using Microsoft.DurableTask.Client;
+using Microsoft.DurableTask.Converters;
+using Microsoft.DurableTask.Worker;
+using Microsoft.DurableTask.Worker.Shims;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.Azure.Functions.Worker;
+
+/// <summary>
+/// Extensions for <see cref="IFunctionsWorkerApplicationBuilder"/>.
+/// </summary>
+public static class FunctionsWorkerApplicationBuilderExtensions
+{
+    /// <summary>
+    /// Configures the Durable Functions extension for the worker.
+    /// </summary>
+    /// <param name="builder">The builder to configure.</param>
+    /// <returns>The <paramref name="builder"/> for call chaining.</returns>
+    public static IFunctionsWorkerApplicationBuilder ConfigureDurableExtension(this IFunctionsWorkerApplicationBuilder builder)
+    {
+        if (builder is null)
+        {
+            throw new ArgumentNullException(nameof(builder));
+        }
+
+        builder.Services.TryAddSingleton<FunctionsDurableClientProvider>();
+        builder.Services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<IConfigureOptions<DurableTaskClientOptions>, ConfigureClientOptions>());
+        builder.Services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<IPostConfigureOptions<DurableTaskClientOptions>, PostConfigureClientOptions>());
+        builder.Services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<IConfigureOptions<DurableTaskWorkerOptions>, ConfigureWorkerOptions>());
+        builder.Services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<IPostConfigureOptions<DurableTaskWorkerOptions>, PostConfigureWorkerOptions>());
+
+        builder.Services.TryAddSingleton(sp =>
+        {
+            DurableTaskWorkerOptions options = sp.GetRequiredService<IOptions<DurableTaskWorkerOptions>>().Value;
+            ILoggerFactory factory = sp.GetRequiredService<ILoggerFactory>();
+            return new DurableTaskShimFactory(options, factory); // For GrpcOrchestrationRunner
+        });
+
+        builder.Services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<IConfigureOptions<WorkerOptions>, ConfigureInputConverter>());
+        if (!builder.Services.Any(d => d.ServiceType == typeof(DurableTaskFunctionsMiddleware)))
+        {
+            builder.UseMiddleware<DurableTaskFunctionsMiddleware>();
+        }
+
+        return builder;
+    }
+
+    private class ConfigureInputConverter : IConfigureOptions<WorkerOptions>
+    {
+        public void Configure(WorkerOptions options)
+        {
+            options.InputConverters.Register<OrchestrationInputConverter>();
+        }
+    }
+
+    private class ConfigureClientOptions : IConfigureOptions<DurableTaskClientOptions>
+    {
+        public void Configure(DurableTaskClientOptions options)
+        {
+            options.EnableEntitySupport = true;
+        }
+    }
+
+    private class PostConfigureClientOptions : IPostConfigureOptions<DurableTaskClientOptions>
+    {
+        readonly IOptionsMonitor<WorkerOptions> workerOptions;
+
+        public PostConfigureClientOptions(IOptionsMonitor<WorkerOptions> workerOptions)
+        {
+            this.workerOptions = workerOptions;
+        }
+
+        public void PostConfigure(string name, DurableTaskClientOptions options)
+        {
+            if (this.workerOptions.Get(name).Serializer is { } serializer)
+            {
+                options.DataConverter = new ObjectConverterShim(serializer);
+            }
+        }
+    }
+
+    private class ConfigureWorkerOptions : IConfigureOptions<DurableTaskWorkerOptions>
+    {
+        public void Configure(DurableTaskWorkerOptions options)
+        {
+            options.EnableEntitySupport = true;
+        }
+    }
+
+    private class PostConfigureWorkerOptions : IPostConfigureOptions<DurableTaskWorkerOptions>
+    {
+        readonly IOptionsMonitor<WorkerOptions> workerOptions;
+
+        public PostConfigureWorkerOptions(IOptionsMonitor<WorkerOptions> workerOptions)
+        {
+            this.workerOptions = workerOptions;
+        }
+
+        public void PostConfigure(string name, DurableTaskWorkerOptions options)
+        {
+            if (this.workerOptions.Get(name).Serializer is { } serializer)
+            {
+                options.DataConverter = new ObjectConverterShim(serializer);
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- Start the PR description with some context for the change. -->

This PR addresses an issue where registering the durable worker extension twice would break the extension. The extension registration has now been made idempotent and safe to call multiple times. Additionally, durable extension registration has been made available in an extension method off `IFunctionsWorkerApplicationBuilder` to simplify cases where auto-registration via source gen is not available.

<!-- Make sure to delete the markdown comments and the below sections when squash merging -->
### Issue describing the changes in this PR

resolves #2804

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)
* [x] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk
* [x] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
    * [ ] Otherwise: major or minor version updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
* [x] My changes **do not** add EventIds to our EventSource logs
    * [ ] Otherwise: Ensure the EventIds are within the supported range in our existing Windows infrastructure. You may validate this with a deployed app's telemetry. You may also extend the range by completing a PR such as [this one](https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files).
* [ ] My changes **should** be added to v3.x branch.
    * [ ] Otherwise: This change only applies to Durable Functions v2.x and **will not** be merged to branch v3.x.

