### PR TITLE
Add suspend/resume tests

### DIFF
--- a/test/e2e/Apps/BasicDotNetIsolated/HelloCities.cs
+++ b/test/e2e/Apps/BasicDotNetIsolated/HelloCities.cs
@@ -8,6 +8,7 @@ using Microsoft.DurableTask.Client;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Azure.Durable.Tests.E2E;
+
 public static class HelloCities
 {
     [Function(nameof(HelloCities))]

--- a/test/e2e/Apps/BasicDotNetIsolated/HelloCities.cs
+++ b/test/e2e/Apps/BasicDotNetIsolated/HelloCities.cs
@@ -7,74 +7,72 @@ using Microsoft.DurableTask;
 using Microsoft.DurableTask.Client;
 using Microsoft.Extensions.Logging;
 
-namespace Microsoft.Azure.Durable.Tests.E2E
+namespace Microsoft.Azure.Durable.Tests.E2E;
+public static class HelloCities
 {
-    public static class HelloCities
+    [Function(nameof(HelloCities))]
+    public static async Task<List<string>> RunOrchestrator(
+        [OrchestrationTrigger] TaskOrchestrationContext context)
     {
-        [Function(nameof(HelloCities))]
-        public static async Task<List<string>> RunOrchestrator(
-            [OrchestrationTrigger] TaskOrchestrationContext context)
-        {
-            ILogger logger = context.CreateReplaySafeLogger(nameof(HelloCities));
-            logger.LogInformation("Saying hello.");
-            var outputs = new List<string>();
+        ILogger logger = context.CreateReplaySafeLogger(nameof(HelloCities));
+        logger.LogInformation("Saying hello.");
+        var outputs = new List<string>();
 
-            // Replace name and input with values relevant for your Durable Functions Activity
-            outputs.Add(await context.CallActivityAsync<string>(nameof(SayHello), "Tokyo"));
-            outputs.Add(await context.CallActivityAsync<string>(nameof(SayHello), "Seattle"));
-            outputs.Add(await context.CallActivityAsync<string>(nameof(SayHello), "London"));
+        // Replace name and input with values relevant for your Durable Functions Activity
+        outputs.Add(await context.CallActivityAsync<string>(nameof(SayHello), "Tokyo"));
+        outputs.Add(await context.CallActivityAsync<string>(nameof(SayHello), "Seattle"));
+        outputs.Add(await context.CallActivityAsync<string>(nameof(SayHello), "London"));
 
-            // returns ["Hello Tokyo!", "Hello Seattle!", "Hello London!"]
-            return outputs;
-        }
+        // returns ["Hello Tokyo!", "Hello Seattle!", "Hello London!"]
+        return outputs;
+    }
 
-        [Function(nameof(SayHello))]
-        public static string SayHello([ActivityTrigger] string name, FunctionContext executionContext)
-        {
-            ILogger logger = executionContext.GetLogger("SayHello");
-            logger.LogInformation("Saying hello to {name}.", name);
-            return $"Hello {name}!";
-        }
+    [Function(nameof(SayHello))]
+    public static string SayHello([ActivityTrigger] string name, FunctionContext executionContext)
+    {
+        ILogger logger = executionContext.GetLogger("SayHello");
+        logger.LogInformation("Saying hello to {name}.", name);
+        return $"Hello {name}!";
+    }
 
-        [Function("HelloCities_HttpStart")]
-        public static async Task<HttpResponseData> HttpStart(
-            [HttpTrigger(AuthorizationLevel.Anonymous, "get", "post")] HttpRequestData req,
-            [DurableClient] DurableTaskClient client,
-            FunctionContext executionContext)
-        {
-            ILogger logger = executionContext.GetLogger("HelloCities_HttpStart");
+    [Function("HelloCities_HttpStart")]
+    public static async Task<HttpResponseData> HttpStart(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", "post")] HttpRequestData req,
+        [DurableClient] DurableTaskClient client,
+        FunctionContext executionContext)
+    {
+        ILogger logger = executionContext.GetLogger("HelloCities_HttpStart");
 
-            // Function input comes from the request content.
-            string instanceId = await client.ScheduleNewOrchestrationInstanceAsync(
-                nameof(HelloCities));
+        // Function input comes from the request content.
+        string instanceId = await client.ScheduleNewOrchestrationInstanceAsync(
+            nameof(HelloCities));
 
-            logger.LogInformation("Started orchestration with ID = '{instanceId}'.", instanceId);
+        logger.LogInformation("Started orchestration with ID = '{instanceId}'.", instanceId);
 
-            // Returns an HTTP 202 response with an instance management payload.
-            // See https://learn.microsoft.com/azure/azure-functions/durable/durable-functions-http-api#start-orchestration
-            return await client.CreateCheckStatusResponseAsync(req, instanceId);
-        }
+        // Returns an HTTP 202 response with an instance management payload.
+        // See https://learn.microsoft.com/azure/azure-functions/durable/durable-functions-http-api#start-orchestration
+        return await client.CreateCheckStatusResponseAsync(req, instanceId);
+    }
 
-        [Function("HelloCities_HttpStart_Scheduled")]
-        public static async Task<HttpResponseData> HttpStartScheduled(
-            [HttpTrigger(AuthorizationLevel.Anonymous, "get", "post")] HttpRequestData req,
-            [DurableClient] DurableTaskClient client,
-            FunctionContext executionContext,
-            DateTime scheduledStartTime)
-        {
-            ILogger logger = executionContext.GetLogger("HelloCities_HttpStart");
+    [Function("HelloCities_HttpStart_Scheduled")]
+    public static async Task<HttpResponseData> HttpStartScheduled(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", "post")] HttpRequestData req,
+        [DurableClient] DurableTaskClient client,
+        FunctionContext executionContext,
+        DateTime scheduledStartTime)
+    {
+        ILogger logger = executionContext.GetLogger("HelloCities_HttpStart");
 
-            var startOptions = new StartOrchestrationOptions(StartAt: scheduledStartTime);
+        var startOptions = new StartOrchestrationOptions(StartAt: scheduledStartTime);
 
-            // Function input comes from the request content.
-            string instanceId = await client.ScheduleNewOrchestrationInstanceAsync(
-                nameof(HelloCities), startOptions);
+        // Function input comes from the request content.
+        string instanceId = await client.ScheduleNewOrchestrationInstanceAsync(
+            nameof(HelloCities), startOptions);
 
-            logger.LogInformation("Started orchestration with ID = '{instanceId}'.", instanceId);
+        logger.LogInformation("Started orchestration with ID = '{instanceId}'.", instanceId);
 
-            // Returns an HTTP 202 response with an instance management payload.
-            // See https://learn.microsoft.com/azure/azure-functions/durable/durable-functions-http-api#start-orchestration
-            return await client.CreateCheckStatusResponseAsync(req, instanceId);
-        }
+        // Returns an HTTP 202 response with an instance management payload.
+        // See https://learn.microsoft.com/azure/azure-functions/durable/durable-functions-http-api#start-orchestration
+        return await client.CreateCheckStatusResponseAsync(req, instanceId);
     }
 }

--- a/test/e2e/Apps/BasicDotNetIsolated/OrchestrationQuery.cs
+++ b/test/e2e/Apps/BasicDotNetIsolated/OrchestrationQuery.cs
@@ -8,6 +8,7 @@ using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.DurableTask.Client;
 
 namespace Microsoft.Azure.Durable.Tests.E2E;
+
 public static class OrchestrationQueryFunctions
 {
     [Function(nameof(GetAllInstances))]

--- a/test/e2e/Apps/BasicDotNetIsolated/PurgeOrchestrationHistory.cs
+++ b/test/e2e/Apps/BasicDotNetIsolated/PurgeOrchestrationHistory.cs
@@ -8,44 +8,43 @@ using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.DurableTask.Client;
 using Microsoft.Extensions.Logging;
 
-namespace Microsoft.Azure.Durable.Tests.E2E
+namespace Microsoft.Azure.Durable.Tests.E2E;
+
+public static class PurgeOrchestrationHistory
 {
-    public static class PurgeOrchestrationHistory
+    [Function(nameof(PurgeOrchestrationHistory))]
+    public static async Task<HttpResponseData> PurgeHistory(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", "post")] HttpRequestData req,
+        [DurableClient] DurableTaskClient client,
+        FunctionContext executionContext,
+        DateTime? purgeStartTime=null,
+        DateTime? purgeEndTime=null)
     {
-        [Function(nameof(PurgeOrchestrationHistory))]
-        public static async Task<HttpResponseData> PurgeHistory(
-            [HttpTrigger(AuthorizationLevel.Anonymous, "get", "post")] HttpRequestData req,
-            [DurableClient] DurableTaskClient client,
-            FunctionContext executionContext,
-            DateTime? purgeStartTime=null,
-            DateTime? purgeEndTime=null)
+        ILogger logger = executionContext.GetLogger("HelloCities_HttpStart");
+
+        logger.LogInformation("Starting purge all instance history");
+        try
         {
-            ILogger logger = executionContext.GetLogger("HelloCities_HttpStart");
+            var requestPurgeResult = await client.PurgeAllInstancesAsync(new PurgeInstancesFilter(purgeStartTime, purgeEndTime, new List<OrchestrationRuntimeStatus>{
+                OrchestrationRuntimeStatus.Completed,
+                OrchestrationRuntimeStatus.Failed,
+                OrchestrationRuntimeStatus.Terminated
+            }));
 
-            logger.LogInformation("Starting purge all instance history");
-            try 
-            {
-                var requestPurgeResult = await client.PurgeAllInstancesAsync(new PurgeInstancesFilter(purgeStartTime, purgeEndTime, new List<OrchestrationRuntimeStatus>{
-                    OrchestrationRuntimeStatus.Completed,
-                    OrchestrationRuntimeStatus.Failed,
-                    OrchestrationRuntimeStatus.Terminated
-                }));
+            logger.LogInformation("Finished purge all instance history");
 
-                logger.LogInformation("Finished purge all instance history");
-
-                var response =  req.CreateResponse(HttpStatusCode.OK);
-                response.Headers.Add("Content-Type", "text/plain");
-                await response.WriteStringAsync($"Purged {requestPurgeResult.PurgedInstanceCount} records");
-                return response;    
-            }
-            catch (RpcException ex) 
-            {
-                logger.LogError(ex, "Failed to purge all instance history");
-                var response =  req.CreateResponse(HttpStatusCode.InternalServerError);
-                response.Headers.Add("Content-Type", "text/plain");
-                await response.WriteStringAsync($"Failed to purge all instance history: {ex.Message}");
-                return response;
-            }
+            var response =  req.CreateResponse(HttpStatusCode.OK);
+            response.Headers.Add("Content-Type", "text/plain");
+            await response.WriteStringAsync($"Purged {requestPurgeResult.PurgedInstanceCount} records");
+            return response;
+        }
+        catch (RpcException ex)
+        {
+            logger.LogError(ex, "Failed to purge all instance history");
+            var response =  req.CreateResponse(HttpStatusCode.InternalServerError);
+            response.Headers.Add("Content-Type", "text/plain");
+            await response.WriteStringAsync($"Failed to purge all instance history: {ex.Message}");
+            return response;
         }
     }
 }

--- a/test/e2e/Apps/BasicDotNetIsolated/SuspendResumeOrchestration.cs
+++ b/test/e2e/Apps/BasicDotNetIsolated/SuspendResumeOrchestration.cs
@@ -8,6 +8,7 @@ using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.DurableTask.Client;
 
 namespace Microsoft.Azure.Durable.Tests.E2E;
+
 public static class SuspendResumeOrchestration
 {
     [Function("SuspendInstance")]

--- a/test/e2e/Apps/BasicDotNetIsolated/SuspendResumeOrchestration.cs
+++ b/test/e2e/Apps/BasicDotNetIsolated/SuspendResumeOrchestration.cs
@@ -1,0 +1,54 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Net;
+using Grpc.Core;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
+using Microsoft.DurableTask.Client;
+
+namespace Microsoft.Azure.Durable.Tests.E2E;
+public static class SuspendResumeOrchestration
+{
+    [Function("SuspendInstance")]
+    public static async Task<HttpResponseData> Suspend(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", "post")] HttpRequestData req,
+        [DurableClient] DurableTaskClient client,
+        string instanceId)
+    {
+        string suspendReason = "Suspending the instance for test.";
+        try 
+        {
+            await client.SuspendInstanceAsync(instanceId, suspendReason);
+            return req.CreateResponse(HttpStatusCode.OK);
+        }
+        catch (RpcException ex) 
+        {
+            var response = req.CreateResponse(HttpStatusCode.BadRequest);
+            response.Headers.Add("Content-Type", "text/plain");
+            await response.WriteStringAsync(ex.Message);
+            return response;
+        }
+    }
+
+    [Function("ResumeInstance")]
+    public static async Task<HttpResponseData> Resume(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", "post")] HttpRequestData req,
+        [DurableClient] DurableTaskClient client,
+        string instanceId)
+    {
+        string suspendReason = "Resuming the instance for test.";
+        try 
+        {
+            await client.ResumeInstanceAsync(instanceId, suspendReason);
+            return req.CreateResponse(HttpStatusCode.OK);
+        }
+        catch (RpcException ex) 
+        {
+            var response = req.CreateResponse(HttpStatusCode.BadRequest);
+            response.Headers.Add("Content-Type", "text/plain");
+            await response.WriteStringAsync(ex.Message);
+            return response;
+        }
+    }
+}

--- a/test/e2e/Apps/BasicDotNetIsolated/SuspendResumeOrchestration.cs
+++ b/test/e2e/Apps/BasicDotNetIsolated/SuspendResumeOrchestration.cs
@@ -37,10 +37,10 @@ public static class SuspendResumeOrchestration
         [DurableClient] DurableTaskClient client,
         string instanceId)
     {
-        string suspendReason = "Resuming the instance for test.";
+        string resumeReason = "Resuming the instance for test.";
         try 
         {
-            await client.ResumeInstanceAsync(instanceId, suspendReason);
+            await client.ResumeInstanceAsync(instanceId, resumeReason);
             return req.CreateResponse(HttpStatusCode.OK);
         }
         catch (RpcException ex) 

--- a/test/e2e/Apps/BasicDotNetIsolated/TerminateOrchestration.cs
+++ b/test/e2e/Apps/BasicDotNetIsolated/TerminateOrchestration.cs
@@ -10,6 +10,7 @@ using Microsoft.DurableTask.Client;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Azure.Durable.Tests.E2E;
+
 public static class LongRunningOrchestration
 {
     [Function(nameof(LongRunningOrchestrator))]

--- a/test/e2e/Apps/BasicDotNetIsolated/TerminateOrchestration.cs
+++ b/test/e2e/Apps/BasicDotNetIsolated/TerminateOrchestration.cs
@@ -9,72 +9,70 @@ using Microsoft.DurableTask;
 using Microsoft.DurableTask.Client;
 using Microsoft.Extensions.Logging;
 
-namespace Microsoft.Azure.Durable.Tests.E2E
+namespace Microsoft.Azure.Durable.Tests.E2E;
+public static class LongRunningOrchestration
 {
-    public static class LongRunningOrchestration
+    [Function(nameof(LongRunningOrchestrator))]
+    public static async Task<List<string>> LongRunningOrchestrator(
+        [OrchestrationTrigger] TaskOrchestrationContext context)
     {
-        [Function(nameof(LongRunningOrchestrator))]
-        public static async Task<List<string>> LongRunningOrchestrator(
-            [OrchestrationTrigger] TaskOrchestrationContext context)
+        ILogger logger = context.CreateReplaySafeLogger(nameof(HelloCities));
+        logger.LogInformation("Starting long-running orchestration.");
+        var outputs = new List<string>();
+
+        // Call our fake activity 100,000 times to simulate an orchestration that might run for >= 10,000s (2.7 hours)
+        for (int i = 0; i < 100000; i++) 
         {
-            ILogger logger = context.CreateReplaySafeLogger(nameof(HelloCities));
-            logger.LogInformation("Starting long-running orchestration.");
-            var outputs = new List<string>();
-
-            // Call our fake activity 100,000 times to simulate an orchestration that might run for >= 10,000s (2.7 hours)
-            for (int i = 0; i < 100000; i++) 
-            {
-                outputs.Add(await context.CallActivityAsync<string>(nameof(SimulatedWorkActivity), 100));
-            }
-
-            return outputs;
+            outputs.Add(await context.CallActivityAsync<string>(nameof(SimulatedWorkActivity), 100));
         }
 
-        [Function(nameof(SimulatedWorkActivity))]
-        public static string SimulatedWorkActivity([ActivityTrigger]int sleepMs, FunctionContext executionContext)
+        return outputs;
+    }
+
+    [Function(nameof(SimulatedWorkActivity))]
+    public static string SimulatedWorkActivity([ActivityTrigger]int sleepMs, FunctionContext executionContext)
+    {
+        // Sleep the provided number of ms to simulate a long-running activity operation
+        ILogger logger = executionContext.GetLogger("SimulatedWorkActivity");
+        logger.LogInformation("Sleeping for {sleepMs}ms.", sleepMs);
+        Thread.Sleep(sleepMs);
+        return $"Slept for {sleepMs}ms.";
+    }
+
+    [Function("LongOrchestrator_HttpStart")]
+    public static async Task<HttpResponseData> HttpStart(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", "post")] HttpRequestData req,
+        [DurableClient] DurableTaskClient client,
+        FunctionContext executionContext)
+    {
+        ILogger logger = executionContext.GetLogger("LongOrchestrator_HttpStart");
+
+        string instanceId = await client.ScheduleNewOrchestrationInstanceAsync(
+            nameof(LongRunningOrchestrator));
+
+        logger.LogInformation("Started orchestration with ID = '{instanceId}'.", instanceId);
+        
+        return await client.CreateCheckStatusResponseAsync(req, instanceId);
+    }
+
+    [Function("TerminateInstance")]
+    public static async Task<HttpResponseData> Run(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", "post")] HttpRequestData req,
+        [DurableClient] DurableTaskClient client,
+        string instanceId)
+    {
+        string reason = "Long-running orchestration was terminated early.";
+        try 
         {
-            // Sleep the provided number of ms to simulate a long-running activity operation
-            ILogger logger = executionContext.GetLogger("SimulatedWorkActivity");
-            logger.LogInformation("Sleeping for {sleepMs}ms.", sleepMs);
-            Thread.Sleep(sleepMs);
-            return $"Slept for {sleepMs}ms.";
+            await client.TerminateInstanceAsync(instanceId, reason);
+            return req.CreateResponse(HttpStatusCode.OK);
         }
-
-        [Function("LongOrchestrator_HttpStart")]
-        public static async Task<HttpResponseData> HttpStart(
-            [HttpTrigger(AuthorizationLevel.Anonymous, "get", "post")] HttpRequestData req,
-            [DurableClient] DurableTaskClient client,
-            FunctionContext executionContext)
+        catch (RpcException ex) 
         {
-            ILogger logger = executionContext.GetLogger("LongOrchestrator_HttpStart");
-
-            string instanceId = await client.ScheduleNewOrchestrationInstanceAsync(
-                nameof(LongRunningOrchestrator));
-
-            logger.LogInformation("Started orchestration with ID = '{instanceId}'.", instanceId);
-            
-            return await client.CreateCheckStatusResponseAsync(req, instanceId);
-        }
-
-        [Function("TerminateInstance")]
-        public static async Task<HttpResponseData> Run(
-            [HttpTrigger(AuthorizationLevel.Anonymous, "get", "post")] HttpRequestData req,
-            [DurableClient] DurableTaskClient client,
-            string instanceId)
-        {
-            string reason = "Long-running orchestration was terminated early.";
-            try 
-            {
-                await client.TerminateInstanceAsync(instanceId, reason);
-                return req.CreateResponse(HttpStatusCode.OK);
-            }
-            catch (RpcException ex) 
-            {
-                var response = req.CreateResponse(HttpStatusCode.BadRequest);
-                response.Headers.Add("Content-Type", "text/plain");
-                await response.WriteStringAsync(ex.Message);
-                return response;
-            }
+            var response = req.CreateResponse(HttpStatusCode.BadRequest);
+            response.Headers.Add("Content-Type", "text/plain");
+            await response.WriteStringAsync(ex.Message);
+            return response;
         }
     }
 }

--- a/test/e2e/Tests/Helpers/DurableHelpers.cs
+++ b/test/e2e/Tests/Helpers/DurableHelpers.cs
@@ -52,6 +52,21 @@ internal class DurableHelpers
         return new OrchestrationStatusDetails(statusQueryResponseString);
     }
 
+    internal static async Task WaitForOrchestrationState(string statusQueryGetUri, string desiredState, int maxTimeoutSeconds)
+    {
+        DateTime timeoutTime = DateTime.Now + TimeSpan.FromSeconds(maxTimeoutSeconds);
+        while (DateTime.Now < timeoutTime)
+        {
+            var currentStatus = await GetRunningOrchestrationDetailsAsync(statusQueryGetUri);
+            if (currentStatus.RuntimeStatus == desiredState)
+            {
+                return;
+            }
+            await Task.Delay(100);
+        }
+        throw new TimeoutException($"Orchestration did not reach {desiredState} status within {maxTimeoutSeconds} seconds.");
+    }
+
     private static string TokenizeAndGetValueFromKeyAsString(string? json, string key)
     {
         if (string.IsNullOrEmpty(json))

--- a/test/e2e/Tests/Helpers/DurableHelpers.cs
+++ b/test/e2e/Tests/Helpers/DurableHelpers.cs
@@ -52,7 +52,7 @@ internal class DurableHelpers
         return new OrchestrationStatusDetails(statusQueryResponseString);
     }
 
-    internal static async Task WaitForOrchestrationState(string statusQueryGetUri, string desiredState, int maxTimeoutSeconds)
+    internal static async Task WaitForOrchestrationStateAsync(string statusQueryGetUri, string desiredState, int maxTimeoutSeconds)
     {
         DateTime timeoutTime = DateTime.Now + TimeSpan.FromSeconds(maxTimeoutSeconds);
         while (DateTime.Now < timeoutTime)

--- a/test/e2e/Tests/Helpers/DurableHelpers.cs
+++ b/test/e2e/Tests/Helpers/DurableHelpers.cs
@@ -9,6 +9,13 @@ internal class DurableHelpers
 {
     static readonly HttpClient _httpClient = new HttpClient();
 
+    static readonly List<string> finalStates = new List<string>()
+    {
+        "Completed",
+        "Terminated",
+        "Failed"
+    };
+
     internal class OrchestrationStatusDetails
     {
         public string RuntimeStatus { get; set; } = string.Empty;
@@ -61,6 +68,10 @@ internal class DurableHelpers
             if (currentStatus.RuntimeStatus == desiredState)
             {
                 return;
+            }
+            if (finalStates.Contains(currentStatus.RuntimeStatus))
+            {
+                throw new TaskCanceledException($"Orchestration reached {currentStatus.RuntimeStatus} state when test was expecting {desiredState}");
             }
             await Task.Delay(100);
         }

--- a/test/e2e/Tests/Tests/HelloCitiesTest.cs
+++ b/test/e2e/Tests/Tests/HelloCitiesTest.cs
@@ -44,7 +44,7 @@ public class HttpEndToEndTests
         Assert.Equal(expectedStatusCode, response.StatusCode);
         string statusQueryGetUri = await DurableHelpers.ParseStatusQueryGetUriAsync(response);
 
-        await DurableHelpers.WaitForOrchestrationStateAsync(statusQueryGetUri, "Completed", 5);
+        await DurableHelpers.WaitForOrchestrationStateAsync(statusQueryGetUri, "Completed", 30);
 
         var orchestrationDetails = await DurableHelpers.GetRunningOrchestrationDetailsAsync(statusQueryGetUri);
         Assert.Contains(partialExpectedOutput, orchestrationDetails.Output);
@@ -68,10 +68,10 @@ public class HttpEndToEndTests
 
         if (scheduledStartTime > DateTime.UtcNow + TimeSpan.FromSeconds(1))
         {
-            await DurableHelpers.WaitForOrchestrationStateAsync(statusQueryGetUri, "Pending", 5);
+            await DurableHelpers.WaitForOrchestrationStateAsync(statusQueryGetUri, "Pending", 30);
         }
 
-        await DurableHelpers.WaitForOrchestrationStateAsync(statusQueryGetUri, "Completed", Math.Max(startDelaySeconds, 0) + 5);
+        await DurableHelpers.WaitForOrchestrationStateAsync(statusQueryGetUri, "Completed", Math.Max(startDelaySeconds, 0) + 30);
 
         // This +1s should not be necessary - however, experimentally the orchestration may run up to one second before the scheduled time.
         // It is unclear currently whether this is a bug where orchestrations run early, or a clock difference/error,

--- a/test/e2e/Tests/Tests/HelloCitiesTest.cs
+++ b/test/e2e/Tests/Tests/HelloCitiesTest.cs
@@ -44,7 +44,7 @@ public class HttpEndToEndTests
         Assert.Equal(expectedStatusCode, response.StatusCode);
         string statusQueryGetUri = await DurableHelpers.ParseStatusQueryGetUriAsync(response);
 
-        await DurableHelpers.WaitForOrchestrationState(statusQueryGetUri, "Completed", 5);
+        await DurableHelpers.WaitForOrchestrationStateAsync(statusQueryGetUri, "Completed", 5);
 
         var orchestrationDetails = await DurableHelpers.GetRunningOrchestrationDetailsAsync(statusQueryGetUri);
         Assert.Contains(partialExpectedOutput, orchestrationDetails.Output);
@@ -68,10 +68,10 @@ public class HttpEndToEndTests
 
         if (scheduledStartTime > DateTime.UtcNow + TimeSpan.FromSeconds(1))
         {
-            await DurableHelpers.WaitForOrchestrationState(statusQueryGetUri, "Pending", 5);
+            await DurableHelpers.WaitForOrchestrationStateAsync(statusQueryGetUri, "Pending", 5);
         }
 
-        await DurableHelpers.WaitForOrchestrationState(statusQueryGetUri, "Completed", Math.Max(startDelaySeconds, 0) + 5);
+        await DurableHelpers.WaitForOrchestrationStateAsync(statusQueryGetUri, "Completed", Math.Max(startDelaySeconds, 0) + 5);
 
         // This +1s should not be necessary - however, experimentally the orchestration may run up to one second before the scheduled time.
         // It is unclear currently whether this is a bug where orchestrations run early, or a clock difference/error,

--- a/test/e2e/Tests/Tests/HelloCitiesTest.cs
+++ b/test/e2e/Tests/Tests/HelloCitiesTest.cs
@@ -43,14 +43,15 @@ public class HttpEndToEndTests
 
         Assert.Equal(expectedStatusCode, response.StatusCode);
         string statusQueryGetUri = await DurableHelpers.ParseStatusQueryGetUriAsync(response);
-        Thread.Sleep(1000);
+
+        await DurableHelpers.WaitForOrchestrationState(statusQueryGetUri, "Completed", 5);
+
         var orchestrationDetails = await DurableHelpers.GetRunningOrchestrationDetailsAsync(statusQueryGetUri);
-        Assert.Equal("Completed", orchestrationDetails.RuntimeStatus);
         Assert.Contains(partialExpectedOutput, orchestrationDetails.Output);
     }
 
     [Theory]
-    [InlineData("HelloCities_HttpStart_Scheduled", 10, HttpStatusCode.Accepted)]
+    [InlineData("HelloCities_HttpStart_Scheduled", 5, HttpStatusCode.Accepted)]
     [InlineData("HelloCities_HttpStart_Scheduled", -5, HttpStatusCode.Accepted)]
     public async Task ScheduledStartTests(string functionName, int startDelaySeconds, HttpStatusCode expectedStatusCode)
     {
@@ -65,28 +66,20 @@ public class HttpEndToEndTests
 
         Assert.Equal(expectedStatusCode, response.StatusCode);
 
-        var orchestrationDetails = await DurableHelpers.GetRunningOrchestrationDetailsAsync(statusQueryGetUri);
-        while (DateTime.UtcNow < scheduledStartTime + TimeSpan.FromSeconds(-1))
+        if (scheduledStartTime > DateTime.UtcNow + TimeSpan.FromSeconds(1))
         {
-            WriteOutput($"Test scheduled for {scheduledStartTime}, current time {DateTime.Now}");
-            orchestrationDetails = await DurableHelpers.GetRunningOrchestrationDetailsAsync(statusQueryGetUri);
-            Assert.Equal("Pending", orchestrationDetails.RuntimeStatus);
-            Thread.Sleep(1000);
+            await DurableHelpers.WaitForOrchestrationState(statusQueryGetUri, "Pending", 5);
         }
 
-        // Give a small amount of time for the orchestration to complete, even if scheduled to run immediately
-        Thread.Sleep(3000);
-        WriteOutput($"Test scheduled for {scheduledStartTime}, current time {DateTime.Now}, looking for completed");
+        await DurableHelpers.WaitForOrchestrationState(statusQueryGetUri, "Completed", Math.Max(startDelaySeconds, 0) + 5);
+
+        // This +1s should not be necessary - however, experimentally the orchestration may run up to one second before the scheduled time.
+        // It is unclear currently whether this is a bug where orchestrations run early, or a clock difference/error,
+        // but leaving this logic in for now until further investigation.
+        Assert.True(DateTime.UtcNow + TimeSpan.FromSeconds(1) >= scheduledStartTime);
+
         var finalOrchestrationDetails = await DurableHelpers.GetRunningOrchestrationDetailsAsync(statusQueryGetUri);
-        int retryAttempts = 0;
-        while (finalOrchestrationDetails.RuntimeStatus != "Completed" && retryAttempts < 10)
-        {
-            Thread.Sleep(1000);
-            finalOrchestrationDetails = await DurableHelpers.GetRunningOrchestrationDetailsAsync(statusQueryGetUri);
-            retryAttempts++;
-        }
-        Assert.Equal("Completed", finalOrchestrationDetails.RuntimeStatus);
-
-        Assert.True(finalOrchestrationDetails.LastUpdatedTime > scheduledStartTime);
+        WriteOutput($"Last updated at {finalOrchestrationDetails.LastUpdatedTime}, scheduled to complete at {scheduledStartTime}");
+        Assert.True(finalOrchestrationDetails.LastUpdatedTime + TimeSpan.FromSeconds(1) >= scheduledStartTime);
     }
 }

--- a/test/e2e/Tests/Tests/OrchestrationQueryTests.cs
+++ b/test/e2e/Tests/Tests/OrchestrationQueryTests.cs
@@ -46,13 +46,9 @@ public class OrchestrationQueryTests
         string instanceId = await DurableHelpers.ParseInstanceIdAsync(response);
         string statusQueryGetUri = await DurableHelpers.ParseStatusQueryGetUriAsync(response);
 
-        Thread.Sleep(1000);
-
+        await DurableHelpers.WaitForOrchestrationState(statusQueryGetUri, "Running", 5);
         try
         {
-            var orchestrationDetails = await DurableHelpers.GetRunningOrchestrationDetailsAsync(statusQueryGetUri);
-            Assert.Equal("Running", orchestrationDetails.RuntimeStatus);
-
             using HttpResponseMessage statusResponse = await HttpHelpers.InvokeHttpTrigger("GetRunningInstances", "");
 
             Assert.Equal(HttpStatusCode.OK, statusResponse.StatusCode);

--- a/test/e2e/Tests/Tests/OrchestrationQueryTests.cs
+++ b/test/e2e/Tests/Tests/OrchestrationQueryTests.cs
@@ -46,7 +46,7 @@ public class OrchestrationQueryTests
         string instanceId = await DurableHelpers.ParseInstanceIdAsync(response);
         string statusQueryGetUri = await DurableHelpers.ParseStatusQueryGetUriAsync(response);
 
-        await DurableHelpers.WaitForOrchestrationState(statusQueryGetUri, "Running", 5);
+        await DurableHelpers.WaitForOrchestrationStateAsync(statusQueryGetUri, "Running", 5);
         try
         {
             using HttpResponseMessage statusResponse = await HttpHelpers.InvokeHttpTrigger("GetRunningInstances", "");

--- a/test/e2e/Tests/Tests/OrchestrationQueryTests.cs
+++ b/test/e2e/Tests/Tests/OrchestrationQueryTests.cs
@@ -46,7 +46,7 @@ public class OrchestrationQueryTests
         string instanceId = await DurableHelpers.ParseInstanceIdAsync(response);
         string statusQueryGetUri = await DurableHelpers.ParseStatusQueryGetUriAsync(response);
 
-        await DurableHelpers.WaitForOrchestrationStateAsync(statusQueryGetUri, "Running", 5);
+        await DurableHelpers.WaitForOrchestrationStateAsync(statusQueryGetUri, "Running", 30);
         try
         {
             using HttpResponseMessage statusResponse = await HttpHelpers.InvokeHttpTrigger("GetRunningInstances", "");

--- a/test/e2e/Tests/Tests/PurgeInstancesTests.cs
+++ b/test/e2e/Tests/Tests/PurgeInstancesTests.cs
@@ -78,7 +78,7 @@ public class PurgeInstancesTests
         Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
         string statusQueryGetUri = await DurableHelpers.ParseStatusQueryGetUriAsync(response);
 
-        await DurableHelpers.WaitForOrchestrationState(statusQueryGetUri, "Completed", 5);
+        await DurableHelpers.WaitForOrchestrationStateAsync(statusQueryGetUri, "Completed", 5);
 
         DateTime purgeEndTime = DateTime.UtcNow + TimeSpan.FromMinutes(1);
         using HttpResponseMessage purgeResponse = await HttpHelpers.InvokeHttpTrigger("PurgeOrchestrationHistory", $"?purgeEndTime={purgeEndTime:o}");

--- a/test/e2e/Tests/Tests/PurgeInstancesTests.cs
+++ b/test/e2e/Tests/Tests/PurgeInstancesTests.cs
@@ -78,7 +78,7 @@ public class PurgeInstancesTests
         Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
         string statusQueryGetUri = await DurableHelpers.ParseStatusQueryGetUriAsync(response);
 
-        await DurableHelpers.WaitForOrchestrationStateAsync(statusQueryGetUri, "Completed", 5);
+        await DurableHelpers.WaitForOrchestrationStateAsync(statusQueryGetUri, "Completed", 30);
 
         DateTime purgeEndTime = DateTime.UtcNow + TimeSpan.FromMinutes(1);
         using HttpResponseMessage purgeResponse = await HttpHelpers.InvokeHttpTrigger("PurgeOrchestrationHistory", $"?purgeEndTime={purgeEndTime:o}");

--- a/test/e2e/Tests/Tests/PurgeInstancesTests.cs
+++ b/test/e2e/Tests/Tests/PurgeInstancesTests.cs
@@ -76,7 +76,9 @@ public class PurgeInstancesTests
     {
         using HttpResponseMessage response = await HttpHelpers.InvokeHttpTrigger("HelloCities_HttpStart", "");
         Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
-        Thread.Sleep(1000);
+        string statusQueryGetUri = await DurableHelpers.ParseStatusQueryGetUriAsync(response);
+
+        await DurableHelpers.WaitForOrchestrationState(statusQueryGetUri, "Completed", 5);
 
         DateTime purgeEndTime = DateTime.UtcNow + TimeSpan.FromMinutes(1);
         using HttpResponseMessage purgeResponse = await HttpHelpers.InvokeHttpTrigger("PurgeOrchestrationHistory", $"?purgeEndTime={purgeEndTime:o}");

--- a/test/e2e/Tests/Tests/SuspendResumeTests.cs
+++ b/test/e2e/Tests/Tests/SuspendResumeTests.cs
@@ -30,18 +30,18 @@ public class SuspendResumeTests
         string instanceId = await DurableHelpers.ParseInstanceIdAsync(response);
         string statusQueryGetUri = await DurableHelpers.ParseStatusQueryGetUriAsync(response);
 
-        await DurableHelpers.WaitForOrchestrationState(statusQueryGetUri, "Running", 5);
+        await DurableHelpers.WaitForOrchestrationStateAsync(statusQueryGetUri, "Running", 5);
         try
         {
             using HttpResponseMessage suspendResponse = await HttpHelpers.InvokeHttpTrigger("SuspendInstance", $"?instanceId={instanceId}");
             await AssertRequestSucceedsAsync(suspendResponse);
 
-            await DurableHelpers.WaitForOrchestrationState(statusQueryGetUri, "Suspended", 5);
+            await DurableHelpers.WaitForOrchestrationStateAsync(statusQueryGetUri, "Suspended", 5);
 
             using HttpResponseMessage resumeResponse = await HttpHelpers.InvokeHttpTrigger("ResumeInstance", $"?instanceId={instanceId}");
             await AssertRequestSucceedsAsync(resumeResponse);
 
-            await DurableHelpers.WaitForOrchestrationState(statusQueryGetUri, "Running", 5);
+            await DurableHelpers.WaitForOrchestrationStateAsync(statusQueryGetUri, "Running", 5);
         }
         finally
         {
@@ -58,13 +58,13 @@ public class SuspendResumeTests
         string instanceId = await DurableHelpers.ParseInstanceIdAsync(response);
         string statusQueryGetUri = await DurableHelpers.ParseStatusQueryGetUriAsync(response);
 
-        await DurableHelpers.WaitForOrchestrationState(statusQueryGetUri, "Running", 5);
+        await DurableHelpers.WaitForOrchestrationStateAsync(statusQueryGetUri, "Running", 5);
         try
         {
             using HttpResponseMessage suspendResponse = await HttpHelpers.InvokeHttpTrigger("SuspendInstance", $"?instanceId={instanceId}");
             await AssertRequestSucceedsAsync(suspendResponse);
 
-            await DurableHelpers.WaitForOrchestrationState(statusQueryGetUri, "Suspended", 5);
+            await DurableHelpers.WaitForOrchestrationStateAsync(statusQueryGetUri, "Suspended", 5);
 
             using HttpResponseMessage resumeResponse = await HttpHelpers.InvokeHttpTrigger("SuspendInstance", $"?instanceId={instanceId}");
             await AssertRequestFailsAsync(resumeResponse);
@@ -91,7 +91,7 @@ public class SuspendResumeTests
         string instanceId = await DurableHelpers.ParseInstanceIdAsync(response);
         string statusQueryGetUri = await DurableHelpers.ParseStatusQueryGetUriAsync(response);
 
-        await DurableHelpers.WaitForOrchestrationState(statusQueryGetUri, "Running", 5);
+        await DurableHelpers.WaitForOrchestrationStateAsync(statusQueryGetUri, "Running", 5);
         try
         {
             using HttpResponseMessage resumeResponse = await HttpHelpers.InvokeHttpTrigger("ResumeInstance", $"?instanceId={instanceId}");
@@ -119,7 +119,7 @@ public class SuspendResumeTests
         string instanceId = await DurableHelpers.ParseInstanceIdAsync(response);
         string statusQueryGetUri = await DurableHelpers.ParseStatusQueryGetUriAsync(response);
 
-        await DurableHelpers.WaitForOrchestrationState(statusQueryGetUri, "Completed", 5);
+        await DurableHelpers.WaitForOrchestrationStateAsync(statusQueryGetUri, "Completed", 5);
         try
         {
             using HttpResponseMessage suspendResponse = await HttpHelpers.InvokeHttpTrigger("SuspendInstance", $"?instanceId={instanceId}");

--- a/test/e2e/Tests/Tests/SuspendResumeTests.cs
+++ b/test/e2e/Tests/Tests/SuspendResumeTests.cs
@@ -1,0 +1,179 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Net;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.Azure.Durable.Tests.DotnetIsolatedE2E;
+
+[Collection(Constants.FunctionAppCollectionName)]
+public class SuspendResumeTests
+{
+    private readonly FunctionAppFixture _fixture;
+    private readonly ITestOutputHelper _output;
+
+    public SuspendResumeTests(FunctionAppFixture fixture, ITestOutputHelper testOutputHelper)
+    {
+        _fixture = fixture;
+        _fixture.TestLogs.UseTestLogger(testOutputHelper);
+        _output = testOutputHelper;
+    }
+
+
+    [Fact]
+    public async Task SuspendAndResumeRunningOrchestration_ShouldSucceed()
+    {
+        using HttpResponseMessage response = await HttpHelpers.InvokeHttpTrigger("LongOrchestrator_HttpStart", "");
+
+        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
+        string instanceId = await DurableHelpers.ParseInstanceIdAsync(response);
+        string statusQueryGetUri = await DurableHelpers.ParseStatusQueryGetUriAsync(response);
+
+        Thread.Sleep(1000);
+
+        var orchestrationDetails = await DurableHelpers.GetRunningOrchestrationDetailsAsync(statusQueryGetUri);
+        Assert.Equal("Running", orchestrationDetails.RuntimeStatus);
+
+        using HttpResponseMessage suspendResponse = await HttpHelpers.InvokeHttpTrigger("SuspendInstance", $"?instanceId={instanceId}");
+        await AssertRequestSucceedsAsync(suspendResponse);
+
+        Thread.Sleep(1000);
+
+        orchestrationDetails = await DurableHelpers.GetRunningOrchestrationDetailsAsync(statusQueryGetUri);
+        Assert.Equal("Suspended", orchestrationDetails.RuntimeStatus);
+
+        Thread.Sleep(1000);
+
+        using HttpResponseMessage resumeResponse = await HttpHelpers.InvokeHttpTrigger("ResumeInstance", $"?instanceId={instanceId}");
+        await AssertRequestSucceedsAsync(resumeResponse);
+
+        Thread.Sleep(1000);
+
+        orchestrationDetails = await DurableHelpers.GetRunningOrchestrationDetailsAsync(statusQueryGetUri);
+        Assert.Equal("Running", orchestrationDetails.RuntimeStatus);
+
+        await TryTerminateInstanceAsync(instanceId);
+    }
+
+    [Fact]
+    public async Task SuspendSuspendedOrchestration_ShouldFail()
+    {
+        using HttpResponseMessage response = await HttpHelpers.InvokeHttpTrigger("LongOrchestrator_HttpStart", "");
+
+        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
+        string instanceId = await DurableHelpers.ParseInstanceIdAsync(response);
+        string statusQueryGetUri = await DurableHelpers.ParseStatusQueryGetUriAsync(response);
+
+        Thread.Sleep(1000);
+
+        var orchestrationDetails = await DurableHelpers.GetRunningOrchestrationDetailsAsync(statusQueryGetUri);
+        Assert.Equal("Running", orchestrationDetails.RuntimeStatus);
+
+        using HttpResponseMessage suspendResponse = await HttpHelpers.InvokeHttpTrigger("SuspendInstance", $"?instanceId={instanceId}");
+        await AssertRequestSucceedsAsync(suspendResponse);
+
+        Thread.Sleep(1000);
+
+        using HttpResponseMessage resumeResponse = await HttpHelpers.InvokeHttpTrigger("SuspendInstance", $"?instanceId={instanceId}");
+        await AssertRequestFailsAsync(resumeResponse);
+
+        // Give some time for Core Tools to write logs out
+        Thread.Sleep(500);
+
+        Assert.Contains(_fixture.TestLogs.CoreToolsLogs, x => x.Contains("Cannot suspend orchestration instance in the Suspended state.") &&
+                                                              x.Contains(instanceId));
+
+        await TryTerminateInstanceAsync(instanceId);
+    }
+
+
+    [Fact]
+    public async Task ResumeRunningOrchestration_ShouldFail()
+    {
+        using HttpResponseMessage response = await HttpHelpers.InvokeHttpTrigger("LongOrchestrator_HttpStart", "");
+
+        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
+        string instanceId = await DurableHelpers.ParseInstanceIdAsync(response);
+        string statusQueryGetUri = await DurableHelpers.ParseStatusQueryGetUriAsync(response);
+
+        Thread.Sleep(1000);
+
+        var orchestrationDetails = await DurableHelpers.GetRunningOrchestrationDetailsAsync(statusQueryGetUri);
+        Assert.Equal("Running", orchestrationDetails.RuntimeStatus);
+
+        Thread.Sleep(1000);
+
+        using HttpResponseMessage resumeResponse = await HttpHelpers.InvokeHttpTrigger("ResumeInstance", $"?instanceId={instanceId}");
+        await AssertRequestFailsAsync(resumeResponse);
+
+        // Give some time for Core Tools to write logs out
+        Thread.Sleep(500);
+
+        Assert.Contains(_fixture.TestLogs.CoreToolsLogs, x => x.Contains("Cannot resume orchestration instance in the Running state.") &&
+                                                              x.Contains(instanceId));
+
+        await TryTerminateInstanceAsync(instanceId);
+    }
+
+
+    [Fact]
+    public async Task SuspendResumeCompletedOrchestration_ShouldFail()
+    {
+        using HttpResponseMessage response = await HttpHelpers.InvokeHttpTrigger("HelloCities_HttpStart", "");
+
+        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
+        string instanceId = await DurableHelpers.ParseInstanceIdAsync(response);
+        string statusQueryGetUri = await DurableHelpers.ParseStatusQueryGetUriAsync(response);
+
+        Thread.Sleep(1000);
+
+        using HttpResponseMessage suspendResponse = await HttpHelpers.InvokeHttpTrigger("SuspendInstance", $"?instanceId={instanceId}");
+        await AssertRequestFailsAsync(suspendResponse);
+
+        using HttpResponseMessage resumeResponse = await HttpHelpers.InvokeHttpTrigger("ResumeInstance", $"?instanceId={instanceId}");
+        await AssertRequestFailsAsync(resumeResponse);
+
+        // Give some time for Core Tools to write logs out
+        Thread.Sleep(500);
+
+
+        Assert.Contains(_fixture.TestLogs.CoreToolsLogs, x => x.Contains("Cannot suspend orchestration instance in the Completed state.") &&
+                                                              x.Contains(instanceId));
+        Assert.Contains(_fixture.TestLogs.CoreToolsLogs, x => x.Contains("Cannot resume orchestration instance in the Completed state.") &&
+                                                              x.Contains(instanceId));
+
+        await TryTerminateInstanceAsync(instanceId);
+    }
+
+    private static async Task AssertRequestSucceedsAsync(HttpResponseMessage suspendResponse)
+    {
+        Assert.Equal(HttpStatusCode.OK, suspendResponse.StatusCode);
+
+        string? responseMessage = await suspendResponse.Content.ReadAsStringAsync();
+        Assert.NotNull(responseMessage);
+        Assert.Empty(responseMessage);
+    }
+
+    private static async Task AssertRequestFailsAsync(HttpResponseMessage terminateResponse)
+    {
+        Assert.Equal(HttpStatusCode.BadRequest, terminateResponse.StatusCode);
+
+        string? terminateResponseMessage = await terminateResponse.Content.ReadAsStringAsync();
+        Assert.NotNull(terminateResponseMessage);
+        // Unclear error message - see https://github.com/Azure/azure-functions-durable-extension/issues/3027, will update this code when that bug is fixed
+        Assert.Equal("Status(StatusCode=\"Unknown\", Detail=\"Exception was thrown by handler.\")", terminateResponseMessage);
+    }
+
+    private static async Task<bool> TryTerminateInstanceAsync(string instanceId)
+    {
+        try
+        {
+            // Clean up the instance by terminating it - no-op if this fails
+            using HttpResponseMessage terminateResponse = await HttpHelpers.InvokeHttpTrigger("TerminateInstance", $"?instanceId={instanceId}");
+            return true;
+        }
+        catch (Exception ex) { }
+        return false;
+    }
+}

--- a/test/e2e/Tests/Tests/SuspendResumeTests.cs
+++ b/test/e2e/Tests/Tests/SuspendResumeTests.cs
@@ -30,30 +30,18 @@ public class SuspendResumeTests
         string instanceId = await DurableHelpers.ParseInstanceIdAsync(response);
         string statusQueryGetUri = await DurableHelpers.ParseStatusQueryGetUriAsync(response);
 
-        Thread.Sleep(1000);
-
-        var orchestrationDetails = await DurableHelpers.GetRunningOrchestrationDetailsAsync(statusQueryGetUri);
-        Assert.Equal("Running", orchestrationDetails.RuntimeStatus);
-
+        await DurableHelpers.WaitForOrchestrationState(statusQueryGetUri, "Running", 5);
         try
         {
             using HttpResponseMessage suspendResponse = await HttpHelpers.InvokeHttpTrigger("SuspendInstance", $"?instanceId={instanceId}");
             await AssertRequestSucceedsAsync(suspendResponse);
 
-            Thread.Sleep(1000);
-
-            orchestrationDetails = await DurableHelpers.GetRunningOrchestrationDetailsAsync(statusQueryGetUri);
-            Assert.Equal("Suspended", orchestrationDetails.RuntimeStatus);
-
-            Thread.Sleep(1000);
+            await DurableHelpers.WaitForOrchestrationState(statusQueryGetUri, "Suspended", 5);
 
             using HttpResponseMessage resumeResponse = await HttpHelpers.InvokeHttpTrigger("ResumeInstance", $"?instanceId={instanceId}");
             await AssertRequestSucceedsAsync(resumeResponse);
 
-            Thread.Sleep(1000);
-
-            orchestrationDetails = await DurableHelpers.GetRunningOrchestrationDetailsAsync(statusQueryGetUri);
-            Assert.Equal("Running", orchestrationDetails.RuntimeStatus);
+            await DurableHelpers.WaitForOrchestrationState(statusQueryGetUri, "Running", 5);
         }
         finally
         {
@@ -70,17 +58,13 @@ public class SuspendResumeTests
         string instanceId = await DurableHelpers.ParseInstanceIdAsync(response);
         string statusQueryGetUri = await DurableHelpers.ParseStatusQueryGetUriAsync(response);
 
-        Thread.Sleep(1000);
-
+        await DurableHelpers.WaitForOrchestrationState(statusQueryGetUri, "Running", 5);
         try
         {
-            var orchestrationDetails = await DurableHelpers.GetRunningOrchestrationDetailsAsync(statusQueryGetUri);
-            Assert.Equal("Running", orchestrationDetails.RuntimeStatus);
-
             using HttpResponseMessage suspendResponse = await HttpHelpers.InvokeHttpTrigger("SuspendInstance", $"?instanceId={instanceId}");
             await AssertRequestSucceedsAsync(suspendResponse);
 
-            Thread.Sleep(1000);
+            await DurableHelpers.WaitForOrchestrationState(statusQueryGetUri, "Suspended", 5);
 
             using HttpResponseMessage resumeResponse = await HttpHelpers.InvokeHttpTrigger("SuspendInstance", $"?instanceId={instanceId}");
             await AssertRequestFailsAsync(resumeResponse);
@@ -107,14 +91,9 @@ public class SuspendResumeTests
         string instanceId = await DurableHelpers.ParseInstanceIdAsync(response);
         string statusQueryGetUri = await DurableHelpers.ParseStatusQueryGetUriAsync(response);
 
-        Thread.Sleep(1000);
+        await DurableHelpers.WaitForOrchestrationState(statusQueryGetUri, "Running", 5);
         try
         {
-            var orchestrationDetails = await DurableHelpers.GetRunningOrchestrationDetailsAsync(statusQueryGetUri);
-            Assert.Equal("Running", orchestrationDetails.RuntimeStatus);
-
-            Thread.Sleep(1000);
-
             using HttpResponseMessage resumeResponse = await HttpHelpers.InvokeHttpTrigger("ResumeInstance", $"?instanceId={instanceId}");
             await AssertRequestFailsAsync(resumeResponse);
 
@@ -140,7 +119,7 @@ public class SuspendResumeTests
         string instanceId = await DurableHelpers.ParseInstanceIdAsync(response);
         string statusQueryGetUri = await DurableHelpers.ParseStatusQueryGetUriAsync(response);
 
-        Thread.Sleep(1000);
+        await DurableHelpers.WaitForOrchestrationState(statusQueryGetUri, "Completed", 5);
         try
         {
             using HttpResponseMessage suspendResponse = await HttpHelpers.InvokeHttpTrigger("SuspendInstance", $"?instanceId={instanceId}");
@@ -164,23 +143,23 @@ public class SuspendResumeTests
         }
     }
 
-    private static async Task AssertRequestSucceedsAsync(HttpResponseMessage suspendResponse)
+    private static async Task AssertRequestSucceedsAsync(HttpResponseMessage response)
     {
-        Assert.Equal(HttpStatusCode.OK, suspendResponse.StatusCode);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
-        string? responseMessage = await suspendResponse.Content.ReadAsStringAsync();
+        string? responseMessage = await response.Content.ReadAsStringAsync();
         Assert.NotNull(responseMessage);
         Assert.Empty(responseMessage);
     }
 
-    private static async Task AssertRequestFailsAsync(HttpResponseMessage terminateResponse)
+    private static async Task AssertRequestFailsAsync(HttpResponseMessage response)
     {
-        Assert.Equal(HttpStatusCode.BadRequest, terminateResponse.StatusCode);
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
 
-        string? terminateResponseMessage = await terminateResponse.Content.ReadAsStringAsync();
-        Assert.NotNull(terminateResponseMessage);
+        string? responseMessage = await response.Content.ReadAsStringAsync();
+        Assert.NotNull(responseMessage);
         // Unclear error message - see https://github.com/Azure/azure-functions-durable-extension/issues/3027, will update this code when that bug is fixed
-        Assert.Equal("Status(StatusCode=\"Unknown\", Detail=\"Exception was thrown by handler.\")", terminateResponseMessage);
+        Assert.Equal("Status(StatusCode=\"Unknown\", Detail=\"Exception was thrown by handler.\")", responseMessage);
     }
 
     private static async Task<bool> TryTerminateInstanceAsync(string instanceId)

--- a/test/e2e/Tests/Tests/SuspendResumeTests.cs
+++ b/test/e2e/Tests/Tests/SuspendResumeTests.cs
@@ -35,25 +35,30 @@ public class SuspendResumeTests
         var orchestrationDetails = await DurableHelpers.GetRunningOrchestrationDetailsAsync(statusQueryGetUri);
         Assert.Equal("Running", orchestrationDetails.RuntimeStatus);
 
-        using HttpResponseMessage suspendResponse = await HttpHelpers.InvokeHttpTrigger("SuspendInstance", $"?instanceId={instanceId}");
-        await AssertRequestSucceedsAsync(suspendResponse);
+        try
+        {
+            using HttpResponseMessage suspendResponse = await HttpHelpers.InvokeHttpTrigger("SuspendInstance", $"?instanceId={instanceId}");
+            await AssertRequestSucceedsAsync(suspendResponse);
 
-        Thread.Sleep(1000);
+            Thread.Sleep(1000);
 
-        orchestrationDetails = await DurableHelpers.GetRunningOrchestrationDetailsAsync(statusQueryGetUri);
-        Assert.Equal("Suspended", orchestrationDetails.RuntimeStatus);
+            orchestrationDetails = await DurableHelpers.GetRunningOrchestrationDetailsAsync(statusQueryGetUri);
+            Assert.Equal("Suspended", orchestrationDetails.RuntimeStatus);
 
-        Thread.Sleep(1000);
+            Thread.Sleep(1000);
 
-        using HttpResponseMessage resumeResponse = await HttpHelpers.InvokeHttpTrigger("ResumeInstance", $"?instanceId={instanceId}");
-        await AssertRequestSucceedsAsync(resumeResponse);
+            using HttpResponseMessage resumeResponse = await HttpHelpers.InvokeHttpTrigger("ResumeInstance", $"?instanceId={instanceId}");
+            await AssertRequestSucceedsAsync(resumeResponse);
 
-        Thread.Sleep(1000);
+            Thread.Sleep(1000);
 
-        orchestrationDetails = await DurableHelpers.GetRunningOrchestrationDetailsAsync(statusQueryGetUri);
-        Assert.Equal("Running", orchestrationDetails.RuntimeStatus);
-
-        await TryTerminateInstanceAsync(instanceId);
+            orchestrationDetails = await DurableHelpers.GetRunningOrchestrationDetailsAsync(statusQueryGetUri);
+            Assert.Equal("Running", orchestrationDetails.RuntimeStatus);
+        }
+        finally
+        {
+            await TryTerminateInstanceAsync(instanceId);
+        }
     }
 
     [Fact]
@@ -67,24 +72,29 @@ public class SuspendResumeTests
 
         Thread.Sleep(1000);
 
-        var orchestrationDetails = await DurableHelpers.GetRunningOrchestrationDetailsAsync(statusQueryGetUri);
-        Assert.Equal("Running", orchestrationDetails.RuntimeStatus);
+        try
+        {
+            var orchestrationDetails = await DurableHelpers.GetRunningOrchestrationDetailsAsync(statusQueryGetUri);
+            Assert.Equal("Running", orchestrationDetails.RuntimeStatus);
 
-        using HttpResponseMessage suspendResponse = await HttpHelpers.InvokeHttpTrigger("SuspendInstance", $"?instanceId={instanceId}");
-        await AssertRequestSucceedsAsync(suspendResponse);
+            using HttpResponseMessage suspendResponse = await HttpHelpers.InvokeHttpTrigger("SuspendInstance", $"?instanceId={instanceId}");
+            await AssertRequestSucceedsAsync(suspendResponse);
 
-        Thread.Sleep(1000);
+            Thread.Sleep(1000);
 
-        using HttpResponseMessage resumeResponse = await HttpHelpers.InvokeHttpTrigger("SuspendInstance", $"?instanceId={instanceId}");
-        await AssertRequestFailsAsync(resumeResponse);
+            using HttpResponseMessage resumeResponse = await HttpHelpers.InvokeHttpTrigger("SuspendInstance", $"?instanceId={instanceId}");
+            await AssertRequestFailsAsync(resumeResponse);
 
-        // Give some time for Core Tools to write logs out
-        Thread.Sleep(500);
+            // Give some time for Core Tools to write logs out
+            Thread.Sleep(500);
 
-        Assert.Contains(_fixture.TestLogs.CoreToolsLogs, x => x.Contains("Cannot suspend orchestration instance in the Suspended state.") &&
-                                                              x.Contains(instanceId));
-
-        await TryTerminateInstanceAsync(instanceId);
+            Assert.Contains(_fixture.TestLogs.CoreToolsLogs, x => x.Contains("Cannot suspend orchestration instance in the Suspended state.") &&
+                                                                  x.Contains(instanceId));
+        }
+        finally
+        {
+            await TryTerminateInstanceAsync(instanceId);
+        }
     }
 
 
@@ -98,22 +108,26 @@ public class SuspendResumeTests
         string statusQueryGetUri = await DurableHelpers.ParseStatusQueryGetUriAsync(response);
 
         Thread.Sleep(1000);
+        try
+        {
+            var orchestrationDetails = await DurableHelpers.GetRunningOrchestrationDetailsAsync(statusQueryGetUri);
+            Assert.Equal("Running", orchestrationDetails.RuntimeStatus);
 
-        var orchestrationDetails = await DurableHelpers.GetRunningOrchestrationDetailsAsync(statusQueryGetUri);
-        Assert.Equal("Running", orchestrationDetails.RuntimeStatus);
+            Thread.Sleep(1000);
 
-        Thread.Sleep(1000);
+            using HttpResponseMessage resumeResponse = await HttpHelpers.InvokeHttpTrigger("ResumeInstance", $"?instanceId={instanceId}");
+            await AssertRequestFailsAsync(resumeResponse);
 
-        using HttpResponseMessage resumeResponse = await HttpHelpers.InvokeHttpTrigger("ResumeInstance", $"?instanceId={instanceId}");
-        await AssertRequestFailsAsync(resumeResponse);
+            // Give some time for Core Tools to write logs out
+            Thread.Sleep(500);
 
-        // Give some time for Core Tools to write logs out
-        Thread.Sleep(500);
-
-        Assert.Contains(_fixture.TestLogs.CoreToolsLogs, x => x.Contains("Cannot resume orchestration instance in the Running state.") &&
-                                                              x.Contains(instanceId));
-
-        await TryTerminateInstanceAsync(instanceId);
+            Assert.Contains(_fixture.TestLogs.CoreToolsLogs, x => x.Contains("Cannot resume orchestration instance in the Running state.") &&
+                                                                  x.Contains(instanceId));
+        }
+        finally
+        {
+            await TryTerminateInstanceAsync(instanceId);
+        }
     }
 
 
@@ -127,23 +141,27 @@ public class SuspendResumeTests
         string statusQueryGetUri = await DurableHelpers.ParseStatusQueryGetUriAsync(response);
 
         Thread.Sleep(1000);
+        try
+        {
+            using HttpResponseMessage suspendResponse = await HttpHelpers.InvokeHttpTrigger("SuspendInstance", $"?instanceId={instanceId}");
+            await AssertRequestFailsAsync(suspendResponse);
 
-        using HttpResponseMessage suspendResponse = await HttpHelpers.InvokeHttpTrigger("SuspendInstance", $"?instanceId={instanceId}");
-        await AssertRequestFailsAsync(suspendResponse);
+            using HttpResponseMessage resumeResponse = await HttpHelpers.InvokeHttpTrigger("ResumeInstance", $"?instanceId={instanceId}");
+            await AssertRequestFailsAsync(resumeResponse);
 
-        using HttpResponseMessage resumeResponse = await HttpHelpers.InvokeHttpTrigger("ResumeInstance", $"?instanceId={instanceId}");
-        await AssertRequestFailsAsync(resumeResponse);
-
-        // Give some time for Core Tools to write logs out
-        Thread.Sleep(500);
+            // Give some time for Core Tools to write logs out
+            Thread.Sleep(500);
 
 
-        Assert.Contains(_fixture.TestLogs.CoreToolsLogs, x => x.Contains("Cannot suspend orchestration instance in the Completed state.") &&
-                                                              x.Contains(instanceId));
-        Assert.Contains(_fixture.TestLogs.CoreToolsLogs, x => x.Contains("Cannot resume orchestration instance in the Completed state.") &&
-                                                              x.Contains(instanceId));
-
-        await TryTerminateInstanceAsync(instanceId);
+            Assert.Contains(_fixture.TestLogs.CoreToolsLogs, x => x.Contains("Cannot suspend orchestration instance in the Completed state.") &&
+                                                                  x.Contains(instanceId));
+            Assert.Contains(_fixture.TestLogs.CoreToolsLogs, x => x.Contains("Cannot resume orchestration instance in the Completed state.") &&
+                                                                  x.Contains(instanceId));
+        }
+        finally
+        {
+            await TryTerminateInstanceAsync(instanceId);
+        }
     }
 
     private static async Task AssertRequestSucceedsAsync(HttpResponseMessage suspendResponse)
@@ -173,7 +191,7 @@ public class SuspendResumeTests
             using HttpResponseMessage terminateResponse = await HttpHelpers.InvokeHttpTrigger("TerminateInstance", $"?instanceId={instanceId}");
             return true;
         }
-        catch (Exception ex) { }
+        catch (Exception) { }
         return false;
     }
 }

--- a/test/e2e/Tests/Tests/TerminateOrchestratorTests.cs
+++ b/test/e2e/Tests/Tests/TerminateOrchestratorTests.cs
@@ -30,12 +30,12 @@ public class TerminateOrchestratorTests
         string instanceId = await DurableHelpers.ParseInstanceIdAsync(response);
         string statusQueryGetUri = await DurableHelpers.ParseStatusQueryGetUriAsync(response);
 
-        await DurableHelpers.WaitForOrchestrationState(statusQueryGetUri, "Running", 5);
+        await DurableHelpers.WaitForOrchestrationStateAsync(statusQueryGetUri, "Running", 5);
 
         using HttpResponseMessage terminateResponse = await HttpHelpers.InvokeHttpTrigger("TerminateInstance", $"?instanceId={instanceId}");
         await AssertTerminateRequestSucceedsAsync(terminateResponse);
 
-        await DurableHelpers.WaitForOrchestrationState(statusQueryGetUri, "Terminated", 5);
+        await DurableHelpers.WaitForOrchestrationStateAsync(statusQueryGetUri, "Terminated", 5);
     }
 
 
@@ -49,12 +49,12 @@ public class TerminateOrchestratorTests
         string instanceId = await DurableHelpers.ParseInstanceIdAsync(response);
         string statusQueryGetUri = await DurableHelpers.ParseStatusQueryGetUriAsync(response);
 
-        await DurableHelpers.WaitForOrchestrationState(statusQueryGetUri, "Pending", 5);
+        await DurableHelpers.WaitForOrchestrationStateAsync(statusQueryGetUri, "Pending", 5);
 
         using HttpResponseMessage terminateResponse = await HttpHelpers.InvokeHttpTrigger("TerminateInstance", $"?instanceId={instanceId}");
         await AssertTerminateRequestSucceedsAsync(terminateResponse);
 
-        await DurableHelpers.WaitForOrchestrationState(statusQueryGetUri, "Terminated", 5);
+        await DurableHelpers.WaitForOrchestrationStateAsync(statusQueryGetUri, "Terminated", 5);
     }
 
 
@@ -67,12 +67,12 @@ public class TerminateOrchestratorTests
         string instanceId = await DurableHelpers.ParseInstanceIdAsync(response);
         string statusQueryGetUri = await DurableHelpers.ParseStatusQueryGetUriAsync(response);
 
-        await DurableHelpers.WaitForOrchestrationState(statusQueryGetUri, "Running", 5);
+        await DurableHelpers.WaitForOrchestrationStateAsync(statusQueryGetUri, "Running", 5);
 
         using HttpResponseMessage terminateResponse = await HttpHelpers.InvokeHttpTrigger("TerminateInstance", $"?instanceId={instanceId}");
         await AssertTerminateRequestSucceedsAsync(terminateResponse);
 
-        await DurableHelpers.WaitForOrchestrationState(statusQueryGetUri, "Terminated", 5);
+        await DurableHelpers.WaitForOrchestrationStateAsync(statusQueryGetUri, "Terminated", 5);
 
         using HttpResponseMessage terminateAgainResponse = await HttpHelpers.InvokeHttpTrigger("TerminateInstance", $"?instanceId={instanceId}");
         await AssertTerminateRequestFailsAsync(terminateAgainResponse);
@@ -94,7 +94,7 @@ public class TerminateOrchestratorTests
         string instanceId = await DurableHelpers.ParseInstanceIdAsync(response);
         string statusQueryGetUri = await DurableHelpers.ParseStatusQueryGetUriAsync(response);
 
-        await DurableHelpers.WaitForOrchestrationState(statusQueryGetUri, "Completed", 5);
+        await DurableHelpers.WaitForOrchestrationStateAsync(statusQueryGetUri, "Completed", 5);
 
         using HttpResponseMessage terminateResponse = await HttpHelpers.InvokeHttpTrigger("TerminateInstance", $"?instanceId={instanceId}");
         await AssertTerminateRequestFailsAsync(terminateResponse);

--- a/test/e2e/Tests/Tests/TerminateOrchestratorTests.cs
+++ b/test/e2e/Tests/Tests/TerminateOrchestratorTests.cs
@@ -30,12 +30,12 @@ public class TerminateOrchestratorTests
         string instanceId = await DurableHelpers.ParseInstanceIdAsync(response);
         string statusQueryGetUri = await DurableHelpers.ParseStatusQueryGetUriAsync(response);
 
-        await DurableHelpers.WaitForOrchestrationStateAsync(statusQueryGetUri, "Running", 5);
+        await DurableHelpers.WaitForOrchestrationStateAsync(statusQueryGetUri, "Running", 30);
 
         using HttpResponseMessage terminateResponse = await HttpHelpers.InvokeHttpTrigger("TerminateInstance", $"?instanceId={instanceId}");
         await AssertTerminateRequestSucceedsAsync(terminateResponse);
 
-        await DurableHelpers.WaitForOrchestrationStateAsync(statusQueryGetUri, "Terminated", 5);
+        await DurableHelpers.WaitForOrchestrationStateAsync(statusQueryGetUri, "Terminated", 30);
     }
 
 
@@ -49,12 +49,12 @@ public class TerminateOrchestratorTests
         string instanceId = await DurableHelpers.ParseInstanceIdAsync(response);
         string statusQueryGetUri = await DurableHelpers.ParseStatusQueryGetUriAsync(response);
 
-        await DurableHelpers.WaitForOrchestrationStateAsync(statusQueryGetUri, "Pending", 5);
+        await DurableHelpers.WaitForOrchestrationStateAsync(statusQueryGetUri, "Pending", 30);
 
         using HttpResponseMessage terminateResponse = await HttpHelpers.InvokeHttpTrigger("TerminateInstance", $"?instanceId={instanceId}");
         await AssertTerminateRequestSucceedsAsync(terminateResponse);
 
-        await DurableHelpers.WaitForOrchestrationStateAsync(statusQueryGetUri, "Terminated", 5);
+        await DurableHelpers.WaitForOrchestrationStateAsync(statusQueryGetUri, "Terminated", 30);
     }
 
 
@@ -67,12 +67,12 @@ public class TerminateOrchestratorTests
         string instanceId = await DurableHelpers.ParseInstanceIdAsync(response);
         string statusQueryGetUri = await DurableHelpers.ParseStatusQueryGetUriAsync(response);
 
-        await DurableHelpers.WaitForOrchestrationStateAsync(statusQueryGetUri, "Running", 5);
+        await DurableHelpers.WaitForOrchestrationStateAsync(statusQueryGetUri, "Running", 30);
 
         using HttpResponseMessage terminateResponse = await HttpHelpers.InvokeHttpTrigger("TerminateInstance", $"?instanceId={instanceId}");
         await AssertTerminateRequestSucceedsAsync(terminateResponse);
 
-        await DurableHelpers.WaitForOrchestrationStateAsync(statusQueryGetUri, "Terminated", 5);
+        await DurableHelpers.WaitForOrchestrationStateAsync(statusQueryGetUri, "Terminated", 30);
 
         using HttpResponseMessage terminateAgainResponse = await HttpHelpers.InvokeHttpTrigger("TerminateInstance", $"?instanceId={instanceId}");
         await AssertTerminateRequestFailsAsync(terminateAgainResponse);
@@ -94,7 +94,7 @@ public class TerminateOrchestratorTests
         string instanceId = await DurableHelpers.ParseInstanceIdAsync(response);
         string statusQueryGetUri = await DurableHelpers.ParseStatusQueryGetUriAsync(response);
 
-        await DurableHelpers.WaitForOrchestrationStateAsync(statusQueryGetUri, "Completed", 5);
+        await DurableHelpers.WaitForOrchestrationStateAsync(statusQueryGetUri, "Completed", 30);
 
         using HttpResponseMessage terminateResponse = await HttpHelpers.InvokeHttpTrigger("TerminateInstance", $"?instanceId={instanceId}");
         await AssertTerminateRequestFailsAsync(terminateResponse);

--- a/test/e2e/Tests/Tests/TerminateOrchestratorTests.cs
+++ b/test/e2e/Tests/Tests/TerminateOrchestratorTests.cs
@@ -30,18 +30,12 @@ public class TerminateOrchestratorTests
         string instanceId = await DurableHelpers.ParseInstanceIdAsync(response);
         string statusQueryGetUri = await DurableHelpers.ParseStatusQueryGetUriAsync(response);
 
-        Thread.Sleep(1000);
-
-        var orchestrationDetails = await DurableHelpers.GetRunningOrchestrationDetailsAsync(statusQueryGetUri);
-        Assert.Equal("Running", orchestrationDetails.RuntimeStatus);
+        await DurableHelpers.WaitForOrchestrationState(statusQueryGetUri, "Running", 5);
 
         using HttpResponseMessage terminateResponse = await HttpHelpers.InvokeHttpTrigger("TerminateInstance", $"?instanceId={instanceId}");
         await AssertTerminateRequestSucceedsAsync(terminateResponse);
 
-        Thread.Sleep(1000);
-
-        orchestrationDetails = await DurableHelpers.GetRunningOrchestrationDetailsAsync(statusQueryGetUri);
-        Assert.Equal("Terminated", orchestrationDetails.RuntimeStatus);
+        await DurableHelpers.WaitForOrchestrationState(statusQueryGetUri, "Terminated", 5);
     }
 
 
@@ -55,18 +49,12 @@ public class TerminateOrchestratorTests
         string instanceId = await DurableHelpers.ParseInstanceIdAsync(response);
         string statusQueryGetUri = await DurableHelpers.ParseStatusQueryGetUriAsync(response);
 
-        Thread.Sleep(1000);
-
-        var orchestrationDetails = await DurableHelpers.GetRunningOrchestrationDetailsAsync(statusQueryGetUri);
-        Assert.Equal("Pending", orchestrationDetails.RuntimeStatus);
+        await DurableHelpers.WaitForOrchestrationState(statusQueryGetUri, "Pending", 5);
 
         using HttpResponseMessage terminateResponse = await HttpHelpers.InvokeHttpTrigger("TerminateInstance", $"?instanceId={instanceId}");
         await AssertTerminateRequestSucceedsAsync(terminateResponse);
 
-        Thread.Sleep(1000);
-
-        orchestrationDetails = await DurableHelpers.GetRunningOrchestrationDetailsAsync(statusQueryGetUri);
-        Assert.Equal("Terminated", orchestrationDetails.RuntimeStatus);
+        await DurableHelpers.WaitForOrchestrationState(statusQueryGetUri, "Terminated", 5);
     }
 
 
