### PR TITLE
Add test for orchestrator termination

### DIFF
--- a/test/e2e/Apps/BasicDotNetIsolated/TerminateOrchestration.cs
+++ b/test/e2e/Apps/BasicDotNetIsolated/TerminateOrchestration.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System.Net;
+using Grpc.Core;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.DurableTask;
@@ -46,25 +48,33 @@ namespace Microsoft.Azure.Durable.Tests.E2E
         {
             ILogger logger = executionContext.GetLogger("LongOrchestrator_HttpStart");
 
-            // Function input comes from the request content.
             string instanceId = await client.ScheduleNewOrchestrationInstanceAsync(
                 nameof(LongRunningOrchestrator));
 
             logger.LogInformation("Started orchestration with ID = '{instanceId}'.", instanceId);
-
-            // Returns an HTTP 202 response with an instance management payload.
-            // See https://learn.microsoft.com/azure/azure-functions/durable/durable-functions-http-api#start-orchestration
+            
             return await client.CreateCheckStatusResponseAsync(req, instanceId);
         }
 
         [Function("TerminateInstance")]
-        public static Task Run(
+        public static async Task<HttpResponseData> Run(
             [HttpTrigger(AuthorizationLevel.Anonymous, "get", "post")] HttpRequestData req,
             [DurableClient] DurableTaskClient client,
             string instanceId)
         {
             string reason = "Long-running orchestration was terminated early.";
-            return client.TerminateInstanceAsync(instanceId, reason);
+            try 
+            {
+                await client.TerminateInstanceAsync(instanceId, reason);
+                return req.CreateResponse(HttpStatusCode.OK);
+            }
+            catch (RpcException ex) 
+            {
+                var response = req.CreateResponse(HttpStatusCode.BadRequest);
+                response.Headers.Add("Content-Type", "text/plain");
+                await response.WriteStringAsync(ex.Message);
+                return response;
+            }
         }
     }
 }

--- a/test/e2e/Apps/BasicDotNetIsolated/TerminateOrchestration.cs
+++ b/test/e2e/Apps/BasicDotNetIsolated/TerminateOrchestration.cs
@@ -1,0 +1,70 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
+using Microsoft.DurableTask;
+using Microsoft.DurableTask.Client;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Azure.Durable.Tests.E2E
+{
+    public static class LongRunningOrchestration
+    {
+        [Function(nameof(LongRunningOrchestrator))]
+        public static async Task<List<string>> LongRunningOrchestrator(
+            [OrchestrationTrigger] TaskOrchestrationContext context)
+        {
+            ILogger logger = context.CreateReplaySafeLogger(nameof(HelloCities));
+            logger.LogInformation("Starting long-running orchestration.");
+            var outputs = new List<string>();
+
+            // Call our fake activity 100,000 times to simulate an orchestration that might run for >= 10,000s (2.7 hours)
+            for (int i = 0; i < 100000; i++) 
+            {
+                outputs.Add(await context.CallActivityAsync<string>(nameof(SimulatedWorkActivity), 100));
+            }
+
+            return outputs;
+        }
+
+        [Function(nameof(SimulatedWorkActivity))]
+        public static string SimulatedWorkActivity([ActivityTrigger]int sleepMs, FunctionContext executionContext)
+        {
+            // Sleep the provided number of ms to simulate a long-running activity operation
+            ILogger logger = executionContext.GetLogger("SimulatedWorkActivity");
+            logger.LogInformation("Sleeping for {sleepMs}ms.", sleepMs);
+            Thread.Sleep(sleepMs);
+            return $"Slept for {sleepMs}ms.";
+        }
+
+        [Function("LongOrchestrator_HttpStart")]
+        public static async Task<HttpResponseData> HttpStart(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "get", "post")] HttpRequestData req,
+            [DurableClient] DurableTaskClient client,
+            FunctionContext executionContext)
+        {
+            ILogger logger = executionContext.GetLogger("LongOrchestrator_HttpStart");
+
+            // Function input comes from the request content.
+            string instanceId = await client.ScheduleNewOrchestrationInstanceAsync(
+                nameof(LongRunningOrchestrator));
+
+            logger.LogInformation("Started orchestration with ID = '{instanceId}'.", instanceId);
+
+            // Returns an HTTP 202 response with an instance management payload.
+            // See https://learn.microsoft.com/azure/azure-functions/durable/durable-functions-http-api#start-orchestration
+            return await client.CreateCheckStatusResponseAsync(req, instanceId);
+        }
+
+        [Function("TerminateInstance")]
+        public static Task Run(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "get", "post")] HttpRequestData req,
+            [DurableClient] DurableTaskClient client,
+            string instanceId)
+        {
+            string reason = "Long-running orchestration was terminated early.";
+            return client.TerminateInstanceAsync(instanceId, reason);
+        }
+    }
+}

--- a/test/e2e/Tests/Helpers/DurableHelpers.cs
+++ b/test/e2e/Tests/Helpers/DurableHelpers.cs
@@ -31,6 +31,27 @@ internal class DurableHelpers
         }
     }
 
