### PR TITLE
Add SQL backend for E2E Tests

### DIFF
--- a/.github/workflows/E2ETest.yml
+++ b/.github/workflows/E2ETest.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Setup E2E tests
         shell: pwsh
         run: |
-          .\test\e2e\Tests\build-e2e-test.ps1 -StartMSSqlContainer -SkipStorageEmulator
+          .\test\e2e\Tests\build-e2e-test.ps1 -StartMSSqlContainer
 
       - name: Build
         working-directory: test/e2e/Tests

--- a/.github/workflows/E2ETest.yml
+++ b/.github/workflows/E2ETest.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Setup E2E tests
         shell: pwsh
         run: |
-          echo "MSSQL_SA_PASSWORD=$([Guid]::NewGuid())" >> $env:GITHUB_ENV
+          $env:MSSQL_SA_PASSWORD = "$([Guid]::NewGuid())"
           .\test\e2e\Tests\build-e2e-test.ps1 -StartMSSqlContainer
 
       - name: Build

--- a/.github/workflows/E2ETest.yml
+++ b/.github/workflows/E2ETest.yml
@@ -14,8 +14,45 @@ on:
       - 'test/e2e/**'
 
 jobs:
-  build:
+  build-azurestorage:
     runs-on: ubuntu-latest
+    env:
+      E2E_TEST_DURABLE_BACKEND: 'AzureStorage'
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET Core
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: 6.0.x
+
+      - name: Setup .NET Core
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: 8.0.x
+
+      - name: Set up Node.js (needed for Azurite)
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18.x' # Azurite requires at least Node 18
+
+      - name: Setup E2E tests
+        shell: pwsh
+        run: |
+          .\test\e2e\Tests\build-e2e-test.ps1
+
+      - name: Build
+        working-directory: test/e2e/Tests
+        run: dotnet build
+
+      - name: Run E2E tests
+        working-directory: test/e2e/Tests
+        run: dotnet test --filter AzureStorage!=Skip
+
+  build-mssql:
+    runs-on: ubuntu-latest
+    env:
+      E2E_TEST_DURABLE_BACKEND: "MSSQL"
     steps:
       - uses: actions/checkout@v4
 
@@ -32,21 +69,12 @@ jobs:
       - name: Setup E2E tests
         shell: pwsh
         run: |
-          .\test\e2e\Tests\build-e2e-test.ps1 -SkipStorageEmulator
+          .\test\e2e\Tests\build-e2e-test.ps1 -StartMSSqlContainer -SkipStorageEmulator
 
       - name: Build
         working-directory: test/e2e/Tests
         run: dotnet build
 
-      # Install Azurite
-      - name: Set up Node.js (needed for Azurite)
-        uses: actions/setup-node@v3
-        with:
-          node-version: '18.x' # Azurite requires at least Node 18
-
-      - name: Install Azurite
-        run: npm install -g azurite
-
       - name: Run E2E tests
         working-directory: test/e2e/Tests
-        run: azurite --silent --blobPort 10000 --queuePort 10001 --tablePort 10002 & dotnet test
+        run: dotnet test --filter MSSQL!=Skip

--- a/.github/workflows/E2ETest.yml
+++ b/.github/workflows/E2ETest.yml
@@ -14,7 +14,7 @@ on:
       - 'test/e2e/**'
 
 jobs:
-  build-azurestorage:
+  e2e-azurestorage:
     runs-on: ubuntu-latest
     env:
       E2E_TEST_DURABLE_BACKEND: 'AzureStorage'
@@ -49,7 +49,7 @@ jobs:
         working-directory: test/e2e/Tests
         run: dotnet test --filter AzureStorage!=Skip
 
-  build-mssql:
+  e2e-mssql:
     runs-on: ubuntu-latest
     env:
       E2E_TEST_DURABLE_BACKEND: "MSSQL"
@@ -69,6 +69,7 @@ jobs:
       - name: Setup E2E tests
         shell: pwsh
         run: |
+          echo "MSSQL_SA_PASSWORD=$([Guid]::NewGuid())" >> $env:GITHUB_ENV
           .\test\e2e\Tests\build-e2e-test.ps1 -StartMSSqlContainer
 
       - name: Build

