### PR TITLE
[WIP] Add logs at FunctionsDurableClient For Investigations

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
+++ b/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
@@ -6,7 +6,8 @@
     <RootNamespace>Microsoft.Azure.WebJobs.Extensions.DurableTask</RootNamespace>
     <MajorVersion>3</MajorVersion>
     <MinorVersion>0</MinorVersion>
-    <PatchVersion>2</PatchVersion>
+    <PatchVersion>3</PatchVersion>
+	<VersionSuffix>private</VersionSuffix>
     <VersionPrefix>$(MajorVersion).$(MinorVersion).$(PatchVersion)</VersionPrefix>
     <FileVersion>$(MajorVersion).$(MinorVersion).$(PatchVersion)</FileVersion>
     <AssemblyVersion>$(MajorVersion).0.0.0</AssemblyVersion>

--- a/src/Worker.Extensions.DurableTask/EtwEventSource.cs
+++ b/src/Worker.Extensions.DurableTask/EtwEventSource.cs
@@ -1,0 +1,349 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+#nullable enable
+using System.Diagnostics.Tracing;
+
+namespace Microsoft.Azure.Functions.Worker.Extensions.DurableTask
+{
+    /// <summary>
+    /// ETW Event Provider for the WebJobs.Extensions.DurableTask extension.
+    /// </summary>
+    [EventSource(Name = "WebJobs-Extensions-DurableTask")]
+    internal sealed class EtwEventSource : EventSource
+    {
+        public static readonly EtwEventSource Instance = new EtwEventSource();
+
+        // Private .ctor - callers should use the shared static instance.
+        private EtwEventSource()
+        { }
+
+#pragma warning disable SA1313 // Parameter names should begin with lower-case letter
+
+        [Event(201, Level = EventLevel.Informational, Version = 2)]
+        public void FunctionScheduled(
+            string TaskHub,
+            string AppName,
+            string SlotName,
+            string FunctionName,
+            string InstanceId,
+            string Reason,
+            string FunctionType,
+            string ExtensionVersion,
+            bool IsReplay)
+        {
+            this.WriteEvent(201, TaskHub, AppName, SlotName, FunctionName, InstanceId, Reason, FunctionType, ExtensionVersion, IsReplay);
+        }
+
+        [Event(202, Level = EventLevel.Informational, Version = 5)]
+        public void FunctionStarting(
+            string TaskHub,
+            string AppName,
+            string SlotName,
+            string FunctionName,
+            int TaskEventId,
+            string InstanceId,
+            string? Input,
+            string FunctionType,
+            string ExtensionVersion,
+            bool IsReplay)
+        {
+            this.WriteEvent(202, TaskHub, AppName, SlotName, FunctionName, TaskEventId, InstanceId, Input ?? "(null)", FunctionType, ExtensionVersion, IsReplay);
+        }
+
+        [Event(203, Level = EventLevel.Informational, Version = 4)]
+        public void FunctionAwaited(
+            string TaskHub,
+            string AppName,
+            string SlotName,
+            string FunctionName,
+            string InstanceId,
+            string FunctionType,
+            string ExtensionVersion,
+            bool IsReplay)
+        {
+            this.WriteEvent(203, TaskHub, AppName, SlotName, FunctionName, InstanceId, FunctionType, ExtensionVersion, IsReplay);
+        }
+
+        [Event(204, Level = EventLevel.Informational, Version = 2)]
+        public void FunctionListening(
+            string TaskHub,
+            string AppName,
+            string SlotName,
+            string FunctionName,
+            string InstanceId,
+            string Reason,
+            string FunctionType,
+            string ExtensionVersion,
+            bool IsReplay)
+        {
+            this.WriteEvent(204, TaskHub, AppName, SlotName, FunctionName, InstanceId, Reason, FunctionType, ExtensionVersion, IsReplay);
+        }
+
+        [Event(205, Level = EventLevel.Informational, Version = 2)]
+        public void ExternalEventRaised(
+            string TaskHub,
+            string AppName,
+            string SlotName,
+            string FunctionName,
+            string InstanceId,
+            string EventName,
+            string? Input,
+            string FunctionType,
+            string ExtensionVersion,
+            bool IsReplay)
+        {
+            this.WriteEvent(205, TaskHub, AppName, SlotName, FunctionName, InstanceId, EventName, Input ?? "(null)", FunctionType, ExtensionVersion, IsReplay);
+        }
+
+        [Event(206, Level = EventLevel.Informational, Version = 5)]
+        public void FunctionCompleted(
+            string TaskHub,
+            string AppName,
+            string SlotName,
+            string FunctionName,
+            int TaskEventId,
+            string InstanceId,
+            string? Output,
+            bool ContinuedAsNew,
+            string FunctionType,
+            string ExtensionVersion,
+            bool IsReplay)
+        {
+            this.WriteEvent(206, TaskHub, AppName, SlotName, FunctionName, TaskEventId, InstanceId, Output ?? "(null)", ContinuedAsNew, FunctionType, ExtensionVersion, IsReplay);
+        }
+
+        [Event(207, Level = EventLevel.Warning, Version = 2)]
+        public void FunctionTerminated(
+            string TaskHub,
+            string AppName,
+            string SlotName,
+            string FunctionName,
+            string InstanceId,
+            string Reason,
+            string FunctionType,
+            string ExtensionVersion,
+            bool IsReplay)
+        {
+            this.WriteEvent(207, TaskHub, AppName, SlotName, FunctionName, InstanceId, Reason, FunctionType, ExtensionVersion, IsReplay);
+        }
+
+        [Event(208, Level = EventLevel.Error, Version = 4)]
+        public void FunctionFailed(
+            string TaskHub,
+            string AppName,
+            string SlotName,
+            string FunctionName,
+            int TaskEventId,
+            string InstanceId,
+            string Reason,
+            string FunctionType,
+            string ExtensionVersion,
+            bool IsReplay)
+        {
+            this.WriteEvent(208, TaskHub, AppName, SlotName, FunctionName, TaskEventId, InstanceId, Reason, FunctionType, ExtensionVersion, IsReplay);
+        }
+
+        [Event(209, Level = EventLevel.Informational, Version = 2)]
+        public void TimerExpired(
+            string TaskHub,
+            string AppName,
+            string SlotName,
+            string FunctionName,
+            string InstanceId,
+            string Reason,
+            string FunctionType,
+            string ExtensionVersion,
+            bool IsReplay)
+        {
+            this.WriteEvent(209, TaskHub, AppName, SlotName, FunctionName, InstanceId, Reason, FunctionType, ExtensionVersion, IsReplay);
+        }
+
+
+        [Event(213, Level = EventLevel.Informational)]
+        public void ExtensionInformationalEvent(
+            string TaskHub,
+            string AppName,
+            string SlotName,
+            string? FunctionName,
+            string? InstanceId,
+            string Details,
+            string ExtensionVersion)
+        {
+            this.WriteEvent(213, TaskHub, AppName, SlotName, FunctionName ?? string.Empty, InstanceId ?? string.Empty, Details, ExtensionVersion);
+        }
+
+        [Event(214, Level = EventLevel.Warning)]
+        public void ExtensionWarningEvent(
+            string TaskHub,
+            string AppName,
+            string SlotName,
+            string? FunctionName,
+            string? InstanceId,
+            string Details,
+            string ExtensionVersion)
+        {
+            this.WriteEvent(214, TaskHub, AppName, SlotName, FunctionName ?? string.Empty, InstanceId ?? string.Empty, Details, ExtensionVersion);
+        }
+
+        [Event(215, Level = EventLevel.Informational, Version = 2)]
+        public void ExternalEventSaved(
+            string TaskHub,
+            string AppName,
+            string SlotName,
+            string FunctionName,
+            string InstanceId,
+            string EventName,
+            string FunctionType,
+            string ExtensionVersion,
+            bool IsReplay)
+        {
+            this.WriteEvent(215, TaskHub, AppName, SlotName, FunctionName, InstanceId, EventName, FunctionType, ExtensionVersion, IsReplay);
+        }
+
+        [Event(216, Level = EventLevel.Informational)]
+        public void FunctionRewound(
+            string TaskHub,
+            string AppName,
+            string SlotName,
+            string FunctionName,
+            string InstanceId,
+            string? Reason,
+            string FunctionType,
+            string ExtensionVersion,
+            bool IsReplay)
+        {
+            this.WriteEvent(216, TaskHub, AppName, SlotName, FunctionName, InstanceId, Reason ?? string.Empty, FunctionType, ExtensionVersion, IsReplay);
+        }
+
+        [Event(217, Level = EventLevel.Informational)]
+        public void EntityOperationQueued(
+            string TaskHub,
+            string AppName,
+            string SlotName,
+            string FunctionName,
+            string InstanceId,
+            string OperationId,
+            string OperationName,
+            string FunctionType,
+            string ExtensionVersion,
+            bool IsReplay)
+        {
+            this.WriteEvent(217, TaskHub, AppName, SlotName, FunctionName, InstanceId, OperationId, OperationName, FunctionType, ExtensionVersion, IsReplay);
+        }
+
+        [Event(218, Level = EventLevel.Informational)]
+        public void EntityResponseReceived(
+            string TaskHub,
+            string AppName,
+            string SlotName,
+            string FunctionName,
+            string InstanceId,
+            string OperationId,
+            string? Result,
+            string FunctionType,
+            string ExtensionVersion,
+            bool IsReplay)
+        {
+            this.WriteEvent(218, TaskHub, AppName, SlotName, FunctionName, InstanceId, OperationId, Result ?? "(null)", FunctionType, ExtensionVersion, IsReplay);
+        }
+
+        [Event(219, Level = EventLevel.Informational, Version = 2)]
+        public void EntityLockAcquired(
+            string TaskHub,
+            string AppName,
+            string SlotName,
+            string FunctionName,
+            string InstanceId,
+            string RequestingInstanceId,
+            string? RequestingExecutionId,
+            string RequestId,
+            string FunctionType,
+            string ExtensionVersion,
+            bool IsReplay)
+        {
+            this.WriteEvent(219, TaskHub, AppName, SlotName, FunctionName, InstanceId, RequestingInstanceId, RequestingExecutionId ?? "", RequestId, FunctionType, ExtensionVersion, IsReplay);
+        }
+
+        [Event(220, Level = EventLevel.Informational)]
+        public void EntityLockReleased(
+            string TaskHub,
+            string AppName,
+            string SlotName,
+            string FunctionName,
+            string InstanceId,
+            string RequestingInstance,
+            string RequestId,
+            string FunctionType,
+            string ExtensionVersion,
+            bool IsReplay)
+        {
+            this.WriteEvent(220, TaskHub, AppName, SlotName, FunctionName, InstanceId, RequestingInstance, RequestId, FunctionType, ExtensionVersion, IsReplay);
+        }
+
+        [Event(221, Level = EventLevel.Informational)]
+        public void OperationCompleted(
+            string TaskHub,
+            string AppName,
+            string SlotName,
+            string FunctionName,
+            string InstanceId,
+            string OperationId,
+            string OperationName,
+            string? Input,
+            string? Output,
+            double Duration,
+            string FunctionType,
+            string ExtensionVersion,
+            bool IsReplay)
+        {
+            this.WriteEvent(221, TaskHub, AppName, SlotName, FunctionName, InstanceId, OperationId, OperationName, Input ?? "(null)", Output ?? "(null)", Duration, FunctionType, ExtensionVersion, IsReplay);
+        }
+
+        [Event(222, Level = EventLevel.Error)]
+        public void OperationFailed(
+            string TaskHub,
+            string AppName,
+            string SlotName,
+            string FunctionName,
+            string InstanceId,
+            string OperationId,
+            string OperationName,
+            string? Input,
+            string Exception,
+            double Duration,
+            string FunctionType,
+            string ExtensionVersion,
+            bool IsReplay)
+        {
+            this.WriteEvent(222, TaskHub, AppName, SlotName, FunctionName, InstanceId, OperationId, OperationName, Input ?? "(null)", Exception, Duration, FunctionType, ExtensionVersion, IsReplay);
+        }
+
+        [Event(223, Level = EventLevel.Informational)]
+        public void ExtensionConfiguration(
+            string TaskHub,
+            string AppName,
+            string SlotName,
+            string Details,
+            string ExtensionVersion)
+        {
+            this.WriteEvent(223, TaskHub, AppName, SlotName, Details, ExtensionVersion);
+        }
+
+        [Event(224, Level = EventLevel.Warning)]
+        public void FunctionAborted(
+            string TaskHub,
+            string AppName,
+            string SlotName,
+            string FunctionName,
+            string InstanceId,
+            string Reason,
+            string FunctionType,
+            string ExtensionVersion,
+            bool IsReplay)
+        {
+            this.WriteEvent(224, TaskHub, AppName, SlotName, FunctionName, InstanceId, Reason, FunctionType, ExtensionVersion, IsReplay);
+        }
+
+#pragma warning restore SA1313 // Parameter names should begin with lower-case letter
+    }
+}