+    internal static async Task<string> ParseStatusQueryGetUriAsync(HttpResponseMessage invocationStartResponse)
+    {
+        string? responseString = await invocationStartResponse.Content.ReadAsStringAsync();
+        return TokenizeAndGetValueFromKeyAsString(responseString, "StatusQueryGetUri");
+    }
+
+    internal static async Task<string> ParseInstanceIdAsync(HttpResponseMessage invocationStartResponse)
+    {
+        string? responseString = await invocationStartResponse.Content.ReadAsStringAsync();
+        return TokenizeAndGetValueFromKeyAsString(responseString, "Id");
+    }
+
+    internal static async Task<OrchestrationStatusDetails> GetRunningOrchestrationDetailsAsync(string statusQueryGetUri)
+    {
+        var statusQueryResponse = await _httpClient.GetAsync(statusQueryGetUri);
+
+        string? statusQueryResponseString = await statusQueryResponse.Content.ReadAsStringAsync();
+
+        return new OrchestrationStatusDetails(statusQueryResponseString);
+    }
+
     private static string TokenizeAndGetValueFromKeyAsString(string? json, string key)
     {
         if (string.IsNullOrEmpty(json))
@@ -45,26 +66,5 @@ internal class DurableHelpers
 
         string? statusQueryGetUri = responseJsonNode[key]?.GetValue<string>();
         return statusQueryGetUri ?? string.Empty;
-    }
-
-    internal static async Task<string> ParseStatusQueryGetUri(HttpResponseMessage invocationStartResponse)
-    {
-        string? responseString = await invocationStartResponse.Content.ReadAsStringAsync();
-        return TokenizeAndGetValueFromKeyAsString(responseString, "StatusQueryGetUri");
-    }
-
-    internal static async Task<string> ParseInstanceId(HttpResponseMessage invocationStartResponse)
-    {
-        string? responseString = await invocationStartResponse.Content.ReadAsStringAsync();
-        return TokenizeAndGetValueFromKeyAsString(responseString, "Id");
-    }
-
-    internal static async Task<OrchestrationStatusDetails> GetRunningOrchestrationDetails(string statusQueryGetUri)
-    {
-        var statusQueryResponse = await _httpClient.GetAsync(statusQueryGetUri);
-
-        string? statusQueryResponseString = statusQueryResponse.Content.ReadAsStringAsync().Result;
-
-        return new OrchestrationStatusDetails(statusQueryResponseString);
     }
 }

--- a/test/e2e/Tests/Helpers/DurableHelpers.cs
+++ b/test/e2e/Tests/Helpers/DurableHelpers.cs
@@ -47,23 +47,23 @@ internal class DurableHelpers
         return statusQueryGetUri ?? string.Empty;
     }
 
-    internal static string ParseStatusQueryGetUri(HttpResponseMessage invocationStartResponse)
+    internal static async Task<string> ParseStatusQueryGetUri(HttpResponseMessage invocationStartResponse)
     {
-        string? responseString = invocationStartResponse.Content?.ReadAsStringAsync().Result;
+        string? responseString = await invocationStartResponse.Content.ReadAsStringAsync();
         return TokenizeAndGetValueFromKeyAsString(responseString, "StatusQueryGetUri");
     }
 
-    internal static string ParseInstanceId(HttpResponseMessage invocationStartResponse)
+    internal static async Task<string> ParseInstanceId(HttpResponseMessage invocationStartResponse)
     {
-        string? responseString = invocationStartResponse.Content?.ReadAsStringAsync().Result;
+        string? responseString = await invocationStartResponse.Content.ReadAsStringAsync();
         return TokenizeAndGetValueFromKeyAsString(responseString, "Id");
     }
 
-    internal static OrchestrationStatusDetails GetRunningOrchestrationDetails(string statusQueryGetUri)
+    internal static async Task<OrchestrationStatusDetails> GetRunningOrchestrationDetails(string statusQueryGetUri)
     {
-        var statusQueryResponse = _httpClient.GetAsync(statusQueryGetUri);
+        var statusQueryResponse = await _httpClient.GetAsync(statusQueryGetUri);
 
-        string? statusQueryResponseString = statusQueryResponse.Result.Content.ReadAsStringAsync().Result;
+        string? statusQueryResponseString = statusQueryResponse.Content.ReadAsStringAsync().Result;
 
         return new OrchestrationStatusDetails(statusQueryResponseString);
     }

--- a/test/e2e/Tests/Helpers/DurableHelpers.cs
+++ b/test/e2e/Tests/Helpers/DurableHelpers.cs
@@ -31,23 +31,34 @@ internal class DurableHelpers
         }
     }
 
-    internal static string ParseStatusQueryGetUri(HttpResponseMessage invocationStartResponse)
+    private static string TokenizeAndGetValueFromKeyAsString(string? json, string key)
     {
-        string? responseString = invocationStartResponse.Content?.ReadAsStringAsync().Result;
-
-        if (string.IsNullOrEmpty(responseString))
+        if (string.IsNullOrEmpty(json))
         {
             return string.Empty;
         }
-        JsonNode? responseJsonNode = JsonNode.Parse(responseString);
+        JsonNode? responseJsonNode = JsonNode.Parse(json);
         if (responseJsonNode == null)
         {
             return string.Empty;
         }
 
-        string? statusQueryGetUri = responseJsonNode["StatusQueryGetUri"]?.GetValue<string>();
+        string? statusQueryGetUri = responseJsonNode[key]?.GetValue<string>();
         return statusQueryGetUri ?? string.Empty;
     }
+
+    internal static string ParseStatusQueryGetUri(HttpResponseMessage invocationStartResponse)
+    {
+        string? responseString = invocationStartResponse.Content?.ReadAsStringAsync().Result;
+        return TokenizeAndGetValueFromKeyAsString(responseString, "StatusQueryGetUri");
+    }
+
+    internal static string ParseInstanceId(HttpResponseMessage invocationStartResponse)
+    {
+        string? responseString = invocationStartResponse.Content?.ReadAsStringAsync().Result;
+        return TokenizeAndGetValueFromKeyAsString(responseString, "Id");
+    }
+
     internal static OrchestrationStatusDetails GetRunningOrchestrationDetails(string statusQueryGetUri)
     {
         var statusQueryResponse = _httpClient.GetAsync(statusQueryGetUri);

--- a/test/e2e/Tests/Tests/HelloCitiesTest.cs
+++ b/test/e2e/Tests/Tests/HelloCitiesTest.cs
@@ -42,9 +42,9 @@ public class HttpEndToEndTests
         string actualMessage = await response.Content.ReadAsStringAsync();
 
         Assert.Equal(expectedStatusCode, response.StatusCode);
-        string statusQueryGetUri = await DurableHelpers.ParseStatusQueryGetUri(response);
+        string statusQueryGetUri = await DurableHelpers.ParseStatusQueryGetUriAsync(response);
         Thread.Sleep(1000);
-        var orchestrationDetails = await DurableHelpers.GetRunningOrchestrationDetails(statusQueryGetUri);
+        var orchestrationDetails = await DurableHelpers.GetRunningOrchestrationDetailsAsync(statusQueryGetUri);
         Assert.Equal("Completed", orchestrationDetails.RuntimeStatus);
         Assert.Contains(partialExpectedOutput, orchestrationDetails.Output);
     }
