### PR TITLE
Use consistent scaler IDs for target-based and scale monitor implementations (v2)

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/AzureStorageDurabilityProvider.cs
+++ b/src/WebJobs.Extensions.DurableTask/AzureStorageDurabilityProvider.cs
@@ -243,6 +243,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             return new DurableTaskMetricsProvider(hubName, logger, performanceMonitor: null, storageAccount);
         }
 
+        // Common routine for getting the scaler ID. Note that we MUST use the same ID for both the
+        // scale monitor and the target scaler.
+        private static string GetScalerUniqueId(string hubName)
+        {
+            return $"DurableTask-AzureStorage:{hubName ?? "default"}";
+        }
+
         /// <inheritdoc/>
         public override bool TryGetScaleMonitor(
             string functionId,
@@ -255,11 +262,17 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             {
                 if (this.singletonScaleMonitor == null)
                 {
-                    CloudStorageAccount storageAccount = this.storageAccountProvider.GetStorageAccountDetails(connectionName).ToCloudStorageAccount();
-                    DurableTaskMetricsProvider metricsProvider = this.GetMetricsProvider(hubName, storageAccount, this.logger);
-                    this.singletonScaleMonitor = new DurableTaskScaleMonitor(
+                    DurableTaskMetricsProvider metricsProvider = this.GetMetricsProvider(
                         hubName,
-                        storageAccount,
+                        this.storageAccountProvider.GetStorageAccountDetails(connectionName).ToCloudStorageAccount(),
+                        this.logger);
+
+                    // Scalers in Durable Functions are shared for all functions in the same task hub.
+                    // So instead of using a function ID, we use the task hub name as the basis for the descriptor ID.
+                    string id = GetScalerUniqueId(hubName);
+                    this.singletonScaleMonitor = new DurableTaskScaleMonitor(
+                        id,
+                        hubName,
                         this.logger,
                         metricsProvider);
                 }
@@ -283,12 +296,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 if (this.singletonTargetScaler == null)
                 {
                     // This is only called by the ScaleController, it doesn't run in the Functions Host process.
-                    CloudStorageAccount storageAccount = this.storageAccountProvider.GetStorageAccountDetails(connectionName).ToCloudStorageAccount();
-                    DurableTaskMetricsProvider metricsProvider = this.GetMetricsProvider(hubName, storageAccount, this.logger);
+                    DurableTaskMetricsProvider metricsProvider = this.GetMetricsProvider(
+                        hubName,
+                        this.storageAccountProvider.GetStorageAccountDetails(connectionName).ToCloudStorageAccount(),
+                        this.logger);
 
                     // Scalers in Durable Functions are shared for all functions in the same task hub.
                     // So instead of using a function ID, we use the task hub name as the basis for the descriptor ID.
-                    string id = $"DurableTask-AzureStorage:{hubName ?? "default"}";
+                    string id = GetScalerUniqueId(hubName);
                     this.singletonTargetScaler = new DurableTaskTargetScaler(id, metricsProvider, this, this.logger);
                 }
 

--- a/src/WebJobs.Extensions.DurableTask/Listener/DurableTaskScaleMonitor.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/DurableTaskScaleMonitor.cs
@@ -9,7 +9,6 @@ using System.Threading.Tasks;
 using DurableTask.AzureStorage.Monitoring;
 using Microsoft.Azure.WebJobs.Host.Scale;
 using Microsoft.Extensions.Logging;
-using Microsoft.WindowsAzure.Storage;
 using Newtonsoft.Json;
 
 namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
@@ -17,27 +16,19 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
     internal sealed class DurableTaskScaleMonitor : IScaleMonitor<DurableTaskTriggerMetrics>
     {
         private readonly string hubName;
-        private readonly CloudStorageAccount storageAccount;
         private readonly ScaleMonitorDescriptor scaleMonitorDescriptor;
         private readonly ILogger logger;
         private readonly DurableTaskMetricsProvider durableTaskMetricsProvider;
 
-        private DisconnectedPerformanceMonitor performanceMonitor;
-
         public DurableTaskScaleMonitor(
+            string id,
             string hubName,
-            CloudStorageAccount storageAccount,
             ILogger logger,
-            DurableTaskMetricsProvider durableTaskMetricsProvider,
-            DisconnectedPerformanceMonitor performanceMonitor = null)
+            DurableTaskMetricsProvider durableTaskMetricsProvider)
         {
             this.hubName = hubName;
-            this.storageAccount = storageAccount;
             this.logger = logger;
-            this.performanceMonitor = performanceMonitor;
             this.durableTaskMetricsProvider = durableTaskMetricsProvider;
-
-            string id = $"DurableTaskTrigger-{this.hubName}".ToLower();
 #if FUNCTIONS_V3_OR_GREATER
             // Scalers in Durable Functions are shared for all functions in the same task hub.
             // So instead of using a function ID, we use the task hub name as the basis for the descriptor ID.


### PR DESCRIPTION
Fixes an issue in the Scale Controller where the scaler IDs were inconsistent between the target-based and scale monitor implementations, resulting in failures when trying to get scale metrics.

<!-- Make sure to delete the markdown comments and the below sections when squash merging -->
### Issue describing the changes in this PR

resolves #issue_for_this_pr

### Pull request checklist

* [ ] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)
* [ ] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk
* [ ] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
    * [ ] Otherwise: major or minor version updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
* [ ] My changes **do not** add EventIds to our EventSource logs
    * [ ] Otherwise: Ensure the EventIds are within the supported range in our existing Windows infrastructure. You may validate this with a deployed app's telemetry. You may also extend the range by completing a PR such as [this one](https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files).
* [ ] My changes **should** be added to v3.x branch.
    * [ ] Otherwise: This change only applies to Durable Functions v2.x and **will not** be merged to branch v3.x.