@@ -79,15 +67,13 @@ public class TerminateOrchestratorTests
         string instanceId = await DurableHelpers.ParseInstanceIdAsync(response);
         string statusQueryGetUri = await DurableHelpers.ParseStatusQueryGetUriAsync(response);
 
-        Thread.Sleep(1000);
-
-        var orchestrationDetails = await DurableHelpers.GetRunningOrchestrationDetailsAsync(statusQueryGetUri);
-        Assert.Equal("Running", orchestrationDetails.RuntimeStatus);
+        await DurableHelpers.WaitForOrchestrationState(statusQueryGetUri, "Running", 5);
 
         using HttpResponseMessage terminateResponse = await HttpHelpers.InvokeHttpTrigger("TerminateInstance", $"?instanceId={instanceId}");
         await AssertTerminateRequestSucceedsAsync(terminateResponse);
 
-        Thread.Sleep(1000);
+        await DurableHelpers.WaitForOrchestrationState(statusQueryGetUri, "Terminated", 5);
+
         using HttpResponseMessage terminateAgainResponse = await HttpHelpers.InvokeHttpTrigger("TerminateInstance", $"?instanceId={instanceId}");
         await AssertTerminateRequestFailsAsync(terminateAgainResponse);
 
@@ -96,9 +82,6 @@ public class TerminateOrchestratorTests
 
         Assert.Contains(_fixture.TestLogs.CoreToolsLogs, x => x.Contains("Cannot terminate orchestration instance in the Terminated state.") &&
                                                               x.Contains(instanceId));
