### PR TITLE
Improve exception handling in .NET isolated

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/OutOfProcMiddleware.cs
+++ b/src/WebJobs.Extensions.DurableTask/OutOfProcMiddleware.cs
@@ -691,7 +691,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         {
             try
             {
-                string serializedMessage = exception.Split('\n')[0];
+                if (exception[0] != '{')
+                {
+                    details = null;
+                    return false;
+                }
+
+                int newlineIndex = exception.IndexOf('\n');
+                string serializedMessage = newlineIndex < 0 ? exception : exception.Substring(0, newlineIndex).Trim();
                 P.TaskFailureDetails? taskFailureDetails = JsonConvert.DeserializeObject<P.TaskFailureDetails>(serializedMessage);
                 if (taskFailureDetails != null)
                 {

--- a/src/WebJobs.Extensions.DurableTask/OutOfProcMiddleware.cs
+++ b/src/WebJobs.Extensions.DurableTask/OutOfProcMiddleware.cs
@@ -13,6 +13,7 @@ using DurableTask.Core.Exceptions;
 using DurableTask.Core.History;
 using DurableTask.Core.Middleware;
 using Microsoft.Azure.WebJobs.Host.Executors;
+using Newtonsoft.Json;
 using P = Microsoft.DurableTask.Protobuf;
 
 namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
@@ -606,6 +607,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 Exception rpcException = e.InnerException;
                 if (TryGetRpcExceptionFields(rpcException.Message, out string? exception, out string? stackTrace))
                 {
+                    if (TryExtractSerializedFailureDetailsFromException(exception, out FailureDetails? details) && details is not null)
+                    {
+                        return details;
+                    }
+
                     if (TrySplitExceptionTypeFromMessage(exception, out string? exceptionType, out string? exceptionMessage))
                     {
                         return new FailureDetails(exceptionType, exceptionMessage, stackTrace, innerFailure: null, isNonRetriable: false);
@@ -622,6 +628,21 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
             // Don't recognize this exception - return it as-is
             return new FailureDetails(e);
+        }
+
+        private static FailureDetails? GetFailureDetails(P.TaskFailureDetails taskFailureDetails)
+        {
+            if (taskFailureDetails is null)
+            {
+                return null;
+            }
+
+            return new FailureDetails(
+                taskFailureDetails.ErrorType ?? string.Empty,
+                taskFailureDetails.ErrorMessage ?? string.Empty,
+                taskFailureDetails.StackTrace,
+                GetFailureDetails(taskFailureDetails.InnerFailure),
+                taskFailureDetails.IsNonRetriable);
         }
 
         private static bool TryGetRpcExceptionFields(
@@ -664,6 +685,27 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             }
 
             return true;
+        }
+
+        private static bool TryExtractSerializedFailureDetailsFromException(string exception, out FailureDetails? details)
+        {
+            try
+            {
+                string serializedMessage = exception.Split('\n')[0];
+                P.TaskFailureDetails? taskFailureDetails = JsonConvert.DeserializeObject<P.TaskFailureDetails>(serializedMessage);
+                if (taskFailureDetails != null)
+                {
+                    details = GetFailureDetails(taskFailureDetails);
+                    return true;
+                }
+            }
+            catch (Exception)
+            {
+                // Apparently the exception message was not serialized by the worker middleware, continue
+            }
+
+            details = null;
+            return false;
         }
 
         private static bool TrySplitExceptionTypeFromMessage(

--- a/src/WebJobs.Extensions.DurableTask/OutOfProcMiddleware.cs
+++ b/src/WebJobs.Extensions.DurableTask/OutOfProcMiddleware.cs
@@ -584,6 +584,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     isReplay: false,
                     scheduledEvent.EventId);
 
+                bool detailsParsedFromSerializedException;
+
                 activityResult = new ActivityExecutionResult
                 {
                     ResponseEvent = new TaskFailedEvent(
@@ -591,8 +593,17 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                         taskScheduledId: scheduledEvent.EventId,
                         reason: $"Function '{functionName}' failed with an unhandled exception.",
                         details: null,
-                        GetFailureDetails(result.Exception)),
+                        GetFailureDetails(result.Exception, out detailsParsedFromSerializedException)),
                 };
+
+                if (!detailsParsedFromSerializedException)
+                {
+                    this.TraceHelper.ExtensionWarningEvent(
+                        this.Options.HubName,
+                        functionName.Name,
+                        instance.InstanceId,
+                        "Failure details not parsed from serialized exception details, worker failed to serialize exception");
+                }
             }
 
             // Send the result of the activity function to the DTFx dispatch pipeline.
@@ -600,8 +611,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             dispatchContext.SetProperty(activityResult);
         }
 
-        private static FailureDetails GetFailureDetails(Exception e)
+        private static FailureDetails GetFailureDetails(Exception e, out bool fromSerializedException)
         {
+            fromSerializedException = false;
             if (e.InnerException != null && e.InnerException.Message.StartsWith("Result:"))
             {
                 Exception rpcException = e.InnerException;
@@ -609,6 +621,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 {
                     if (TryExtractSerializedFailureDetailsFromException(exception, out FailureDetails? details) && details is not null)
                     {
+                        fromSerializedException = true;
                         return details;
                     }
 
@@ -708,7 +721,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             }
             catch (Exception)
             {
-                // Apparently the exception message was not serialized by the worker middleware, continue
+                // Apparently the exception message was not serialized by the worker middleware, this will be logged in CallActivityAsync()
             }
 
             details = null;

--- a/src/WebJobs.Extensions.DurableTask/OutOfProcMiddleware.cs
+++ b/src/WebJobs.Extensions.DurableTask/OutOfProcMiddleware.cs
@@ -596,7 +596,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                         GetFailureDetails(result.Exception, out detailsParsedFromSerializedException)),
                 };
 
