### PR TITLE
Improve Error Type Accuracy in TaskFailedException FailureDetails with .NET-Isolated app

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -64,7 +64,7 @@
     <PackageVersion Include="Microsoft.CodeAnalysis" Version="3.9.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="3.9.0" />
     <PackageVersion Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.65" />
-    <PackageVersion Include="Microsoft.DurableTask.Abstractions" Version="1.8.0" />
+    <PackageVersion Include="Microsoft.DurableTask.Abstractions" Version="1.8.1" />
     <PackageVersion Include="Microsoft.DurableTask.Generators" Version="1.0.0-preview.1" />
     <PackageVersion Include="Microsoft.DurableTask.SqlServer.AzureFunctions" Version="1.5.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="9.0.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -64,7 +64,7 @@
     <PackageVersion Include="Microsoft.CodeAnalysis" Version="3.9.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="3.9.0" />
     <PackageVersion Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.65" />
-	  <PackageVersion Include="Microsoft.DurableTask.Abstractions" Version="1.8.0" />
+    <PackageVersion Include="Microsoft.DurableTask.Abstractions" Version="1.8.0" />
     <PackageVersion Include="Microsoft.DurableTask.Generators" Version="1.0.0-preview.1" />
     <PackageVersion Include="Microsoft.DurableTask.SqlServer.AzureFunctions" Version="1.5.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="9.0.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -64,6 +64,7 @@
     <PackageVersion Include="Microsoft.CodeAnalysis" Version="3.9.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="3.9.0" />
     <PackageVersion Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.65" />
+	  <PackageVersion Include="Microsoft.DurableTask.Abstractions" Version="1.8.0" />
     <PackageVersion Include="Microsoft.DurableTask.Generators" Version="1.0.0-preview.1" />
     <PackageVersion Include="Microsoft.DurableTask.SqlServer.AzureFunctions" Version="1.5.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="9.0.0" />

--- a/src/Worker.Extensions.DurableTask/Exceptions/DurableSerializationException.cs
+++ b/src/Worker.Extensions.DurableTask/Exceptions/DurableSerializationException.cs
@@ -11,14 +11,20 @@ internal class DurableSerializationException : Exception
     // We set the base class properties of this exception to the same as the parent, 
     // so that methods in the worker after this can still (typically) access the same information vs w/o
     // this exception type. 
-    internal DurableSerializationException(Exception fromException) : base(fromException.Message, fromException.InnerException)
+    internal DurableSerializationException(Exception fromException) : base(CreateExceptionMessage(fromException), fromException.InnerException)
     {
         this.fromException = fromException;
     }
 
     public override string ToString()
     {
-        TaskFailureDetails? failureDetails = TaskFailureDetailsConverter.TaskFailureFromException(this.fromException);
+        return this.Message;
+    }
+
+    // Serilize FailureDetails to JSON
+    private static string CreateExceptionMessage(Exception ex)
+    {
+        TaskFailureDetails? failureDetails = TaskFailureDetailsConverter.TaskFailureFromException(ex);
         return JsonConvert.SerializeObject(failureDetails);
     }
 

--- a/test/e2e/Apps/BasicDotNetIsolated/ActivityErrorHandling.cs
+++ b/test/e2e/Apps/BasicDotNetIsolated/ActivityErrorHandling.cs
@@ -55,7 +55,7 @@ public static class ActivityErrorHandling
         ILogger logger = executionContext.GetLogger("CatchActivityExceptionFailureDetails_HttpStart");
 
         string instanceId = await client.ScheduleNewOrchestrationInstanceAsync(
-            nameof(CatchActivityExceptionFailreDetails));
+            nameof(CatchActivityExceptionFailureDetails));
 
         logger.LogInformation("Started orchestration with ID = '{instanceId}'.", instanceId);
 
@@ -117,8 +117,8 @@ public static class ActivityErrorHandling
         }
     }
 