-
-        orchestrationDetails = await DurableHelpers.GetRunningOrchestrationDetailsAsync(statusQueryGetUri);
-        Assert.Equal("Terminated", orchestrationDetails.RuntimeStatus);
     }
 
 
@@ -111,10 +94,7 @@ public class TerminateOrchestratorTests
         string instanceId = await DurableHelpers.ParseInstanceIdAsync(response);
         string statusQueryGetUri = await DurableHelpers.ParseStatusQueryGetUriAsync(response);
 
-        Thread.Sleep(1000);
-
-        var orchestrationDetails = await DurableHelpers.GetRunningOrchestrationDetailsAsync(statusQueryGetUri);
-        Assert.Equal("Completed", orchestrationDetails.RuntimeStatus);
+        await DurableHelpers.WaitForOrchestrationState(statusQueryGetUri, "Completed", 5);
 
         using HttpResponseMessage terminateResponse = await HttpHelpers.InvokeHttpTrigger("TerminateInstance", $"?instanceId={instanceId}");
         await AssertTerminateRequestFailsAsync(terminateResponse);


### PR DESCRIPTION
<!-- Start the PR description with some context for the change. -->
Adds testing for suspend/resume in Durable

<!-- Make sure to delete the markdown comments and the below sections when squash merging -->

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)
* [x] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk
* [x] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
    * [ ] Otherwise: major or minor version updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
* [x] My changes **do not** add EventIds to our EventSource logs
    * [ ] Otherwise: Ensure the EventIds are within the supported range in our existing Windows infrastructure. You may validate this with a deployed app's telemetry. You may also extend the range by completing a PR such as [this one](https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files).
* [x] My changes **should** be added to **v2.x** branch.
    * [ ] Otherwise: This change applies exclusively to WebJobs.Extensions.DurableTask v3.x. It will be retained only in the `dev` and `main` branches and will not be merged into the `v2.x` branch.