-                if (!detailsParsedFromSerializedException)
+                if (!detailsParsedFromSerializedException && this.extension.PlatformInformationService.GetWorkerRuntimeType() == WorkerRuntimeType.DotNetIsolated)
                 {
                     this.TraceHelper.ExtensionWarningEvent(
                         this.Options.HubName,

--- a/src/Worker.Extensions.DurableTask/DurableTaskFunctionsMiddleware.cs
+++ b/src/Worker.Extensions.DurableTask/DurableTaskFunctionsMiddleware.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
+using Microsoft.Azure.Functions.Worker.Extensions.DurableTask.Exceptions;
 using Microsoft.Azure.Functions.Worker.Middleware;
 using Microsoft.DurableTask.Worker.Grpc;
 
@@ -15,19 +16,28 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.DurableTask;
 internal class DurableTaskFunctionsMiddleware : IFunctionsWorkerMiddleware
 {
     /// <inheritdoc />
-    public Task Invoke(FunctionContext functionContext, FunctionExecutionDelegate next)
+    public async Task Invoke(FunctionContext functionContext, FunctionExecutionDelegate next)
     {
         if (IsOrchestrationTrigger(functionContext, out BindingMetadata? triggerBinding))
         {
-            return RunOrchestrationAsync(functionContext, triggerBinding, next);
+            await RunOrchestrationAsync(functionContext, triggerBinding, next);
+            return;
         }
 
         if (IsEntityTrigger(functionContext, out triggerBinding))
         {
-            return RunEntityAsync(functionContext, triggerBinding, next);
+            await RunEntityAsync(functionContext, triggerBinding, next);
+            return;
         }
-
-        return next(functionContext);
+        try
+        {
+            await next(functionContext);
+            return;
+        }
+        catch (Exception ex)
+        {
+            throw new DurableSerializationException(ex);
+        }
     }
 
     private static bool IsOrchestrationTrigger(

--- a/src/Worker.Extensions.DurableTask/DurableTaskFunctionsMiddleware.cs
+++ b/src/Worker.Extensions.DurableTask/DurableTaskFunctionsMiddleware.cs
@@ -29,15 +29,14 @@ internal class DurableTaskFunctionsMiddleware : IFunctionsWorkerMiddleware
             await RunEntityAsync(functionContext, triggerBinding, next);
             return;
         }
-        try
+
+        if (IsActivityTrigger(functionContext, out triggerBinding))
         {
-            await next(functionContext);
+            await RunActivityAsync(functionContext, triggerBinding, next);
             return;
         }
-        catch (Exception ex)
-        {
-            throw new DurableSerializationException(ex);
-        }
+
+        await next(functionContext);
     }
 
     private static bool IsOrchestrationTrigger(
@@ -103,5 +102,34 @@ internal class DurableTaskFunctionsMiddleware : IFunctionsWorkerMiddleware
 
         await next(context);
         context.GetInvocationResult().Value = dispatcher.Result;
+    }
+
+    private static bool IsActivityTrigger(
+        FunctionContext context, [NotNullWhen(true)] out BindingMetadata? activityTriggerBinding)
+    {
+        foreach (BindingMetadata binding in context.FunctionDefinition.InputBindings.Values)
+        {
+            if (string.Equals(binding.Type, "activityTrigger", StringComparison.OrdinalIgnoreCase))
+            {
+                activityTriggerBinding = binding;
+                return true;
+            }
+        }
+
+        activityTriggerBinding = null;
+        return false;
+    }
+
+    private static async Task RunActivityAsync(FunctionContext functionContext, BindingMetadata triggerBinding, FunctionExecutionDelegate next)
+    {
+        try
+        {
+            await next(functionContext);
+            return;
+        }
+        catch (Exception ex)
+        {
+            throw new DurableSerializationException(ex);
+        }
     }
 }

--- a/src/Worker.Extensions.DurableTask/DurableTaskFunctionsMiddleware.cs
+++ b/src/Worker.Extensions.DurableTask/DurableTaskFunctionsMiddleware.cs
@@ -16,27 +16,24 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.DurableTask;
 internal class DurableTaskFunctionsMiddleware : IFunctionsWorkerMiddleware
 {
     /// <inheritdoc />
-    public async Task Invoke(FunctionContext functionContext, FunctionExecutionDelegate next)
+    public Task Invoke(FunctionContext functionContext, FunctionExecutionDelegate next)
     {
         if (IsOrchestrationTrigger(functionContext, out BindingMetadata? triggerBinding))
         {
-            await RunOrchestrationAsync(functionContext, triggerBinding, next);
-            return;
+            return RunOrchestrationAsync(functionContext, triggerBinding, next);
         }
 
         if (IsEntityTrigger(functionContext, out triggerBinding))
         {
-            await RunEntityAsync(functionContext, triggerBinding, next);
-            return;
+            return RunEntityAsync(functionContext, triggerBinding, next);
         }
 
         if (IsActivityTrigger(functionContext, out triggerBinding))
         {
-            await RunActivityAsync(functionContext, triggerBinding, next);
-            return;
+            return RunActivityAsync(functionContext, triggerBinding, next);
         }
 
-        await next(functionContext);
+        return next(functionContext);
     }
 
     private static bool IsOrchestrationTrigger(

--- a/src/Worker.Extensions.DurableTask/Exceptions/DurableSerializationException.cs
+++ b/src/Worker.Extensions.DurableTask/Exceptions/DurableSerializationException.cs
@@ -18,25 +18,9 @@ internal class DurableSerializationException : Exception
 
     public override string ToString()
     {
-        TaskFailureDetails? failureDetails = ExceptionToTaskFailureDetailsRecursive(this.FromException);
+        TaskFailureDetails? failureDetails = TaskFailureDetailsConverter.TaskFailureFromException(this.FromException);
         return JsonConvert.SerializeObject(failureDetails);
     }
 
     public override string? StackTrace => this.FromException.StackTrace;
-
-    private static TaskFailureDetails? ExceptionToTaskFailureDetailsRecursive(Exception? fromException)
-    {
-        if (fromException is null)
-        {
-            return null;
-        }
-        return new TaskFailureDetails()
-        {
-            ErrorType = fromException.GetType().FullName,
-            ErrorMessage = fromException.Message,
-            StackTrace = fromException.StackTrace,
-            InnerFailure = ExceptionToTaskFailureDetailsRecursive(fromException.InnerException),
-            IsNonRetriable = false
-        };
-    }
 }

--- a/src/Worker.Extensions.DurableTask/Exceptions/DurableSerializationException.cs
+++ b/src/Worker.Extensions.DurableTask/Exceptions/DurableSerializationException.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using Microsoft.DurableTask.Protobuf;
+using Newtonsoft.Json;
+
+namespace Microsoft.Azure.Functions.Worker.Extensions.DurableTask.Exceptions;
+
+internal class DurableSerializationException : Exception
+{
+    private Exception FromException;
+
+    // We set the base class properties of this exception to the same as the parent, 
+    // so that methods in the worker after this can still (typically) access the same information vs w/o
+    // this exception type. 
+    internal DurableSerializationException(Exception fromException) : base(fromException.Message, fromException.InnerException)
+    {
+        this.FromException = fromException;
+    }
+
+    public override string ToString()
+    {
+        TaskFailureDetails? failureDetails = ExceptionToTaskFailureDetailsRecursive(this.FromException);
+        return JsonConvert.SerializeObject(failureDetails);
+    }
+
+    public override string? StackTrace => this.FromException.StackTrace;
+
+    private static TaskFailureDetails? ExceptionToTaskFailureDetailsRecursive(Exception? fromException)
+    {
+        if (fromException is null)
+        {
+            return null;
+        }
+        return new TaskFailureDetails()
+        {
+            ErrorType = fromException.GetType().FullName,
+            ErrorMessage = fromException.Message,
+            StackTrace = fromException.StackTrace,
+            InnerFailure = ExceptionToTaskFailureDetailsRecursive(fromException.InnerException),
+            IsNonRetriable = false
+        };
+    }
+}

--- a/src/Worker.Extensions.DurableTask/Exceptions/DurableSerializationException.cs
+++ b/src/Worker.Extensions.DurableTask/Exceptions/DurableSerializationException.cs
@@ -6,21 +6,21 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.DurableTask.Exceptions;
 
 internal class DurableSerializationException : Exception
 {
-    private Exception FromException;
+    private readonly Exception fromException;
 
     // We set the base class properties of this exception to the same as the parent, 
     // so that methods in the worker after this can still (typically) access the same information vs w/o
     // this exception type. 
     internal DurableSerializationException(Exception fromException) : base(fromException.Message, fromException.InnerException)
     {
-        this.FromException = fromException;
+        this.fromException = fromException;
     }
 
     public override string ToString()
     {
-        TaskFailureDetails? failureDetails = TaskFailureDetailsConverter.TaskFailureFromException(this.FromException);
+        TaskFailureDetails? failureDetails = TaskFailureDetailsConverter.TaskFailureFromException(this.fromException);
         return JsonConvert.SerializeObject(failureDetails);
     }
 
-    public override string? StackTrace => this.FromException.StackTrace;
+    public override string? StackTrace => this.fromException.StackTrace;
 }

--- a/src/Worker.Extensions.DurableTask/TaskFailureDetailsConverter.cs
+++ b/src/Worker.Extensions.DurableTask/TaskFailureDetailsConverter.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using P = Microsoft.DurableTask.Protobuf;
+
+namespace Microsoft.Azure.Functions.Worker.Extensions.DurableTask;
+internal class TaskFailureDetailsConverter
+{
+    internal static P.TaskFailureDetails? TaskFailureFromException(Exception? fromException)
+    {
+        if (fromException is null)
+        {
+            return null;
+        }
+        return new P.TaskFailureDetails()
+        {
+            ErrorType = fromException.GetType().FullName,
+            ErrorMessage = fromException.Message,
+            StackTrace = fromException.StackTrace,
+            InnerFailure = TaskFailureFromException(fromException.InnerException),
+            IsNonRetriable = false
+        };
+    }
+}

--- a/test/e2e/Apps/BasicDotNetIsolated/ActivityErrorHandling.cs
+++ b/test/e2e/Apps/BasicDotNetIsolated/ActivityErrorHandling.cs
@@ -2,20 +2,17 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System.Collections.Concurrent;
-using System.Net;
-using Grpc.Core;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.DurableTask;
 using Microsoft.DurableTask.Client;
-using Microsoft.DurableTask.Entities;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Azure.Durable.Tests.E2E;
 
 public static class ActivityErrorHandling
 {
-    private static ConcurrentDictionary<string, int> retryCount = new ConcurrentDictionary<string, int>();
+    private static ConcurrentDictionary<string, int> globalRetryCount = new ConcurrentDictionary<string, int>();
 
     [Function("RethrowActivityException_HttpStart")]
     public static async Task<HttpResponseData> RethrowHttpStart(
@@ -39,7 +36,7 @@ public static class ActivityErrorHandling
         [DurableClient] DurableTaskClient client,
         FunctionContext executionContext)
     {
-        ILogger logger = executionContext.GetLogger("RethrowActivityException_HttpStart");
+        ILogger logger = executionContext.GetLogger("CatchActivityException_HttpStart");
 
         string instanceId = await client.ScheduleNewOrchestrationInstanceAsync(
             nameof(CatchActivityException));
@@ -137,7 +134,7 @@ public static class ActivityErrorHandling
     [Function(nameof(RaiseException))]
     public static string RaiseException([ActivityTrigger] string instanceId, FunctionContext executionContext)
     {
-        if (retryCount.AddOrUpdate(instanceId, 1, (key, oldValue) => oldValue + 1) == 1)
+        if (globalRetryCount.AddOrUpdate(instanceId, 1, (key, oldValue) => oldValue + 1) == 1)
         {
             throw new InvalidOperationException("This activity failed");
         }
@@ -150,7 +147,7 @@ public static class ActivityErrorHandling
     [Function(nameof(RaiseComplexException))]
     public static string RaiseComplexException([ActivityTrigger] string instanceId, FunctionContext executionContext)
     {
-        if (retryCount.AddOrUpdate(instanceId, 1, (key, oldValue) => oldValue + 1) == 1)
+        if (globalRetryCount.AddOrUpdate(instanceId, 1, (key, oldValue) => oldValue + 1) == 1)
         {
             var exception = new InvalidOperationException("This activity failed\r\nMore information about the failure", innerException: new OverflowException("Inner exception message"));
             throw exception;

--- a/test/e2e/Apps/BasicDotNetIsolated/ActivityErrorHandling.cs
+++ b/test/e2e/Apps/BasicDotNetIsolated/ActivityErrorHandling.cs
@@ -8,11 +8,12 @@ using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.DurableTask;
 using Microsoft.DurableTask.Client;
+using Microsoft.DurableTask.Entities;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Azure.Durable.Tests.E2E;
 
-public static class ErrorHandlingOrchestration
+public static class ActivityErrorHandling
 {
     private static ConcurrentDictionary<string, int> retryCount = new ConcurrentDictionary<string, int>();
 
@@ -120,13 +121,16 @@ public static class ErrorHandlingOrchestration
         [OrchestrationTrigger] TaskOrchestrationContext context)
     {
         var options = TaskOptions.FromRetryHandler(retryContext => {
-            if (retryContext.LastFailure.IsCausedBy<InvalidOperationException>() && retryContext.LastAttemptNumber < 3) {
+            if (retryContext.LastFailure.IsCausedBy<InvalidOperationException>() && 
+                    retryContext.LastFailure.InnerFailure is not null && 
+                    retryContext.LastFailure.InnerFailure.IsCausedBy<OverflowException>() && 
+                    retryContext.LastAttemptNumber < 3) {
                 return true;
             }
             return false;
         });
 
-        var output = await context.CallActivityAsync<string>(nameof(RaiseComplexException), context.InstanceId, options: options);
+        string output = await context.CallActivityAsync<string>(nameof(RaiseComplexException), context.InstanceId, options: options);
         return output;
     }
 

--- a/test/e2e/Apps/BasicDotNetIsolated/EntityErrorHandling.cs
+++ b/test/e2e/Apps/BasicDotNetIsolated/EntityErrorHandling.cs
@@ -2,8 +2,6 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System.Collections.Concurrent;
-using System.Net;
-using Grpc.Core;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.DurableTask;

--- a/test/e2e/Apps/BasicDotNetIsolated/EntityErrorHandling.cs
+++ b/test/e2e/Apps/BasicDotNetIsolated/EntityErrorHandling.cs
@@ -1,0 +1,130 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Collections.Concurrent;
+using System.Net;
+using Grpc.Core;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
+using Microsoft.DurableTask;
+using Microsoft.DurableTask.Client;
+using Microsoft.DurableTask.Entities;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Azure.Durable.Tests.E2E;
+
+public static class EntityErrorHandling
+{
+    private static ConcurrentDictionary<string, int> retryCount = new ConcurrentDictionary<string, int>();
+
+    [Function("RethrowEntityException_HttpStart")]
+    public static async Task<HttpResponseData> ThrowEntityHttpStart(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", "post")] HttpRequestData req,
+        [DurableClient] DurableTaskClient client,
+        FunctionContext executionContext)
+    {
+        ILogger logger = executionContext.GetLogger("ThrowEntityException_HttpStart");
+
+        string instanceId = await client.ScheduleNewOrchestrationInstanceAsync(nameof(ThrowEntityOrchestration));
+
+        logger.LogInformation("Started orchestration with ID = '{instanceId}'.", instanceId);
+
+        return await client.CreateCheckStatusResponseAsync(req, instanceId);
+    }
+
+    [Function("CatchEntityException_HttpStart")]
+    public static async Task<HttpResponseData> CatchEntityHttpStart(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", "post")] HttpRequestData req,
+        [DurableClient] DurableTaskClient client,
+        FunctionContext executionContext)
+    {
+        ILogger logger = executionContext.GetLogger("CatchEntityException_HttpStart");
+
+        string instanceId = await client.ScheduleNewOrchestrationInstanceAsync(nameof(CatchEntityOrchestration));
+
+        logger.LogInformation("Started orchestration with ID = '{instanceId}'.", instanceId);
+
+        return await client.CreateCheckStatusResponseAsync(req, instanceId);
+    }
+
+    [Function("RetryEntityException_HttpStart")]
+    public static async Task<HttpResponseData> RetryEntityHttpStart(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", "post")] HttpRequestData req,
+        [DurableClient] DurableTaskClient client,
+        FunctionContext executionContext)
+    {
+        ILogger logger = executionContext.GetLogger("RetryEntityException_HttpStart");
+
+        string instanceId = await client.ScheduleNewOrchestrationInstanceAsync(nameof(RetryEntityOrchestration));
+
+        logger.LogInformation("Started orchestration with ID = '{instanceId}'.", instanceId);
+
+        return await client.CreateCheckStatusResponseAsync(req, instanceId);
+    }
+
+    [Function(nameof(ThrowEntityOrchestration))]
+    public static async Task<string> ThrowEntityOrchestration([OrchestrationTrigger] TaskOrchestrationContext context)
+    {
+        var entityId = new EntityInstanceId(nameof(Counter), "MyExceptionEntity");
+
+        int entityResult = await context.Entities.CallEntityAsync<int>(entityId, "ThrowFirstTimeOnly", context.InstanceId);
+        return "Success";
+    }
+
+    [Function(nameof(CatchEntityOrchestration))]
+    public static async Task<string> CatchEntityOrchestration([OrchestrationTrigger] TaskOrchestrationContext context)
+    {
+        var entityId = new EntityInstanceId(nameof(Counter), "MyExceptionEntity");
+
+        try
+        {
+            int entityResult = await context.Entities.CallEntityAsync<int>(entityId, "ThrowFirstTimeOnly", context.InstanceId);
+            return "Success";
+        }
+        // This is interesting - activities, when thrown, raise the native exception type. Entities, however, always raise
+        // EntityOperationFailedException with the 
+        catch (EntityOperationFailedException ex) 
+        {
+            return ex.Message;
+        }
+    }
+
+    [Function(nameof(RetryEntityOrchestration))]
+    public static async Task<string> RetryEntityOrchestration([OrchestrationTrigger] TaskOrchestrationContext context)
+    {
+        var entityId = new EntityInstanceId(nameof(Counter), "MyExceptionEntity");
+
+        try
+        {
+            int entityResult = await context.Entities.CallEntityAsync<int>(entityId, "ThrowFirstTimeOnly", context.InstanceId);
+            return "Success";
+        }
+        catch (EntityOperationFailedException)
+        {
+            int entityResult = await context.Entities.CallEntityAsync<int>(entityId, "ThrowFirstTimeOnly", context.InstanceId);
+            return "Success";
+        }
+    }
+
+    [Function(nameof(Counter))]
+    public static Task Counter([EntityTrigger] TaskEntityDispatcher dispatcher)
+    {
+        return dispatcher.DispatchAsync(operation =>
+        {
+            string? instanceId = operation.GetInput<string>();
+            if (instanceId is null)
+            {
+                throw new ArgumentException("Did not get a valid instanceId as input to the entity");
+            }
+
+            // Entity logic would go here - this entity does nothing
+
+            if (retryCount.AddOrUpdate(instanceId, 1, (key, oldValue) => oldValue + 1) == 1)
+            {
+                var exception = new InvalidOperationException("This entity failed\r\nMore information about the failure", innerException: new OverflowException("Inner exception message"));
+                throw exception;
+            }
+            return new(0);
+        });
+    }
+}

--- a/test/e2e/Apps/BasicDotNetIsolated/ErrorHandlingOrchestration.cs
+++ b/test/e2e/Apps/BasicDotNetIsolated/ErrorHandlingOrchestration.cs
@@ -126,7 +126,7 @@ public static class ErrorHandlingOrchestration
             return false;
         });
 
-        var output = await context.CallActivityAsync<string>(nameof(RaiseException), context.InstanceId, options: options);
+        var output = await context.CallActivityAsync<string>(nameof(RaiseComplexException), context.InstanceId, options: options);
         return output;
     }
 
@@ -136,6 +136,20 @@ public static class ErrorHandlingOrchestration
         if (retryCount.AddOrUpdate(instanceId, 1, (key, oldValue) => oldValue + 1) == 1)
         {
             throw new InvalidOperationException("This activity failed");
+        }
+        else
+        {
+            return "Success";
+        }
+    }
+
+    [Function(nameof(RaiseComplexException))]
+    public static string RaiseComplexException([ActivityTrigger] string instanceId, FunctionContext executionContext)
+    {
+        if (retryCount.AddOrUpdate(instanceId, 1, (key, oldValue) => oldValue + 1) == 1)
+        {
+            var exception = new InvalidOperationException("This activity failed\r\nMore information about the failure", innerException: new OverflowException("Inner exception message"));
+            throw exception;
         }
         else
         {

--- a/test/e2e/Apps/BasicDotNetIsolated/ErrorHandlingOrchestration.cs
+++ b/test/e2e/Apps/BasicDotNetIsolated/ErrorHandlingOrchestration.cs
@@ -1,0 +1,145 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Collections.Concurrent;
+using System.Net;
+using Grpc.Core;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
+using Microsoft.DurableTask;
+using Microsoft.DurableTask.Client;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Azure.Durable.Tests.E2E;
+
+public static class ErrorHandlingOrchestration
+{
+    private static ConcurrentDictionary<string, int> retryCount = new ConcurrentDictionary<string, int>();
+
+    [Function("RethrowActivityException_HttpStart")]
+    public static async Task<HttpResponseData> RethrowHttpStart(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", "post")] HttpRequestData req,
+        [DurableClient] DurableTaskClient client,
+        FunctionContext executionContext)
+    {
+        ILogger logger = executionContext.GetLogger("RethrowActivityException_HttpStart");
+
+        string instanceId = await client.ScheduleNewOrchestrationInstanceAsync(
+            nameof(RethrowActivityException));
+
+        logger.LogInformation("Started orchestration with ID = '{instanceId}'.", instanceId);
+
+        return await client.CreateCheckStatusResponseAsync(req, instanceId);
+    }
+
+    [Function("CatchActivityException_HttpStart")]
+    public static async Task<HttpResponseData> CatchHttpStart(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", "post")] HttpRequestData req,
+        [DurableClient] DurableTaskClient client,
+        FunctionContext executionContext)
+    {
+        ILogger logger = executionContext.GetLogger("RethrowActivityException_HttpStart");
+
+        string instanceId = await client.ScheduleNewOrchestrationInstanceAsync(
+            nameof(CatchActivityException));
+
+        logger.LogInformation("Started orchestration with ID = '{instanceId}'.", instanceId);
+
+        return await client.CreateCheckStatusResponseAsync(req, instanceId);
+    }
+
+    [Function("RetryActivityException_HttpStart")]
+    public static async Task<HttpResponseData> RetryHttpStart(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", "post")] HttpRequestData req,
+        [DurableClient] DurableTaskClient client,
+        FunctionContext executionContext)
+    {
+        ILogger logger = executionContext.GetLogger("RetryActivityException_HttpStart");
+
+        string instanceId = await client.ScheduleNewOrchestrationInstanceAsync(
+            nameof(RetryActivityFunction));
+
+        logger.LogInformation("Started orchestration with ID = '{instanceId}'.", instanceId);
+
+        return await client.CreateCheckStatusResponseAsync(req, instanceId);
+    }
+
+    [Function("CustomRetryActivityException_HttpStart")]
+    public static async Task<HttpResponseData> CustomRetryHttpStart(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", "post")] HttpRequestData req,
+        [DurableClient] DurableTaskClient client,
+        FunctionContext executionContext)
+    {
+        ILogger logger = executionContext.GetLogger("CustomRetryActivityException_HttpStart");
+
+        string instanceId = await client.ScheduleNewOrchestrationInstanceAsync(
+            nameof(CustomRetryActivityFunction));
+
+        logger.LogInformation("Started orchestration with ID = '{instanceId}'.", instanceId);
+
+        return await client.CreateCheckStatusResponseAsync(req, instanceId);
+    }
+
+    [Function(nameof(RethrowActivityException))]
+    public static async Task<string> RethrowActivityException(
+        [OrchestrationTrigger] TaskOrchestrationContext context)
+    {
+        var output = await context.CallActivityAsync<string>(nameof(RaiseException), context.InstanceId);
+        return output;
+    }
+
+    [Function(nameof(CatchActivityException))]
+    public static async Task<string> CatchActivityException(
+        [OrchestrationTrigger] TaskOrchestrationContext context)
+    {
+        try 
+        {
+            var output = await context.CallActivityAsync<string>(nameof(RaiseException), context.InstanceId);
+            return output;
+        }
+        catch (TaskFailedException ex)
+        {
+            return ex.Message;
+        }
+    }
+
+    [Function(nameof(RetryActivityFunction))]
+    public static async Task<string> RetryActivityFunction(
+        [OrchestrationTrigger] TaskOrchestrationContext context)
+    {
+        var options = TaskOptions.FromRetryPolicy(new RetryPolicy(
+            maxNumberOfAttempts: 3,
+            firstRetryInterval: TimeSpan.FromSeconds(3)));
+
+        var output = await context.CallActivityAsync<string>(nameof(RaiseException), context.InstanceId, options: options);
+        return output;
+    }
+
+    [Function(nameof(CustomRetryActivityFunction))]
+    public static async Task<string> CustomRetryActivityFunction(
+        [OrchestrationTrigger] TaskOrchestrationContext context)
+    {
+        var options = TaskOptions.FromRetryHandler(retryContext => {
+            if (retryContext.LastFailure.IsCausedBy<InvalidOperationException>() && retryContext.LastAttemptNumber < 3) {
+                return true;
+            }
+            return false;
+        });
+
+        var output = await context.CallActivityAsync<string>(nameof(RaiseException), context.InstanceId, options: options);
+        return output;
+    }
+
+    [Function(nameof(RaiseException))]
+    public static string RaiseException([ActivityTrigger] string instanceId, FunctionContext executionContext)
+    {
+        if (retryCount.AddOrUpdate(instanceId, 1, (key, oldValue) => oldValue + 1) == 1)
+        {
+            throw new InvalidOperationException("This activity failed");
+        }
+        else
+        {
+            return "Success";
+        }
+    }
+}

--- a/test/e2e/Apps/BasicDotNetIsolated/TimeoutOrchestration.cs
+++ b/test/e2e/Apps/BasicDotNetIsolated/TimeoutOrchestration.cs
@@ -1,9 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System.Collections.Concurrent;
-using System.Net;
-using Grpc.Core;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.DurableTask;
@@ -61,10 +58,7 @@ public static class TimeoutOrchestration
     [Function(nameof(LongActivity))]
     public static string LongActivity([ActivityTrigger] string instanceId, FunctionContext executionContext)
     {
-        for (int i = 0; i < 5; i++) 
-        {
-            Thread.Sleep(1000);
-        }
+        Thread.Sleep(5000);
         return "The activity function completed successfully";
     }
 }

--- a/test/e2e/Apps/BasicDotNetIsolated/TimeoutOrchestration.cs
+++ b/test/e2e/Apps/BasicDotNetIsolated/TimeoutOrchestration.cs
@@ -1,0 +1,70 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Collections.Concurrent;
+using System.Net;
+using Grpc.Core;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
+using Microsoft.DurableTask;
+using Microsoft.DurableTask.Client;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Azure.Durable.Tests.E2E;
+
+public static class TimeoutOrchestration
+{
+    [Function("TimeoutOrchestrator_HttpStart")]
+    public static async Task<HttpResponseData> TimerHttpStart(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", "post")] HttpRequestData req,
+        [DurableClient] DurableTaskClient client,
+        FunctionContext executionContext, 
+        int timeoutSeconds)
+    {
+        ILogger logger = executionContext.GetLogger("TimeoutOrchestrator_HttpStart");
+
+        string instanceId = await client.ScheduleNewOrchestrationInstanceAsync(
+            nameof(TimeoutOrchestrator), timeoutSeconds);
+
+        logger.LogInformation("Started orchestration with ID = '{instanceId}'.", instanceId);
+
+        return await client.CreateCheckStatusResponseAsync(req, instanceId);
+    }
+
+    [Function(nameof(TimeoutOrchestrator))]
+    public static async Task<string> TimeoutOrchestrator(
+        [OrchestrationTrigger] TaskOrchestrationContext context, 
+        int timeoutSeconds)
+    {
+        TimeSpan timeout = TimeSpan.FromSeconds(timeoutSeconds);
+        DateTime deadline = context.CurrentUtcDateTime.Add(timeout);
+
+        using (var cts = new CancellationTokenSource())
+        {
+            Task<string> activityTask = context.CallActivityAsync<string>(nameof(LongActivity));
+            Task timeoutTask = context.CreateTimer(deadline, cts.Token);
+
+            Task winner = await Task.WhenAny(activityTask, timeoutTask);
+            if (winner == activityTask)
+            {
+                // success case
+                cts.Cancel();
+                return activityTask.Result;
+            }
+            else
+            {
+                return "The activity function timed out";
+            }
+        }
+    }
+
+    [Function(nameof(LongActivity))]
+    public static string LongActivity([ActivityTrigger] string instanceId, FunctionContext executionContext)
+    {
+        for (int i = 0; i < 5; i++) 
+        {
+            Thread.Sleep(1000);
+        }
+        return "The activity function completed successfully";
+    }
+}

--- a/test/e2e/Tests/Helpers/TestLoggerProvider.cs
+++ b/test/e2e/Tests/Helpers/TestLoggerProvider.cs
@@ -56,7 +56,7 @@ internal class TestLoggerProvider : ILoggerProvider, ILogger
         string formattedString = formatter(state, exception);
         _messageSink.OnMessage(new DiagnosticMessage(formattedString));
         _logs.Add(formattedString);
-        _currentTestOutput?.WriteLine(formattedString);
+        try { _currentTestOutput?.WriteLine(formattedString); } catch { }
     }
 
     private class DisposableOutput : IDisposable

--- a/test/e2e/Tests/Tests/ErrorHandlingTests.cs
+++ b/test/e2e/Tests/Tests/ErrorHandlingTests.cs
@@ -36,6 +36,21 @@ public class ErrorHandlingTests
     }
 
     [Fact]
+    public async Task OrchestratorWithUncaughtEntityException_ShouldFail()
+    {
+        using HttpResponseMessage response = await HttpHelpers.InvokeHttpTrigger("RethrowEntityException_HttpStart", "");
+
+        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
+        string statusQueryGetUri = await DurableHelpers.ParseStatusQueryGetUriAsync(response);
+
+        await DurableHelpers.WaitForOrchestrationStateAsync(statusQueryGetUri, "Failed", 30);
+
+        var orchestrationDetails = await DurableHelpers.GetRunningOrchestrationDetailsAsync(statusQueryGetUri);
+        Assert.StartsWith("Microsoft.DurableTask.Entities.EntityOperationFailedException", orchestrationDetails.Output);
+        Assert.Contains("This entity failed", orchestrationDetails.Output);
+    }
+
+    [Fact]
     public async Task OrchestratorWithCaughtActivityException_ShouldSucceed()
     {
         using HttpResponseMessage response = await HttpHelpers.InvokeHttpTrigger("CatchActivityException_HttpStart", "");
@@ -48,6 +63,26 @@ public class ErrorHandlingTests
         var orchestrationDetails = await DurableHelpers.GetRunningOrchestrationDetailsAsync(statusQueryGetUri);
         Assert.StartsWith("Task 'RaiseException' (#0) failed with an unhandled exception:", orchestrationDetails.Output);
         Assert.Contains("This activity failed", orchestrationDetails.Output);
+    }
+
+    [Fact]
+    public async Task OrchestratorWithCaughtEntityException_ShouldSucceed()
+    {
+        using HttpResponseMessage response = await HttpHelpers.InvokeHttpTrigger("CatchEntityException_HttpStart", "");
+
+        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
+        string statusQueryGetUri = await DurableHelpers.ParseStatusQueryGetUriAsync(response);
+
+        await DurableHelpers.WaitForOrchestrationStateAsync(statusQueryGetUri, "Completed", 30);
+
+        var orchestrationDetails = await DurableHelpers.GetRunningOrchestrationDetailsAsync(statusQueryGetUri);
+        Assert.StartsWith("Operation 'ThrowFirstTimeOnly' of entity '@counter@MyExceptionEntity' failed:", orchestrationDetails.Output);
+        Assert.Contains("This entity failed", orchestrationDetails.Output);
+        Assert.Contains("More information about the failure", orchestrationDetails.Output);
+
+        // For now, we deliberately do not return inner exception details on entity failure. 
+        // If this changes in the future, update this test. 
+        Assert.DoesNotContain("Inner exception message", orchestrationDetails.Output);
     }
 
     [Fact]
@@ -68,6 +103,31 @@ public class ErrorHandlingTests
 
         Assert.Contains(_fixture.TestLogs.CoreToolsLogs, x => x.Contains(nameof(InvalidOperationException)) &&
                                                               x.Contains("This activity failed"));
+    }
+
+    [Fact]
+    public async Task OrchestratorWithRetriedEntityException_ShouldSucceed()
+    {
+        using HttpResponseMessage response = await HttpHelpers.InvokeHttpTrigger("RetryEntityException_HttpStart", "");
+
+        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
+        string statusQueryGetUri = await DurableHelpers.ParseStatusQueryGetUriAsync(response);
+
+        await DurableHelpers.WaitForOrchestrationStateAsync(statusQueryGetUri, "Completed", 30);
+
+        var orchestrationDetails = await DurableHelpers.GetRunningOrchestrationDetailsAsync(statusQueryGetUri);
+        Assert.Equal("Success", orchestrationDetails.Output);
+
+        // Give some time for Core Tools to write logs out
+        Thread.Sleep(500);
+
+        // For entities, these logs are not emitted as one continuous log, but each line of the exception .ToString() is
+        // logged individually.
+        Assert.Contains(_fixture.TestLogs.CoreToolsLogs, x => x.Contains(nameof(InvalidOperationException)) &&
+                                                              x.Contains("This entity failed"));
+        Assert.Contains(_fixture.TestLogs.CoreToolsLogs, x => x.Contains("More information about the failure"));
+        Assert.Contains(_fixture.TestLogs.CoreToolsLogs, x => x.Contains(nameof(OverflowException)) &&
+                                                              x.Contains("Inner exception message"));
     }
 
     [Fact]

--- a/test/e2e/Tests/Tests/ErrorHandlingTests.cs
+++ b/test/e2e/Tests/Tests/ErrorHandlingTests.cs
@@ -24,7 +24,6 @@ public class ErrorHandlingTests
     public async Task OrchestratorWithUncaughtActivityException_ShouldFail()
     {
         using HttpResponseMessage response = await HttpHelpers.InvokeHttpTrigger("RethrowActivityException_HttpStart", "");
-        string actualMessage = await response.Content.ReadAsStringAsync();
 
         Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
         string statusQueryGetUri = await DurableHelpers.ParseStatusQueryGetUriAsync(response);
@@ -37,10 +36,9 @@ public class ErrorHandlingTests
     }
 
     [Fact]
-    public async Task OrchestratorWithCaughtActivityException_ShouldSucced()
+    public async Task OrchestratorWithCaughtActivityException_ShouldSucceed()
     {
         using HttpResponseMessage response = await HttpHelpers.InvokeHttpTrigger("CatchActivityException_HttpStart", "");
-        string actualMessage = await response.Content.ReadAsStringAsync();
 
         Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
         string statusQueryGetUri = await DurableHelpers.ParseStatusQueryGetUriAsync(response);
@@ -53,10 +51,9 @@ public class ErrorHandlingTests
     }
 
     [Fact]
-    public async Task OrchestratorWithRetriedActivityException_ShouldSucced()
+    public async Task OrchestratorWithRetriedActivityException_ShouldSucceed()
     {
         using HttpResponseMessage response = await HttpHelpers.InvokeHttpTrigger("RetryActivityException_HttpStart", "");
-        string actualMessage = await response.Content.ReadAsStringAsync();
 
         Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
         string statusQueryGetUri = await DurableHelpers.ParseStatusQueryGetUriAsync(response);
@@ -74,10 +71,9 @@ public class ErrorHandlingTests
     }
 
     [Fact]
-    public async Task OrchestratorWithCustomRetriedActivityException_ShouldSucced()
+    public async Task OrchestratorWithCustomRetriedActivityException_ShouldSucceed()
     {
         using HttpResponseMessage response = await HttpHelpers.InvokeHttpTrigger("CustomRetryActivityException_HttpStart", "");
-        string actualMessage = await response.Content.ReadAsStringAsync();
 
         Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
         string statusQueryGetUri = await DurableHelpers.ParseStatusQueryGetUriAsync(response);

--- a/test/e2e/Tests/Tests/ErrorHandlingTests.cs
+++ b/test/e2e/Tests/Tests/ErrorHandlingTests.cs
@@ -61,7 +61,7 @@ public class ErrorHandlingTests
         Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
         string statusQueryGetUri = await DurableHelpers.ParseStatusQueryGetUriAsync(response);
 
-        await DurableHelpers.WaitForOrchestrationStateAsync(statusQueryGetUri, "Completed", 10);
+        await DurableHelpers.WaitForOrchestrationStateAsync(statusQueryGetUri, "Completed", 30);
 
         var orchestrationDetails = await DurableHelpers.GetRunningOrchestrationDetailsAsync(statusQueryGetUri);
         Assert.Equal("Success", orchestrationDetails.Output);
@@ -82,7 +82,7 @@ public class ErrorHandlingTests
         Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
         string statusQueryGetUri = await DurableHelpers.ParseStatusQueryGetUriAsync(response);
 
-        await DurableHelpers.WaitForOrchestrationStateAsync(statusQueryGetUri, "Completed", 10);
+        await DurableHelpers.WaitForOrchestrationStateAsync(statusQueryGetUri, "Completed", 30);
 
         var orchestrationDetails = await DurableHelpers.GetRunningOrchestrationDetailsAsync(statusQueryGetUri);
         Assert.Equal("Success", orchestrationDetails.Output);
@@ -90,7 +90,10 @@ public class ErrorHandlingTests
         // Give some time for Core Tools to write logs out
         Thread.Sleep(500);
 
+        // We want to ensure that multiline exception messages and inner exceptions are preserved
         Assert.Contains(_fixture.TestLogs.CoreToolsLogs, x => x.Contains(nameof(InvalidOperationException)) &&
-                                                              x.Contains("This activity failed"));
+                                                              x.Contains(nameof(OverflowException)) &&
+                                                              x.Contains("This activity failed") &&
+                                                              x.Contains("More information about the failure"));
     }
 }