@@ -61,15 +61,15 @@ public class HttpEndToEndTests
         using HttpResponseMessage response = await HttpHelpers.InvokeHttpTrigger(functionName, urlQueryString);
         string actualMessage = await response.Content.ReadAsStringAsync();
 
-        string statusQueryGetUri = await DurableHelpers.ParseStatusQueryGetUri(response);
+        string statusQueryGetUri = await DurableHelpers.ParseStatusQueryGetUriAsync(response);
 
         Assert.Equal(expectedStatusCode, response.StatusCode);
 
-        var orchestrationDetails = await DurableHelpers.GetRunningOrchestrationDetails(statusQueryGetUri);
+        var orchestrationDetails = await DurableHelpers.GetRunningOrchestrationDetailsAsync(statusQueryGetUri);
         while (DateTime.UtcNow < scheduledStartTime + TimeSpan.FromSeconds(-1))
         {
             WriteOutput($"Test scheduled for {scheduledStartTime}, current time {DateTime.Now}");
-            orchestrationDetails = await DurableHelpers.GetRunningOrchestrationDetails(statusQueryGetUri);
+            orchestrationDetails = await DurableHelpers.GetRunningOrchestrationDetailsAsync(statusQueryGetUri);
             Assert.Equal("Pending", orchestrationDetails.RuntimeStatus);
             Thread.Sleep(1000);
         }
@@ -77,12 +77,12 @@ public class HttpEndToEndTests
         // Give a small amount of time for the orchestration to complete, even if scheduled to run immediately
         Thread.Sleep(3000);
         WriteOutput($"Test scheduled for {scheduledStartTime}, current time {DateTime.Now}, looking for completed");
-        var finalOrchestrationDetails = await DurableHelpers.GetRunningOrchestrationDetails(statusQueryGetUri);
+        var finalOrchestrationDetails = await DurableHelpers.GetRunningOrchestrationDetailsAsync(statusQueryGetUri);
         int retryAttempts = 0;
         while (finalOrchestrationDetails.RuntimeStatus != "Completed" && retryAttempts < 10)
         {
             Thread.Sleep(1000);
-            finalOrchestrationDetails = await DurableHelpers.GetRunningOrchestrationDetails(statusQueryGetUri);
+            finalOrchestrationDetails = await DurableHelpers.GetRunningOrchestrationDetailsAsync(statusQueryGetUri);
             retryAttempts++;
         }
         Assert.Equal("Completed", finalOrchestrationDetails.RuntimeStatus);

--- a/test/e2e/Tests/Tests/HelloCitiesTest.cs
+++ b/test/e2e/Tests/Tests/HelloCitiesTest.cs
@@ -42,9 +42,9 @@ public class HttpEndToEndTests
         string actualMessage = await response.Content.ReadAsStringAsync();
 
         Assert.Equal(expectedStatusCode, response.StatusCode);
-        string statusQueryGetUri = DurableHelpers.ParseStatusQueryGetUri(response);
+        string statusQueryGetUri = await DurableHelpers.ParseStatusQueryGetUri(response);
         Thread.Sleep(1000);
-        var orchestrationDetails = DurableHelpers.GetRunningOrchestrationDetails(statusQueryGetUri);
+        var orchestrationDetails = await DurableHelpers.GetRunningOrchestrationDetails(statusQueryGetUri);
         Assert.Equal("Completed", orchestrationDetails.RuntimeStatus);
         Assert.Contains(partialExpectedOutput, orchestrationDetails.Output);
     }

--- a/test/e2e/Tests/Tests/HelloCitiesTest.cs
+++ b/test/e2e/Tests/Tests/HelloCitiesTest.cs
@@ -61,15 +61,15 @@ public class HttpEndToEndTests
         using HttpResponseMessage response = await HttpHelpers.InvokeHttpTrigger(functionName, urlQueryString);
         string actualMessage = await response.Content.ReadAsStringAsync();
 
-        string statusQueryGetUri = DurableHelpers.ParseStatusQueryGetUri(response);
+        string statusQueryGetUri = await DurableHelpers.ParseStatusQueryGetUri(response);
 
         Assert.Equal(expectedStatusCode, response.StatusCode);
 
-        var orchestrationDetails = DurableHelpers.GetRunningOrchestrationDetails(statusQueryGetUri);
+        var orchestrationDetails = await DurableHelpers.GetRunningOrchestrationDetails(statusQueryGetUri);
         while (DateTime.UtcNow < scheduledStartTime + TimeSpan.FromSeconds(-1))
         {
             WriteOutput($"Test scheduled for {scheduledStartTime}, current time {DateTime.Now}");
-            orchestrationDetails = DurableHelpers.GetRunningOrchestrationDetails(statusQueryGetUri);
+            orchestrationDetails = await DurableHelpers.GetRunningOrchestrationDetails(statusQueryGetUri);
             Assert.Equal("Pending", orchestrationDetails.RuntimeStatus);
             Thread.Sleep(1000);
         }
