### PR TITLE
DurableTaskMetricsProvider as singleton istead of DurableTaskScaleMonitor and DurableTaskTargetScaler

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/Listener/DurableTaskScaleMonitor.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/DurableTaskScaleMonitor.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
 using DurableTask.AzureStorage.Monitoring;
@@ -20,7 +21,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         private readonly DurableTaskMetricsProvider durableTaskMetricsProvider;
 
         public DurableTaskScaleMonitor(
-            string id,
+            string functionId,
             string hubName,
             ILogger logger,
             DurableTaskMetricsProvider durableTaskMetricsProvider)
@@ -30,8 +31,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             this.durableTaskMetricsProvider = durableTaskMetricsProvider;
 
             // Scalers in Durable Functions are shared for all functions in the same task hub.
-            // So instead of using a function ID, we use the task hub name as the basis for the descriptor ID.
-            this.scaleMonitorDescriptor = new ScaleMonitorDescriptor(id: id, functionId: id);
+            this.scaleMonitorDescriptor = new ScaleMonitorDescriptor(id: $"{functionId}-DurableTask-{hubName ?? "default"}".ToLower(CultureInfo.InvariantCulture), functionId: functionId);
         }
 
         public ScaleMonitorDescriptor Descriptor

--- a/test/FunctionsV2/DurableTaskListenerTests.cs
+++ b/test/FunctionsV2/DurableTaskListenerTests.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             IScaleMonitor scaleMonitor = this.listener.GetMonitor();
 
             Assert.Equal(typeof(DurableTaskScaleMonitor), scaleMonitor.GetType());
-            Assert.Equal($"DurableTask-AzureStorage:DurableTaskHub", scaleMonitor.Descriptor.Id);
+            Assert.Equal(this.functionId, scaleMonitor.Descriptor.Id);
 
             IScaleMonitor scaleMonitor2 = this.listener.GetMonitor();
 

--- a/test/FunctionsV2/DurableTaskListenerTests.cs
+++ b/test/FunctionsV2/DurableTaskListenerTests.cs
@@ -12,6 +12,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 {
     public class DurableTaskListenerTests
     {
+        private static string hubName = "DurableTaskHub";
         private readonly string functionId = "DurableTaskTriggerFunctionId";
         private readonly FunctionName functionName = new FunctionName("DurableTaskTriggerFunctionName");
         private readonly DurableTaskExtension config;
@@ -37,7 +38,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             IScaleMonitor scaleMonitor = this.listener.GetMonitor();
 
             Assert.Equal(typeof(DurableTaskScaleMonitor), scaleMonitor.GetType());
-            Assert.Equal(this.functionId, scaleMonitor.Descriptor.Id);
+            Assert.Equal($"{this.functionId}-DurableTask-{hubName}".ToLower(), scaleMonitor.Descriptor.Id);
 
             IScaleMonitor scaleMonitor2 = this.listener.GetMonitor();
 
@@ -47,7 +48,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         private static DurableTaskExtension GetDurableTaskConfig()
         {
             var options = new DurableTaskOptions();
-            options.HubName = "DurableTaskHub";
+            options.HubName = hubName;
             options.WebhookUriProviderOverride = () => new Uri("https://sampleurl.net");
             var wrappedOptions = new OptionsWrapper<DurableTaskOptions>(options);
             var nameResolver = TestHelpers.GetTestNameResolver();

--- a/test/FunctionsV2/DurableTaskScaleMonitorTests.cs
+++ b/test/FunctionsV2/DurableTaskScaleMonitorTests.cs
@@ -21,6 +21,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
     public class DurableTaskScaleMonitorTests
     {
         private readonly string hubName = "DurableTaskTriggerHubName";
+        private readonly string functionId = "FunctionId";
         private readonly StorageAccountClientProvider clientProvider = new StorageAccountClientProvider(TestHelpers.GetStorageConnectionString());
         private readonly ITestOutputHelper output;
         private readonly EndToEndTraceHelper traceHelper;
@@ -48,10 +49,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 this.performanceMonitor.Object,
                 this.clientProvider);
 
-            string scalerId = $"DurableTask-AzureStorage:{this.hubName}";
-
             this.scaleMonitor = new DurableTaskScaleMonitor(
-                scalerId,
+                this.functionId,
                 this.hubName,
                 logger,
                 metricsProvider);
@@ -61,7 +60,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         [Trait("Category", PlatformSpecificHelpers.TestCategory)]
         public void ScaleMonitorDescriptor_ReturnsExpectedValue()
         {
-            Assert.Equal($"DurableTask-AzureStorage:{this.hubName}", this.scaleMonitor.Descriptor.Id);
+            Assert.Equal(($"{this.functionId}-DurableTask-{this.hubName}").ToLower(), this.scaleMonitor.Descriptor.Id);
         }
 
         [Fact]


### PR DESCRIPTION
These fixes are recommended by the Azure Functions Scale Controller team.


<!-- Make sure to delete the markdown comments and the below sections when squash merging -->
### Issue describing the changes in this PR

resolves #issue_for_this_pr

### Pull request checklist

* [ ] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)
* [ ] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk
* [ ] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
    * [ ] Otherwise: major or minor version updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
* [ ] My changes **do not** add EventIds to our EventSource logs
    * [ ] Otherwise: Ensure the EventIds are within the supported range in our existing Windows infrastructure. You may validate this with a deployed app's telemetry. You may also extend the range by completing a PR such as [this one](https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files).
* [ ] My changes **should** be added to **v2.x** branch.
    * [ ] Otherwise: This change applies exclusively to WebJobs.Extensions.DurableTask v3.x. It will be retained only in the `dev` and `main` branches and will not be merged into the `v2.x` branch.