--- a/test/e2e/Tests/Tests/ErrorHandlingTests.cs
+++ b/test/e2e/Tests/Tests/ErrorHandlingTests.cs
@@ -1,0 +1,96 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Net;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.Azure.Durable.Tests.DotnetIsolatedE2E;
+
+[Collection(Constants.FunctionAppCollectionName)]
+public class ErrorHandlingTests
+{
+    private readonly FunctionAppFixture _fixture;
+    private readonly ITestOutputHelper _output;
+
+    public ErrorHandlingTests(FunctionAppFixture fixture, ITestOutputHelper testOutputHelper)
+    {
+        _fixture = fixture;
+        _fixture.TestLogs.UseTestLogger(testOutputHelper);
+        _output = testOutputHelper;
+    }
+
+    [Fact]
+    public async Task OrchestratorWithUncaughtActivityException_ShouldFail()
+    {
+        using HttpResponseMessage response = await HttpHelpers.InvokeHttpTrigger("RethrowActivityException_HttpStart", "");
+        string actualMessage = await response.Content.ReadAsStringAsync();
+
+        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
+        string statusQueryGetUri = await DurableHelpers.ParseStatusQueryGetUriAsync(response);
+
+        await DurableHelpers.WaitForOrchestrationStateAsync(statusQueryGetUri, "Failed", 30);
+
+        var orchestrationDetails = await DurableHelpers.GetRunningOrchestrationDetailsAsync(statusQueryGetUri);
+        Assert.StartsWith("Microsoft.DurableTask.TaskFailedException", orchestrationDetails.Output);
+        Assert.Contains("This activity failed", orchestrationDetails.Output);
+    }
+
+    [Fact]
+    public async Task OrchestratorWithCaughtActivityException_ShouldSucced()
+    {
+        using HttpResponseMessage response = await HttpHelpers.InvokeHttpTrigger("CatchActivityException_HttpStart", "");
+        string actualMessage = await response.Content.ReadAsStringAsync();
+
+        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
+        string statusQueryGetUri = await DurableHelpers.ParseStatusQueryGetUriAsync(response);
+
+        await DurableHelpers.WaitForOrchestrationStateAsync(statusQueryGetUri, "Completed", 30);
+
+        var orchestrationDetails = await DurableHelpers.GetRunningOrchestrationDetailsAsync(statusQueryGetUri);
+        Assert.StartsWith("Task 'RaiseException' (#0) failed with an unhandled exception:", orchestrationDetails.Output);
+        Assert.Contains("This activity failed", orchestrationDetails.Output);
+    }
+
+    [Fact]
+    public async Task OrchestratorWithRetriedActivityException_ShouldSucced()
+    {
+        using HttpResponseMessage response = await HttpHelpers.InvokeHttpTrigger("RetryActivityException_HttpStart", "");
+        string actualMessage = await response.Content.ReadAsStringAsync();
+
+        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
+        string statusQueryGetUri = await DurableHelpers.ParseStatusQueryGetUriAsync(response);
+
+        await DurableHelpers.WaitForOrchestrationStateAsync(statusQueryGetUri, "Completed", 10);
+
+        var orchestrationDetails = await DurableHelpers.GetRunningOrchestrationDetailsAsync(statusQueryGetUri);
+        Assert.Equal("Success", orchestrationDetails.Output);
+
+        // Give some time for Core Tools to write logs out
+        Thread.Sleep(500);
+
+        Assert.Contains(_fixture.TestLogs.CoreToolsLogs, x => x.Contains(nameof(InvalidOperationException)) &&
+                                                              x.Contains("This activity failed"));
+    }
+
+    [Fact]
+    public async Task OrchestratorWithCustomRetriedActivityException_ShouldSucced()
+    {
+        using HttpResponseMessage response = await HttpHelpers.InvokeHttpTrigger("CustomRetryActivityException_HttpStart", "");
+        string actualMessage = await response.Content.ReadAsStringAsync();
+
+        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
+        string statusQueryGetUri = await DurableHelpers.ParseStatusQueryGetUriAsync(response);
+
+        await DurableHelpers.WaitForOrchestrationStateAsync(statusQueryGetUri, "Completed", 10);
+
+        var orchestrationDetails = await DurableHelpers.GetRunningOrchestrationDetailsAsync(statusQueryGetUri);
+        Assert.Equal("Success", orchestrationDetails.Output);
+
+        // Give some time for Core Tools to write logs out
+        Thread.Sleep(500);
+
+        Assert.Contains(_fixture.TestLogs.CoreToolsLogs, x => x.Contains(nameof(InvalidOperationException)) &&
+                                                              x.Contains("This activity failed"));
+    }
+}