@@ -77,12 +77,12 @@ public class HttpEndToEndTests
         // Give a small amount of time for the orchestration to complete, even if scheduled to run immediately
         Thread.Sleep(3000);
         WriteOutput($"Test scheduled for {scheduledStartTime}, current time {DateTime.Now}, looking for completed");
-        var finalOrchestrationDetails = DurableHelpers.GetRunningOrchestrationDetails(statusQueryGetUri);
+        var finalOrchestrationDetails = await DurableHelpers.GetRunningOrchestrationDetails(statusQueryGetUri);
         int retryAttempts = 0;
         while (finalOrchestrationDetails.RuntimeStatus != "Completed" && retryAttempts < 10)
         {
             Thread.Sleep(1000);
-            finalOrchestrationDetails = DurableHelpers.GetRunningOrchestrationDetails(statusQueryGetUri);
+            finalOrchestrationDetails = await DurableHelpers.GetRunningOrchestrationDetails(statusQueryGetUri);
             retryAttempts++;
         }
         Assert.Equal("Completed", finalOrchestrationDetails.RuntimeStatus);

--- a/test/e2e/Tests/Tests/TerminateOrchestratorTests.cs
+++ b/test/e2e/Tests/Tests/TerminateOrchestratorTests.cs
@@ -139,6 +139,7 @@ public class TerminateOrchestratorTests
 
         string? terminateResponseMessage = await terminateResponse.Content.ReadAsStringAsync();
         Assert.NotNull(terminateResponseMessage);
+        // Unclear error message - see https://github.com/Azure/azure-functions-durable-extension/issues/3027, will update this code when that bug is fixed
         Assert.Equal("Status(StatusCode=\"Unknown\", Detail=\"Exception was thrown by handler.\")", terminateResponseMessage);
     }
 

--- a/test/e2e/Tests/Tests/TerminateOrchestratorTests.cs
+++ b/test/e2e/Tests/Tests/TerminateOrchestratorTests.cs
@@ -20,28 +20,15 @@ public class TerminateOrchestratorTests
         _output = testOutputHelper;
     }
 
-    // Due to some kind of asynchronous race condition in XUnit, when running these tests in pipelines,
-    // the output may be disposed before the message is written. Just ignore these types of errors for now. 
-    private void WriteOutput(string message)
-    {
-        try
-        {
-            _output.WriteLine(message);
-        }
-        catch
-        {
-            // Ignore
-        }
-    }
 
     [Theory]
-    [InlineData("LongOrchestrator_HttpStart", HttpStatusCode.Accepted)]
-    public async Task HttpTriggerTests(string functionName, HttpStatusCode expectedStatusCode)
+    [InlineData("LongOrchestrator_HttpStart")]
+    public async Task TerminateRunningOrchestration_ShouldSucceed(string functionName)
     {
         using HttpResponseMessage response = await HttpHelpers.InvokeHttpTrigger(functionName, "");
         string actualMessage = await response.Content.ReadAsStringAsync();
 
-        Assert.Equal(expectedStatusCode, response.StatusCode);
+        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
         string instanceId = DurableHelpers.ParseInstanceId(response);
         string statusQueryGetUri = DurableHelpers.ParseStatusQueryGetUri(response);
 
@@ -53,7 +40,7 @@ public class TerminateOrchestratorTests
         using HttpResponseMessage terminateResponse = await HttpHelpers.InvokeHttpTrigger("TerminateInstance", $"?instanceId={instanceId}");
         Assert.Equal(HttpStatusCode.OK, terminateResponse.StatusCode);
 
-        string? terminateResponseMessage = terminateResponse.Content?.ReadAsStringAsync().Result;
+        string? terminateResponseMessage = await terminateResponse.Content.ReadAsStringAsync();
         Assert.NotNull(terminateResponseMessage);
         Assert.Empty(terminateResponseMessage);
 

--- a/test/e2e/Tests/Tests/TerminateOrchestratorTests.cs
+++ b/test/e2e/Tests/Tests/TerminateOrchestratorTests.cs
@@ -34,7 +34,7 @@ public class TerminateOrchestratorTests
 
         Thread.Sleep(1000);
 
-        var orchestrationDetails = DurableHelpers.GetRunningOrchestrationDetails(statusQueryGetUri);
+        var orchestrationDetails = await DurableHelpers.GetRunningOrchestrationDetails(statusQueryGetUri);
         Assert.Equal("Running", orchestrationDetails.RuntimeStatus);
 
         using HttpResponseMessage terminateResponse = await HttpHelpers.InvokeHttpTrigger("TerminateInstance", $"?instanceId={instanceId}");
@@ -46,7 +46,7 @@ public class TerminateOrchestratorTests
 
         Thread.Sleep(1000);
 
-        orchestrationDetails = DurableHelpers.GetRunningOrchestrationDetails(statusQueryGetUri);
+        orchestrationDetails = await DurableHelpers.GetRunningOrchestrationDetails(statusQueryGetUri);
         Assert.Equal("Terminated", orchestrationDetails.RuntimeStatus);
     }
 }

--- a/test/e2e/Tests/Tests/TerminateOrchestratorTests.cs
+++ b/test/e2e/Tests/Tests/TerminateOrchestratorTests.cs
@@ -29,8 +29,8 @@ public class TerminateOrchestratorTests
         string actualMessage = await response.Content.ReadAsStringAsync();
 
         Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
-        string instanceId = DurableHelpers.ParseInstanceId(response);
-        string statusQueryGetUri = DurableHelpers.ParseStatusQueryGetUri(response);
+        string instanceId = await DurableHelpers.ParseInstanceId(response);
+        string statusQueryGetUri = await DurableHelpers.ParseStatusQueryGetUri(response);
 
         Thread.Sleep(1000);
 