--- a/src/Worker.Extensions.DurableTask/FunctionsDurableClientProvider.cs
+++ b/src/Worker.Extensions.DurableTask/FunctionsDurableClientProvider.cs
@@ -109,11 +109,13 @@ internal partial class FunctionsDurableClientProvider : IAsyncDisposable
             {
                 this.logger.LogTrace("DurableTaskClient resolved from cache");
 
-                EtwEventSource.Instance.ExtensionConfiguration(
+                EtwEventSource.Instance.ExtensionInformationalEvent(
                     taskHub,
-                    connectionName,
-                    connectionName,
-                    $"Connected to '{connectionName}' with '{endpoint}', DurableTaskClient resolved from cache",
+                    AppName: string.Empty,
+                    SlotName: string.Empty,
+                    FunctionName: string.Empty,
+                    InstanceId: string.Empty,
+                    $"Connecion Name:  '{connectionName}',  Endpoint: '{endpoint}', DurableTaskClient resolved from cache with read",
                     "1.2.3-log"
                     );
 
@@ -132,12 +134,14 @@ internal partial class FunctionsDurableClientProvider : IAsyncDisposable
             if (this.clients!.TryGetValue(key, out ClientHolder? holder))
             {
                 this.logger.LogTrace("DurableTaskClient resolved from cache");
-                
-                EtwEventSource.Instance.ExtensionConfiguration(
+
+                EtwEventSource.Instance.ExtensionInformationalEvent(
                     taskHub,
-                    connectionName,
-                    connectionName,
-                    $"Connected to '{connectionName}' with '{endpoint}', DurableTaskClient resolved from cache",
+                    AppName: string.Empty,
+                    SlotName: string.Empty,
+                    FunctionName: string.Empty,
+                    InstanceId: string.Empty,
+                    $"Connecion Name:  '{connectionName}',  Endpoint: '{endpoint}, DurableTaskClient resolved from cache",
                     "1.2.3-log"
                     );
                 return holder.Client;
@@ -148,12 +152,14 @@ internal partial class FunctionsDurableClientProvider : IAsyncDisposable
                 endpoint,
                 taskHub,
                 connectionName);
-            
-            EtwEventSource.Instance.ExtensionConfiguration(
+
+            EtwEventSource.Instance.ExtensionInformationalEvent(
                     taskHub,
-                    connectionName,
-                    connectionName,
-                    $"DurableTaskClient cache miss, Connected to '{connectionName}' with '{endpoint}, Taskhub: '{taskHub}'",
+                    AppName: string.Empty,
+                    SlotName: string.Empty,
+                    FunctionName: string.Empty,
+                    InstanceId: string.Empty,
+                    $"DurableTaskClient cache miss, constructing for Endpoint: Connecion Name:  '{connectionName}',  Endpoint: '{endpoint}",
                     "1.2.3-log"
                     );
 
@@ -165,6 +171,16 @@ internal partial class FunctionsDurableClientProvider : IAsyncDisposable
                 EnableEntitySupport = this.options.EnableEntitySupport,
             };
 
+            EtwEventSource.Instance.ExtensionInformationalEvent(
+                    taskHub,
+                    AppName: string.Empty,
+                    SlotName: string.Empty,
+                    FunctionName: string.Empty,
+                    InstanceId: string.Empty,
+                    $"Created new grpc channel, channel state '{channel.State}'",
+                    "1.2.3-log"
+                    );
+
             ILogger logger = this.loggerFactory.CreateLogger<GrpcDurableTaskClient>();
             GrpcDurableTaskClient client = new(taskHub, options, logger);
             holder = new(client, channel);
@@ -173,11 +189,13 @@ internal partial class FunctionsDurableClientProvider : IAsyncDisposable
         }
         catch (Exception ex)
         {
-            EtwEventSource.Instance.ExtensionConfiguration(
+            EtwEventSource.Instance.ExtensionInformationalEvent(
                     taskHub,
-                    connectionName,
-                    connectionName,
-                    $"Error occurred while building grpc channel, trying connected to '{connectionName}' with '{endpoint}, Taskhub: '{taskHub}'. Exception Type: {ex.GetType()}, Exception Message: '{ex.Message}' ",
+                    AppName: string.Empty,
+                    SlotName: string.Empty,
+                    FunctionName: string.Empty,
+                    InstanceId: string.Empty,
+                    $"Error occurred while constructing grpc channel. ConnectionName: '{connectionName}', Endpoint: '{endpoint}'. Exception Type: {ex.GetType()}, Exception Message: '{ex.Message}' ",
                     "1.2.3-log"
                     );
             this.sync.ExitWriteLock();

--- a/src/Worker.Extensions.DurableTask/FunctionsDurableClientProvider.cs
+++ b/src/Worker.Extensions.DurableTask/FunctionsDurableClientProvider.cs
@@ -159,7 +159,7 @@ internal partial class FunctionsDurableClientProvider : IAsyncDisposable
                     SlotName: string.Empty,
                     FunctionName: string.Empty,
                     InstanceId: string.Empty,
-                    $"DurableTaskClient cache miss, constructing for Endpoint: Connecion Name:  '{connectionName}',  Endpoint: '{endpoint}",
+                    $"DurableTaskClient cache miss, creating new grpc channel : Connecion Name:  '{connectionName}',  Endpoint: '{endpoint}. Curernt Grpc channel count: '{this.clients.Count}'",
                     "1.2.3-log"
                     );
 
@@ -170,16 +170,6 @@ internal partial class FunctionsDurableClientProvider : IAsyncDisposable
                 DataConverter = this.options.DataConverter,
                 EnableEntitySupport = this.options.EnableEntitySupport,
             };
-
-            EtwEventSource.Instance.ExtensionInformationalEvent(
-                    taskHub,
-                    AppName: string.Empty,
-                    SlotName: string.Empty,
-                    FunctionName: string.Empty,
-                    InstanceId: string.Empty,
-                    $"Created new grpc channel, channel state '{channel.State}'",
-                    "1.2.3-log"
-                    );
 
             ILogger logger = this.loggerFactory.CreateLogger<GrpcDurableTaskClient>();
             GrpcDurableTaskClient client = new(taskHub, options, logger);
@@ -198,7 +188,6 @@ internal partial class FunctionsDurableClientProvider : IAsyncDisposable
                     $"Error occurred while constructing grpc channel. ConnectionName: '{connectionName}', Endpoint: '{endpoint}'. Exception Type: {ex.GetType()}, Exception Message: '{ex.Message}' ",
                     "1.2.3-log"
                     );
-            this.sync.ExitWriteLock();
             throw;
         }
         finally

