### PR TITLE
Revert ITelemetryModule updates

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/Correlation/TelemetryActivator.cs
+++ b/src/WebJobs.Extensions.DurableTask/Correlation/TelemetryActivator.cs
@@ -66,7 +66,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Correlation
         {
             this.TelemetryModule.DisposeAsync().AsTask().GetAwaiter().GetResult();
             this.WebJobsTelemetryModule.DisposeAsync().AsTask().GetAwaiter().GetResult();
-
         }
 
         /// <summary>

--- a/src/WebJobs.Extensions.DurableTask/Correlation/TelemetryActivator.cs
+++ b/src/WebJobs.Extensions.DurableTask/Correlation/TelemetryActivator.cs
@@ -17,11 +17,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Correlation
     /// <summary>
     /// TelemetryActivator initializes Distributed Tracing. This class only works for netstandard2.0.
     /// </summary>
-    public class TelemetryActivator : ITelemetryModule, IAsyncDisposable, IDisposable
+    public class TelemetryActivator : ITelemetryActivator, IAsyncDisposable, IDisposable
     {
         private readonly DurableTaskOptions options;
         private readonly INameResolver nameResolver;
+        private EndToEndTraceHelper endToEndTraceHelper;
         private TelemetryClient telemetryClient;
+        private IAsyncDisposable telemetryModule;
 
         /// <summary>
         /// Constructor for initializing Distributed Tracing.
@@ -33,6 +35,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Correlation
             this.options = options.Value;
             this.nameResolver = nameResolver;
         }
+
+        /// <summary>
+        /// OnSend is an action that enable to hook of sending telemetry.
+        /// You can use this property for testing.
+        /// </summary>
+        public Action<ITelemetry> OnSend { get; set; } = null;
 
         internal IAsyncDisposable TelemetryModule { get; set; }
 
@@ -57,13 +65,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Correlation
         /// <inheritdoc/>
         public void Dispose()
         {
-            this.DisposeAsync().AsTask().GetAwaiter().GetResult();
+            this.TelemetryModule.DisposeAsync().AsTask().GetAwaiter().GetResult();
+            this.WebJobsTelemetryModule.DisposeAsync().AsTask().GetAwaiter().GetResult();
+
         }
 
         /// <summary>
         /// Initialize is initialize the telemetry client.
         /// </summary>
