### PR TITLE
Add E2E test for DTS backend

### DIFF
--- a/.github/workflows/E2ETest.yml
+++ b/.github/workflows/E2ETest.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Setup E2E tests
         shell: pwsh
         run: |
-          $env:MSSQL_SA_PASSWORD = "Str0ngP@ss!2025"
+          $env:MSSQL_SA_PASSWORD = "TEST12_$([Guid]::NewGuid())!"
           .\test\e2e\Tests\build-e2e-test.ps1 -StartMSSqlContainer
 
       - name: Build

--- a/.github/workflows/E2ETest.yml
+++ b/.github/workflows/E2ETest.yml
@@ -66,10 +66,13 @@ jobs:
         with:
           dotnet-version: 8.0.x
 
+      - name: Initialize Environment Variables
+        run: | 
+          echo "MSSQL_SA_PASSWORD=TEST12_$(echo $RANDOM)!" >> $GITHUB_ENV
+
       - name: Setup E2E tests
         shell: pwsh
         run: |
-          $env:MSSQL_SA_PASSWORD = "TEST12_$([Guid]::NewGuid())!"
           .\test\e2e\Tests\build-e2e-test.ps1 -StartMSSqlContainer
 
       - name: Build

--- a/.github/workflows/E2ETest.yml
+++ b/.github/workflows/E2ETest.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Setup E2E tests
         shell: pwsh
         run: |
-          $env:MSSQL_SA_PASSWORD = "$([Guid]::NewGuid())"
+          $env:MSSQL_SA_PASSWORD = "Str0ngP@ss!2025"
           .\test\e2e\Tests\build-e2e-test.ps1 -StartMSSqlContainer
 
       - name: Build

--- a/.github/workflows/E2ETest.yml
+++ b/.github/workflows/E2ETest.yml
@@ -83,7 +83,7 @@ jobs:
   e2e-dts:
     runs-on: ubuntu-latest
     env:
-      E2E_TEST_DURABLE_BACKEND: "DTS"
+      E2E_TEST_DURABLE_BACKEND: "azureManaged"
     steps:
       - uses: actions/checkout@v4
 
@@ -108,4 +108,4 @@ jobs:
 
       - name: Run E2E tests
         working-directory: test/e2e/Tests
-        run: dotnet test --filter DTS!=Skip
+        run: dotnet test --logger "console;verbosity=detailed" --filter DTS!=Skip

--- a/.github/workflows/E2ETest.yml
+++ b/.github/workflows/E2ETest.yml
@@ -79,3 +79,33 @@ jobs:
       - name: Run E2E tests
         working-directory: test/e2e/Tests
         run: dotnet test --filter MSSQL!=Skip
+
+  e2e-dts:
+    runs-on: ubuntu-latest
+    env:
+      E2E_TEST_DURABLE_BACKEND: "DTS"
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET Core
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: 6.0.x
+
+      - name: Setup .NET Core
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: 8.0.x
+
+      - name: Setup E2E tests
+        shell: pwsh
+        run: |
+          .\test\e2e\Tests\build-e2e-test.ps1 -StartDTSContainer
+
+      - name: Build
+        working-directory: test/e2e/Tests
+        run: dotnet build
+
+      - name: Run E2E tests
+        working-directory: test/e2e/Tests
+        run: dotnet test --filter DTS!=Skip

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -47,6 +47,7 @@
     <PackageVersion Include="Microsoft.Azure.DurableTask.Redis" Version="0.1.9-alpha" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker" Version="1.21.0" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="1.2.0" />
+    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask.AzureManaged" Version="0.4.1-alpha" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask.SqlServer" Version="1.5.0" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.2.0" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="1.2.0" />

--- a/test/e2e/Apps/BasicDotNetIsolated/EntityErrorHandling.cs
+++ b/test/e2e/Apps/BasicDotNetIsolated/EntityErrorHandling.cs
@@ -80,7 +80,7 @@ public static class EntityErrorHandling
             return "Success";
         }
         // This is interesting - activities, when thrown, raise the native exception type. Entities, however, always raise