--- a/.gitignore
+++ b/.gitignore
@@ -300,3 +300,6 @@ functions-extensions/
 
 # E2E Tests build output
 /src/WebJobs.Extensions.DurableTask/out/*
+
+# Runsettings files
+**/*.runsettings

--- a/test/e2e/Apps/BasicDotNetIsolated/app.csproj
+++ b/test/e2e/Apps/BasicDotNetIsolated/app.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.18.1" />
     <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.22.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="1.2.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask.SqlServer" Version="1.5.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/e2e/Tests/E2ETests.csproj
+++ b/test/e2e/Tests/E2ETests.csproj
@@ -5,6 +5,7 @@
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <RunSettingsFilePath>$(MSBuildProjectDirectory)\test.runsettings</RunSettingsFilePath>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/e2e/Tests/Fixtures/FixtureHelpers.cs
+++ b/test/e2e/Tests/Fixtures/FixtureHelpers.cs
@@ -12,6 +12,8 @@ namespace Microsoft.Azure.Durable.Tests.DotnetIsolatedE2E;
 
 public static class FixtureHelpers
 {
+    private const string MSSQL_SA_PASSWORD = "IntentionallyExposedPassword1";
+
     public static Process GetFuncHostProcess(string appPath, bool enableAuth = false)
     {
         var cliPath = Path.Combine(Path.GetTempPath(), @"DurableTaskExtensionE2ETests/Azure.Functions.Cli/func");
@@ -78,6 +80,26 @@ public static class FixtureHelpers
             {
                 // Best effort
             }
+        }
+    }
+
+    internal static void AddDurableBackendEnvironmentVariables(Process funcProcess, ILogger testLogger)
+    {
+        string? durableBackendEnvVarValue = Environment.GetEnvironmentVariable("E2E_TEST_DURABLE_BACKEND");
+        Console.WriteLine($"E2E_TEST_DURABLE_BACKEND = {durableBackendEnvVarValue}");
+        switch ((durableBackendEnvVarValue ?? "").ToLowerInvariant())
+        {
+            case "azurestorage":
+                return;
+            case "mssql":
+                funcProcess.StartInfo.EnvironmentVariables["SQLDB_Connection"] = $"Server=localhost,1433;Database=DurableDB;User Id=sa;Password={MSSQL_SA_PASSWORD};";
+                funcProcess.StartInfo.EnvironmentVariables["AzureFunctionsJobHost__extensions__durableTask__storageProvider__type"] = "mssql";
+                funcProcess.StartInfo.EnvironmentVariables["AzureFunctionsJobHost__extensions__durableTask__storageProvider__connectionStringName"] = "SQLDB_Connection";
+                funcProcess.StartInfo.EnvironmentVariables["AzureFunctionsJobHost__extensions__durableTask__storageProvider__createDatabaseIfNotExists"] = "true";
+                return;
+            default:
+                testLogger.LogWarning("WARN: Environment variable E2E_TEST_DURABLE_BACKEND not set, tests configured for Azure Storage");
+                return;
         }
     }
 }