--- a/src/Worker.Extensions.DurableTask/FunctionsDurableClientProvider.cs
+++ b/src/Worker.Extensions.DurableTask/FunctionsDurableClientProvider.cs
@@ -108,6 +108,15 @@ internal partial class FunctionsDurableClientProvider : IAsyncDisposable
             if (this.clients!.TryGetValue(key, out ClientHolder? holder))
             {
                 this.logger.LogTrace("DurableTaskClient resolved from cache");
+
+                EtwEventSource.Instance.ExtensionConfiguration(
+                    taskHub,
+                    connectionName,
+                    connectionName,
+                    $"Connected to '{connectionName}' with '{endpoint}', DurableTaskClient resolved from cache",
+                    "1.2.3-log"
+                    );
+
                 return holder.Client;
             }
         }
@@ -123,6 +132,14 @@ internal partial class FunctionsDurableClientProvider : IAsyncDisposable
             if (this.clients!.TryGetValue(key, out ClientHolder? holder))
             {
                 this.logger.LogTrace("DurableTaskClient resolved from cache");
+                
+                EtwEventSource.Instance.ExtensionConfiguration(
+                    taskHub,
+                    connectionName,
+                    connectionName,
+                    $"Connected to '{connectionName}' with '{endpoint}', DurableTaskClient resolved from cache",
+                    "1.2.3-log"
+                    );
                 return holder.Client;
             }
 