-        // EntityOperationFailedException with the 
+        // EntityOperationFailedException
         catch (EntityOperationFailedException ex) 
         {
             return ex.Message;

--- a/test/e2e/Apps/BasicDotNetIsolated/app.csproj
+++ b/test/e2e/Apps/BasicDotNetIsolated/app.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask.SqlServer"/>
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask.AzureManaged"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/test/e2e/Tests/E2ETests.csproj
+++ b/test/e2e/Tests/E2ETests.csproj
@@ -5,6 +5,8 @@
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <!-- Only add the following line when you want to locally debug
+    <RunSettingsFilePath>$(MSBuildProjectDirectory)\test.runsettings</RunSettingsFilePath> -->   
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/e2e/Tests/E2ETests.csproj
+++ b/test/e2e/Tests/E2ETests.csproj
@@ -5,7 +5,6 @@
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <RunSettingsFilePath>$(MSBuildProjectDirectory)\test.runsettings</RunSettingsFilePath>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/e2e/Tests/Fixtures/FixtureHelpers.cs
+++ b/test/e2e/Tests/Fixtures/FixtureHelpers.cs
@@ -99,6 +99,12 @@ public static class FixtureHelpers
                 funcProcess.StartInfo.EnvironmentVariables["AzureFunctionsJobHost__extensions__durableTask__storageProvider__connectionStringName"] = "SQLDB_Connection";
                 funcProcess.StartInfo.EnvironmentVariables["AzureFunctionsJobHost__extensions__durableTask__storageProvider__createDatabaseIfNotExists"] = "true";
                 return;
+            case "azuremanaged":
+                funcProcess.StartInfo.EnvironmentVariables["AzureFunctionsJobHost__extensions__durableTask__hubName"] = "default";
+                funcProcess.StartInfo.EnvironmentVariables["AzureFunctionsJobHost__extensions__durableTask__storageProvider__type"] = "azureManaged";
+                funcProcess.StartInfo.EnvironmentVariables["AzureFunctionsJobHost__extensions__durableTask__storageProvider__connectionStringName"] = "DURABLE_TASK_SCHEDULER_CONNECTION_STRING";
+                funcProcess.StartInfo.EnvironmentVariables["DURABLE_TASK_SCHEDULER_CONNECTION_STRING"] = $"Endpoint=http://localhost:8080;Authentication=None";
+                return;
             default:
                 testLogger.LogWarning("Environment variable E2E_TEST_DURABLE_BACKEND not set, tests configured for Azure Storage");
                 return;

--- a/test/e2e/Tests/Fixtures/FixtureHelpers.cs
+++ b/test/e2e/Tests/Fixtures/FixtureHelpers.cs
@@ -99,7 +99,7 @@ public static class FixtureHelpers
                 funcProcess.StartInfo.EnvironmentVariables["AzureFunctionsJobHost__extensions__durableTask__storageProvider__connectionStringName"] = "SQLDB_Connection";
                 funcProcess.StartInfo.EnvironmentVariables["AzureFunctionsJobHost__extensions__durableTask__storageProvider__createDatabaseIfNotExists"] = "true";
                 return;
-            case "azuremanaged":
+            case "dts":
                 funcProcess.StartInfo.EnvironmentVariables["AzureFunctionsJobHost__extensions__durableTask__hubName"] = "default";
                 funcProcess.StartInfo.EnvironmentVariables["AzureFunctionsJobHost__extensions__durableTask__storageProvider__type"] = "azureManaged";
                 funcProcess.StartInfo.EnvironmentVariables["AzureFunctionsJobHost__extensions__durableTask__storageProvider__connectionStringName"] = "DURABLE_TASK_SCHEDULER_CONNECTION_STRING";

--- a/test/e2e/Tests/Fixtures/FixtureHelpers.cs
+++ b/test/e2e/Tests/Fixtures/FixtureHelpers.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
@@ -94,7 +94,7 @@ public static class FixtureHelpers
                 {
                     testLogger.LogWarning("Environment variable MSSQL_SA_PASSWORD not set, connection string to SQL emulator may fail");
                 }
-                funcProcess.StartInfo.EnvironmentVariables["SQLDB_Connection"] = $"Server=localhost,1433;Database=DurableDB;User Id=sa;Password={sqlPassword};";
+                funcProcess.StartInfo.EnvironmentVariables["SQLDB_Connection"] = $"Server=localhost,1433;Database=DurableDB;User Id=sa;Password={sqlPassword};Encrypt=True;TrustServerCertificate=True";
                 funcProcess.StartInfo.EnvironmentVariables["AzureFunctionsJobHost__extensions__durableTask__storageProvider__type"] = "mssql";
                 funcProcess.StartInfo.EnvironmentVariables["AzureFunctionsJobHost__extensions__durableTask__storageProvider__connectionStringName"] = "SQLDB_Connection";
                 funcProcess.StartInfo.EnvironmentVariables["AzureFunctionsJobHost__extensions__durableTask__storageProvider__createDatabaseIfNotExists"] = "true";

--- a/test/e2e/Tests/Fixtures/FixtureHelpers.cs
+++ b/test/e2e/Tests/Fixtures/FixtureHelpers.cs
@@ -104,6 +104,7 @@ public static class FixtureHelpers
                 funcProcess.StartInfo.EnvironmentVariables["AzureFunctionsJobHost__extensions__durableTask__storageProvider__type"] = "azureManaged";
                 funcProcess.StartInfo.EnvironmentVariables["AzureFunctionsJobHost__extensions__durableTask__storageProvider__connectionStringName"] = "DURABLE_TASK_SCHEDULER_CONNECTION_STRING";
                 funcProcess.StartInfo.EnvironmentVariables["DURABLE_TASK_SCHEDULER_CONNECTION_STRING"] = $"Endpoint=http://localhost:8080;Authentication=None";
+                Console.WriteLine("using dts backend for testing");
                 return;
             default:
                 testLogger.LogWarning("Environment variable E2E_TEST_DURABLE_BACKEND not set, tests configured for Azure Storage");

--- a/test/e2e/Tests/Fixtures/FixtureHelpers.cs
+++ b/test/e2e/Tests/Fixtures/FixtureHelpers.cs
@@ -99,7 +99,9 @@ public static class FixtureHelpers
                 funcProcess.StartInfo.EnvironmentVariables["AzureFunctionsJobHost__extensions__durableTask__storageProvider__connectionStringName"] = "SQLDB_Connection";
                 funcProcess.StartInfo.EnvironmentVariables["AzureFunctionsJobHost__extensions__durableTask__storageProvider__createDatabaseIfNotExists"] = "true";
                 return;
-            case "dts":
+            case "azuremanaged":
+                funcProcess.StartInfo.EnvironmentVariables["AzureFunctionsJobHost__logging__logLevel__default"] = "Debug";
+                funcProcess.StartInfo.EnvironmentVariables["AzureFunctionsJobHost__logging__logLevel__Host.Startup"] = "Debug";
                 funcProcess.StartInfo.EnvironmentVariables["AzureFunctionsJobHost__extensions__durableTask__hubName"] = "default";
                 funcProcess.StartInfo.EnvironmentVariables["AzureFunctionsJobHost__extensions__durableTask__storageProvider__type"] = "azureManaged";
                 funcProcess.StartInfo.EnvironmentVariables["AzureFunctionsJobHost__extensions__durableTask__storageProvider__connectionStringName"] = "DURABLE_TASK_SCHEDULER_CONNECTION_STRING";

--- a/test/e2e/Tests/Fixtures/FixtureHelpers.cs
+++ b/test/e2e/Tests/Fixtures/FixtureHelpers.cs
@@ -106,7 +106,6 @@ public static class FixtureHelpers
                 funcProcess.StartInfo.EnvironmentVariables["AzureFunctionsJobHost__extensions__durableTask__storageProvider__type"] = "azureManaged";
                 funcProcess.StartInfo.EnvironmentVariables["AzureFunctionsJobHost__extensions__durableTask__storageProvider__connectionStringName"] = "DURABLE_TASK_SCHEDULER_CONNECTION_STRING";
                 funcProcess.StartInfo.EnvironmentVariables["DURABLE_TASK_SCHEDULER_CONNECTION_STRING"] = $"Endpoint=http://localhost:8080;Authentication=None";
-                Console.WriteLine("using dts backend for testing");
                 return;
             default:
                 testLogger.LogWarning("Environment variable E2E_TEST_DURABLE_BACKEND not set, tests configured for Azure Storage");

--- a/test/e2e/Tests/Fixtures/FixtureHelpers.cs
+++ b/test/e2e/Tests/Fixtures/FixtureHelpers.cs
@@ -94,7 +94,7 @@ public static class FixtureHelpers
                 {
                     testLogger.LogWarning("Environment variable MSSQL_SA_PASSWORD not set, connection string to SQL emulator may fail");
                 }
-                funcProcess.StartInfo.EnvironmentVariables["SQLDB_Connection"] = $"Server=localhost,1433;Database=DurableDB;User Id=sa;Password={sqlPassword};Encrypt=True;TrustServerCertificate=True";
+                funcProcess.StartInfo.EnvironmentVariables["SQLDB_Connection"] = $"Server=localhost,1433;Database=DurableDB;User Id=sa;Password={sqlPassword};";
                 funcProcess.StartInfo.EnvironmentVariables["AzureFunctionsJobHost__extensions__durableTask__storageProvider__type"] = "mssql";
                 funcProcess.StartInfo.EnvironmentVariables["AzureFunctionsJobHost__extensions__durableTask__storageProvider__connectionStringName"] = "SQLDB_Connection";
                 funcProcess.StartInfo.EnvironmentVariables["AzureFunctionsJobHost__extensions__durableTask__storageProvider__createDatabaseIfNotExists"] = "true";

--- a/test/e2e/Tests/Tests/ErrorHandlingTests.cs
+++ b/test/e2e/Tests/Tests/ErrorHandlingTests.cs
@@ -22,6 +22,7 @@ public class ErrorHandlingTests
 
     [Fact]
     [Trait("MSSQL", "Skip")] // This test fails for MSSQL unless this bug is fixed: https://github.com/microsoft/durabletask-mssql/issues/287
+    [Trait("DTS", "Skip")] // DTS will fail this test unless this bug is fixed: https://msazure.visualstudio.com/Antares/_workitems/edit/30049587
     public async Task OrchestratorWithUncaughtActivityException_ShouldFail()
     {
         using HttpResponseMessage response = await HttpHelpers.InvokeHttpTrigger("RethrowActivityException_HttpStart", "");
@@ -33,15 +34,13 @@ public class ErrorHandlingTests
 
         var orchestrationDetails = await DurableHelpers.GetRunningOrchestrationDetailsAsync(statusQueryGetUri);
         
-        // In DTS, the output message is:
-        // "Task 'RaiseException' (#0) failed with an unhandled exception: This activity failed"
-        // Assert.StartsWith("Microsoft.DurableTask.TaskFailedException", orchestrationDetails.Output);
-
+        Assert.StartsWith("Microsoft.DurableTask.TaskFailedException", orchestrationDetails.Output);
         Assert.Contains("This activity failed", orchestrationDetails.Output);
     }
 
     [Fact]
     [Trait("MSSQL", "Skip")] // Durable Entities are not supported in MSSQL/Dotnet Isolated, see https://github.com/microsoft/durabletask-mssql/issues/205
+    [Trait("DTS", "Skip")] // DTS will fail this test unless this bug is fixed: https://msazure.visualstudio.com/Antares/_workitems/edit/30049587
     public async Task OrchestratorWithUncaughtEntityException_ShouldFail()
     {
         using HttpResponseMessage response = await HttpHelpers.InvokeHttpTrigger("RethrowEntityException_HttpStart", "");
@@ -53,10 +52,7 @@ public class ErrorHandlingTests
 
         var orchestrationDetails = await DurableHelpers.GetRunningOrchestrationDetailsAsync(statusQueryGetUri);
         
-        // In DTS, the output message is:
-        // Operation 'ThrowFirstTimeOnly' of entity '@counter@MyExceptionEntity' failed: This entity failed
-        // Assert.StartsWith("Microsoft.DurableTask.Entities.EntityOperationFailedException", orchestrationDetails.Output);
-
+        Assert.StartsWith("Microsoft.DurableTask.Entities.EntityOperationFailedException", orchestrationDetails.Output);
         Assert.Contains("This entity failed", orchestrationDetails.Output);
     }
 
@@ -118,7 +114,7 @@ public class ErrorHandlingTests
 
     [Fact]
     [Trait("MSSQL", "Skip")] // Durable Entities are not supported in MSSQL/Dotnet Isolated, see https://github.com/microsoft/durabletask-mssql/issues/205
-    [Trait("DTS", "Skip")] // DTS will fail this test becasue the exception  type is `InvalidOperationException` instead of `EntityOperationFailedException`
+    [Trait("DTS", "Skip")] // DTS will fail this test unless this issue is fixed, see https://msazure.visualstudio.com/Antares/_workitems/edit/31778744
     public async Task OrchestratorWithRetriedEntityException_ShouldSucceed()
     {
         using HttpResponseMessage response = await HttpHelpers.InvokeHttpTrigger("RetryEntityException_HttpStart", "");

--- a/test/e2e/Tests/Tests/ErrorHandlingTests.cs
+++ b/test/e2e/Tests/Tests/ErrorHandlingTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System.Net;
@@ -22,7 +22,7 @@ public class ErrorHandlingTests
 
     [Fact]
     [Trait("MSSQL", "Skip")] // This test fails for MSSQL unless this bug is fixed: https://github.com/microsoft/durabletask-mssql/issues/287
-    [Trait("DTS", "Skip")] // DTS will fail this test unless this bug is fixed: https://msazure.visualstudio.com/Antares/_workitems/edit/30049587
+    [Trait("DTS", "Skip")] // DTS will fail this test unless this bug is fixed: https://msazure.visualstudio.com/Antares/_workitems/edit/31779638
     public async Task OrchestratorWithUncaughtActivityException_ShouldFail()
     {
         using HttpResponseMessage response = await HttpHelpers.InvokeHttpTrigger("RethrowActivityException_HttpStart", "");
@@ -40,7 +40,7 @@ public class ErrorHandlingTests
 
     [Fact]
     [Trait("MSSQL", "Skip")] // Durable Entities are not supported in MSSQL/Dotnet Isolated, see https://github.com/microsoft/durabletask-mssql/issues/205
-    [Trait("DTS", "Skip")] // DTS will fail this test unless this bug is fixed: https://msazure.visualstudio.com/Antares/_workitems/edit/30049587
+    [Trait("DTS", "Skip")] // DTS will fail this test unless this bug is fixed: https://msazure.visualstudio.com/Antares/_workitems/edit/31779638
     public async Task OrchestratorWithUncaughtEntityException_ShouldFail()
     {
         using HttpResponseMessage response = await HttpHelpers.InvokeHttpTrigger("RethrowEntityException_HttpStart", "");

--- a/test/e2e/Tests/Tests/ErrorHandlingTests.cs
+++ b/test/e2e/Tests/Tests/ErrorHandlingTests.cs
@@ -32,7 +32,7 @@ public class ErrorHandlingTests
         await DurableHelpers.WaitForOrchestrationStateAsync(statusQueryGetUri, "Failed", 30);
 
         var orchestrationDetails = await DurableHelpers.GetRunningOrchestrationDetailsAsync(statusQueryGetUri);
-       // Assert.StartsWith("Microsoft.DurableTask.TaskFailedException", orchestrationDetails.Output);
+        Assert.StartsWith("Microsoft.DurableTask.TaskFailedException", orchestrationDetails.Output);
         Assert.Contains("This activity failed", orchestrationDetails.Output);
     }
 
@@ -48,7 +48,7 @@ public class ErrorHandlingTests
         await DurableHelpers.WaitForOrchestrationStateAsync(statusQueryGetUri, "Failed", 30);
 
         var orchestrationDetails = await DurableHelpers.GetRunningOrchestrationDetailsAsync(statusQueryGetUri);
-        //Assert.StartsWith("Microsoft.DurableTask.Entities.EntityOperationFailedException", orchestrationDetails.Output);
+        Assert.StartsWith("Microsoft.DurableTask.Entities.EntityOperationFailedException", orchestrationDetails.Output);
         Assert.Contains("This entity failed", orchestrationDetails.Output);
     }
 

--- a/test/e2e/Tests/Tests/ErrorHandlingTests.cs
+++ b/test/e2e/Tests/Tests/ErrorHandlingTests.cs
@@ -32,7 +32,11 @@ public class ErrorHandlingTests
         await DurableHelpers.WaitForOrchestrationStateAsync(statusQueryGetUri, "Failed", 30);
 
         var orchestrationDetails = await DurableHelpers.GetRunningOrchestrationDetailsAsync(statusQueryGetUri);
-        Assert.StartsWith("Microsoft.DurableTask.TaskFailedException", orchestrationDetails.Output);
+        
+        // In DTS, the output message is:
+        // "Task 'RaiseException' (#0) failed with an unhandled exception: This activity failed"
+        // Assert.StartsWith("Microsoft.DurableTask.TaskFailedException", orchestrationDetails.Output);
+
         Assert.Contains("This activity failed", orchestrationDetails.Output);
     }
 
@@ -48,7 +52,11 @@ public class ErrorHandlingTests
         await DurableHelpers.WaitForOrchestrationStateAsync(statusQueryGetUri, "Failed", 30);
 
         var orchestrationDetails = await DurableHelpers.GetRunningOrchestrationDetailsAsync(statusQueryGetUri);
-        Assert.StartsWith("Microsoft.DurableTask.Entities.EntityOperationFailedException", orchestrationDetails.Output);
+        
+        // In DTS, the output message is:
+        // Operation 'ThrowFirstTimeOnly' of entity '@counter@MyExceptionEntity' failed: This entity failed
+        // Assert.StartsWith("Microsoft.DurableTask.Entities.EntityOperationFailedException", orchestrationDetails.Output);
+
         Assert.Contains("This entity failed", orchestrationDetails.Output);
     }
 