--- a/test/e2e/Tests/Fixtures/FixtureHelpers.cs
+++ b/test/e2e/Tests/Fixtures/FixtureHelpers.cs
@@ -12,8 +12,6 @@ namespace Microsoft.Azure.Durable.Tests.DotnetIsolatedE2E;
 
 public static class FixtureHelpers
 {
-    private const string MSSQL_SA_PASSWORD = "IntentionallyExposedPassword1";
-
     public static Process GetFuncHostProcess(string appPath, bool enableAuth = false)
     {
         var cliPath = Path.Combine(Path.GetTempPath(), @"DurableTaskExtensionE2ETests/Azure.Functions.Cli/func");
@@ -86,19 +84,23 @@ public static class FixtureHelpers
     internal static void AddDurableBackendEnvironmentVariables(Process funcProcess, ILogger testLogger)
     {
         string? durableBackendEnvVarValue = Environment.GetEnvironmentVariable("E2E_TEST_DURABLE_BACKEND");
-        Console.WriteLine($"E2E_TEST_DURABLE_BACKEND = {durableBackendEnvVarValue}");
         switch ((durableBackendEnvVarValue ?? "").ToLowerInvariant())
         {
             case "azurestorage":
                 return;
             case "mssql":
-                funcProcess.StartInfo.EnvironmentVariables["SQLDB_Connection"] = $"Server=localhost,1433;Database=DurableDB;User Id=sa;Password={MSSQL_SA_PASSWORD};";
+                string? sqlPassword = Environment.GetEnvironmentVariable("MSSQL_SA_PASSWORD");
+                if (string.IsNullOrEmpty(sqlPassword))
+                {
+                    testLogger.LogWarning("Environment variable MSSQL_SA_PASSWORD not set, connection string to SQL emulator may fail");
+                }
+                funcProcess.StartInfo.EnvironmentVariables["SQLDB_Connection"] = $"Server=localhost,1433;Database=DurableDB;User Id=sa;Password={sqlPassword};";
                 funcProcess.StartInfo.EnvironmentVariables["AzureFunctionsJobHost__extensions__durableTask__storageProvider__type"] = "mssql";
                 funcProcess.StartInfo.EnvironmentVariables["AzureFunctionsJobHost__extensions__durableTask__storageProvider__connectionStringName"] = "SQLDB_Connection";
                 funcProcess.StartInfo.EnvironmentVariables["AzureFunctionsJobHost__extensions__durableTask__storageProvider__createDatabaseIfNotExists"] = "true";
                 return;
             default:
-                testLogger.LogWarning("WARN: Environment variable E2E_TEST_DURABLE_BACKEND not set, tests configured for Azure Storage");
+                testLogger.LogWarning("Environment variable E2E_TEST_DURABLE_BACKEND not set, tests configured for Azure Storage");
                 return;
         }
     }

--- a/test/e2e/Tests/Fixtures/FunctionAppFixture.cs
+++ b/test/e2e/Tests/Fixtures/FunctionAppFixture.cs
@@ -73,6 +73,8 @@ public class FunctionAppFixture : IAsyncLifetime
             //    _funcProcess.StartInfo.EnvironmentVariables["DURABLE_ATTACH_DEBUGGER"] = "True";
             //}
 
+            FixtureHelpers.AddDurableBackendEnvironmentVariables(this._funcProcess, this._logger);
+
             FixtureHelpers.StartProcessWithLogging(this._funcProcess, this._logger);
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))

--- a/test/e2e/Tests/Tests/ErrorHandlingTests.cs
+++ b/test/e2e/Tests/Tests/ErrorHandlingTests.cs
@@ -21,7 +21,7 @@ public class ErrorHandlingTests
     }
 
     [Fact]
-    [Trait("MSSQL", "Skip")] // This test fails for MSSQL until results are returned, as implemented here https://github.com/microsoft/durabletask-mssql/pull/286/files
+    [Trait("MSSQL", "Skip")] // This test fails for MSSQL this bug is fixed: https://github.com/microsoft/durabletask-mssql/issues/287
     public async Task OrchestratorWithUncaughtActivityException_ShouldFail()
     {
         using HttpResponseMessage response = await HttpHelpers.InvokeHttpTrigger("RethrowActivityException_HttpStart", "");

--- a/test/e2e/Tests/Tests/ErrorHandlingTests.cs
+++ b/test/e2e/Tests/Tests/ErrorHandlingTests.cs
@@ -21,6 +21,7 @@ public class ErrorHandlingTests
     }
 
     [Fact]
+    [Trait("MSSQL", "Skip")] // This test fails for MSSQL until results are returned, as implemented here https://github.com/microsoft/durabletask-mssql/pull/286/files
     public async Task OrchestratorWithUncaughtActivityException_ShouldFail()
     {
         using HttpResponseMessage response = await HttpHelpers.InvokeHttpTrigger("RethrowActivityException_HttpStart", "");
@@ -36,6 +37,7 @@ public class ErrorHandlingTests
     }
 
     [Fact]
+    [Trait("MSSQL", "Skip")] // Durable Entities are not supported in MSSQL/Dotnet Isolated, see https://github.com/microsoft/durabletask-mssql/issues/205
     public async Task OrchestratorWithUncaughtEntityException_ShouldFail()
     {
         using HttpResponseMessage response = await HttpHelpers.InvokeHttpTrigger("RethrowEntityException_HttpStart", "");
@@ -66,6 +68,7 @@ public class ErrorHandlingTests
     }
 
     [Fact]
