### PR TITLE
Fix the e2e app sln file

### DIFF
--- a/test/e2e/Apps/BasicDotNetIsolated/BasicDotNetIsolated.sln
+++ b/test/e2e/Apps/BasicDotNetIsolated/BasicDotNetIsolated.sln
@@ -5,14 +5,6 @@ VisualStudioVersion = 17.5.002.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "app", "app.csproj", "{A3D6D881-0115-409E-92F0-3D50FB152524}"
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "obj", "obj", "{44B4C292-28D2-4963-89FE-41DDC7C13E97}"
-EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Debug", "Debug", "{CF64E527-9C6F-447E-AD05-0EE52407CCF1}"
-EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "net8.0", "net8.0", "{9ABF536C-4F1B-42F5-AAFE-7AD88832DBDB}"
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WorkerExtensions", "obj\Debug\net8.0\WorkerExtensions\WorkerExtensions.csproj", "{65AF45AC-6495-4740-BB7C-67BD125DF158}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/test/e2e/Apps/BasicDotNetIsolated/BasicDotNetIsolated.sln
+++ b/test/e2e/Apps/BasicDotNetIsolated/BasicDotNetIsolated.sln
@@ -23,11 +23,6 @@ Global
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
-	GlobalSection(NestedProjects) = preSolution
-		{CF64E527-9C6F-447E-AD05-0EE52407CCF1} = {44B4C292-28D2-4963-89FE-41DDC7C13E97}
-		{9ABF536C-4F1B-42F5-AAFE-7AD88832DBDB} = {CF64E527-9C6F-447E-AD05-0EE52407CCF1}
-		{65AF45AC-6495-4740-BB7C-67BD125DF158} = {9ABF536C-4F1B-42F5-AAFE-7AD88832DBDB}
-	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {D4D85C8B-ADB6-47BE-A565-B37D31B6FCD5}
 	EndGlobalSection


### PR DESCRIPTION
<!-- Start the PR description with some context for the change. -->
Fixes an issue with the e2e app .sln file that prevented opening a fresh clone of the repo in Visual Studio. 

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)
* [x] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk
* [x] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
    * [ ] Otherwise: major or minor version updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
* [x] My changes **do not** add EventIds to our EventSource logs
    * [ ] Otherwise: Ensure the EventIds are within the supported range in our existing Windows infrastructure. You may validate this with a deployed app's telemetry. You may also extend the range by completing a PR such as [this one](https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files).
* [ ] My changes **should** be added to **v2.x** branch.
    * [x] Otherwise: This change applies exclusively to WebJobs.Extensions.DurableTask v3.x. It will be retained only in the `dev` and `main` branches and will not be merged into the `v2.x` branch.