@@ -131,6 +148,15 @@ internal partial class FunctionsDurableClientProvider : IAsyncDisposable
                 endpoint,
                 taskHub,
                 connectionName);
+            
+            EtwEventSource.Instance.ExtensionConfiguration(
+                    taskHub,
+                    connectionName,
+                    connectionName,
+                    $"DurableTaskClient cache miss, Connected to '{connectionName}' with '{endpoint}, Taskhub: '{taskHub}'",
+                    "1.2.3-log"
+                    );
+
             GrpcChannel channel = CreateChannel(key);
             GrpcDurableTaskClientOptions options = new()
             {
@@ -144,6 +170,18 @@ internal partial class FunctionsDurableClientProvider : IAsyncDisposable
             holder = new(client, channel);
             this.clients[key] = holder;
             return client;
+        }
+        catch (Exception ex)
+        {
+            EtwEventSource.Instance.ExtensionConfiguration(
+                    taskHub,
+                    connectionName,
+                    connectionName,
+                    $"Error occurred while building grpc channel, trying connected to '{connectionName}' with '{endpoint}, Taskhub: '{taskHub}'. Exception Type: {ex.GetType()}, Exception Message: '{ex.Message}' ",
+                    "1.2.3-log"
+                    );
+            this.sync.ExitWriteLock();
+            throw;
         }
         finally
         {

--- a/src/Worker.Extensions.DurableTask/FunctionsDurableClientProvider.cs
+++ b/src/Worker.Extensions.DurableTask/FunctionsDurableClientProvider.cs
@@ -116,7 +116,7 @@ internal partial class FunctionsDurableClientProvider : IAsyncDisposable
                     FunctionName: string.Empty,
                     InstanceId: string.Empty,
                     $"Connecion Name:  '{connectionName}',  Endpoint: '{endpoint}', DurableTaskClient resolved from cache with read",
-                    "1.2.3-log"
+                    "1.2.3-grpclog"
                     );
 
                 return holder.Client;
