### PR TITLE
Update release template (v2.x)

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-release-template.md
+++ b/.github/ISSUE_TEMPLATE/new-release-template.md
@@ -1,6 +1,6 @@
 ---
 name: New release template
-about: Template for creating new releases of Durable Functions (WebJobs and Worker extension)
+about: Template for creating new releases of Durable Functions
 title: ''
 labels: ''
 assignees: bachuv, nytiannn
@@ -41,6 +41,7 @@ _Due: <1-business-days-before-release>_
 
 **DTFx Release Completion (assigned to: )**
 _Due: <release-deadline>_
+- [ ] Add the DTFx packages to the [ADO feed](https://azfunc.visualstudio.com/internal/_artifacts/feed/durabletask-internal)
 - [ ] Upload DTFx packages to NuGet (directly to nuget.org).
 - [ ] Delete `Microsoft.DurableTask.Sidecar.Protobuf` from MyGet, and publish it to NuGet _iff_ it was updated as an Extension dependency. 
 - [ ] Publish release notes for DTFx.
@@ -48,12 +49,14 @@ _Due: <release-deadline>_
 
 **DotNet Isolated SDK Release Completion: (assigned to:)**
 _Due: <release-deadline>_
+- [ ] Add the .NET isolated SDK packages to the [ADO feed](https://azfunc.visualstudio.com/internal/_artifacts/feed/durabletask-internal)
 - [ ] Upload .NET isolated SDK packages to NuGet (directly to nuget.org).
 - [ ] Publish release notes in the durable-dotnet repo.
 
 **Release Completion (assigned to: )**
 _Due: <release-deadline>_
 - [ ] Run the [Durable Functions release pipeline](https://azfunc.visualstudio.com/internal/_build?definitionId=673) and select `v3.x` or `dev` as the branch. Choose `dev` if you are making a v2.x relese, otherwise choose v3.x.
+- [ ] Add the Durable Functions packages to the [ADO feed](https://azfunc.visualstudio.com/internal/_artifacts/feed/durabletask-internal)
 - [ ] Upload the Durable Functions package to NuGet (directly to nuget.org).
 - [ ] Upload .NET Isolated worker extension package to NuGet (directly to nuget.org).
 - [ ] Create a PR in the [Azure Functions templates repo](https://github.com/Azure/azure-functions-templates) targeting branch `dev` to update all references of "Microsoft.Azure.WebJobs.Extensions.DurableTask" (search for this string in the code) to the latest version.

--- a/.github/ISSUE_TEMPLATE/new-release-template.md
+++ b/.github/ISSUE_TEMPLATE/new-release-template.md
@@ -27,7 +27,7 @@ _Due: <2-business-days-before-release>_
 - [ ] Review the [Dependabot vulnerability alerts](https://github.com/Azure/azure-functions-durable-extension/security/dependabot) and address them. Note: code samples / test projects _may_ be excluded from this check.
 - [ ] Check for package size, make sure it's not surprisingly heavier than a previous release.
 - [ ] Update .NET Isolated SDK version at Worker.Extensions.Durabletask.csproj and check if we need to update the Worker.Extensions.Durabletask version.
-- [ ] Run [the extension release pipeline](https://azfunc.visualstudio.com/internal/_build?definitionId=673) to create the new package and add it to the [ADO test feed](https://azfunc.visualstudio.com/internal/_artifacts/feed/durabletask-internal) for testing.
+- [ ] Run [the extension release pipeline](https://azfunc.visualstudio.com/internal/_build?definitionId=673) to create the new WebJobs.Extensions.Durabletask and Worker.Extensions.Durabletask packages and add them to the [ADO test feed].(https://azfunc.visualstudio.com/internal/_artifacts/feed/durabletask-internal) for testing.
 - [ ] Keep branch `v2.x` updated with branch `dev` (v3.x). Do not merge PRs that are specific to Durable Functions v3.
 
 **Validation**

--- a/.github/ISSUE_TEMPLATE/new-release-template.md
+++ b/.github/ISSUE_TEMPLATE/new-release-template.md
@@ -41,8 +41,7 @@ _Due: <1-business-days-before-release>_
 **DTFx Release Completion (assigned to: )**
 _Due: <release-deadline>_
 - [ ] Add the DTFx packages to the [ADO feed](https://azfunc.visualstudio.com/internal/_artifacts/feed/durabletask-internal)
-- [ ] Upload DTFx packages to NuGet (directly to nuget.org).
-- [ ] Delete `Microsoft.DurableTask.Sidecar.Protobuf` from MyGet, and publish it to NuGet _iff_ it was updated as an Extension dependency. 
+- [ ] Upload DTFx packages to NuGet (directly to nuget.org). 
 - [ ] Publish release notes for DTFx.
 - [ ] Patch increment DTFx packages that were released (either DT-AzureStorage only or if there were Core changes DT-AzureStorage, DT-Core, and DT-ApplicationInsights) in WebJobs.Extensions.DurableTask.csproj
 
@@ -61,4 +60,3 @@ _Due: <release-deadline>_
 - [ ] Create a PR in the [Azure Functions templates repo](https://github.com/Azure/azure-functions-templates) targeting branch `dev` to update all references of "Microsoft.Azure.WebJobs.Extensions.DurableTask" (search for this string in the code) to the latest version.
 - [ ] _if and only if this is a new major release_, Create a PR in the [Azure Functions bundles repo](https://github.com/Azure/azure-functions-extension-bundles) to update bundles to the latest version .
 - [ ] Publish release notes.
-- [ ] Post announcement on Twitter (Chris).

--- a/.github/ISSUE_TEMPLATE/new-release-template.md
+++ b/.github/ISSUE_TEMPLATE/new-release-template.md
@@ -3,7 +3,7 @@ name: New release template
 about: Template for creating new releases of Durable Functions
 title: ''
 labels: ''
-assignees: bachuv, nytiannn
+assignees: bachuv, nytiannn, andystaples
 
 ---
 
@@ -28,12 +28,12 @@ _Due: <2-business-days-before-release>_
 - [ ] Check for package size, make sure it's not surprisingly heavier than a previous release.
 - [ ] Update .NET Isolated SDK version at Worker.Extensions.Durabletask.csproj and check if we need to update the Worker.Extensions.Durabletask version.
 - [ ] Run [the extension release pipeline](https://azfunc.visualstudio.com/internal/_build?definitionId=673) to create the new WebJobs.Extensions.Durabletask and Worker.Extensions.Durabletask packages and add them to the [ADO test feed].(https://azfunc.visualstudio.com/internal/_artifacts/feed/durabletask-internal) for testing.
-- [ ] Keep branch `v2.x` updated with branch `dev` (v3.x). Do not merge PRs that are specific to Durable Functions v3.
+- [ ] Cherry-pick any PRs that need to be in the `v2.x` branch
 
 **Validation**
 _Due: <1-business-days-before-release>_
 - [ ] Run private performance tests and ensure no regressions. **(assigned to: )**
-- [ ] Smoke test Functions V1, Functions V2, and Functions V3 .NET apps. **(assigned to: )**
+- [ ] Smoke test Functions V2, and Functions V3 .NET apps if you are releasing WebJobs.Extensions.DurableTask v2.x. **(assigned to: )**
 - [ ] Smoke test .NET apps with backend Netherite, MSSQL. **(assigned to: )**
 - [ ] Smoke test .NET isolated apps. **(assigned to: )** - check that the correct version of the webjobs extension is loaded by going to bin\Debug\net8.0\.azurefunctions\Microsoft.Azure.WebJobs.Extensions.DurableTask.dll, right click on Properties, go to the Details tab and check the version
 - [ ] Merge (**choose create a merge commit, NOT squash merge**) dev into main. Person performing validation must approve PR.
@@ -54,7 +54,7 @@ _Due: <release-deadline>_
 
 **Release Completion (assigned to: )**
 _Due: <release-deadline>_
-- [ ] Run the [Durable Functions release pipeline](https://azfunc.visualstudio.com/internal/_build?definitionId=673) and select `v3.x` or `dev` as the branch. Choose `dev` if you are making a v2.x relese, otherwise choose v3.x.
+- [ ] Run the [Durable Functions release pipeline](https://azfunc.visualstudio.com/internal/_build?definitionId=673) and select `dev` or `v2.x` as the branch. Choose `dev` if you are making a v3.x release, otherwise choose `v2.x` for a v2 release.
 - [ ] Add the Durable Functions packages to the [ADO feed](https://azfunc.visualstudio.com/internal/_artifacts/feed/durabletask-internal)
 - [ ] Upload the Durable Functions package to NuGet (directly to nuget.org).
 - [ ] Upload .NET Isolated worker extension package to NuGet (directly to nuget.org).

--- a/.github/ISSUE_TEMPLATE/new-release-template.md
+++ b/.github/ISSUE_TEMPLATE/new-release-template.md
@@ -1,9 +1,9 @@
 ---
 name: New release template
-about: Template for creating new releases of Durable Functions
+about: Template for creating new releases of Durable Functions (WebJobs and Worker extension)
 title: ''
 labels: ''
-assignees: davidmrdavid, bachuv, nytiannn
+assignees: bachuv, nytiannn
 
 ---
 
@@ -11,42 +11,40 @@ assignees: davidmrdavid, bachuv, nytiannn
 _Due: <2-3-business-days-before-release>_
 - [ ] Check DTFx package versions (either DT-AzureStorage only or if there were Core changes DT-AzureStorage, DT-Core, and DT-ApplicationInsights)
 - [ ] Review the [DTFx Dependabot vulnerability alerts](https://github.com/Azure/durabletask/security/dependabot) and address them. Note: code samples / test projects _may_ be excluded from this check.
-- [ ] Delete DTFx test packages from the [ADO feed](https://dev.azure.com/durabletaskframework/Durable%20Task%20Framework%20CI/_artifacts/feed/durabletask).
-- [ ] Run the [DTFx release pipeline](https://durabletaskframework.visualstudio.com/Durable%20Task%20Framework%20CI/_build?definitionId=21) ([defined here](https://github.com/Azure/durabletask/blob/main/azure-pipelines-release.yml)) to obtain new packages.
-- [ ] Publish DTFx packages to the [ADO feed](https://dev.azure.com/durabletaskframework/Durable%20Task%20Framework%20CI/_artifacts/feed/durabletask) for testing.
-- [ ] Keep branch `azure-storage-v12` updated with branch `main`.
+- [ ] Run the [DTFx release pipeline](https://azfunc.visualstudio.com/internal/_build?definitionId=640) ([defined here](https://github.com/Azure/durabletask/blob/main/eng/ci/official-build.yml)) to obtain new packages.
+- [ ] Publish DTFx packages to the [ADO test feed](https://azfunc.visualstudio.com/internal/_artifacts/feed/durabletask-test) for testing.
 
 **Prep DotNet Isolated SDK Release: (assigned to:)**
 _Due: <2-3-business-days-before-release>_
 - [ ] If there were DTFx.Core changes, check its reference version [here](https://github.com/microsoft/durabletask-dotnet/blob/c838535adb6aedb6671cf193389ce63a6b4a9b24/src/Abstractions/Abstractions.csproj#L10). If updates are required, document the changes in [release notes](https://github.com/microsoft/durabletask-dotnet/blob/c838535adb6aedb6671cf193389ce63a6b4a9b24/src/Abstractions/RELEASENOTES.md).
 - [ ] Check dotnet isolated SDK versions [here](https://github.com/microsoft/durabletask-dotnet/blob/c838535adb6aedb6671cf193389ce63a6b4a9b24/eng/targets/Release.props#L20). If updated, document the changes in the [change logs](https://github.com/microsoft/durabletask-dotnet/blob/c838535adb6aedb6671cf193389ce63a6b4a9b24/CHANGELOG.md).
-- [ ] Run pipeline [Release .Net out-of-proc SDK](https://durabletaskframework.visualstudio.com/Durable%20Task%20Framework%20CI/_build?definitionId=29) to create the new package and publish it to the ADO feed for testing.
+- [ ] Run pipeline [Release .Net out-of-proc SDK](https://azfunc.visualstudio.com/internal/_build?definitionId=657) to create the new package and publish it to the ADO feed for testing.
 
-**Prep Release (assigned to: )**
+**Prep WebJobs and Worker Extensions Release (assigned to: )**
 _Due: <2-business-days-before-release>_
 - [ ] Update DTFx packages and Analyzer versions at WebJobs.Extensions.Durabletask.csproj and check if we need to update the WebJobs.Extensions.Durabletask version.
 - [ ] Locally, run `dotnet list package --vulnerable` to ensure the release is not affected by any vulnerable dependencies.
 - [ ] Review the [Dependabot vulnerability alerts](https://github.com/Azure/azure-functions-durable-extension/security/dependabot) and address them. Note: code samples / test projects _may_ be excluded from this check.
-- [ ] Add the Durable Functions package to the [ADO test feed](https://dev.azure.com/durabletaskframework/Durable%20Task%20Framework%20CI/_artifacts/feed/durabletask-test).
 - [ ] Check for package size, make sure it's not surprisingly heavier than a previous release.
 - [ ] Update .NET Isolated SDK version at Worker.Extensions.Durabletask.csproj and check if we need to update the Worker.Extensions.Durabletask version.
-- [ ] Run pipeline [Release .Net Isolated Worker Extension](https://durabletaskframework.visualstudio.com/Durable%20Task%20Framework%20CI/_build?definitionId=30) to create the new package and add it to the ADO feed for testing.
-- [ ] Merge (**choose create a merge commit, NOT squash merge**) dev into main. Person performing validation must approve PR.
-- [ ] Keep branch `v3.x` updated with branch `dev`. Do not merge PRs that are specific to Durable Functions v2.
+- [ ] Run [the extension release pipeline](https://azfunc.visualstudio.com/internal/_build?definitionId=673) to create the new package and add it to the [ADO test feed](https://azfunc.visualstudio.com/internal/_artifacts/feed/durabletask-internal) for testing.
+- [ ] Keep branch `v2.x` updated with branch `dev` (v3.x). Do not merge PRs that are specific to Durable Functions v3.
 
 **Validation**
 _Due: <1-business-days-before-release>_
 - [ ] Run private performance tests and ensure no regressions. **(assigned to: )**
 - [ ] Smoke test Functions V1, Functions V2, and Functions V3 .NET apps. **(assigned to: )**
 - [ ] Smoke test .NET apps with backend Netherite, MSSQL. **(assigned to: )**
-- [ ] Smoke test .NET isolated apps. **(assigned to: )**
+- [ ] Smoke test .NET isolated apps. **(assigned to: )** - check that the correct version of the webjobs extension is loaded by going to bin\Debug\net8.0\.azurefunctions\Microsoft.Azure.WebJobs.Extensions.DurableTask.dll, right click on Properties, go to the Details tab and check the version
+- [ ] Merge (**choose create a merge commit, NOT squash merge**) dev into main. Person performing validation must approve PR.
+
 
 **DTFx Release Completion (assigned to: )**
 _Due: <release-deadline>_
 - [ ] Upload DTFx packages to NuGet (directly to nuget.org).
 - [ ] Delete `Microsoft.DurableTask.Sidecar.Protobuf` from MyGet, and publish it to NuGet _iff_ it was updated as an Extension dependency. 
 - [ ] Publish release notes for DTFx.
-- [ ] Patch increment DTFx packages that were released (either DT-AzureStorage only or if there were Core changes DT-AzureStorage, DT-Core, and DT-ApplicationInsights)
+- [ ] Patch increment DTFx packages that were released (either DT-AzureStorage only or if there were Core changes DT-AzureStorage, DT-Core, and DT-ApplicationInsights) in WebJobs.Extensions.DurableTask.csproj
 
 **DotNet Isolated SDK Release Completion: (assigned to:)**
 _Due: <release-deadline>_
@@ -55,15 +53,10 @@ _Due: <release-deadline>_
 
 **Release Completion (assigned to: )**
 _Due: <release-deadline>_
-- [ ] Delete Durable Functions packages from the [ADO test feed](https://dev.azure.com/durabletaskframework/Durable%20Task%20Framework%20CI/_artifacts/feed/durabletask-test).
-- [ ] Run the [Durable Functions release pipeline](https://dev.azure.com/durabletaskframework/Durable%20Task%20Framework%20CI/_build?definitionId=23) and select `main` as the branch.
-- [ ] Add the Durable Functions package to the [ADO feed](https://dev.azure.com/durabletaskframework/Durable%20Task%20Framework%20CI/_artifacts/feed/durabletask) using [this pipeline](https://dev.azure.com/durabletaskframework/Durable%20Task%20Framework%20CI/_release?_a=releases&view=mine&definitionId=11).
+- [ ] Run the [Durable Functions release pipeline](https://azfunc.visualstudio.com/internal/_build?definitionId=673) and select `v3.x` or `dev` as the branch. Choose `dev` if you are making a v2.x relese, otherwise choose v3.x.
 - [ ] Upload the Durable Functions package to NuGet (directly to nuget.org).
 - [ ] Upload .NET Isolated worker extension package to NuGet (directly to nuget.org).
 - [ ] Create a PR in the [Azure Functions templates repo](https://github.com/Azure/azure-functions-templates) targeting branch `dev` to update all references of "Microsoft.Azure.WebJobs.Extensions.DurableTask" (search for this string in the code) to the latest version.
 - [ ] _if and only if this is a new major release_, Create a PR in the [Azure Functions bundles repo](https://github.com/Azure/azure-functions-extension-bundles) to update bundles to the latest version .
-- [ ] Merge all pending PR docs from `pending_docs.md.`
-- [ ] Reset `pending_docs.md` and `release_notes.md` in the `dev` branch. You will want to save `release_notes.md` somewhere for when you publish release notes.
-- [ ] Publish release notes from the pre-reset `release_notes.md.`
+- [ ] Publish release notes.
 - [ ] Post announcement on Twitter (Chris).
-- [ ] Increment Durable Functions patch version.

--- a/.github/ISSUE_TEMPLATE/new-release-template.md
+++ b/.github/ISSUE_TEMPLATE/new-release-template.md
@@ -33,8 +33,6 @@ _Due: <2-business-days-before-release>_
 **Validation**
 _Due: <1-business-days-before-release>_
 - [ ] Run private performance tests and ensure no regressions. **(assigned to: )**
-- [ ] Smoke test Functions V2 and Functions V3 .NET apps if you are releasing WebJobs.Extensions.DurableTask v2.x. **(assigned to: )**
-- [ ] Smoke test .NET apps with backend Netherite, MSSQL. **(assigned to: )**
 - [ ] Smoke test .NET isolated apps. **(assigned to: )** - check that the correct version of the webjobs extension is loaded by going to bin\Debug\net8.0\.azurefunctions\Microsoft.Azure.WebJobs.Extensions.DurableTask.dll, right click on Properties, go to the Details tab and check the version
 - [ ] Merge (**choose create a merge commit, NOT squash merge**) dev into main. Person performing validation must approve PR.
 

--- a/.github/ISSUE_TEMPLATE/new-release-template.md
+++ b/.github/ISSUE_TEMPLATE/new-release-template.md
@@ -33,7 +33,7 @@ _Due: <2-business-days-before-release>_
 **Validation**
 _Due: <1-business-days-before-release>_
 - [ ] Run private performance tests and ensure no regressions. **(assigned to: )**
-- [ ] Smoke test Functions V2, and Functions V3 .NET apps if you are releasing WebJobs.Extensions.DurableTask v2.x. **(assigned to: )**
+- [ ] Smoke test Functions V2 and Functions V3 .NET apps if you are releasing WebJobs.Extensions.DurableTask v2.x. **(assigned to: )**
 - [ ] Smoke test .NET apps with backend Netherite, MSSQL. **(assigned to: )**
 - [ ] Smoke test .NET isolated apps. **(assigned to: )** - check that the correct version of the webjobs extension is loaded by going to bin\Debug\net8.0\.azurefunctions\Microsoft.Azure.WebJobs.Extensions.DurableTask.dll, right click on Properties, go to the Details tab and check the version
 - [ ] Merge (**choose create a merge commit, NOT squash merge**) dev into main. Person performing validation must approve PR.
@@ -54,7 +54,7 @@ _Due: <release-deadline>_
 
 **Release Completion (assigned to: )**
 _Due: <release-deadline>_
-- [ ] Run the [Durable Functions release pipeline](https://azfunc.visualstudio.com/internal/_build?definitionId=673) and select `dev` or `v2.x` as the branch. Choose `dev` if you are making a v3.x release, otherwise choose `v2.x` for a v2 release.
+- [ ] Run the [Durable Functions release pipeline](https://azfunc.visualstudio.com/internal/_build?definitionId=673) and select `dev` or `v2.x` as the branch. Choose `dev` if you are making a v3.x release, otherwise choose `v2.x` for a v2.x release.
 - [ ] Add the Durable Functions packages to the [ADO feed](https://azfunc.visualstudio.com/internal/_artifacts/feed/durabletask-internal)
 - [ ] Upload the Durable Functions package to NuGet (directly to nuget.org).
 - [ ] Upload .NET Isolated worker extension package to NuGet (directly to nuget.org).

--- a/.github/ISSUE_TEMPLATE/new-release-template.md
+++ b/.github/ISSUE_TEMPLATE/new-release-template.md
@@ -38,7 +38,6 @@ _Due: <1-business-days-before-release>_
 - [ ] Smoke test .NET isolated apps. **(assigned to: )** - check that the correct version of the webjobs extension is loaded by going to bin\Debug\net8.0\.azurefunctions\Microsoft.Azure.WebJobs.Extensions.DurableTask.dll, right click on Properties, go to the Details tab and check the version
 - [ ] Merge (**choose create a merge commit, NOT squash merge**) dev into main. Person performing validation must approve PR.
 
-
 **DTFx Release Completion (assigned to: )**
 _Due: <release-deadline>_
 - [ ] Add the DTFx packages to the [ADO feed](https://azfunc.visualstudio.com/internal/_artifacts/feed/durabletask-internal)


### PR DESCRIPTION
This PR makes updates to our release issue template.

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)
* [x] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk
* [x] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
    * [ ] Otherwise: major or minor version updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
* [x] My changes **do not** add EventIds to our EventSource logs
    * [ ] Otherwise: Ensure the EventIds are within the supported range in our existing Windows infrastructure. You may validate this with a deployed app's telemetry. You may also extend the range by completing a PR such as [this one](https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files).
* [x] My changes **should** be added to v3.x branch.
    * [ ] Otherwise: This change only applies to Durable Functions v2.x and **will not** be merged to branch v3.x.