--- a/test/e2e/Tests/Tests/TerminateOrchestratorTests.cs
+++ b/test/e2e/Tests/Tests/TerminateOrchestratorTests.cs
@@ -20,13 +20,29 @@ public class TerminateOrchestratorTests
         _output = testOutputHelper;
     }
 
-
-    [Theory]
-    [InlineData("LongOrchestrator_HttpStart")]
-    public async Task TerminateRunningOrchestration_ShouldSucceed(string functionName)
+    private static async Task AssertTerminateRequestFails(HttpResponseMessage terminateResponse)
     {
-        using HttpResponseMessage response = await HttpHelpers.InvokeHttpTrigger(functionName, "");
-        string actualMessage = await response.Content.ReadAsStringAsync();
+        Assert.Equal(HttpStatusCode.BadRequest, terminateResponse.StatusCode);
+
+        string? terminateResponseMessage = await terminateResponse.Content.ReadAsStringAsync();
+        Assert.NotNull(terminateResponseMessage);
+        Assert.Equal("Status(StatusCode=\"Unknown\", Detail=\"Exception was thrown by handler.\")", terminateResponseMessage);
+    }
+
+    private static async Task AssertTerminateRequestSucceeds(HttpResponseMessage terminateResponse)
+    {
+        Assert.Equal(HttpStatusCode.OK, terminateResponse.StatusCode);
+
+        string? terminateResponseMessage = await terminateResponse.Content.ReadAsStringAsync();
+        Assert.NotNull(terminateResponseMessage);
+        Assert.Empty(terminateResponseMessage);
+    }
+
+
+    [Fact]
+    public async Task TerminateRunningOrchestration_ShouldSucceed()
+    {
+        using HttpResponseMessage response = await HttpHelpers.InvokeHttpTrigger("LongOrchestrator_HttpStart", "");
 
         Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
         string instanceId = await DurableHelpers.ParseInstanceId(response);
@@ -38,6 +54,33 @@ public class TerminateOrchestratorTests
         Assert.Equal("Running", orchestrationDetails.RuntimeStatus);
 
         using HttpResponseMessage terminateResponse = await HttpHelpers.InvokeHttpTrigger("TerminateInstance", $"?instanceId={instanceId}");
+        await AssertTerminateRequestSucceeds(terminateResponse);
+
+        Thread.Sleep(1000);
+
+        orchestrationDetails = await DurableHelpers.GetRunningOrchestrationDetails(statusQueryGetUri);
+        Assert.Equal("Terminated", orchestrationDetails.RuntimeStatus);
+    }
+
+
+    // This test is likely exposing some unintended behavior. Currently, attempting to terminate scheduled orchestrations has no effect.
+    // If the behavior of Terminate is changed to accomodate terminating scheduled orchestrations, this test will need to be modified accordingly.
+    [Fact]
+    public async Task TerminateScheduledOrchestration_ShouldDoNothing()
+    {
+        DateTime scheduledStartTime = DateTime.UtcNow + TimeSpan.FromMinutes(1);
+        using HttpResponseMessage response = await HttpHelpers.InvokeHttpTrigger("HelloCities_HttpStart_Scheduled", $"?scheduledStartTime={scheduledStartTime.ToString("o")}");
+
+        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
+        string instanceId = await DurableHelpers.ParseInstanceId(response);
+        string statusQueryGetUri = await DurableHelpers.ParseStatusQueryGetUri(response);
+
+        Thread.Sleep(1000);
+
+        var orchestrationDetails = await DurableHelpers.GetRunningOrchestrationDetails(statusQueryGetUri);
+        Assert.Equal("Pending", orchestrationDetails.RuntimeStatus);
+
+        using HttpResponseMessage terminateResponse = await HttpHelpers.InvokeHttpTrigger("TerminateInstance", $"?instanceId={instanceId}");
         Assert.Equal(HttpStatusCode.OK, terminateResponse.StatusCode);
 
         string? terminateResponseMessage = await terminateResponse.Content.ReadAsStringAsync();
@@ -47,6 +90,70 @@ public class TerminateOrchestratorTests
         Thread.Sleep(1000);
 
         orchestrationDetails = await DurableHelpers.GetRunningOrchestrationDetails(statusQueryGetUri);
+        Assert.Equal("Pending", orchestrationDetails.RuntimeStatus);
+    }
+
+
+    [Fact]
+    public async Task TerminateTerminatedOrchestration_ShouldFail()
+    {
+        using HttpResponseMessage response = await HttpHelpers.InvokeHttpTrigger("LongOrchestrator_HttpStart", "");
+
+        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
+        string instanceId = await DurableHelpers.ParseInstanceId(response);
+        string statusQueryGetUri = await DurableHelpers.ParseStatusQueryGetUri(response);
+
+        Thread.Sleep(1000);
+
+        var orchestrationDetails = await DurableHelpers.GetRunningOrchestrationDetails(statusQueryGetUri);
+        Assert.Equal("Running", orchestrationDetails.RuntimeStatus);
+
+        using HttpResponseMessage terminateResponse = await HttpHelpers.InvokeHttpTrigger("TerminateInstance", $"?instanceId={instanceId}");
+        await AssertTerminateRequestSucceeds(terminateResponse);
+
+        Thread.Sleep(1000);
+        using HttpResponseMessage terminateAgainResponse = await HttpHelpers.InvokeHttpTrigger("TerminateInstance", $"?instanceId={instanceId}");
+        await AssertTerminateRequestFails(terminateAgainResponse);
+
+        // Give some time for Core Tools to write logs out
+        Thread.Sleep(500);
+
+        Assert.Contains(_fixture.TestLogs.CoreToolsLogs, x => x.Contains("Cannot terminate orchestration instance in the Terminated state.") &&
+                                                              x.Contains(instanceId));
+
+        orchestrationDetails = await DurableHelpers.GetRunningOrchestrationDetails(statusQueryGetUri);
         Assert.Equal("Terminated", orchestrationDetails.RuntimeStatus);
+    }
+
+
+    [Fact]
+    public async Task TerminateCompletedOrchestration_ShouldFail()
+    {
+        using HttpResponseMessage response = await HttpHelpers.InvokeHttpTrigger("HelloCities_HttpStart", "");
+
+        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
+        string instanceId = await DurableHelpers.ParseInstanceId(response);
+        string statusQueryGetUri = await DurableHelpers.ParseStatusQueryGetUri(response);
+
+        Thread.Sleep(1000);
+
+        var orchestrationDetails = await DurableHelpers.GetRunningOrchestrationDetails(statusQueryGetUri);
+        Assert.Equal("Completed", orchestrationDetails.RuntimeStatus);
+
+        using HttpResponseMessage terminateResponse = await HttpHelpers.InvokeHttpTrigger("TerminateInstance", $"?instanceId={instanceId}");
+        await AssertTerminateRequestFails(terminateResponse);
+
+        // Give some time for Core Tools to write logs out
+        Thread.Sleep(500);
+
+        Assert.Contains(_fixture.TestLogs.CoreToolsLogs, x => x.Contains("Cannot terminate orchestration instance in the Completed state.") &&
+                                                              x.Contains(instanceId));
+    }
+
+    [Fact]
+    public async Task TerminateNonExistantOrchestration_ShouldFail()
+    {
+        using HttpResponseMessage terminateResponse = await HttpHelpers.InvokeHttpTrigger("TerminateInstance", $"?instanceId={Guid.NewGuid().ToString()}");
+        await AssertTerminateRequestFails(terminateResponse);
     }
 }