@@ -141,8 +141,8 @@ internal partial class FunctionsDurableClientProvider : IAsyncDisposable
                     SlotName: string.Empty,
                     FunctionName: string.Empty,
                     InstanceId: string.Empty,
-                    $"Connecion Name:  '{connectionName}',  Endpoint: '{endpoint}, DurableTaskClient resolved from cache",
-                    "1.2.3-log"
+                    $"Connecion Name:  '{connectionName}',  Endpoint: '{endpoint}, DurableTaskClient resolved from cache with write",
+                    "1.2.3-grpclog"
                     );
                 return holder.Client;
             }
@@ -160,7 +160,7 @@ internal partial class FunctionsDurableClientProvider : IAsyncDisposable
                     FunctionName: string.Empty,
                     InstanceId: string.Empty,
                     $"DurableTaskClient cache miss, creating new grpc channel : Connecion Name:  '{connectionName}',  Endpoint: '{endpoint}. Curernt Grpc channel count: '{this.clients.Count}'",
-                    "1.2.3-log"
+                    "1.2.3-grpclog"
                     );
 
             GrpcChannel channel = CreateChannel(key);
@@ -186,7 +186,7 @@ internal partial class FunctionsDurableClientProvider : IAsyncDisposable
                     FunctionName: string.Empty,
                     InstanceId: string.Empty,
                     $"Error occurred while constructing grpc channel. ConnectionName: '{connectionName}', Endpoint: '{endpoint}'. Exception Type: {ex.GetType()}, Exception Message: '{ex.Message}' ",