--- a/test/e2e/Tests/Tests/HelloCitiesTest.cs
+++ b/test/e2e/Tests/Tests/HelloCitiesTest.cs
@@ -73,13 +73,13 @@ public class HttpEndToEndTests
 
         await DurableHelpers.WaitForOrchestrationStateAsync(statusQueryGetUri, "Completed", Math.Max(startDelaySeconds, 0) + 30);
 
-        // This +1s should not be necessary - however, experimentally the orchestration may run up to one second before the scheduled time.
+        // This +2s should not be necessary - however, experimentally the orchestration may run up to ~1 second before the scheduled time.
         // It is unclear currently whether this is a bug where orchestrations run early, or a clock difference/error,
         // but leaving this logic in for now until further investigation.
-        Assert.True(DateTime.UtcNow + TimeSpan.FromSeconds(1) >= scheduledStartTime);
+        Assert.True(DateTime.UtcNow + TimeSpan.FromSeconds(2) >= scheduledStartTime);
 
         var finalOrchestrationDetails = await DurableHelpers.GetRunningOrchestrationDetailsAsync(statusQueryGetUri);
         WriteOutput($"Last updated at {finalOrchestrationDetails.LastUpdatedTime}, scheduled to complete at {scheduledStartTime}");
-        Assert.True(finalOrchestrationDetails.LastUpdatedTime + TimeSpan.FromSeconds(1) >= scheduledStartTime);
+        Assert.True(finalOrchestrationDetails.LastUpdatedTime + TimeSpan.FromSeconds(2) >= scheduledStartTime);
     }
 }