-    [Function(nameof(CatchActivityExceptionFailreDetails))]
-    public static async Task<TaskFailureDetails> CatchActivityExceptionFailreDetails(
+    [Function(nameof(CatchActivityExceptionFailureDetails))]
+    public static async Task<TaskFailureDetails> CatchActivityExceptionFailureDetails(
         [OrchestrationTrigger] TaskOrchestrationContext context)
     {
         try 

--- a/test/e2e/Apps/BasicDotNetIsolated/ActivityErrorHandling.cs
+++ b/test/e2e/Apps/BasicDotNetIsolated/ActivityErrorHandling.cs
@@ -118,7 +118,7 @@ public static class ActivityErrorHandling
     }
 
     [Function(nameof(CatchActivityExceptionFailureDetails))]
-    public static async Task<TaskFailureDetails> CatchActivityExceptionFailureDetails(
+    public static async Task<TaskFailureDetails?> CatchActivityExceptionFailureDetails(
         [OrchestrationTrigger] TaskOrchestrationContext context)
     {
         try 

--- a/test/e2e/Apps/BasicDotNetIsolated/ActivityErrorHandling.cs
+++ b/test/e2e/Apps/BasicDotNetIsolated/ActivityErrorHandling.cs
@@ -112,7 +112,7 @@ public static class ActivityErrorHandling
             return output;
         }
         catch (TaskFailedException ex)
-        {      
+        {  
             return ex.Message;
         }
     }

--- a/test/e2e/Apps/BasicDotNetIsolated/ActivityErrorHandling.cs
+++ b/test/e2e/Apps/BasicDotNetIsolated/ActivityErrorHandling.cs
@@ -46,6 +46,22 @@ public static class ActivityErrorHandling
         return await client.CreateCheckStatusResponseAsync(req, instanceId);
     }
 
+    [Function("CatchActivityExceptionFailureDetails_HttpStart")]
+    public static async Task<HttpResponseData> CatchFailureDetailsHttpStart(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", "post")] HttpRequestData req,
+        [DurableClient] DurableTaskClient client,
+        FunctionContext executionContext)
+    {
+        ILogger logger = executionContext.GetLogger("CatchActivityExceptionFailureDetails_HttpStart");
+
+        string instanceId = await client.ScheduleNewOrchestrationInstanceAsync(
+            nameof(CatchActivityExceptionFailreDetails));
+
+        logger.LogInformation("Started orchestration with ID = '{instanceId}'.", instanceId);
+
+        return await client.CreateCheckStatusResponseAsync(req, instanceId);
+    }
+
     [Function("RetryActivityException_HttpStart")]
     public static async Task<HttpResponseData> RetryHttpStart(
         [HttpTrigger(AuthorizationLevel.Anonymous, "get", "post")] HttpRequestData req,
@@ -96,8 +112,23 @@ public static class ActivityErrorHandling
             return output;
         }
         catch (TaskFailedException ex)
-        {
+        {      
             return ex.Message;
+        }
+    }
+
+    [Function(nameof(CatchActivityExceptionFailreDetails))]
+    public static async Task<TaskFailureDetails> CatchActivityExceptionFailreDetails(
+        [OrchestrationTrigger] TaskOrchestrationContext context)
+    {
+        try 
+        {
+            await context.CallActivityAsync<string>(nameof(RaiseException), context.InstanceId);
+            return null;
+        }
+        catch (TaskFailedException ex)
+        {      
+            return ex.FailureDetails;
         }
     }
 

--- a/test/e2e/Tests/E2ETests.csproj
+++ b/test/e2e/Tests/E2ETests.csproj
@@ -10,7 +10,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration" />
+	  <PackageReference Include="Microsoft.DurableTask.Abstractions"/>
+	  <PackageReference Include="Microsoft.DurableTask.Abstractions"/>
+	  <PackageReference Include="Microsoft.Extensions.Configuration" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables"  />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json"  />
     <PackageReference Include="Microsoft.Extensions.Logging"  />

--- a/test/e2e/Tests/E2ETests.csproj
+++ b/test/e2e/Tests/E2ETests.csproj
@@ -10,9 +10,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-	  <PackageReference Include="Microsoft.DurableTask.Abstractions"/>
-	  <PackageReference Include="Microsoft.DurableTask.Abstractions"/>
-	  <PackageReference Include="Microsoft.Extensions.Configuration" />
+    <PackageReference Include="Microsoft.DurableTask.Abstractions"/>
+    <PackageReference Include="Microsoft.Extensions.Configuration" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables"  />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json"  />
     <PackageReference Include="Microsoft.Extensions.Logging"  />


### PR DESCRIPTION
<!-- Start the PR description with some context for the change. -->


<!-- Make sure to delete the markdown comments and the below sections when squash merging -->
### Issue describing the changes in this PR
partialy solves #2689  

This PR ensures that when orchestrators catch exceptions, the FailureDetails.ErrorType will match the type of the original exception thrown by the activity or sub-orchestration function.

For example, if an activity function throws an InvalidOperationException, the FailureDetails.ErrorType in the resulting TaskFailedException should be "InvalidOperationException" .



### Pull request checklist

* [ ] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)
* [ ] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk
* [ ] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
    * [ ] Otherwise: major or minor version updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
* [ ] My changes **do not** add EventIds to our EventSource logs
    * [ ] Otherwise: Ensure the EventIds are within the supported range in our existing Windows infrastructure. You may validate this with a deployed app's telemetry. You may also extend the range by completing a PR such as [this one](https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files).
* [ ] My changes **should** be added to **v2.x** branch.
    * [ ] Otherwise: This change applies exclusively to WebJobs.Extensions.DurableTask v3.x. It will be retained only in the `dev` and `main` branches and will not be merged into the `v2.x` branch.