-                    "1.2.3-log"
+                    "1.2.3-grpclog"
                     );
             throw;
         }

--- a/src/Worker.Extensions.DurableTask/Worker.Extensions.DurableTask.csproj
+++ b/src/Worker.Extensions.DurableTask/Worker.Extensions.DurableTask.csproj
@@ -30,7 +30,7 @@
 
     <!-- Version information -->
     <VersionPrefix>1.2.3</VersionPrefix>
-    <VersionSuffix>log</VersionSuffix>
+    <VersionSuffix>grpclog</VersionSuffix>
     <AssemblyVersion>$(VersionPrefix).0</AssemblyVersion>
     <!-- FileVersionRevision is expected to be set by the CI.  -->
     <FileVersion Condition="'$(FileVersionRevision)' != ''">$(VersionPrefix).$(FileVersionRevision)</FileVersion>

--- a/src/Worker.Extensions.DurableTask/Worker.Extensions.DurableTask.csproj
+++ b/src/Worker.Extensions.DurableTask/Worker.Extensions.DurableTask.csproj
@@ -29,8 +29,8 @@
     <AssemblyOriginatorKeyFile>..\..\sign.snk</AssemblyOriginatorKeyFile>
 
     <!-- Version information -->
-    <VersionPrefix>1.2.2</VersionPrefix>
-    <VersionSuffix></VersionSuffix>
+    <VersionPrefix>1.2.3</VersionPrefix>
+    <VersionSuffix>log</VersionSuffix>
     <AssemblyVersion>$(VersionPrefix).0</AssemblyVersion>
     <!-- FileVersionRevision is expected to be set by the CI.  -->
     <FileVersion Condition="'$(FileVersionRevision)' != ''">$(VersionPrefix).$(FileVersionRevision)</FileVersion>


### PR DESCRIPTION
<!-- Start the PR description with some context for the change. -->


<!-- Make sure to delete the markdown comments and the below sections when squash merging -->
To create custom private package only, no need to merge. 

resolves #issue_for_this_pr

### Pull request checklist

* [ ] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)
* [ ] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk
* [ ] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
    * [ ] Otherwise: major or minor version updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
* [ ] My changes **do not** add EventIds to our EventSource logs
    * [ ] Otherwise: Ensure the EventIds are within the supported range in our existing Windows infrastructure. You may validate this with a deployed app's telemetry. You may also extend the range by completing a PR such as [this one](https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files).
* [ ] My changes **should** be added to **v2.x** branch.
    * [ ] Otherwise: This change applies exclusively to WebJobs.Extensions.DurableTask v3.x. It will be retained only in the `dev` and `main` branches and will not be merged into the `v2.x` branch.
