### PR TITLE
Increase DurableTask DotNet Dependency to v1.4.0 

### DIFF
--- a/src/Worker.Extensions.DurableTask/Worker.Extensions.DurableTask.csproj
+++ b/src/Worker.Extensions.DurableTask/Worker.Extensions.DurableTask.csproj
@@ -39,8 +39,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Core" Version="1.16.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Abstractions" Version="1.3.0" />
-    <PackageReference Include="Microsoft.DurableTask.Client.Grpc" Version="1.3.0" />
-    <PackageReference Include="Microsoft.DurableTask.Worker.Grpc" Version="1.3.0" />
+    <PackageReference Include="Microsoft.DurableTask.Client.Grpc" Version="1.4.0" />
+    <PackageReference Include="Microsoft.DurableTask.Worker.Grpc" Version="1.4.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
<!-- Start the PR description with some context for the change. -->


<!-- Make sure to delete the markdown comments and the below sections when squash merging -->

Increase durabletask dotnet dependencies version for worker extension v1.2.0 release. 
Microsoft.DurableTask.Client.Grpc 1.3.0 -> 1.4.0
Microsoft.DurableTask.Worker.Grpc 1.3.0 -> 1.4.0

resolves #issue_for_this_pr

### Pull request checklist

* [ ] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)
* [ ] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk
* [ ] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
    * [ ] Otherwise: major or minor version updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
* [ ] My changes **do not** add EventIds to our EventSource logs
    * [ ] Otherwise: Ensure the EventIds are within the supported range in our existing Windows infrastructure. You may validate this with a deployed app's telemetry. You may also extend the range by completing a PR such as [this one](https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files).
* [ ] My changes **should** be added to v3.x branch.
    * [ ] Otherwise: This change only applies to Durable Functions v2.x and **will not** be merged to branch v3.x.
