### PR TITLE
Fixing URLs containing Orchestration Instances IDs with Spaces

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
+++ b/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
@@ -11,6 +11,7 @@ using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Web;
 using DurableTask.Core;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.Routing.Template;
@@ -295,7 +296,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     basePath = this.GetWebhookUri().AbsolutePath;
                 }
 
-                string path = "/" + request.RequestUri.AbsolutePath.Substring(basePath.Length).Trim('/');
+                string path = "/" + WebUtility.UrlDecode(request.RequestUri.AbsolutePath).Substring(basePath.Length).Trim('/');
                 var routeValues = new RouteValueDictionary();
                 if (StartOrchestrationRoute.TryMatch(path, routeValues))
                 {

--- a/test/Common/HttpApiHandlerTests.cs
+++ b/test/Common/HttpApiHandlerTests.cs
@@ -813,7 +813,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         {
             var instanceId = "test instance id with spaces";
             var list = new List<DurableOrchestrationStatus>
-
             {
                 new DurableOrchestrationStatus
                 {

--- a/test/Common/HttpApiHandlerTests.cs
+++ b/test/Common/HttpApiHandlerTests.cs
@@ -811,17 +811,17 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         [Trait("Category", PlatformSpecificHelpers.TestCategory)]
         public async Task HandleGetStatusRequestAsync_Correctly_Parses_InstanceId_With_Spaces()
         {
+            var instanceId = "test instance id with spaces";
             var list = (IList<DurableOrchestrationStatus>)new List<DurableOrchestrationStatus>
             {
                 new DurableOrchestrationStatus
                 {
                     Name = "DoThis",
-                    InstanceId = "01",
+                    InstanceId = instanceId,
                     RuntimeStatus = OrchestrationRuntimeStatus.Completed,
                 },
             };
 
-            var instanceId = "test instance id with spaces";
             var clientMock = new Mock<IDurableClient>();
             clientMock
                 .Setup(x => x.GetStatusAsync(instanceId, false, false, true))
@@ -838,7 +838,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                     RequestUri = getStatusRequestUriBuilder.Uri,
                 });
 
+            var actual = JsonConvert.DeserializeObject<StatusResponsePayload>(await responseMessage.Content.ReadAsStringAsync());
             Assert.Equal(HttpStatusCode.OK, responseMessage.StatusCode);
+            Assert.Equal(instanceId, actual.InstanceId);
         }
 
         [Fact]

--- a/test/Common/HttpApiHandlerTests.cs
+++ b/test/Common/HttpApiHandlerTests.cs
@@ -812,7 +812,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         public async Task HandleGetStatusRequestAsync_Correctly_Parses_InstanceId_With_Spaces()
         {
             var instanceId = "test instance id with spaces";
-            var list = (IList<DurableOrchestrationStatus>)new List<DurableOrchestrationStatus>
+            var list = new List<DurableOrchestrationStatus>
+
             {
                 new DurableOrchestrationStatus
                 {


### PR DESCRIPTION
<!-- Start the PR description with some context for the change. -->


<!-- Make sure to delete the markdown comments and the below sections when squash merging -->
### Fixing URLs containing Orchestration Instances IDs with Spaces

Resolves #2590 where the URLs containing the orchestration instance ID were returning a 404 when the instance ID had spaces. Also added a simple test to make sure that the URL is correctly parsed in this case, specifically testing the "statusQueryGetUri". 

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)
* [x] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk
* [x] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
    * [ ] Otherwise: major or minor version updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
* [x] My changes **do not** add EventIds to our EventSource logs
    * [ ] Otherwise: Ensure the EventIds are within the supported range in our existing Windows infrastructure. You may validate this with a deployed app's telemetry. You may also extend the range by completing a PR such as [this one](https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files).
* [ ] My changes **should** be added to **v2.x** branch.
    * [ ] Otherwise: This change applies exclusively to WebJobs.Extensions.DurableTask v3.x. It will be retained only in the `dev` and `main` branches and will not be merged into the `v2.x` branch.
