### PR TITLE
Add orchestration query tests

### DIFF
--- a/test/e2e/Apps/BasicDotNetIsolated/OrchestrationQuery.cs
+++ b/test/e2e/Apps/BasicDotNetIsolated/OrchestrationQuery.cs
@@ -1,0 +1,58 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Net;
+using Grpc.Core;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
+using Microsoft.DurableTask.Client;
+using DTC = Microsoft.DurableTask.Client;
+
+namespace Microsoft.Azure.Durable.Tests.E2E;
+public static class OrchestrationQuery
+{
+    [Function(nameof(GetAllStatus))]
+    public static async Task<HttpResponseData> GetAllStatus(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", "post")] HttpRequestData req,
+        [DurableClient] DTC.DurableTaskClient client)
+    {
+        try 
+        {
+            var instances = client.GetAllInstancesAsync();
+
+            var response = req.CreateResponse(HttpStatusCode.OK);
+            await response.WriteAsJsonAsync(instances);
+            return response;
+        }
+        catch (RpcException ex) 
+        {
+            var response = req.CreateResponse(HttpStatusCode.BadRequest);
+            response.Headers.Add("Content-Type", "text/plain");
+            await response.WriteStringAsync(ex.Message);
+            return response;
+        }
+    }
+    
+    [Function(nameof(GetRunningStatus))]
+    public static async Task<HttpResponseData> GetRunningStatus(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", "post")] HttpRequestData req,
+        [DurableClient] DTC.DurableTaskClient client)
+    {
+        try 
+        {
+            DTC.OrchestrationQuery filter = new DTC.OrchestrationQuery(Statuses: new List<OrchestrationRuntimeStatus> { OrchestrationRuntimeStatus.Running, OrchestrationRuntimeStatus.Pending, OrchestrationRuntimeStatus.Suspended });
+            var instances = client.GetAllInstancesAsync(filter);
+
+            var response = req.CreateResponse(HttpStatusCode.OK);
+            await response.WriteAsJsonAsync(instances);
+            return response;
+        }
+        catch (RpcException ex) 
+        {
+            var response = req.CreateResponse(HttpStatusCode.BadRequest);
+            response.Headers.Add("Content-Type", "text/plain");
+            await response.WriteStringAsync(ex.Message);
+            return response;
+        }
+    }
+}