-        public void Initialize(TelemetryConfiguration configuration)
+        public void Initialize(ILogger logger)
         {
             if (this.options.Tracing.DistributedTracingEnabled)
             {
@@ -72,14 +82,17 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Correlation
                     return;
                 }
 
+                this.endToEndTraceHelper = new EndToEndTraceHelper(logger, this.options.Tracing.TraceReplayEvents);
+                TelemetryConfiguration telemetryConfiguration = this.SetupTelemetryConfiguration();
+
                 if (this.options.Tracing.Version == Options.DurableDistributedTracingVersion.V2)
                 {
                     DurableTelemetryModule module = new DurableTelemetryModule();
-                    module.Initialize(configuration);
+                    module.Initialize(telemetryConfiguration);
                     this.TelemetryModule = module;
 
                     WebJobsTelemetryModule webJobsModule = new WebJobsTelemetryModule();
-                    webJobsModule.Initialize(configuration);
+                    webJobsModule.Initialize(telemetryConfiguration);
                     this.WebJobsTelemetryModule = webJobsModule;
                 }
                 else
@@ -87,7 +100,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Correlation
                     this.SetUpV1DistributedTracing();
                     if (CorrelationSettings.Current.EnableDistributedTracing)
                     {
-                        this.SetUpTelemetryClient(configuration);
+                        this.SetUpTelemetryClient(telemetryConfiguration);
 
                         if (CorrelationSettings.Current.EnableDistributedTracing)
                         {
@@ -135,7 +148,75 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Correlation
 
         private void SetUpTelemetryClient(TelemetryConfiguration telemetryConfiguration)
         {
+            this.endToEndTraceHelper.ExtensionInformationalEvent(
+                    hubName: this.options.HubName,
+                    functionName: string.Empty,
+                    instanceId: string.Empty,
+                    message: "Setting up the telemetry client...",
+                    writeToUserLogs: true);
+
             this.telemetryClient = new TelemetryClient(telemetryConfiguration);
+        }
+
+        private TelemetryConfiguration SetupTelemetryConfiguration()
+        {
+            TelemetryConfiguration config = TelemetryConfiguration.CreateDefault();
+            if (this.OnSend != null)
+            {
+                config.TelemetryChannel = new NoOpTelemetryChannel { OnSend = this.OnSend };
+            }
+
+            string resolvedInstrumentationKey = this.nameResolver.Resolve("APPINSIGHTS_INSTRUMENTATIONKEY");
+            string resolvedConnectionString = this.nameResolver.Resolve("APPLICATIONINSIGHTS_CONNECTION_STRING");
+
+            bool instrumentationKeyProvided = !string.IsNullOrEmpty(resolvedInstrumentationKey);
+            bool connectionStringProvided = !string.IsNullOrEmpty(resolvedConnectionString);
+
+            if (instrumentationKeyProvided && connectionStringProvided)
+            {
+                this.endToEndTraceHelper.ExtensionWarningEvent(
+                    hubName: this.options.HubName,
+                    functionName: string.Empty,
+                    instanceId: string.Empty,
+                    message: "Both 'APPINSIGHTS_INSTRUMENTATIONKEY' and 'APPLICATIONINSIGHTS_CONNECTION_STRING' are defined in the current environment variables. Please specify one. We recommend specifying 'APPLICATIONINSIGHTS_CONNECTION_STRING'.");
+            }
+
+            if (!instrumentationKeyProvided && !connectionStringProvided)
+            {
+                this.endToEndTraceHelper.ExtensionWarningEvent(
+                    hubName: this.options.HubName,
+                    functionName: string.Empty,
+                    instanceId: string.Empty,
+                    message: "'APPINSIGHTS_INSTRUMENTATIONKEY' or 'APPLICATIONINSIGHTS_CONNECTION_STRING' were not defined in the current environment variables, but distributed tracing is enabled. Please specify one. We recommend specifying 'APPLICATIONINSIGHTS_CONNECTION_STRING'.");
+            }
+
+            if (instrumentationKeyProvided)
+            {
+                this.endToEndTraceHelper.ExtensionInformationalEvent(
+                    hubName: this.options.HubName,
+                    functionName: string.Empty,
+                    instanceId: string.Empty,
+                    message: "Reading APPINSIGHTS_INSTRUMENTATIONKEY...",
+                    writeToUserLogs: true);
+
+#pragma warning disable CS0618 // Type or member is obsolete
+                config.InstrumentationKey = resolvedInstrumentationKey;
+#pragma warning restore CS0618 // Type or member is obsolete
+            }
+
+            if (connectionStringProvided)
+            {
+                this.endToEndTraceHelper.ExtensionInformationalEvent(
+                    hubName: this.options.HubName,
+                    functionName: string.Empty,
+                    instanceId: string.Empty,
+                    message: "Reading APPLICATIONINSIGHTS_CONNECTION_STRING...",
+                    writeToUserLogs: true);
+
+                config.ConnectionString = resolvedConnectionString;
+            }
+
+            return config;
         }
     }
 }

--- a/src/WebJobs.Extensions.DurableTask/Correlation/TelemetryActivator.cs
+++ b/src/WebJobs.Extensions.DurableTask/Correlation/TelemetryActivator.cs
@@ -23,7 +23,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Correlation
         private readonly INameResolver nameResolver;
         private EndToEndTraceHelper endToEndTraceHelper;
         private TelemetryClient telemetryClient;
-        private IAsyncDisposable telemetryModule;
 
         /// <summary>
         /// Constructor for initializing Distributed Tracing.

--- a/src/WebJobs.Extensions.DurableTask/DurableTaskJobHostConfigurationExtensions.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskJobHostConfigurationExtensions.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.Azure.WebJobs.Extensions.DurableTask.ContextImplementations;
 using Microsoft.Azure.WebJobs.Extensions.DurableTask.Correlation;
 using Microsoft.Azure.WebJobs.Extensions.DurableTask.Options;
@@ -89,7 +88,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             serviceCollection.TryAddSingleton<IMessageSerializerSettingsFactory, MessageSerializerSettingsFactory>();
             serviceCollection.TryAddSingleton<IErrorSerializerSettingsFactory, ErrorSerializerSettingsFactory>();
             serviceCollection.TryAddSingleton<IApplicationLifetimeWrapper, HostLifecycleService>();
-            serviceCollection.AddSingleton<ITelemetryModule, TelemetryActivator>();
+            serviceCollection.AddSingleton<ITelemetryActivator, TelemetryActivator>();
             serviceCollection.TryAddSingleton<IDurableClientFactory, DurableClientFactory>();
 #pragma warning disable CS0612, CS0618 // Type or member is obsolete
             serviceCollection.TryAddSingleton<IConnectionStringResolver, WebJobsConnectionStringProvider>();

--- a/test/Common/TestHelpers.cs
+++ b/test/Common/TestHelpers.cs
@@ -63,6 +63,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             IMessageSerializerSettingsFactory serializerSettings = null,
             bool? localRpcEndpointEnabled = false,
             DurableTaskOptions options = null,
+            Action<ITelemetry> onSend = null,
             bool rollbackEntityOperationsOnExceptions = true,
             int entityMessageReorderWindowInMinutes = 30,
             string exactTaskHubName = null,
@@ -155,6 +156,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 durableHttpMessageHandler: durableHttpMessageHandler,
                 lifeCycleNotificationHelper: lifeCycleNotificationHelper,
                 serializerSettings: serializerSettings,
+                onSend: onSend,
                 addDurableClientFactory: addDurableClientFactory,
                 types: types,
                 configureScaleOptions: configureScaleOptions,
@@ -169,6 +171,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             IDurableHttpMessageHandlerFactory durableHttpMessageHandler = null,
             ILifeCycleNotificationHelper lifeCycleNotificationHelper = null,
             IMessageSerializerSettingsFactory serializerSettings = null,
+            Action<ITelemetry> onSend = null,
             Type durabilityProviderFactoryType = null,
             bool addDurableClientFactory = false,
             Action<ScaleOptions> configureScaleOptions = null,
@@ -199,7 +202,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 nameResolver: testNameResolver,
                 durableHttpMessageHandler: durableHttpMessageHandler,
                 lifeCycleNotificationHelper: lifeCycleNotificationHelper,
-                serializerSettingsFactory: serializerSettings);
+                serializerSettingsFactory: serializerSettings,
+                onSend: onSend);
         }
 
         public static IHost GetJobHostExternalEnvironment(IStorageServiceClientProviderFactory clientProviderFactory = null)


### PR DESCRIPTION
This PR reverts commit 85d4c87a76184a9cd78bc30f49ec31169dcc9aa7 because we were seeing missing spans for the Distributed Tracing V2 feature when updating `ITelemetryActivator` to be an `ITelemetryModule`.

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)
* [x] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk
* [ ] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
    * [ ] Otherwise: major or minor version updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
* [x] My changes **do not** add EventIds to our EventSource logs
    * [ ] Otherwise: Ensure the EventIds are within the supported range in our existing Windows infrastructure. You may validate this with a deployed app's telemetry. You may also extend the range by completing a PR such as [this one](https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files).
* [ ] My changes **should** be added to **v2.x** branch.
    * [ ] Otherwise: This change applies exclusively to WebJobs.Extensions.DurableTask v3.x. It will be retained only in the `dev` and `main` branches and will not be merged into the `v2.x` branch.