--- a/test/e2e/Tests/Tests/TerminateOrchestratorTests.cs
+++ b/test/e2e/Tests/Tests/TerminateOrchestratorTests.cs
@@ -20,7 +20,7 @@ public class TerminateOrchestratorTests
         _output = testOutputHelper;
     }
 
-    private static async Task AssertTerminateRequestFails(HttpResponseMessage terminateResponse)
+    private static async Task AssertTerminateRequestFailsAsync(HttpResponseMessage terminateResponse)
     {
         Assert.Equal(HttpStatusCode.BadRequest, terminateResponse.StatusCode);
 
@@ -29,7 +29,7 @@ public class TerminateOrchestratorTests
         Assert.Equal("Status(StatusCode=\"Unknown\", Detail=\"Exception was thrown by handler.\")", terminateResponseMessage);
     }
 
-    private static async Task AssertTerminateRequestSucceeds(HttpResponseMessage terminateResponse)
+    private static async Task AssertTerminateRequestSucceedsAsync(HttpResponseMessage terminateResponse)
     {
         Assert.Equal(HttpStatusCode.OK, terminateResponse.StatusCode);
 
@@ -45,52 +45,46 @@ public class TerminateOrchestratorTests
         using HttpResponseMessage response = await HttpHelpers.InvokeHttpTrigger("LongOrchestrator_HttpStart", "");
 
         Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
-        string instanceId = await DurableHelpers.ParseInstanceId(response);
-        string statusQueryGetUri = await DurableHelpers.ParseStatusQueryGetUri(response);
+        string instanceId = await DurableHelpers.ParseInstanceIdAsync(response);
+        string statusQueryGetUri = await DurableHelpers.ParseStatusQueryGetUriAsync(response);
 
         Thread.Sleep(1000);
 
-        var orchestrationDetails = await DurableHelpers.GetRunningOrchestrationDetails(statusQueryGetUri);
+        var orchestrationDetails = await DurableHelpers.GetRunningOrchestrationDetailsAsync(statusQueryGetUri);
         Assert.Equal("Running", orchestrationDetails.RuntimeStatus);
 
         using HttpResponseMessage terminateResponse = await HttpHelpers.InvokeHttpTrigger("TerminateInstance", $"?instanceId={instanceId}");
-        await AssertTerminateRequestSucceeds(terminateResponse);
+        await AssertTerminateRequestSucceedsAsync(terminateResponse);
 
         Thread.Sleep(1000);
 
-        orchestrationDetails = await DurableHelpers.GetRunningOrchestrationDetails(statusQueryGetUri);
+        orchestrationDetails = await DurableHelpers.GetRunningOrchestrationDetailsAsync(statusQueryGetUri);
         Assert.Equal("Terminated", orchestrationDetails.RuntimeStatus);
     }
 
 