@@ -110,6 +118,7 @@ public class ErrorHandlingTests
 
     [Fact]
     [Trait("MSSQL", "Skip")] // Durable Entities are not supported in MSSQL/Dotnet Isolated, see https://github.com/microsoft/durabletask-mssql/issues/205
+    [Trait("DTS", "Skip")] // DTS will fail this test becasue the exception  type is `InvalidOperationException` instead of `EntityOperationFailedException`
     public async Task OrchestratorWithRetriedEntityException_ShouldSucceed()
     {
         using HttpResponseMessage response = await HttpHelpers.InvokeHttpTrigger("RetryEntityException_HttpStart", "");

--- a/test/e2e/Tests/Tests/ErrorHandlingTests.cs
+++ b/test/e2e/Tests/Tests/ErrorHandlingTests.cs
@@ -32,7 +32,7 @@ public class ErrorHandlingTests
         await DurableHelpers.WaitForOrchestrationStateAsync(statusQueryGetUri, "Failed", 30);
 
         var orchestrationDetails = await DurableHelpers.GetRunningOrchestrationDetailsAsync(statusQueryGetUri);
-        Assert.StartsWith("Microsoft.DurableTask.TaskFailedException", orchestrationDetails.Output);
+       // Assert.StartsWith("Microsoft.DurableTask.TaskFailedException", orchestrationDetails.Output);
         Assert.Contains("This activity failed", orchestrationDetails.Output);
     }
 