+    [Trait("MSSQL", "Skip")] // Durable Entities are not supported in MSSQL/Dotnet Isolated, see https://github.com/microsoft/durabletask-mssql/issues/205
     public async Task OrchestratorWithCaughtEntityException_ShouldSucceed()
     {
         using HttpResponseMessage response = await HttpHelpers.InvokeHttpTrigger("CatchEntityException_HttpStart", "");
@@ -106,6 +109,7 @@ public class ErrorHandlingTests
     }
 
     [Fact]
+    [Trait("MSSQL", "Skip")] // Durable Entities are not supported in MSSQL/Dotnet Isolated, see https://github.com/microsoft/durabletask-mssql/issues/205
     public async Task OrchestratorWithRetriedEntityException_ShouldSucceed()
     {
         using HttpResponseMessage response = await HttpHelpers.InvokeHttpTrigger("RetryEntityException_HttpStart", "");

--- a/test/e2e/Tests/Tests/ErrorHandlingTests.cs
+++ b/test/e2e/Tests/Tests/ErrorHandlingTests.cs
@@ -21,7 +21,7 @@ public class ErrorHandlingTests
     }
 
     [Fact]
-    [Trait("MSSQL", "Skip")] // This test fails for MSSQL this bug is fixed: https://github.com/microsoft/durabletask-mssql/issues/287
+    [Trait("MSSQL", "Skip")] // This test fails for MSSQL unless this bug is fixed: https://github.com/microsoft/durabletask-mssql/issues/287
     public async Task OrchestratorWithUncaughtActivityException_ShouldFail()
     {
         using HttpResponseMessage response = await HttpHelpers.InvokeHttpTrigger("RethrowActivityException_HttpStart", "");

--- a/test/e2e/Tests/build-e2e-test.ps1
+++ b/test/e2e/Tests/build-e2e-test.ps1
@@ -6,9 +6,6 @@
 
 [CmdletBinding()]
 param(
-    [switch]
-    $Clean,
-
     [Switch]
     $SkipStorageEmulator,
 
@@ -19,7 +16,7 @@ param(
     $SkipCoreTools,
 
     [Switch]
-    $SkipBuildOnPack
+    $SkipBuild
 )
 
 $ErrorActionPreference = "Stop"
@@ -28,7 +25,6 @@ $ProjectBaseDirectory = "$PSScriptRoot\..\..\..\"
 $ProjectTemporaryPath = Join-Path ([System.IO.Path]::GetTempPath()) "DurableTaskExtensionE2ETests"
 New-Item -Path $ProjectTemporaryPath -ItemType Directory -ErrorAction SilentlyContinue
 $WebJobsExtensionProjectDirectory = Join-Path $ProjectBaseDirectory "src\WebJobs.Extensions.DurableTask"
-$WorkerExtensionProjectDirectory = Join-Path $ProjectBaseDirectory "src\Worker.Extensions.DurableTask"
 $E2EAppProjectDirectory = Join-Path $ProjectBaseDirectory "test\e2e\Apps\BasicDotNetIsolated"
 
 $LocalNugetCacheDirectory = $env:NUGET_PACKAGES
@@ -101,52 +97,55 @@ else
   Write-Host "------"
 }
 
-Write-Host "Removing old packages from test app"
+if (!$SkipBuild)
+{
+  Write-Host "Removing old packages from test app"
 
-$AppPackageLocation = Join-Path $E2EAppProjectDirectory 'packages'
-if (!(Test-Path $AppPackageLocation)) {
-  New-Item -Path $AppPackageLocation -ItemType Directory -ErrorAction SilentlyContinue
-}
-$AppPackageLocation = Resolve-Path $AppPackageLocation
-Get-ChildItem -Path $AppPackageLocation -Include * -File -Recurse | ForEach-Object { $_.Delete()}
-
-Write-Host "Building WebJobs extension project"
-
-$BuildOutputLocation = Join-Path $WebJobsExtensionProjectDirectory 'out'
-if (!(Test-Path $BuildOutputLocation)) {
-  New-Item -Path $BuildOutputLocation -ItemType Directory -ErrorAction SilentlyContinue
-}
-$BuildOutputLocation = Resolve-Path $BuildOutputLocation
-Get-ChildItem -Path $BuildOutputLocation -Include * -File -Recurse | ForEach-Object { $_.Delete()}
-dotnet build -c Debug "$WebJobsExtensionProjectDirectory\WebJobs.Extensions.DurableTask.csproj" --output $BuildOutputLocation
-
-Write-Host "Moving nupkg from WebJobs extension to $AppPackageLocation"
-Set-Location $BuildOutputLocation
-dotnet nuget push *.nupkg --source $AppPackageLocation
-
-Write-Host "Updating app .csproj to reference built package versions"
-Set-Location $E2EAppProjectDirectory
-$files = Get-ChildItem -Path ./packages -Include * -File -Recurse
-$files | ForEach-Object {
-  if ($_.Name -match 'Microsoft.Azure.WebJobs.Extensions.DurableTask')
-  {
-    $webJobsExtensionVersion = $_.Name -replace 'Microsoft.Azure.WebJobs.Extensions.DurableTask\.|\.nupkg'
-
-    Write-Host "Removing cached version $webJobsExtensionVersion of WebJobs extension from nuget cache, if exists"
-    $cachedVersionFolders = Get-ChildItem -Path (Join-Path $LocalNugetCacheDirectory "microsoft.azure.webjobs.extensions.durabletask") -Directory -ErrorAction Continue
-    $cachedVersionFolders | ForEach-Object {
-      if ($_.Name -eq $webJobsExtensionVersion)
-      {
-        Write-Host "Removing cached version $webJobsExtensionVersion from nuget cache"
-        Remove-Item -Recurse -Force $_.FullName -ErrorAction Stop
+  $AppPackageLocation = Join-Path $E2EAppProjectDirectory 'packages'
+  if (!(Test-Path $AppPackageLocation)) {
+    New-Item -Path $AppPackageLocation -ItemType Directory -ErrorAction SilentlyContinue
+  }
+  $AppPackageLocation = Resolve-Path $AppPackageLocation
+  Get-ChildItem -Path $AppPackageLocation -Include * -File -Recurse | ForEach-Object { $_.Delete()}
+  
+  Write-Host "Building WebJobs extension project"
+  
+  $BuildOutputLocation = Join-Path $WebJobsExtensionProjectDirectory 'out'
+  if (!(Test-Path $BuildOutputLocation)) {
+    New-Item -Path $BuildOutputLocation -ItemType Directory -ErrorAction SilentlyContinue
+  }
+  $BuildOutputLocation = Resolve-Path $BuildOutputLocation
+  Get-ChildItem -Path $BuildOutputLocation -Include * -File -Recurse | ForEach-Object { $_.Delete()}
+  dotnet build -c Debug "$WebJobsExtensionProjectDirectory\WebJobs.Extensions.DurableTask.csproj" --output $BuildOutputLocation
+  
+  Write-Host "Moving nupkg from WebJobs extension to $AppPackageLocation"
+  Set-Location $BuildOutputLocation
+  dotnet nuget push *.nupkg --source $AppPackageLocation
+  
+  Write-Host "Updating app .csproj to reference built package versions"
+  Set-Location $E2EAppProjectDirectory
+  $files = Get-ChildItem -Path ./packages -Include * -File -Recurse
+  $files | ForEach-Object {
+    if ($_.Name -match 'Microsoft.Azure.WebJobs.Extensions.DurableTask')
+    {
+      $webJobsExtensionVersion = $_.Name -replace 'Microsoft.Azure.WebJobs.Extensions.DurableTask\.|\.nupkg'
+  
+      Write-Host "Removing cached version $webJobsExtensionVersion of WebJobs extension from nuget cache, if exists"
+      $cachedVersionFolders = Get-ChildItem -Path (Join-Path $LocalNugetCacheDirectory "microsoft.azure.webjobs.extensions.durabletask") -Directory -ErrorAction Continue
+      $cachedVersionFolders | ForEach-Object {
+        if ($_.Name -eq $webJobsExtensionVersion)
+        {
+          Write-Host "Removing cached version $webJobsExtensionVersion from nuget cache"
+          Remove-Item -Recurse -Force $_.FullName -ErrorAction Stop
+        }
       }
     }
   }
+  
+  Write-Host "Building app project"
+  dotnet clean app.csproj
+  dotnet build app.csproj
 }
-
-Write-Host "Building app project"
-dotnet clean app.csproj
-dotnet build app.csproj
 
 Set-Location $PSScriptRoot
 
@@ -161,15 +160,13 @@ else
   .\start-emulators.ps1 -SkipStorageEmulator:$SkipStorageEmulator -EmulatorStartDir $ProjectTemporaryPath
 }
 
-if ($StartMSSqlContainer)
-{
-  $mssqlPassword = "IntentionallyExposedPassword1"
+function StartMSSQLContainer($mssqlPwd) {
   Write-Host "Pulling down the mcr.microsoft.com/mssql/server:2022-latest image..."
   docker pull mcr.microsoft.com/mssql/server:2022-latest
 
   # Start the SQL Server docker container with the specified edition
   Write-Host "Starting SQL Server 2022-latest Express docker container on port 1433" -ForegroundColor DarkYellow
-  docker run --name mssql-server -e ACCEPT_EULA=Y -e "MSSQL_SA_PASSWORD=$mssqlPassword" -e "MSSQL_PID=Express" -p 1433:1433 -d mcr.microsoft.com/mssql/server:2022-latest
+  docker run --name mssql-server -e ACCEPT_EULA=Y -e "MSSQL_SA_PASSWORD=$mssqlPwd" -e "MSSQL_PID=Express" -p 1433:1433 -d mcr.microsoft.com/mssql/server:2022-latest
 
   if ($LASTEXITCODE -ne 0) {
       exit $LASTEXITCODE
@@ -184,5 +181,16 @@ if ($StartMSSqlContainer)
 }
 
 Set-Location $PSScriptRoot
+
+if ($StartMSSqlContainer)
+{
+  $mssqlPwd = $env:MSSQL_SA_PASSWORD
+  if (!$mssqlPwd) {
+    Write-Warning "No MSSQL_SA_PASSWORD environment variable found! Skipping SQL Server container startup."
+  }
+  else {
+    StartMSSQLContainer $mssqlPwd
+  }
+}
 
 StopOnFailedExecution

--- a/test/e2e/Tests/build-e2e-test.ps1
+++ b/test/e2e/Tests/build-e2e-test.ps1
@@ -15,6 +15,8 @@ param(
     [Switch]
     $SkipCoreTools,
 
+    # This param can be used during local runs of the build script to deliberately skip the build and run only the azurite/mssql logic
+    # For instance, the command ./build-e2e-test.ps1 -SkipBuild -StartMSSqlContainer will start azurite and the MSSQL docker container only. 
     [Switch]
     $SkipBuild
 )

--- a/test/e2e/Tests/build-e2e-test.ps1
+++ b/test/e2e/Tests/build-e2e-test.ps1
@@ -13,7 +13,7 @@ param(
     $SkipStorageEmulator,
 
     [Switch]
-    $StartCosmosDBEmulator,
+    $StartMSSqlContainer,
 
     [Switch]
     $SkipCoreTools,
@@ -150,7 +150,7 @@ dotnet build app.csproj
 
 Set-Location $PSScriptRoot
 
-if ($SkipStorageEmulator -And -not $StartCosmosDBEmulator)
+if ($SkipStorageEmulator)
 {
   Write-Host
   Write-Host "---Skipping emulator startup---"
@@ -158,7 +158,29 @@ if ($SkipStorageEmulator -And -not $StartCosmosDBEmulator)
 }
 else 
 {
-  .\start-emulators.ps1 -SkipStorageEmulator:$SkipStorageEmulator -StartCosmosDBEmulator:$StartCosmosDBEmulator -EmulatorStartDir $ProjectTemporaryPath
+  .\start-emulators.ps1 -SkipStorageEmulator:$SkipStorageEmulator -EmulatorStartDir $ProjectTemporaryPath
+}
+
+if ($StartMSSqlContainer)
+{
+  $mssqlPassword = "IntentionallyExposedPassword1"
+  Write-Host "Pulling down the mcr.microsoft.com/mssql/server:2022-latest image..."
+  docker pull mcr.microsoft.com/mssql/server:2022-latest
+
+  # Start the SQL Server docker container with the specified edition
+  Write-Host "Starting SQL Server 2022-latest Express docker container on port 1433" -ForegroundColor DarkYellow
+  docker run --name mssql-server -e ACCEPT_EULA=Y -e "MSSQL_SA_PASSWORD=$mssqlPassword" -e "MSSQL_PID=Express" -p 1433:1433 -d mcr.microsoft.com/mssql/server:2022-latest
+
+  if ($LASTEXITCODE -ne 0) {
+      exit $LASTEXITCODE
+  }
+
+  # The container needs a bit more time before it can start accepting commands
+  Write-Host "Sleeping for 30 seconds to let the container finish initializing..." -ForegroundColor Yellow
+  Start-Sleep -Seconds 30
+
+  # Check to see what containers are running
+  docker ps
 }
 
 Set-Location $PSScriptRoot

--- a/test/e2e/Tests/start-emulators.ps1
+++ b/test/e2e/Tests/start-emulators.ps1
@@ -7,9 +7,6 @@ param(
     [Switch]
     $SkipStorageEmulator,
     [Parameter(Mandatory=$false)]
-    [Switch]
-    $StartCosmosDBEmulator,
-    [Parameter(Mandatory=$false)]
     $EmulatorStartDir,
     [Parameter(Mandatory=$false)]
     [Switch]
@@ -22,32 +19,9 @@ if (Test-Path($EmulatorStartDir)) {
 
 $DebugPreference = 'Continue'
 
-Write-Host "Start CosmosDB Emulator: $StartCosmosDBEmulator"
 Write-Host "Skip Storage Emulator: $SkipStorageEmulator"
 
-$startedCosmos = $false
 $startedStorage = $false
-
-# Reassigning $IsWindows no longer allowed - might need to refactor this logic
-# if (!$IsWindows -and !$IsLinux -and !$IsMacOs)
-# {
-#     # For pre-PS6
-#     Write-Host "Could not resolve OS. Assuming Windows."
-#     $IsWindows = $true
-# }
-
-if (!$IsWindows -and $StartCosmosDBEmulator)
-{
-    Write-Host "Skipping CosmosDB emulator because it is not supported on non-Windows OS."
-    $StartCosmosDBEmulator = $false
-}
-
-if ($StartCosmosDBEmulator)
-{
-    # Locally, you may need to run PowerShell with administrative privileges
-    Add-MpPreference -ExclusionPath "$env:ProgramFiles\Azure Cosmos DB Emulator"
-    Import-Module "$env:ProgramFiles\Azure Cosmos DB Emulator\PSModules\Microsoft.Azure.CosmosDB.Emulator"
-}
 
 function IsStorageEmulatorRunning()
 {
@@ -67,29 +41,6 @@ function IsStorageEmulatorRunning()
     }
 
     return $false
-}
-
-if ($StartCosmosDBEmulator)
-{
-    Write-Host ""
-    Write-Host "---Starting CosmosDB emulator---"
-    $cosmosStatus = Get-CosmosDbEmulatorStatus
-    Write-Host "CosmosDB emulator status: $cosmosStatus"
-
-    if ($cosmosStatus -eq "StartPending")
-    {
-        $startedCosmos = $true
-    }
-    elseif ($cosmosStatus -ne "Running")
-    {
-        Write-Host "CosmosDB emulator is not running. Starting emulator."
-        Start-Process "$env:ProgramFiles\Azure Cosmos DB Emulator\CosmosDB.Emulator.exe" "/NoExplorer /NoUI /DisableRateLimiting /PartitionCount=50 /Consistency=Strong /EnablePreview /EnableSqlComputeEndpoint" -Verb RunAs
-        $startedCosmos = $true
-    }
-    else
-    {
-        Write-Host "CosmosDB emulator is already running."
-    }
 }
 
 if (!$SkipStorageEmulator)
@@ -130,56 +81,6 @@ if ($NoWait -eq $true)
     Write-Host "'NoWait' specified. Exiting."
     Write-Host
     exit 0
-}
-
-if ($StartCosmosDBEmulator -and $startedCosmos -eq $true)
-{
-    Write-Host "---Waiting for CosmosDB emulator to be running---"
-    $cosmosStatus = Get-CosmosDbEmulatorStatus
-    Write-Host "CosmosDB emulator status: $cosmosStatus"
-
-    $waitSuccess = Wait-CosmosDbEmulator -Status Running -Timeout 60 -ErrorAction Continue
-
-    if ($waitSuccess -ne $true)
-    {
-        Write-Host "CosmosDB emulator not yet running after waiting 60 seconds. Restarting."
-        Write-Host "Shutting down and restarting"
-        Start-Process "$env:ProgramFiles\Azure Cosmos DB Emulator\CosmosDB.Emulator.exe" "/Shutdown" -Verb RunAs
-        sleep 30;
-
-        for ($j=0; $j -lt 3; $j++) {
-            Write-Host "Attempt $j"
-            Start-Process "$env:ProgramFiles\Azure Cosmos DB Emulator\CosmosDB.Emulator.exe" "/NoExplorer /NoUI /DisableRateLimiting /PartitionCount=50 /Consistency=Strong /EnablePreview /EnableSqlComputeEndpoint" -Verb RunAs
-
-            for ($i=0; $i -lt 5; $i++) {
-                $status = Get-CosmosDbEmulatorStatus
-                Write-Host "Cosmos DB Emulator Status: $status"
-
-                if ($status -ne "Running") {
-                    sleep 30;
-                }
-                else {
-                    break;
-                }
-            }
-
-            if ($status -ne "Running") {
-                Write-Host "Shutting down and restarting"
-                Start-Process "$env:ProgramFiles\Azure Cosmos DB Emulator\CosmosDB.Emulator.exe" "/Shutdown" -Verb RunAs
-                sleep 30;
-            }
-            else {
-                break;
-            }
-        }
-
-        if ($status -ne "Running") {
-            Write-Error "Emulator failed to start"
-        }
-    }
-
-    Write-Host "------"
-    Write-Host
 }
 
 if (!$SkipStorageEmulator -and $startedStorage -eq $true)

--- a/test/e2e/Tests/test.runsettings
+++ b/test/e2e/Tests/test.runsettings
@@ -1,0 +1,13 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<RunSettings>
+    <RunConfiguration>
+        <EnvironmentVariables>
+            <!-- Uncomment these environment variables if you want to run tests against MSSQL -->
+            <!-- Ensure the password in MSSQL_SA_PASSWORD is the same one you configured your MSSQL Docker container with -->
+            <!--
+            <MSSQL_SA_PASSWORD>{{YourPasswordHere}}</MSSQL_SA_PASSWORD>
+            <E2E_TEST_DURABLE_BACKEND>MSSQL</E2E_TEST_DURABLE_BACKEND>
+            -->
+        </EnvironmentVariables>
+    </RunConfiguration>
+</RunSettings>

--- a/test/e2e/Tests/test.runsettings
+++ b/test/e2e/Tests/test.runsettings
@@ -4,10 +4,12 @@
         <EnvironmentVariables>
             <!-- Uncomment these environment variables if you want to run tests against MSSQL -->
             <!-- Ensure the password in MSSQL_SA_PASSWORD is the same one you configured your MSSQL Docker container with -->
+            <!-- Do not commit changes to this file. -->
             <!--
             <MSSQL_SA_PASSWORD>{{YourPasswordHere}}</MSSQL_SA_PASSWORD>
             <E2E_TEST_DURABLE_BACKEND>MSSQL</E2E_TEST_DURABLE_BACKEND>
             -->
+            <E2E_TEST_DURABLE_BACKEND>AzureStorage</E2E_TEST_DURABLE_BACKEND>
         </EnvironmentVariables>
     </RunConfiguration>
 </RunSettings>


### PR DESCRIPTION
Adds the MSSQL storage backend for the new end-to-end tests. Runs a subset of the tests against the new backend. 

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)
* [x] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk
* [x] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
    * [ ] Otherwise: major or minor version updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
* [x] My changes **do not** add EventIds to our EventSource logs
    * [ ] Otherwise: Ensure the EventIds are within the supported range in our existing Windows infrastructure. You may validate this with a deployed app's telemetry. You may also extend the range by completing a PR such as [this one](https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files).
* [ ] My changes **should** be added to **v2.x** branch.
    * [x] Otherwise: This change applies exclusively to WebJobs.Extensions.DurableTask v3.x. It will be retained only in the `dev` and `main` branches and will not be merged into the `v2.x` branch.