-    // This test is likely exposing some unintended behavior. Currently, attempting to terminate scheduled orchestrations has no effect.
-    // If the behavior of Terminate is changed to accomodate terminating scheduled orchestrations, this test will need to be modified accordingly.
-    [Fact]
-    public async Task TerminateScheduledOrchestration_ShouldDoNothing()
+    [Fact(Skip = "Will enable when https://github.com/Azure/azure-functions-durable-extension/issues/3025 is fixed")]
+    public async Task TerminateScheduledOrchestration_ShouldSucceed()
     {
         DateTime scheduledStartTime = DateTime.UtcNow + TimeSpan.FromMinutes(1);
         using HttpResponseMessage response = await HttpHelpers.InvokeHttpTrigger("HelloCities_HttpStart_Scheduled", $"?scheduledStartTime={scheduledStartTime.ToString("o")}");
 
         Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
-        string instanceId = await DurableHelpers.ParseInstanceId(response);
-        string statusQueryGetUri = await DurableHelpers.ParseStatusQueryGetUri(response);
+        string instanceId = await DurableHelpers.ParseInstanceIdAsync(response);
+        string statusQueryGetUri = await DurableHelpers.ParseStatusQueryGetUriAsync(response);
 
         Thread.Sleep(1000);
 
-        var orchestrationDetails = await DurableHelpers.GetRunningOrchestrationDetails(statusQueryGetUri);
+        var orchestrationDetails = await DurableHelpers.GetRunningOrchestrationDetailsAsync(statusQueryGetUri);
         Assert.Equal("Pending", orchestrationDetails.RuntimeStatus);
 
         using HttpResponseMessage terminateResponse = await HttpHelpers.InvokeHttpTrigger("TerminateInstance", $"?instanceId={instanceId}");
-        Assert.Equal(HttpStatusCode.OK, terminateResponse.StatusCode);
-
-        string? terminateResponseMessage = await terminateResponse.Content.ReadAsStringAsync();
-        Assert.NotNull(terminateResponseMessage);
-        Assert.Empty(terminateResponseMessage);
+        await AssertTerminateRequestSucceedsAsync(terminateResponse);
 
         Thread.Sleep(1000);
 
-        orchestrationDetails = await DurableHelpers.GetRunningOrchestrationDetails(statusQueryGetUri);
-        Assert.Equal("Pending", orchestrationDetails.RuntimeStatus);
+        orchestrationDetails = await DurableHelpers.GetRunningOrchestrationDetailsAsync(statusQueryGetUri);
+        Assert.Equal("Terminated", orchestrationDetails.RuntimeStatus);
     }
 
 
@@ -100,20 +94,20 @@ public class TerminateOrchestratorTests
         using HttpResponseMessage response = await HttpHelpers.InvokeHttpTrigger("LongOrchestrator_HttpStart", "");
 
         Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
-        string instanceId = await DurableHelpers.ParseInstanceId(response);
-        string statusQueryGetUri = await DurableHelpers.ParseStatusQueryGetUri(response);
+        string instanceId = await DurableHelpers.ParseInstanceIdAsync(response);
+        string statusQueryGetUri = await DurableHelpers.ParseStatusQueryGetUriAsync(response);
 
         Thread.Sleep(1000);
 
-        var orchestrationDetails = await DurableHelpers.GetRunningOrchestrationDetails(statusQueryGetUri);
+        var orchestrationDetails = await DurableHelpers.GetRunningOrchestrationDetailsAsync(statusQueryGetUri);
         Assert.Equal("Running", orchestrationDetails.RuntimeStatus);
 
         using HttpResponseMessage terminateResponse = await HttpHelpers.InvokeHttpTrigger("TerminateInstance", $"?instanceId={instanceId}");
-        await AssertTerminateRequestSucceeds(terminateResponse);
+        await AssertTerminateRequestSucceedsAsync(terminateResponse);
 
         Thread.Sleep(1000);
         using HttpResponseMessage terminateAgainResponse = await HttpHelpers.InvokeHttpTrigger("TerminateInstance", $"?instanceId={instanceId}");
-        await AssertTerminateRequestFails(terminateAgainResponse);
+        await AssertTerminateRequestFailsAsync(terminateAgainResponse);
 
         // Give some time for Core Tools to write logs out
         Thread.Sleep(500);
@@ -121,7 +115,7 @@ public class TerminateOrchestratorTests
         Assert.Contains(_fixture.TestLogs.CoreToolsLogs, x => x.Contains("Cannot terminate orchestration instance in the Terminated state.") &&
                                                               x.Contains(instanceId));
 
-        orchestrationDetails = await DurableHelpers.GetRunningOrchestrationDetails(statusQueryGetUri);
+        orchestrationDetails = await DurableHelpers.GetRunningOrchestrationDetailsAsync(statusQueryGetUri);
         Assert.Equal("Terminated", orchestrationDetails.RuntimeStatus);
     }
 
@@ -132,16 +126,16 @@ public class TerminateOrchestratorTests
         using HttpResponseMessage response = await HttpHelpers.InvokeHttpTrigger("HelloCities_HttpStart", "");
 
         Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
-        string instanceId = await DurableHelpers.ParseInstanceId(response);
-        string statusQueryGetUri = await DurableHelpers.ParseStatusQueryGetUri(response);
+        string instanceId = await DurableHelpers.ParseInstanceIdAsync(response);
+        string statusQueryGetUri = await DurableHelpers.ParseStatusQueryGetUriAsync(response);
 
         Thread.Sleep(1000);
 
-        var orchestrationDetails = await DurableHelpers.GetRunningOrchestrationDetails(statusQueryGetUri);
+        var orchestrationDetails = await DurableHelpers.GetRunningOrchestrationDetailsAsync(statusQueryGetUri);
         Assert.Equal("Completed", orchestrationDetails.RuntimeStatus);
 
         using HttpResponseMessage terminateResponse = await HttpHelpers.InvokeHttpTrigger("TerminateInstance", $"?instanceId={instanceId}");
-        await AssertTerminateRequestFails(terminateResponse);
+        await AssertTerminateRequestFailsAsync(terminateResponse);
 
         // Give some time for Core Tools to write logs out
         Thread.Sleep(500);
@@ -154,6 +148,6 @@ public class TerminateOrchestratorTests
     public async Task TerminateNonExistantOrchestration_ShouldFail()
     {
         using HttpResponseMessage terminateResponse = await HttpHelpers.InvokeHttpTrigger("TerminateInstance", $"?instanceId={Guid.NewGuid().ToString()}");
-        await AssertTerminateRequestFails(terminateResponse);
+        await AssertTerminateRequestFailsAsync(terminateResponse);
     }
 }

--- a/test/e2e/Tests/Tests/TerminateOrchestratorTests.cs
+++ b/test/e2e/Tests/Tests/TerminateOrchestratorTests.cs
@@ -20,24 +20,6 @@ public class TerminateOrchestratorTests
         _output = testOutputHelper;
     }
 