--- a/test/e2e/Tests/Tests/HelloCitiesTest.cs
+++ b/test/e2e/Tests/Tests/HelloCitiesTest.cs
@@ -39,7 +39,6 @@ public class HttpEndToEndTests
     public async Task HttpTriggerTests(string functionName, HttpStatusCode expectedStatusCode, string partialExpectedOutput)
     {
         using HttpResponseMessage response = await HttpHelpers.InvokeHttpTrigger(functionName, "");
-        string actualMessage = await response.Content.ReadAsStringAsync();
 
         Assert.Equal(expectedStatusCode, response.StatusCode);
         string statusQueryGetUri = await DurableHelpers.ParseStatusQueryGetUriAsync(response);
@@ -60,7 +59,6 @@ public class HttpEndToEndTests
         string urlQueryString = $"?ScheduledStartTime={scheduledStartTime.ToString("o")}";
 
         using HttpResponseMessage response = await HttpHelpers.InvokeHttpTrigger(functionName, urlQueryString);
-        string actualMessage = await response.Content.ReadAsStringAsync();
 
         string statusQueryGetUri = await DurableHelpers.ParseStatusQueryGetUriAsync(response);
 

--- a/test/e2e/Tests/Tests/TimeoutTests.cs
+++ b/test/e2e/Tests/Tests/TimeoutTests.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Net;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.Azure.Durable.Tests.DotnetIsolatedE2E;
+
+[Collection(Constants.FunctionAppCollectionName)]
+public class TimeoutTests
+{
+    private readonly FunctionAppFixture _fixture;
+    private readonly ITestOutputHelper _output;
+
+    public TimeoutTests(FunctionAppFixture fixture, ITestOutputHelper testOutputHelper)
+    {
+        _fixture = fixture;
+        _fixture.TestLogs.UseTestLogger(testOutputHelper);
+        _output = testOutputHelper;
+    }
+
+    [Theory]
+    [InlineData(2, "The activity function timed out")]
+    [InlineData(10, "The activity function completed successfully")]
+    public async Task TimeoutFunction_ShouldTimeoutWhenAppropriate(int timeoutSeconds, string expectedOutput)
+    {
+        using HttpResponseMessage response = await HttpHelpers.InvokeHttpTrigger("TimeoutOrchestrator_HttpStart", $"?timeoutSeconds={timeoutSeconds}");
+        string actualMessage = await response.Content.ReadAsStringAsync();
+
+        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
+        string statusQueryGetUri = await DurableHelpers.ParseStatusQueryGetUriAsync(response);
+
+        await DurableHelpers.WaitForOrchestrationStateAsync(statusQueryGetUri, "Completed", 30);
+
+        var orchestrationDetails = await DurableHelpers.GetRunningOrchestrationDetailsAsync(statusQueryGetUri);
+        Assert.Equal(expectedOutput, orchestrationDetails.Output);
+    }
+}

--- a/test/e2e/Tests/build-e2e-test.ps1
+++ b/test/e2e/Tests/build-e2e-test.ps1
@@ -22,6 +22,8 @@ param(
     $SkipBuildOnPack
 )
 
+$ErrorActionPreference = "Stop"
+
 $ProjectBaseDirectory = "$PSScriptRoot\..\..\..\"
 $ProjectTemporaryPath = Join-Path ([System.IO.Path]::GetTempPath()) "DurableTaskExtensionE2ETests"
 New-Item -Path $ProjectTemporaryPath -ItemType Directory -ErrorAction SilentlyContinue


### PR DESCRIPTION
<!-- Start the PR description with some context for the change. -->
Improves exception handling in .NET isolated by serializing the exception details in the worker middleware, then deserializing them back in host middleware. 
This may introduce breaking changes to the way that the Functions Host logs exceptions from Durable activities. 
Also adds testing for error handling, activity retry, and activity timeout scenarios in dotnet-isolated

Resolves #2711 

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)
* [x] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk
* [x] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
    * [ ] Otherwise: major or minor version updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
* [x] My changes **do not** add EventIds to our EventSource logs
    * [ ] Otherwise: Ensure the EventIds are within the supported range in our existing Windows infrastructure. You may validate this with a deployed app's telemetry. You may also extend the range by completing a PR such as [this one](https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files).
* [ ] My changes **should** be added to **v2.x** branch.
    * [x] Otherwise: This change applies exclusively to WebJobs.Extensions.DurableTask v3.x. It will be retained only in the `dev` and `main` branches and will not be merged into the `v2.x` branch.