@@ -48,7 +48,7 @@ public class ErrorHandlingTests
         await DurableHelpers.WaitForOrchestrationStateAsync(statusQueryGetUri, "Failed", 30);
 
         var orchestrationDetails = await DurableHelpers.GetRunningOrchestrationDetailsAsync(statusQueryGetUri);
-        Assert.StartsWith("Microsoft.DurableTask.Entities.EntityOperationFailedException", orchestrationDetails.Output);
+        //Assert.StartsWith("Microsoft.DurableTask.Entities.EntityOperationFailedException", orchestrationDetails.Output);
         Assert.Contains("This entity failed", orchestrationDetails.Output);
     }
 

--- a/test/e2e/Tests/Tests/OrchestrationQueryTests.cs
+++ b/test/e2e/Tests/Tests/OrchestrationQueryTests.cs
@@ -23,6 +23,7 @@ public class OrchestrationQueryTests
 
 
     [Fact]
+    [Trait("DTS", "Skip")] // Skip this test for now as there is a bug in DTS with GetAllInstances
     public async Task ListAllOrchestrations_ShouldSucceed()
     {
         using HttpResponseMessage statusResponse = await HttpHelpers.InvokeHttpTrigger("GetAllInstances", "");
@@ -38,6 +39,7 @@ public class OrchestrationQueryTests
 
 
     [Fact]
+    [Trait("DTS", "Skip")] // Skip this test for now as there is a bug in DTS with GetAllInstances
     public async Task ListRunningOrchestrations_ShouldContainRunningOrchestration()
     {
         using HttpResponseMessage response = await HttpHelpers.InvokeHttpTrigger("LongOrchestrator_HttpStart", "");

--- a/test/e2e/Tests/Tests/OrchestrationQueryTests.cs
+++ b/test/e2e/Tests/Tests/OrchestrationQueryTests.cs
@@ -23,7 +23,6 @@ public class OrchestrationQueryTests
 
 
     [Fact]
-    [Trait("DTS", "Skip")] // Skip this test for now as there is a bug in DTS with GetAllInstances
     public async Task ListAllOrchestrations_ShouldSucceed()
     {
         using HttpResponseMessage statusResponse = await HttpHelpers.InvokeHttpTrigger("GetAllInstances", "");
@@ -39,7 +38,6 @@ public class OrchestrationQueryTests
 
 
     [Fact]
-    [Trait("DTS", "Skip")] // Skip this test for now as there is a bug in DTS with GetAllInstances
     public async Task ListRunningOrchestrations_ShouldContainRunningOrchestration()
     {
         using HttpResponseMessage response = await HttpHelpers.InvokeHttpTrigger("LongOrchestrator_HttpStart", "");

--- a/test/e2e/Tests/Tests/PurgeInstancesTests.cs
+++ b/test/e2e/Tests/Tests/PurgeInstancesTests.cs
@@ -48,6 +48,7 @@ public class PurgeInstancesTests
     }
 
     [Fact]
+    [Trait("DTS", "Skip")] // Skip this test as there is a bug with current DTS backend, the createdTimeTo couldn't be null. 
     public async Task PurgeOrchestrationHistory_End_Succeeds()
     {
         DateTime purgeStartTime = DateTime.MinValue;
@@ -60,6 +61,7 @@ public class PurgeInstancesTests
     }
 
     [Fact]
+    [Trait("DTS", "Skip")] // Skip this test as there is a bug with current DTS backend, the createdTimeTo couldn't be null. 
     public async Task PurgeOrchestrationHistory_NoBoundaries_Succeeds()
     {
         DateTime purgeStartTime = DateTime.MinValue;
@@ -72,6 +74,7 @@ public class PurgeInstancesTests
     }
 
     [Fact]
+    [Trait("DTS", "Skip")] // Skip this test as there is a bug with current DTS backend, the createdTimeTo couldn't be null. 
     public async Task PurgeOrchestrationHistoryAfterInvocation_Succeeds()
     {
         using HttpResponseMessage response = await HttpHelpers.InvokeHttpTrigger("HelloCities_HttpStart", "");
@@ -89,6 +92,7 @@ public class PurgeInstancesTests
     }
 
     [Fact]
+    [Trait("DTS", "Skip")] // Skip this test as there is a bug with current DTS backend, the createdTimeTo couldn't be null. 
     public async Task PurgeAfterPurge_ZeroRows()
     {
         DateTime purgeEndTime = DateTime.UtcNow + TimeSpan.FromMinutes(1);

--- a/test/e2e/Tests/build-e2e-test.ps1
+++ b/test/e2e/Tests/build-e2e-test.ps1
@@ -201,7 +201,7 @@ function StartDTSContainer() {
 
   # Start the DTS Server docker container with the specified edition
   Write-Host "Starting DTS docker container on port 8080" -ForegroundColor DarkYellow
-  docker run -itP -p 8080:8080 -p 8082:8082 -d mcr.microsoft.com/dts/dts-emulator:v0.0.4
+  docker run -i -p 8080:8080 -p 8082:8082 -d mcr.microsoft.com/dts/dts-emulator:v0.0.4
 
   if ($LASTEXITCODE -ne 0) {
       exit $LASTEXITCODE

--- a/test/e2e/Tests/build-e2e-test.ps1
+++ b/test/e2e/Tests/build-e2e-test.ps1
@@ -13,6 +13,9 @@ param(
     $StartMSSqlContainer,
 
     [Switch]
+    $StartDTSContainer,
+
+    [Switch]
     $SkipCoreTools,
 
     # This param can be used during local runs of the build script to deliberately skip the build and run only the azurite/mssql logic
@@ -192,6 +195,26 @@ function StartMSSQLContainer($mssqlPwd) {
   docker ps
 }
 
+function StartDTSContainer() {
+  Write-Host "Pulling down the durabletaskspublic.azurecr.io/dts-emulator:latest-amd64 image..."
+  docker pull durabletaskspublic.azurecr.io/dts-emulator:latest-amd64
+
+  # Start the SQL Server docker container with the specified edition
+  Write-Host "Starting DTS docker container on default ports" -ForegroundColor DarkYellow
+  docker run -itP -e ClientAuth__DisableAuthentication=true -d durabletaskspublic.azurecr.io/dts-emulator:latest-amd64
+
+  if ($LASTEXITCODE -ne 0) {
+      exit $LASTEXITCODE
+  }
+
+  # The container needs a bit more time before it can start accepting commands
+  Write-Host "Sleeping for 30 seconds to let the container finish initializing..." -ForegroundColor Yellow
+  Start-Sleep -Seconds 30
+
+  # Check to see what containers are running
+  docker ps
+}
+
 Set-Location $PSScriptRoot
 
 if ($StartMSSqlContainer)
@@ -203,6 +226,11 @@ if ($StartMSSqlContainer)
   else {
     StartMSSQLContainer $mssqlPwd
   }
+}
+
+if ($StartDTSContainer)
+{
+    StartDTSContainer $mssqlPwd
 }
 
 StopOnFailedExecution

--- a/test/e2e/Tests/build-e2e-test.ps1
+++ b/test/e2e/Tests/build-e2e-test.ps1
@@ -196,12 +196,12 @@ function StartMSSQLContainer($mssqlPwd) {
 }
 
 function StartDTSContainer() {
-  Write-Host "Pulling down the mcr.microsoft.com/dts/dts-emulator image..."
-  docker pull mcr.microsoft.com/dts/dts-emulator
+  Write-Host "Pulling down the mcr.microsoft.com/dts/dts-emulator:v0.0.4 image..."
+  docker pull mcr.microsoft.com/dts/dts-emulator:v0.0.4
 
   # Start the DTS Server docker container with the specified edition
   Write-Host "Starting DTS docker container on port 8080" -ForegroundColor DarkYellow
-  docker run -itP -p 8080:8080 -p 8082:8082 -d mcr.microsoft.com/dts/dts-emulator
+  docker run -itP -p 8080:8080 -p 8082:8082 -d mcr.microsoft.com/dts/dts-emulator:v0.0.4
 
   if ($LASTEXITCODE -ne 0) {
       exit $LASTEXITCODE

--- a/test/e2e/Tests/build-e2e-test.ps1
+++ b/test/e2e/Tests/build-e2e-test.ps1
@@ -196,12 +196,12 @@ function StartMSSQLContainer($mssqlPwd) {
 }
 
 function StartDTSContainer() {
-  Write-Host "Pulling down the durabletaskspublic.azurecr.io/dts-emulator:latest-amd64 image..."
-  docker pull durabletaskspublic.azurecr.io/dts-emulator:latest-amd64
+  Write-Host "Pulling down the mcr.microsoft.com/dts/dts-emulator image..."
+  docker pull mcr.microsoft.com/dts/dts-emulator
 
   # Start the DTS Server docker container with the specified edition
   Write-Host "Starting DTS docker container on port 8080" -ForegroundColor DarkYellow
-  docker run -itP -p 8080:8080 -p 8082:8082 -e ClientAuth__DisableAuthentication=true -d durabletaskspublic.azurecr.io/dts-emulator:latest-amd64
+  docker run -itP -p 8080:8080 -p 8082:8082 -d mcr.microsoft.com/dts/dts-emulator
 
   if ($LASTEXITCODE -ne 0) {
       exit $LASTEXITCODE

--- a/test/e2e/Tests/build-e2e-test.ps1
+++ b/test/e2e/Tests/build-e2e-test.ps1
@@ -200,8 +200,8 @@ function StartDTSContainer() {
   docker pull durabletaskspublic.azurecr.io/dts-emulator:latest-amd64
 
   # Start the DTS Server docker container with the specified edition
-  Write-Host "Starting DTS docker container on default ports" -ForegroundColor DarkYellow
-  docker run -itP -e ClientAuth__DisableAuthentication=true -d durabletaskspublic.azurecr.io/dts-emulator:latest-amd64
+  Write-Host "Starting DTS docker container on port 8080" -ForegroundColor DarkYellow
+  docker run -itP -p 8080:8080 -p 8082:8082 -e ClientAuth__DisableAuthentication=true -d durabletaskspublic.azurecr.io/dts-emulator:latest-amd64
 
   if ($LASTEXITCODE -ne 0) {
       exit $LASTEXITCODE

--- a/test/e2e/Tests/build-e2e-test.ps1
+++ b/test/e2e/Tests/build-e2e-test.ps1
@@ -182,6 +182,10 @@ function StartMSSQLContainer($mssqlPwd) {
   # Start the SQL Server docker container with the specified edition
   Write-Host "Starting SQL Server 2022-latest Express docker container on port 1433" -ForegroundColor DarkYellow
   docker run --name mssql-server -e ACCEPT_EULA=Y -e "MSSQL_SA_PASSWORD=$mssqlPwd" -e "MSSQL_PID=Express" -p 1433:1433 -d mcr.microsoft.com/mssql/server:2022-latest
+  
+  # create the database with strict binary collation
+  Write-Host "Creating database" -ForegroundColor DarkYellow
+  docker exec -d mssql-server /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P "$mssqlPwd" -Q "CREATE DATABASE [DurableDB] COLLATE Latin1_General_100_BIN2_UTF8"
 
   if ($LASTEXITCODE -ne 0) {
       exit $LASTEXITCODE

--- a/test/e2e/Tests/build-e2e-test.ps1
+++ b/test/e2e/Tests/build-e2e-test.ps1
@@ -196,9 +196,6 @@ function StartMSSQLContainer($mssqlPwd) {
 }
 
 function StartDTSContainer() {
-  Write-Host "logging in..."
-  az acr login --name durabletaskspublic
-
   Write-Host "Pulling down the durabletaskspublic.azurecr.io/dts-emulator:latest-amd64 image..."
   docker pull durabletaskspublic.azurecr.io/dts-emulator:latest-amd64
 

--- a/test/e2e/Tests/build-e2e-test.ps1
+++ b/test/e2e/Tests/build-e2e-test.ps1
@@ -196,7 +196,7 @@ function StartMSSQLContainer($mssqlPwd) {
 
   # Create database
   Write-Host "Creating database DurableDB with Latin1_General_100_BIN2_UTF8 ollation" -ForegroundColor DarkYellow
-  docker exec -d mssql-server /opt/mssql-tools18/bin/sqlcmd -S . -U sa -P "$mssqlPwd" -Q "CREATE DATABASE [DurableDB] COLLATE Latin1_General_100_BIN2_UTF8"
+  docker exec -d mssql-server /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "$mssqlPwd" -Q "CREATE DATABASE [DurableDB] COLLATE Latin1_General_100_BIN2_UTF8"
 }
 
 function StartDTSContainer() {

--- a/test/e2e/Tests/build-e2e-test.ps1
+++ b/test/e2e/Tests/build-e2e-test.ps1
@@ -196,10 +196,13 @@ function StartMSSQLContainer($mssqlPwd) {
 }
 
 function StartDTSContainer() {
+  Write-Host "logging in..."
+  az acr login --name durabletaskspublic
+
   Write-Host "Pulling down the durabletaskspublic.azurecr.io/dts-emulator:latest-amd64 image..."
   docker pull durabletaskspublic.azurecr.io/dts-emulator:latest-amd64
 
-  # Start the SQL Server docker container with the specified edition
+  # Start the DTS Server docker container with the specified edition
   Write-Host "Starting DTS docker container on default ports" -ForegroundColor DarkYellow
   docker run -itP -e ClientAuth__DisableAuthentication=true -d durabletaskspublic.azurecr.io/dts-emulator:latest-amd64
 

--- a/test/e2e/Tests/build-e2e-test.ps1
+++ b/test/e2e/Tests/build-e2e-test.ps1
@@ -182,10 +182,6 @@ function StartMSSQLContainer($mssqlPwd) {
   # Start the SQL Server docker container with the specified edition
   Write-Host "Starting SQL Server 2022-latest Express docker container on port 1433" -ForegroundColor DarkYellow
   docker run --name mssql-server -e ACCEPT_EULA=Y -e "MSSQL_SA_PASSWORD=$mssqlPwd" -e "MSSQL_PID=Express" -p 1433:1433 -d mcr.microsoft.com/mssql/server:2022-latest
-  
-  # create the database with strict binary collation
-  Write-Host "Creating database" -ForegroundColor DarkYellow
-  docker exec -d mssql-server /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P "$mssqlPwd" -Q "CREATE DATABASE [DurableDB] COLLATE Latin1_General_100_BIN2_UTF8"
 
   if ($LASTEXITCODE -ne 0) {
       exit $LASTEXITCODE
@@ -197,6 +193,10 @@ function StartMSSQLContainer($mssqlPwd) {
 
   # Check to see what containers are running
   docker ps
+
+  # Create database
+  Write-Host "Creating database DurableDB with Latin1_General_100_BIN2_UTF8 ollation" -ForegroundColor DarkYellow
+  docker exec -d mssql-server /opt/mssql-tools18/bin/sqlcmd -S . -U sa -P "$mssqlPwd" -Q "CREATE DATABASE [DurableDB] COLLATE Latin1_General_100_BIN2_UTF8"
 }
 
 function StartDTSContainer() {

--- a/test/e2e/Tests/build-e2e-test.ps1
+++ b/test/e2e/Tests/build-e2e-test.ps1
@@ -230,7 +230,7 @@ if ($StartMSSqlContainer)
 
 if ($StartDTSContainer)
 {
-    StartDTSContainer $mssqlPwd
+    StartDTSContainer
 }
 
 StopOnFailedExecution

--- a/test/e2e/Tests/build-e2e-test.ps1
+++ b/test/e2e/Tests/build-e2e-test.ps1
@@ -193,10 +193,6 @@ function StartMSSQLContainer($mssqlPwd) {
 
   # Check to see what containers are running
   docker ps
-
-  # Create database
-  Write-Host "Creating database DurableDB with Latin1_General_100_BIN2_UTF8 ollation" -ForegroundColor DarkYellow
-  docker exec -d mssql-server /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "$mssqlPwd" -Q "CREATE DATABASE [DurableDB] COLLATE Latin1_General_100_BIN2_UTF8"
 }
 
 function StartDTSContainer() {

--- a/test/e2e/Tests/test.runsettings
+++ b/test/e2e/Tests/test.runsettings
@@ -9,7 +9,9 @@
             <MSSQL_SA_PASSWORD>{{YourPasswordHere}}</MSSQL_SA_PASSWORD>
             <E2E_TEST_DURABLE_BACKEND>MSSQL</E2E_TEST_DURABLE_BACKEND>
             -->
-            <E2E_TEST_DURABLE_BACKEND>azuremanaged</E2E_TEST_DURABLE_BACKEND>
+            <!-- Uncomment the following environment variables if you want to run test against azureManaged(DTS)
+            <E2E_TEST_DURABLE_BACKEND>azureManaged</E2E_TEST_DURABLE_BACKEND>-->
+            <E2E_TEST_DURABLE_BACKEND>AzureStorage</E2E_TEST_DURABLE_BACKEND>
         </EnvironmentVariables>
     </RunConfiguration>
 </RunSettings>

--- a/test/e2e/Tests/test.runsettings
+++ b/test/e2e/Tests/test.runsettings
@@ -10,8 +10,8 @@
             <E2E_TEST_DURABLE_BACKEND>MSSQL</E2E_TEST_DURABLE_BACKEND>
             -->
 			<!-- Enable this if you want to run tests against DTS
-            <E2E_TEST_DURABLE_BACKEND>azureManaged</E2E_TEST_DURABLE_BACKEND>
-			-->
+            <E2E_TEST_DURABLE_BACKEND>dts</E2E_TEST_DURABLE_BACKEND>
+            -->
 			<E2E_TEST_DURABLE_BACKEND>AzureStorage</E2E_TEST_DURABLE_BACKEND>
         </EnvironmentVariables>
     </RunConfiguration>

--- a/test/e2e/Tests/test.runsettings
+++ b/test/e2e/Tests/test.runsettings
@@ -9,10 +9,7 @@
             <MSSQL_SA_PASSWORD>{{YourPasswordHere}}</MSSQL_SA_PASSWORD>
             <E2E_TEST_DURABLE_BACKEND>MSSQL</E2E_TEST_DURABLE_BACKEND>
             -->
-			<!-- Enable this if you want to run tests against AzureManaged backend
-            <E2E_TEST_DURABLE_BACKEND>DTS</E2E_TEST_DURABLE_BACKEND>
-            -->
-			<E2E_TEST_DURABLE_BACKEND>AzureStorage</E2E_TEST_DURABLE_BACKEND>
+            <E2E_TEST_DURABLE_BACKEND>azuremanaged</E2E_TEST_DURABLE_BACKEND>
         </EnvironmentVariables>
     </RunConfiguration>
 </RunSettings>

--- a/test/e2e/Tests/test.runsettings
+++ b/test/e2e/Tests/test.runsettings
@@ -9,8 +9,10 @@
             <MSSQL_SA_PASSWORD>{{YourPasswordHere}}</MSSQL_SA_PASSWORD>
             <E2E_TEST_DURABLE_BACKEND>MSSQL</E2E_TEST_DURABLE_BACKEND>
             -->
+			<!-- Enable this if you want to run tests against DTS
             <E2E_TEST_DURABLE_BACKEND>azureManaged</E2E_TEST_DURABLE_BACKEND>
-           <!-- <E2E_TEST_DURABLE_BACKEND>AzureStorage</E2E_TEST_DURABLE_BACKEND>-->
+			-->
+			<E2E_TEST_DURABLE_BACKEND>AzureStorage</E2E_TEST_DURABLE_BACKEND>
         </EnvironmentVariables>
     </RunConfiguration>
 </RunSettings>

--- a/test/e2e/Tests/test.runsettings
+++ b/test/e2e/Tests/test.runsettings
@@ -9,7 +9,8 @@
             <MSSQL_SA_PASSWORD>{{YourPasswordHere}}</MSSQL_SA_PASSWORD>
             <E2E_TEST_DURABLE_BACKEND>MSSQL</E2E_TEST_DURABLE_BACKEND>
             -->
-            <E2E_TEST_DURABLE_BACKEND>AzureStorage</E2E_TEST_DURABLE_BACKEND>
+            <E2E_TEST_DURABLE_BACKEND>azureManaged</E2E_TEST_DURABLE_BACKEND>
+           <!-- <E2E_TEST_DURABLE_BACKEND>AzureStorage</E2E_TEST_DURABLE_BACKEND>-->
         </EnvironmentVariables>
     </RunConfiguration>
 </RunSettings>

--- a/test/e2e/Tests/test.runsettings
+++ b/test/e2e/Tests/test.runsettings
@@ -9,8 +9,8 @@
             <MSSQL_SA_PASSWORD>{{YourPasswordHere}}</MSSQL_SA_PASSWORD>
             <E2E_TEST_DURABLE_BACKEND>MSSQL</E2E_TEST_DURABLE_BACKEND>
             -->
-			<!-- Enable this if you want to run tests against DTS
-            <E2E_TEST_DURABLE_BACKEND>dts</E2E_TEST_DURABLE_BACKEND>
+			<!-- Enable this if you want to run tests against AzureManaged backend
+            <E2E_TEST_DURABLE_BACKEND>DTS</E2E_TEST_DURABLE_BACKEND>
             -->
 			<E2E_TEST_DURABLE_BACKEND>AzureStorage</E2E_TEST_DURABLE_BACKEND>
         </EnvironmentVariables>


### PR DESCRIPTION
<!-- Start the PR description with some context for the change. -->


<!-- Make sure to delete the markdown comments and the below sections when squash merging -->
### Issue describing the changes in this PR

Enable E2E test with DTS/AzureManaged backend

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)
* [ ] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk
* [ ] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
    * [ ] Otherwise: major or minor version updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
* [ ] My changes **do not** add EventIds to our EventSource logs
    * [ ] Otherwise: Ensure the EventIds are within the supported range in our existing Windows infrastructure. You may validate this with a deployed app's telemetry. You may also extend the range by completing a PR such as [this one](https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files).
* [ ] My changes **should** be added to **v2.x** branch.
    * [ ] Otherwise: This change applies exclusively to WebJobs.Extensions.DurableTask v3.x. It will be retained only in the `dev` and `main` branches and will not be merged into the `v2.x` branch.