-    private static async Task AssertTerminateRequestFailsAsync(HttpResponseMessage terminateResponse)
-    {
-        Assert.Equal(HttpStatusCode.BadRequest, terminateResponse.StatusCode);
-
-        string? terminateResponseMessage = await terminateResponse.Content.ReadAsStringAsync();
-        Assert.NotNull(terminateResponseMessage);
-        Assert.Equal("Status(StatusCode=\"Unknown\", Detail=\"Exception was thrown by handler.\")", terminateResponseMessage);
-    }
-
-    private static async Task AssertTerminateRequestSucceedsAsync(HttpResponseMessage terminateResponse)
-    {
-        Assert.Equal(HttpStatusCode.OK, terminateResponse.StatusCode);
-
-        string? terminateResponseMessage = await terminateResponse.Content.ReadAsStringAsync();
-        Assert.NotNull(terminateResponseMessage);
-        Assert.Empty(terminateResponseMessage);
-    }
-
 
     [Fact]
     public async Task TerminateRunningOrchestration_ShouldSucceed()
@@ -149,5 +131,23 @@ public class TerminateOrchestratorTests
     {
         using HttpResponseMessage terminateResponse = await HttpHelpers.InvokeHttpTrigger("TerminateInstance", $"?instanceId={Guid.NewGuid().ToString()}");
         await AssertTerminateRequestFailsAsync(terminateResponse);
+    }
+
+    private static async Task AssertTerminateRequestFailsAsync(HttpResponseMessage terminateResponse)
+    {
+        Assert.Equal(HttpStatusCode.BadRequest, terminateResponse.StatusCode);
+
+        string? terminateResponseMessage = await terminateResponse.Content.ReadAsStringAsync();
+        Assert.NotNull(terminateResponseMessage);
+        Assert.Equal("Status(StatusCode=\"Unknown\", Detail=\"Exception was thrown by handler.\")", terminateResponseMessage);
+    }
+
+    private static async Task AssertTerminateRequestSucceedsAsync(HttpResponseMessage terminateResponse)
+    {
+        Assert.Equal(HttpStatusCode.OK, terminateResponse.StatusCode);
+
+        string? terminateResponseMessage = await terminateResponse.Content.ReadAsStringAsync();
+        Assert.NotNull(terminateResponseMessage);
+        Assert.Empty(terminateResponseMessage);
     }
 }

--- a/test/e2e/Tests/Tests/TerminateOrchestratorTests.cs
+++ b/test/e2e/Tests/Tests/TerminateOrchestratorTests.cs
@@ -1,0 +1,65 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Net;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.Azure.Durable.Tests.DotnetIsolatedE2E;
+
+[Collection(Constants.FunctionAppCollectionName)]
+public class TerminateOrchestratorTests
+{
+    private readonly FunctionAppFixture _fixture;
+    private readonly ITestOutputHelper _output;
+
+    public TerminateOrchestratorTests(FunctionAppFixture fixture, ITestOutputHelper testOutputHelper)
+    {
+        _fixture = fixture;
+        _fixture.TestLogs.UseTestLogger(testOutputHelper);
+        _output = testOutputHelper;
+    }
+
+    // Due to some kind of asynchronous race condition in XUnit, when running these tests in pipelines,
+    // the output may be disposed before the message is written. Just ignore these types of errors for now. 
+    private void WriteOutput(string message)
+    {
+        try
+        {
+            _output.WriteLine(message);
+        }
+        catch
+        {
+            // Ignore
+        }
+    }
+
+    [Theory]
+    [InlineData("LongOrchestrator_HttpStart", HttpStatusCode.Accepted)]
+    public async Task HttpTriggerTests(string functionName, HttpStatusCode expectedStatusCode)
+    {
+        using HttpResponseMessage response = await HttpHelpers.InvokeHttpTrigger(functionName, "");
+        string actualMessage = await response.Content.ReadAsStringAsync();
+
+        Assert.Equal(expectedStatusCode, response.StatusCode);
+        string instanceId = DurableHelpers.ParseInstanceId(response);
+        string statusQueryGetUri = DurableHelpers.ParseStatusQueryGetUri(response);
+
+        Thread.Sleep(1000);
+
+        var orchestrationDetails = DurableHelpers.GetRunningOrchestrationDetails(statusQueryGetUri);
+        Assert.Equal("Running", orchestrationDetails.RuntimeStatus);
+
+        using HttpResponseMessage terminateResponse = await HttpHelpers.InvokeHttpTrigger("TerminateInstance", $"?instanceId={instanceId}");
+        Assert.Equal(HttpStatusCode.OK, terminateResponse.StatusCode);
+
+        string? terminateResponseMessage = terminateResponse.Content?.ReadAsStringAsync().Result;
+        Assert.NotNull(terminateResponseMessage);
+        Assert.Empty(terminateResponseMessage);
+
+        Thread.Sleep(1000);
+
+        orchestrationDetails = DurableHelpers.GetRunningOrchestrationDetails(statusQueryGetUri);
+        Assert.Equal("Terminated", orchestrationDetails.RuntimeStatus);
+    }
+}


### PR DESCRIPTION
<!-- Start the PR description with some context for the change. -->
Adds a test for orchestrator termination to the new E2E test suite

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)
* [x] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk
* [x] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
    * [ ] Otherwise: major or minor version updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
* [x] My changes **do not** add EventIds to our EventSource logs
    * [ ] Otherwise: Ensure the EventIds are within the supported range in our existing Windows infrastructure. You may validate this with a deployed app's telemetry. You may also extend the range by completing a PR such as [this one](https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files).
* [ ] My changes **should** be added to **v2.x** branch.
    * [x] Otherwise: This change applies exclusively to WebJobs.Extensions.DurableTask v3.x. It will be retained only in the `dev` and `main` branches and will not be merged into the `v2.x` branch.
