### PR TITLE
Make certain tests sequential to prevent conflicts

### DIFF
--- a/test/e2e/Tests/Constants.cs
+++ b/test/e2e/Tests/Constants.cs
@@ -12,4 +12,5 @@ internal class Constants
     internal static readonly string FunctionsHostUrl = Configuration["FunctionAppUrl"] ?? "http://localhost:7071";
 
     internal const string FunctionAppCollectionName = "DurableTestsCollection";
+    internal const string FunctionAppCollectionSequentialName = "DurableTestsCollectionSequential";
 }

--- a/test/e2e/Tests/Fixtures/FunctionAppFixture.cs
+++ b/test/e2e/Tests/Fixtures/FunctionAppFixture.cs
@@ -164,3 +164,12 @@ public class FunctionAppCollection : ICollectionFixture<FunctionAppFixture>
     // to be the place to apply [CollectionDefinition] and all the
     // ICollectionFixture<> interfaces.
 }
+
+
+[CollectionDefinition(Constants.FunctionAppCollectionSequentialName, DisableParallelization = true)]
+public class FunctionAppCollectionSequential : ICollectionFixture<FunctionAppFixture>
+{
+    // This class has no code, and is never created. Its purpose is simply
+    // to be the place to apply [CollectionDefinition] and all the
+    // ICollectionFixture<> interfaces.
+}

--- a/test/e2e/Tests/Tests/OrchestrationQueryTests.cs
+++ b/test/e2e/Tests/Tests/OrchestrationQueryTests.cs
@@ -8,7 +8,7 @@ using Xunit.Abstractions;
 
 namespace Microsoft.Azure.Durable.Tests.DotnetIsolatedE2E;
 
-[Collection(Constants.FunctionAppCollectionName)]
+[Collection(Constants.FunctionAppCollectionSequentialName)]
 public class OrchestrationQueryTests
 {
     private readonly FunctionAppFixture _fixture;


### PR DESCRIPTION
<!-- Start the PR description with some context for the change. -->
Makes a subset of the E2E tests run sequentially after the rest to prevent conflicts (unexpected purge results, unexpected running orchestrations)

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)
* [x] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk
* [x] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
    * [ ] Otherwise: major or minor version updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
* [x] My changes **do not** add EventIds to our EventSource logs
    * [ ] Otherwise: Ensure the EventIds are within the supported range in our existing Windows infrastructure. You may validate this with a deployed app's telemetry. You may also extend the range by completing a PR such as [this one](https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files).
* [ ] My changes **should** be added to **v2.x** branch.
    * [x] Otherwise: This change applies exclusively to WebJobs.Extensions.DurableTask v3.x. It will be retained only in the `dev` and `main` branches and will not be merged into the `v2.x` branch.