--- a/test/e2e/Apps/BasicDotNetIsolated/OrchestrationQuery.cs
+++ b/test/e2e/Apps/BasicDotNetIsolated/OrchestrationQuery.cs
@@ -10,8 +10,8 @@ using Microsoft.DurableTask.Client;
 namespace Microsoft.Azure.Durable.Tests.E2E;
 public static class OrchestrationQueryFunctions
 {
-    [Function(nameof(GetAllStatus))]
-    public static async Task<HttpResponseData> GetAllStatus(
+    [Function(nameof(GetAllInstances))]
+    public static async Task<HttpResponseData> GetAllInstances(
         [HttpTrigger(AuthorizationLevel.Anonymous, "get", "post")] HttpRequestData req,
         [DurableClient] DurableTaskClient client)
     {
@@ -32,14 +32,18 @@ public static class OrchestrationQueryFunctions
         }
     }
 
-    [Function(nameof(GetRunningStatus))]
-    public static async Task<HttpResponseData> GetRunningStatus(
+    [Function(nameof(GetRunningInstances))]
+    public static async Task<HttpResponseData> GetRunningInstances(
         [HttpTrigger(AuthorizationLevel.Anonymous, "get", "post")] HttpRequestData req,
         [DurableClient] DurableTaskClient client)
     {
         try 
         {
-            OrchestrationQuery filter = new OrchestrationQuery(Statuses: new List<OrchestrationRuntimeStatus> { OrchestrationRuntimeStatus.Running, OrchestrationRuntimeStatus.Pending, OrchestrationRuntimeStatus.Suspended });
+            OrchestrationQuery filter = new OrchestrationQuery(Statuses: new List<OrchestrationRuntimeStatus> { 
+                OrchestrationRuntimeStatus.Running, 
+                OrchestrationRuntimeStatus.Pending, 
+                OrchestrationRuntimeStatus.Suspended 
+            });
             var instances = client.GetAllInstancesAsync(filter);
 
             var response = req.CreateResponse(HttpStatusCode.OK);

--- a/test/e2e/Apps/BasicDotNetIsolated/OrchestrationQuery.cs
+++ b/test/e2e/Apps/BasicDotNetIsolated/OrchestrationQuery.cs
@@ -6,15 +6,14 @@ using Grpc.Core;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.DurableTask.Client;
-using DTC = Microsoft.DurableTask.Client;
 
 namespace Microsoft.Azure.Durable.Tests.E2E;
-public static class OrchestrationQuery
+public static class OrchestrationQueryFunctions
 {
     [Function(nameof(GetAllStatus))]
     public static async Task<HttpResponseData> GetAllStatus(
         [HttpTrigger(AuthorizationLevel.Anonymous, "get", "post")] HttpRequestData req,
-        [DurableClient] DTC.DurableTaskClient client)
+        [DurableClient] DurableTaskClient client)
     {
         try 
         {
@@ -32,15 +31,15 @@ public static class OrchestrationQuery
             return response;
         }
     }
-    
+
     [Function(nameof(GetRunningStatus))]
     public static async Task<HttpResponseData> GetRunningStatus(
         [HttpTrigger(AuthorizationLevel.Anonymous, "get", "post")] HttpRequestData req,
-        [DurableClient] DTC.DurableTaskClient client)
+        [DurableClient] DurableTaskClient client)
     {
         try 
         {
-            DTC.OrchestrationQuery filter = new DTC.OrchestrationQuery(Statuses: new List<OrchestrationRuntimeStatus> { OrchestrationRuntimeStatus.Running, OrchestrationRuntimeStatus.Pending, OrchestrationRuntimeStatus.Suspended });
+            OrchestrationQuery filter = new OrchestrationQuery(Statuses: new List<OrchestrationRuntimeStatus> { OrchestrationRuntimeStatus.Running, OrchestrationRuntimeStatus.Pending, OrchestrationRuntimeStatus.Suspended });
             var instances = client.GetAllInstancesAsync(filter);
 
             var response = req.CreateResponse(HttpStatusCode.OK);

--- a/test/e2e/Tests/Fixtures/FixtureHelpers.cs
+++ b/test/e2e/Tests/Fixtures/FixtureHelpers.cs
@@ -49,8 +49,14 @@ public static class FixtureHelpers
 
     public static void StartProcessWithLogging(Process funcProcess, ILogger logger)
     {
-        funcProcess.ErrorDataReceived += (sender, e) => { try { logger.LogError(e?.Data); } catch (Exception) { Console.WriteLine("ERROR: Could not write error to test logger!"); Console.WriteLine(e?.Data); } };
-        funcProcess.OutputDataReceived += (sender, e) => { try { logger.LogInformation(e?.Data); } catch (Exception) { Console.WriteLine("ERROR: Could not write information to test logger!"); Console.WriteLine(e?.Data); } } ;
+        funcProcess.ErrorDataReceived += (sender, e) => { 
+            try { logger.LogError(e?.Data); } 
+            catch (InvalidOperationException) { } 
+        };
+        funcProcess.OutputDataReceived += (sender, e) => { 
+            try { logger.LogInformation(e?.Data); } 
+            catch (InvalidOperationException) { } 
+        };
 
         funcProcess.Start();
 

--- a/test/e2e/Tests/Fixtures/FixtureHelpers.cs
+++ b/test/e2e/Tests/Fixtures/FixtureHelpers.cs
@@ -49,8 +49,8 @@ public static class FixtureHelpers
 
     public static void StartProcessWithLogging(Process funcProcess, ILogger logger)
     {
-        funcProcess.ErrorDataReceived += (sender, e) => logger.LogError(e?.Data);
-        funcProcess.OutputDataReceived += (sender, e) => logger.LogInformation(e?.Data);
+        funcProcess.ErrorDataReceived += (sender, e) => { try { logger.LogError(e?.Data); } catch (Exception) { Console.WriteLine("ERROR: Could not write error to test logger!"); Console.WriteLine(e?.Data); } };
+        funcProcess.OutputDataReceived += (sender, e) => { try { logger.LogInformation(e?.Data); } catch (Exception) { Console.WriteLine("ERROR: Could not write information to test logger!"); Console.WriteLine(e?.Data); } } ;
 
         funcProcess.Start();
 

--- a/test/e2e/Tests/Tests/OrchestrationQueryTests.cs
+++ b/test/e2e/Tests/Tests/OrchestrationQueryTests.cs
@@ -38,22 +38,6 @@ public class OrchestrationQueryTests
 
 
     [Fact]
-    public async Task ListRunningOrchestrations_ShouldSucceed()
-    {
-        using HttpResponseMessage statusResponse = await HttpHelpers.InvokeHttpTrigger("GetRunningStatus", "");
-
-        Assert.Equal(HttpStatusCode.OK, statusResponse.StatusCode);
-
-        string? statusResponseMessage = await statusResponse.Content.ReadAsStringAsync();
-        Assert.NotNull(statusResponseMessage);
-
-        JsonNode? statusResponseJsonNode = JsonNode.Parse(statusResponseMessage);
-        Assert.NotNull(statusResponseJsonNode);
-        Assert.Empty(statusResponseJsonNode.AsArray());
-    }
-
-
-    [Fact]
     public async Task ListRunningOrchestrations_ShouldContainRunningOrchestration()
     {
         using HttpResponseMessage response = await HttpHelpers.InvokeHttpTrigger("LongOrchestrator_HttpStart", "");
@@ -77,9 +61,8 @@ public class OrchestrationQueryTests
 
             JsonNode? statusResponseJsonNode = JsonNode.Parse(statusResponseMessage);
             Assert.NotNull(statusResponseJsonNode);
-            Assert.Single(statusResponseJsonNode.AsArray());
 
-            Assert.Equal(instanceId, statusResponseJsonNode.AsArray()?[0]?["InstanceId"]?.ToString());
+            Assert.Contains(statusResponseJsonNode.AsArray(), x => x?["InstanceId"]?.ToString() == instanceId);
         }
         finally
         {

--- a/test/e2e/Tests/Tests/OrchestrationQueryTests.cs
+++ b/test/e2e/Tests/Tests/OrchestrationQueryTests.cs
@@ -1,0 +1,100 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Net;
+using System.Text.Json.Nodes;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.Azure.Durable.Tests.DotnetIsolatedE2E;
+
+[Collection(Constants.FunctionAppCollectionName)]
+public class OrchestrationQueryTests
+{
+    private readonly FunctionAppFixture _fixture;
+    private readonly ITestOutputHelper _output;
+
+    public OrchestrationQueryTests(FunctionAppFixture fixture, ITestOutputHelper testOutputHelper)
+    {
+        _fixture = fixture;
+        _fixture.TestLogs.UseTestLogger(testOutputHelper);
+        _output = testOutputHelper;
+    }
+
+
+    [Fact]
+    public async Task ListAllOrchestrations_ShouldSucceed()
+    {
+        using HttpResponseMessage statusResponse = await HttpHelpers.InvokeHttpTrigger("GetAllStatus", "");
+
+        Assert.Equal(HttpStatusCode.OK, statusResponse.StatusCode);
+
+        string? statusResponseMessage = await statusResponse.Content.ReadAsStringAsync();
+        Assert.NotNull(statusResponseMessage);
+
+        JsonNode? statusResponseJsonNode = JsonNode.Parse(statusResponseMessage);
+        Assert.NotNull(statusResponseJsonNode);
+    }
+
+
+    [Fact]
+    public async Task ListRunningOrchestrations_ShouldSucceed()
+    {
+        using HttpResponseMessage statusResponse = await HttpHelpers.InvokeHttpTrigger("GetRunningStatus", "");
+
+        Assert.Equal(HttpStatusCode.OK, statusResponse.StatusCode);
+
+        string? statusResponseMessage = await statusResponse.Content.ReadAsStringAsync();
+        Assert.NotNull(statusResponseMessage);
+
+        JsonNode? statusResponseJsonNode = JsonNode.Parse(statusResponseMessage);
+        Assert.NotNull(statusResponseJsonNode);
+        Assert.Empty(statusResponseJsonNode.AsArray());
+    }
+
+
+    [Fact]
+    public async Task ListRunningOrchestrations_ShouldContainRunningOrchestration()
+    {
+        using HttpResponseMessage response = await HttpHelpers.InvokeHttpTrigger("LongOrchestrator_HttpStart", "");
+
+        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
+        string instanceId = await DurableHelpers.ParseInstanceIdAsync(response);
+        string statusQueryGetUri = await DurableHelpers.ParseStatusQueryGetUriAsync(response);
+
+        Thread.Sleep(1000);
+
+        try
+        {
+            var orchestrationDetails = await DurableHelpers.GetRunningOrchestrationDetailsAsync(statusQueryGetUri);
+            Assert.Equal("Running", orchestrationDetails.RuntimeStatus);
+
+            using HttpResponseMessage statusResponse = await HttpHelpers.InvokeHttpTrigger("GetRunningStatus", "");
+
+            Assert.Equal(HttpStatusCode.OK, statusResponse.StatusCode);
+            string? statusResponseMessage = await statusResponse.Content.ReadAsStringAsync();
+            Assert.NotNull(statusResponseMessage);
+
+            JsonNode? statusResponseJsonNode = JsonNode.Parse(statusResponseMessage);
+            Assert.NotNull(statusResponseJsonNode);
+            Assert.Single(statusResponseJsonNode.AsArray());
+
+            Assert.Equal(instanceId, statusResponseJsonNode.AsArray()?[0]?["InstanceId"]?.ToString());
+        }
+        finally
+        {
+            await TryTerminateInstanceAsync(instanceId);
+        }
+    }
+    private static async Task<bool> TryTerminateInstanceAsync(string instanceId)
+    {
+        try
+        {
+            // Clean up the instance by terminating it - no-op if this fails
+            using HttpResponseMessage terminateResponse = await HttpHelpers.InvokeHttpTrigger("TerminateInstance", $"?instanceId={instanceId}");
+            return true;
+        }
+        catch (Exception) { }
+        return false;
+    }
+}

--- a/test/e2e/Tests/Tests/OrchestrationQueryTests.cs
+++ b/test/e2e/Tests/Tests/OrchestrationQueryTests.cs
@@ -25,7 +25,7 @@ public class OrchestrationQueryTests
     [Fact]
     public async Task ListAllOrchestrations_ShouldSucceed()
     {
-        using HttpResponseMessage statusResponse = await HttpHelpers.InvokeHttpTrigger("GetAllStatus", "");
+        using HttpResponseMessage statusResponse = await HttpHelpers.InvokeHttpTrigger("GetAllInstances", "");
 
         Assert.Equal(HttpStatusCode.OK, statusResponse.StatusCode);
 
@@ -53,7 +53,7 @@ public class OrchestrationQueryTests
             var orchestrationDetails = await DurableHelpers.GetRunningOrchestrationDetailsAsync(statusQueryGetUri);
             Assert.Equal("Running", orchestrationDetails.RuntimeStatus);
 
-            using HttpResponseMessage statusResponse = await HttpHelpers.InvokeHttpTrigger("GetRunningStatus", "");
+            using HttpResponseMessage statusResponse = await HttpHelpers.InvokeHttpTrigger("GetRunningInstances", "");
 
             Assert.Equal(HttpStatusCode.OK, statusResponse.StatusCode);
             string? statusResponseMessage = await statusResponse.Content.ReadAsStringAsync();


### PR DESCRIPTION
Adds tests for client.GetAllInstancesAsync() in dotnet-isolated

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)
* [x] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk
* [x] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
    * [ ] Otherwise: major or minor version updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
* [x] My changes **do not** add EventIds to our EventSource logs
    * [ ] Otherwise: Ensure the EventIds are within the supported range in our existing Windows infrastructure. You may validate this with a deployed app's telemetry. You may also extend the range by completing a PR such as [this one](https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files).
* [x] My changes **should** be added to **v2.x** branch.
    * [ ] Otherwise: This change applies exclusively to WebJobs.Extensions.DurableTask v3.x. It will be retained only in the `dev` and `main` branches and will not be merged into the `v2.x` branch.
