### PR TITLE
Relax type check in `OrchestrationInputConverter`

### DIFF
--- a/src/Worker.Extensions.DurableTask/OrchestrationInputConverter.cs
+++ b/src/Worker.Extensions.DurableTask/OrchestrationInputConverter.cs
@@ -58,11 +58,13 @@ internal class OrchestrationInputConverter : IInputConverter
         // We only convert if:
         // 1. The "Source" is null - IE: there are no declared binding parameters.
         // 2. We have a cached input.
-        // 3. The TargetType matches our cached type.
+        // 3. The TargetType is either:
+        //    a. TargetType is in the inheritance hierarchy of the cached input (i.e. an ancestor type),
+        //    b. TargetType is an interface implemented by the cached input.
         // If these are met, then we assume this parameter is the orchestration input.
         if (context.Source is null
             && context.FunctionContext.Items.TryGetValue(OrchestrationInputKey, out object? value)
-            && context.TargetType == value?.GetType())
+            && context.TargetType.IsInstanceOfType(value))
         {
             // Remove this from the items so we bind this only once.
             context.FunctionContext.Items.Remove(OrchestrationInputKey);

--- a/test/Worker.Extensions.DurableTask.Tests/OrchestrationInputConverterTests.cs
+++ b/test/Worker.Extensions.DurableTask.Tests/OrchestrationInputConverterTests.cs
@@ -1,0 +1,72 @@
+﻿using Microsoft.Azure.Functions.Worker.Converters;
+using Microsoft.Azure.Functions.Worker.Extensions.DurableTask;
+using Moq;
+
+namespace Microsoft.Azure.Functions.Worker.Tests;
+
+public sealed class TestCollectionItem
+{
+}
+
+public sealed class OrchestrationInputConverterTests
+{
+    /// <summary>
+    /// JSON serializer typically deserialize collections as List{T} instances.
+    /// An instance of List{T} can be converted to any of the following interfaces or types:
+    /// </summary>
+    private static readonly Type[] GenericCollectionTypes =
+    {
+        typeof(IEnumerable<>),
+        typeof(IList<>),
+        typeof(ICollection<>),
+        typeof(IReadOnlyList<>),
+        typeof(IReadOnlyCollection<>),
+        typeof(List<>)
+    };
+
+    /// <summary>
+    /// System under test.
+    /// </summary>
+    private readonly IInputConverter inputConverter = new OrchestrationInputConverter();
+
+    private readonly Mock<FunctionContext> functionContextMock = new();
+
+    private readonly Mock<ConverterContext> converterContextMock = new();
+
+    public OrchestrationInputConverterTests()
+    {
+        // Default setup for ConvertAsync method:
+        //   - converterContext.Source should be null.
+        //   - converterContext.FunctionContext should be functionContextMock.Object.
+        converterContextMock.SetupGet(convCtx => convCtx.Source).Returns(default(object));
+        converterContextMock.SetupGet(convCtx => convCtx.FunctionContext).Returns(functionContextMock.Object);
+    }
+
+    /// <summary>
+    /// Generate test cases for each of the generic collection types.
+    /// </summary>
+    /// <param name="type">Collection item type.</param>
+    /// <returns>Test data.</returns>
+    public static TheoryData<Type> GenerateConcreteTestCollectionTypesFor(Type type)
+    {
+        return new TheoryData<Type>(GenericCollectionTypes.Select(ciType => ciType.MakeGenericType(type)));
+    }
+
+    [Theory(DisplayName = "ConvertAsync: Deserialized value is List<T> and target type is collection or collection interface of T")]
+    [MemberData(nameof(GenerateConcreteTestCollectionTypesFor), typeof(TestCollectionItem))]
+    public async Task ConvertAsync_WhenDeserializedValueIsListOfT_AndTargetTypeIsCollectionInterfaceOfT_ReturnsConversionResultSuccess(Type collectionType)
+    {
+        var inputData = new List<TestCollectionItem> {new(), new(), new()};
+        var functionContextItems = new Dictionary<object, object> {{"__orchestrationInput__", inputData}};
+        functionContextMock.SetupGet(funcCtx => funcCtx.Items).Returns(functionContextItems);
+        converterContextMock.SetupGet(convCtx => convCtx.TargetType).Returns(collectionType);
+
+        ConversionResult result = await inputConverter.ConvertAsync(converterContextMock.Object);
+
+        // Assert conversion is successful
+        Assert.Equal(ConversionStatus.Succeeded, result.Status);
+        Assert.Same(inputData, result.Value);
+        // Assert that the input data has been removed from the function context items
+        Assert.Empty(functionContextItems);
+    }
+}


### PR DESCRIPTION
<!-- Start the PR description with some context for the change. -->
`OrchestrationInputConverter` responsible for processing orchestration inputs in isolated model has a strict type check that verifies that deserialized value's type equals _exactly_ to the target type in the function prototype. While it is correct for the majority of cases, it is not so when the target type is a collection interface. Standard behavior of, e.g., `System.Text.Json` serializer to produce a `List<T>` when target deserialization type is, e.g., `IEnumerable<T>`. Now, `List<T>` implements `IEnumerable<T>` and this can safely be passed to the orchestration, however since `typeof(List<T>) != typeof(IEnumerable<T>)`, the check fails and orchestration receives a `null` input.

This PR addresses this issue by slightly relaxing the type check, reporting a successful conversion of actual deserialized value can be assigned to target type due to inheritance or interface implementation. This unblocks collection interfaces _and_ custom json serializers that might return a more concrete type than target deserialization type (i.e. custom polymorphic deserialization).

<!-- Make sure to delete the markdown comments and the below sections when squash merging -->
### Issue describing the changes in this PR

resolves #3035 

### Pull request checklist

* [ ] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)
* [x] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk
* [ ] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
    * [ ] Otherwise: major or minor version updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
* [x] My changes **do not** add EventIds to our EventSource logs
    * [ ] Otherwise: Ensure the EventIds are within the supported range in our existing Windows infrastructure. You may validate this with a deployed app's telemetry. You may also extend the range by completing a PR such as [this one](https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files).
* [x] My changes **should** be added to **v2.x** branch.
    * [ ] Otherwise: This change applies exclusively to WebJobs.Extensions.DurableTask v3.x. It will be retained only in the `dev` and `main` branches and will not be merged into the `v2.x` branch.
