### PR TITLE
Enable version-aware orchestrations (.NET in-proc)

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -6,6 +6,7 @@
 
 - Fail fast if extendedSessionsEnabled set to 'true' for the worker type that doesn't support extended sessions (https://github.com/Azure/azure-functions-durable-extension/pull/2732).
 - Added an `IFunctionsWorkerApplicationBuilder.ConfigureDurableExtension()` extension method for cases where auto-registration does not work (no source gen running). (#2950)
+- Enable version-aware orchestrations (.NET in-proc) (https://github.com/Azure/azure-functions-durable-extension/pull/3072).
 
 ### Bug Fixes
 

--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableClient.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableClient.cs
@@ -29,7 +29,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         DurableOrchestrationClientBase // for v1 legacy compatibility.
 #pragma warning restore 618
     {
-        private const string DefaultVersion = "";
         private const int MaxInstanceIdLength = 256;
 
         private static readonly JValue NullJValue = JValue.CreateNull();
@@ -202,7 +201,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
             OrchestrationStatus[] dedupeStatuses = this.GetStatusesNotToOverride();
             Task<OrchestrationInstance> createTask = this.client.CreateOrchestrationInstanceAsync(
-                orchestratorFunctionName, DefaultVersion, instanceId, input, null, dedupeStatuses);
+                orchestratorFunctionName, this.durableTaskOptions.AppVersion, instanceId, input, null, dedupeStatuses);
 
             this.traceHelper.FunctionScheduled(
                 this.TaskHubName,

--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableClient.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableClient.cs
@@ -201,7 +201,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
             OrchestrationStatus[] dedupeStatuses = this.GetStatusesNotToOverride();
             Task<OrchestrationInstance> createTask = this.client.CreateOrchestrationInstanceAsync(
-                orchestratorFunctionName, this.durableTaskOptions.AppVersion, instanceId, input, null, dedupeStatuses);
+                orchestratorFunctionName, this.durableTaskOptions.DefaultVersion, instanceId, input, null, dedupeStatuses);
 
             this.traceHelper.FunctionScheduled(
                 this.TaskHubName,

--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableEntityContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableEntityContext.cs
@@ -706,7 +706,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     {
                         var dummyTask = innerContext.CreateSubOrchestrationInstance<object>(
                           fireAndForgetMessage.FunctionName,
-                          DurableOrchestrationContext.DefaultVersion,
+                          innerContext.Version,
                           fireAndForgetMessage.InstanceId,
                           fireAndForgetMessage.Input,
                           new Dictionary<string, string>() { { OrchestrationTags.FireAndForget, "" } });

--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableEntityContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableEntityContext.cs
@@ -706,7 +706,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     {
                         var dummyTask = innerContext.CreateSubOrchestrationInstance<object>(
                           fireAndForgetMessage.FunctionName,
-                          innerContext.Version,
+                          this.Config.Options.DefaultVersion,
                           fireAndForgetMessage.InstanceId,
                           fireAndForgetMessage.Input,
                           new Dictionary<string, string>() { { OrchestrationTags.FireAndForget, "" } });

--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableOrchestrationContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableOrchestrationContext.cs
@@ -559,6 +559,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 }
             }
 
+            // Propagate the default version to orchestrators.
+            // TODO: Decide whether we want to propagate the default version to actitities and entities as well.
+            string version = (functionType == FunctionType.Orchestrator)
+                             ? this.Config.Options.DefaultVersion
+                             : string.Empty;
+
             this.Config.ThrowIfFunctionDoesNotExist(functionName, functionType);
 
             Task<TResult> callTask = null;
@@ -572,22 +578,19 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     System.Diagnostics.Debug.Assert(instanceId == null, "The instanceId parameter should not be used for activity functions.");
                     System.Diagnostics.Debug.Assert(operation == null, "The operation parameter should not be used for activity functions.");
                     System.Diagnostics.Debug.Assert(!oneWay, "The oneWay parameter should not be used for activity functions.");
+                    if (retryOptions == null)
                     {
-                        string version = string.Empty;
-                        if (retryOptions == null)
-                        {
-                            this.IncrementActionsOrThrowException();
-                            callTask = this.InnerContext.ScheduleTask<TResult>(functionName, version, input);
-                        }
-                        else
-                        {
-                            this.IncrementActionsOrThrowException();
-                            callTask = this.InnerContext.ScheduleWithRetry<TResult>(
-                                functionName,
-                                version,
-                                retryOptions.GetRetryOptions(),
-                                input);
-                        }
+                        this.IncrementActionsOrThrowException();
+                        callTask = this.InnerContext.ScheduleTask<TResult>(functionName, version, input);
+                    }
+                    else
+                    {
+                        this.IncrementActionsOrThrowException();
+                        callTask = this.InnerContext.ScheduleWithRetry<TResult>(
+                            functionName,
+                            version,
+                            retryOptions.GetRetryOptions(),
+                            input);
                     }
 
                     break;
@@ -608,46 +611,43 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                         throw new ArgumentException(nameof(instanceId), "Orchestration instance ids must not start with @");
                     }
 
+                    if (oneWay)
                     {
-                        string version = this.Config.Options.DefaultVersion;
-                        if (oneWay)
+                        this.IncrementActionsOrThrowException();
+                        var dummyTask = this.InnerContext.CreateSubOrchestrationInstance<TResult>(
+                                functionName,
+                                version,
+                                instanceId,
+                                input,
+                                new Dictionary<string, string>() { { OrchestrationTags.FireAndForget, "" } });
+
+                        System.Diagnostics.Debug.Assert(dummyTask.IsCompleted, "task should be fire-and-forget");
+                    }
+                    else
+                    {
+                        if (this.ContextLocks != null)
+                        {
+                            throw new LockingRulesViolationException("While holding locks, cannot call suborchestrators.");
+                        }
+
+                        if (retryOptions == null)
                         {
                             this.IncrementActionsOrThrowException();
-                            var dummyTask = this.InnerContext.CreateSubOrchestrationInstance<TResult>(
-                                    functionName,
-                                    version,
-                                    instanceId,
-                                    input,
-                                    new Dictionary<string, string>() { { OrchestrationTags.FireAndForget, "" } });
-
-                            System.Diagnostics.Debug.Assert(dummyTask.IsCompleted, "task should be fire-and-forget");
+                            callTask = this.InnerContext.CreateSubOrchestrationInstance<TResult>(
+                                functionName,
+                                version,
+                                instanceId,
+                                input);
                         }
                         else
                         {
-                            if (this.ContextLocks != null)
-                            {
-                                throw new LockingRulesViolationException("While holding locks, cannot call suborchestrators.");
-                            }
-
-                            if (retryOptions == null)
-                            {
-                                this.IncrementActionsOrThrowException();
-                                callTask = this.InnerContext.CreateSubOrchestrationInstance<TResult>(
-                                    functionName,
-                                    version,
-                                    instanceId,
-                                    input);
-                            }
-                            else
-                            {
-                                this.IncrementActionsOrThrowException();
-                                callTask = this.InnerContext.CreateSubOrchestrationInstanceWithRetry<TResult>(
-                                    functionName,
-                                    version,
-                                    instanceId,
-                                    retryOptions.GetRetryOptions(),
-                                    input);
-                            }
+                            this.IncrementActionsOrThrowException();
+                            callTask = this.InnerContext.CreateSubOrchestrationInstanceWithRetry<TResult>(
+                                functionName,
+                                version,
+                                instanceId,
+                                retryOptions.GetRetryOptions(),
+                                input);
                         }
                     }
 

--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableOrchestrationContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableOrchestrationContext.cs
@@ -140,7 +140,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
         private MessageSorter MessageSorter => this.messageSorter ?? (this.messageSorter = new MessageSorter());
 
-        public string Version => "";
+        public string Version => this.InnerContext.Version;
 
         /// <summary>
         /// Returns the orchestrator function input as a raw JSON string value.

--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableOrchestrationContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableOrchestrationContext.cs
@@ -27,8 +27,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         DurableOrchestrationContextBase // for v1 legacy compatibility.
 #pragma warning restore 618
     {
-        public const string DefaultVersion = "";
-
         private readonly Dictionary<string, IEventTaskCompletionSource> pendingExternalEvents =
             new Dictionary<string, IEventTaskCompletionSource>(StringComparer.OrdinalIgnoreCase);
 
@@ -561,8 +559,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 }
             }
 
-            // TODO: Support for versioning
-            string version = DefaultVersion;
+            string version = ((IDurableOrchestrationContext)this).Version;
             this.Config.ThrowIfFunctionDoesNotExist(functionName, functionType);
 
             Task<TResult> callTask = null;

--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableOrchestrationContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableOrchestrationContext.cs
@@ -559,7 +559,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 }
             }
 
-            string version = ((IDurableOrchestrationContext)this).Version;
             this.Config.ThrowIfFunctionDoesNotExist(functionName, functionType);
 
             Task<TResult> callTask = null;
@@ -573,19 +572,22 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     System.Diagnostics.Debug.Assert(instanceId == null, "The instanceId parameter should not be used for activity functions.");
                     System.Diagnostics.Debug.Assert(operation == null, "The operation parameter should not be used for activity functions.");
                     System.Diagnostics.Debug.Assert(!oneWay, "The oneWay parameter should not be used for activity functions.");
-                    if (retryOptions == null)
                     {
-                        this.IncrementActionsOrThrowException();
-                        callTask = this.InnerContext.ScheduleTask<TResult>(functionName, version, input);
-                    }
-                    else
-                    {
-                        this.IncrementActionsOrThrowException();
-                        callTask = this.InnerContext.ScheduleWithRetry<TResult>(
-                            functionName,
-                            version,
-                            retryOptions.GetRetryOptions(),
-                            input);
+                        string version = string.Empty;
+                        if (retryOptions == null)
+                        {
+                            this.IncrementActionsOrThrowException();
+                            callTask = this.InnerContext.ScheduleTask<TResult>(functionName, version, input);
+                        }
+                        else
+                        {
+                            this.IncrementActionsOrThrowException();
+                            callTask = this.InnerContext.ScheduleWithRetry<TResult>(
+                                functionName,
+                                version,
+                                retryOptions.GetRetryOptions(),
+                                input);
+                        }
                     }
 
                     break;
@@ -606,43 +608,46 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                         throw new ArgumentException(nameof(instanceId), "Orchestration instance ids must not start with @");
                     }
 
-                    if (oneWay)
                     {
-                        this.IncrementActionsOrThrowException();
-                        var dummyTask = this.InnerContext.CreateSubOrchestrationInstance<TResult>(
-                                functionName,
-                                version,
-                                instanceId,
-                                input,
-                                new Dictionary<string, string>() { { OrchestrationTags.FireAndForget, "" } });
-
-                        System.Diagnostics.Debug.Assert(dummyTask.IsCompleted, "task should be fire-and-forget");
-                    }
-                    else
-                    {
-                        if (this.ContextLocks != null)
-                        {
-                            throw new LockingRulesViolationException("While holding locks, cannot call suborchestrators.");
-                        }
-
-                        if (retryOptions == null)
+                        string version = this.Config.Options.DefaultVersion;
+                        if (oneWay)
                         {
                             this.IncrementActionsOrThrowException();
-                            callTask = this.InnerContext.CreateSubOrchestrationInstance<TResult>(
-                                functionName,
-                                version,
-                                instanceId,
-                                input);
+                            var dummyTask = this.InnerContext.CreateSubOrchestrationInstance<TResult>(
+                                    functionName,
+                                    version,
+                                    instanceId,
+                                    input,
+                                    new Dictionary<string, string>() { { OrchestrationTags.FireAndForget, "" } });
+
+                            System.Diagnostics.Debug.Assert(dummyTask.IsCompleted, "task should be fire-and-forget");
                         }
                         else
                         {
-                            this.IncrementActionsOrThrowException();
-                            callTask = this.InnerContext.CreateSubOrchestrationInstanceWithRetry<TResult>(
-                                functionName,
-                                version,
-                                instanceId,
-                                retryOptions.GetRetryOptions(),
-                                input);
+                            if (this.ContextLocks != null)
+                            {
+                                throw new LockingRulesViolationException("While holding locks, cannot call suborchestrators.");
+                            }
+
+                            if (retryOptions == null)
+                            {
+                                this.IncrementActionsOrThrowException();
+                                callTask = this.InnerContext.CreateSubOrchestrationInstance<TResult>(
+                                    functionName,
+                                    version,
+                                    instanceId,
+                                    input);
+                            }
+                            else
+                            {
+                                this.IncrementActionsOrThrowException();
+                                callTask = this.InnerContext.CreateSubOrchestrationInstanceWithRetry<TResult>(
+                                    functionName,
+                                    version,
+                                    instanceId,
+                                    retryOptions.GetRetryOptions(),
+                                    input);
+                            }
                         }
                     }
 

--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableOrchestrationContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableOrchestrationContext.cs
@@ -140,6 +140,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
         private MessageSorter MessageSorter => this.messageSorter ?? (this.messageSorter = new MessageSorter());
 
+        public string Version => "";
+
         /// <summary>
         /// Returns the orchestrator function input as a raw JSON string value.
         /// </summary>

--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableOrchestrationContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableOrchestrationContext.cs
@@ -129,6 +129,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         string IDurableOrchestrationContext.Name => this.OrchestrationName;
 
         /// <inheritdoc />
+        string IDurableOrchestrationContext.Version => this.InnerContext.Version;
+
+        /// <inheritdoc />
         string IDurableOrchestrationContext.InstanceId => this.InstanceId;
 
         /// <inheritdoc />
@@ -139,8 +142,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         protected string LockRequestId { get; set; }
 
         private MessageSorter MessageSorter => this.messageSorter ?? (this.messageSorter = new MessageSorter());
-
-        public string Version => this.InnerContext.Version;
 
         /// <summary>
         /// Returns the orchestrator function input as a raw JSON string value.

--- a/src/WebJobs.Extensions.DurableTask/ContextInterfaces/IDurableOrchestrationContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextInterfaces/IDurableOrchestrationContext.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// </summary>
         string Name { get; }
 
-        string Version { get; }
+        string Version { get { return string.Empty; } }
 
         /// <summary>
         /// Gets the instance ID of the currently executing orchestration.

--- a/src/WebJobs.Extensions.DurableTask/ContextInterfaces/IDurableOrchestrationContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextInterfaces/IDurableOrchestrationContext.cs
@@ -19,6 +19,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// </summary>
         string Name { get; }
 
+        string Version { get; }
+
         /// <summary>
         /// Gets the instance ID of the currently executing orchestration.
         /// </summary>

--- a/src/WebJobs.Extensions.DurableTask/ContextInterfaces/IDurableOrchestrationContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextInterfaces/IDurableOrchestrationContext.cs
@@ -19,7 +19,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// </summary>
         string Name { get; }
 
-        string Version { get { return string.Empty; } }
+        /// <summary>
+        /// Gets the version of the current orchestration function.
+        /// </summary>
+        string Version => string.Empty;
 
         /// <summary>
         /// Gets the instance ID of the currently executing orchestration.

--- a/src/WebJobs.Extensions.DurableTask/Options/DurableTaskOptions.cs
+++ b/src/WebJobs.Extensions.DurableTask/Options/DurableTaskOptions.cs
@@ -24,11 +24,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         private string defaultHubName;
 
         /// <summary>
-        /// The AppVersion value provided here will be automatically assigned to every orchestration
+        /// The DefaultVersion value provided here will be automatically assigned to every orchestration
         /// instance created by this app, and this value will be available on IDurableOrchestrationContext
         /// passed to each orchestrator function replay invocation of this orchestration instance.
         /// </summary>
-        public string AppVersion { get; set; }
+        public string DefaultVersion { get; set; }
 
         /// <summary>
         /// Settings used for Durable HTTP functionality.

--- a/src/WebJobs.Extensions.DurableTask/Options/DurableTaskOptions.cs
+++ b/src/WebJobs.Extensions.DurableTask/Options/DurableTaskOptions.cs
@@ -23,6 +23,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         private string resolvedHubName;
         private string defaultHubName;
 
+        public string AppVersion { get; set; }
+
         /// <summary>
         /// Settings used for Durable HTTP functionality.
         /// </summary>

--- a/src/WebJobs.Extensions.DurableTask/Options/DurableTaskOptions.cs
+++ b/src/WebJobs.Extensions.DurableTask/Options/DurableTaskOptions.cs
@@ -23,6 +23,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         private string resolvedHubName;
         private string defaultHubName;
 
+        /// <summary>
+        /// The AppVersion value provided here will be automatically assigned to every orchestration
+        /// instance created by this app, and this value will be available on IDurableOrchestrationContext
+        /// passed to each orchestrator function replay invocation of this orchestration instance.
+        /// </summary>
         public string AppVersion { get; set; }
 
         /// <summary>

--- a/test/Common/OrchestrationVersionTests.cs
+++ b/test/Common/OrchestrationVersionTests.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
                 var expectedContextVersion = JsonSerializer.Serialize(defaultVersion);
                 Assert.Equal(OrchestrationRuntimeStatus.Completed, status.RuntimeStatus);
-                var expectedOutput = $"Orchestration: {expectedContextVersion}; Sub-orchestration: {expectedContextVersion}";
+                var expectedOutput = $"Orchestration: {expectedContextVersion}; Sub-orchestration: {expectedContextVersion}; Orchestration from entity: {expectedContextVersion}";
                 Assert.Equal(expectedOutput, status.Output.ToString());
                 await host.StopAsync();
             }
@@ -73,7 +73,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             // The original orchestration version (1.0) persists. Furthermore, this version
             // is propagated to the sub-orchestration started when this orchestration
             // was already running on the host with defaultVersion set to 2.0.
-            var expectedOutput = $"Orchestration: \"1.0\"; Sub-orchestration: \"1.0\"";
+            var expectedOutput = $"Orchestration: \"1.0\"; Sub-orchestration: \"1.0\"; Orchestration from entity: \"2.0\"";
             Assert.Equal(expectedOutput, status.Output.ToString());
 
             ITestHost GetJobHost(string taskHubName, string defaultVersion)

--- a/test/Common/OrchestrationVersionTests.cs
+++ b/test/Common/OrchestrationVersionTests.cs
@@ -24,6 +24,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         [Trait("Category", PlatformSpecificHelpers.TestCategory)]
         [InlineData(null, "null")]
         [InlineData("", "''")]
+        [InlineData("1.0", "'1.0'")]
         [InlineData("4.5.6-preview", "'4.5.6-preview'")]
         public async Task OrchestrationVersionIsDeterminedByHostAppVersion(string appVersion, string expectedContextVersion)
         {

--- a/test/Common/OrchestrationVersionTests.cs
+++ b/test/Common/OrchestrationVersionTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
+using System.Text.Json;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Host.TestCommon;
 using Xunit;
@@ -22,11 +23,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
         [Theory]
         [Trait("Category", PlatformSpecificHelpers.TestCategory)]
-        [InlineData(null, "null")]
-        [InlineData("", "''")]
-        [InlineData("1.0", "'1.0'")]
-        [InlineData("4.5.6-preview", "'4.5.6-preview'")]
-        public async Task OrchestrationVersionIsDeterminedByHostDefaultVersion(string defaultVersion, string expectedContextVersion)
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("1.0")]
+        [InlineData("4.5.6-preview")]
+        public async Task OrchestrationVersionIsDeterminedByHostDefaultVersion(string defaultVersion)
         {
             using (ITestHost host = TestHelpers.GetJobHost(
                 this.loggerProvider,
@@ -39,6 +40,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 var client = await host.StartOrchestratorAsync(nameof(TestOrchestrations.GetOrchestrationVersion), null, this.output);
                 var status = await client.WaitForCompletionAsync(this.output, timeout: TimeSpan.FromMinutes(1));
 
+                var expectedContextVersion = JsonSerializer.Serialize(defaultVersion);
                 Assert.Equal(OrchestrationRuntimeStatus.Completed, status.RuntimeStatus);
                 var expectedOutput = $"Orchestration: {expectedContextVersion}; Sub-orchestration: {expectedContextVersion}";
                 Assert.Equal(expectedOutput, status.Output.ToString());
@@ -71,7 +73,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             // The original orchestration version (1.0) persists. Furthermore, this version
             // is propagated to the sub-orchestration started when this orchestration
             // was already running on the host with defaultVersion set to 2.0.
-            var expectedOutput = $"Orchestration: '1.0'; Sub-orchestration: '1.0'";
+            var expectedOutput = $"Orchestration: \"1.0\"; Sub-orchestration: \"1.0\"";
             Assert.Equal(expectedOutput, status.Output.ToString());
 
             ITestHost GetJobHost(string taskHubName, string defaultVersion)

--- a/test/Common/OrchestrationVersionTests.cs
+++ b/test/Common/OrchestrationVersionTests.cs
@@ -25,11 +25,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         [InlineData(null, "null")]
         [InlineData("", "''")]
         [InlineData("4.5.6-preview", "'4.5.6-preview'")]
-        public async Task CanCheckOrchestrationVersion(string appVersion, string expectedContextVersion)
+        public async Task OrchestrationVersionIsDeterminedByHostAppVersion(string appVersion, string expectedContextVersion)
         {
             using (ITestHost host = TestHelpers.GetJobHost(
                 this.loggerProvider,
-                nameof(this.CanCheckOrchestrationVersion),
+                nameof(this.OrchestrationVersionIsDeterminedByHostAppVersion),
                 enableExtendedSessions: false,
                 options: new DurableTaskOptions { AppVersion = appVersion }))
             {
@@ -47,9 +47,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
         [Fact]
         [Trait("Category", PlatformSpecificHelpers.TestCategory)]
-        public async Task OriginalOrchestrationVersionPersists()
+        public async Task OrchestrationVersionIsImmutable()
         {
-            var taskHubName = TestHelpers.GetTaskHubNameFromTestName(nameof(this.OriginalOrchestrationVersionPersists), false);
+            var taskHubName = TestHelpers.GetTaskHubNameFromTestName(nameof(this.OrchestrationVersionIsImmutable), false);
 
             using ITestHost host1 = GetJobHost(appVersion: "1.0");
             await host1.StartAsync();
@@ -72,7 +72,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             {
                 return TestHelpers.GetJobHost(
                                 this.loggerProvider,
-                                nameof(this.OriginalOrchestrationVersionPersists),
+                                nameof(this.OrchestrationVersionIsImmutable),
                                 enableExtendedSessions: false,
                                 exactTaskHubName: taskHubName,
                                 options: new DurableTaskOptions { AppVersion = appVersion });

--- a/test/Common/OrchestrationVersionTests.cs
+++ b/test/Common/OrchestrationVersionTests.cs
@@ -26,13 +26,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         [InlineData("", "''")]
         [InlineData("1.0", "'1.0'")]
         [InlineData("4.5.6-preview", "'4.5.6-preview'")]
-        public async Task OrchestrationVersionIsDeterminedByHostAppVersion(string appVersion, string expectedContextVersion)
+        public async Task OrchestrationVersionIsDeterminedByHostAppVersion(string defaultVersion, string expectedContextVersion)
         {
             using (ITestHost host = TestHelpers.GetJobHost(
                 this.loggerProvider,
                 nameof(this.OrchestrationVersionIsDeterminedByHostAppVersion),
                 enableExtendedSessions: false,
-                options: new DurableTaskOptions { AppVersion = appVersion }))
+                options: new DurableTaskOptions { DefaultVersion = defaultVersion }))
             {
                 await host.StartAsync();
 
@@ -52,16 +52,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         {
             var taskHubName = TestHelpers.GetTaskHubNameFromTestName(nameof(this.OrchestrationVersionIsImmutable), false);
 
-            // Start an orchestration on a host with appVersion set to 1.0, and wait until it's paused.
-            using ITestHost host1 = GetJobHost(taskHubName, appVersion: "1.0");
+            // Start an orchestration on a host with defaultVersion set to 1.0, and wait until it's paused.
+            using ITestHost host1 = GetJobHost(taskHubName, defaultVersion: "1.0");
             await host1.StartAsync();
             var client = await host1.StartOrchestratorAsync(nameof(TestOrchestrations.GetOrchestrationVersion_AfterExternalEvent), null, this.output);
             var status = await client.WaitForCustomStatusAsync(TimeSpan.FromMinutes(1), this.output, "Waiting");
             Assert.Equal(OrchestrationRuntimeStatus.Running, status.RuntimeStatus);
             await host1.StopAsync();
 
-            // Resume the same orchestration on a host with appVersion set to 2.0.
-            using ITestHost host2 = GetJobHost(taskHubName, appVersion: "2.0");
+            // Resume the same orchestration on a host with defaultVersion set to 2.0.
+            using ITestHost host2 = GetJobHost(taskHubName, defaultVersion: "2.0");
             await host2.StartAsync();
             await client.RaiseEventAsync("Resume", this.output);
             status = await client.WaitForCompletionAsync(this.output, timeout: TimeSpan.FromMinutes(1));
@@ -70,18 +70,18 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
             // The original orchestration version (1.0) persists. Furthermore, this version
             // is propagated to the sub-orchestration started when this orchestration
-            // was already running on the host with appVersion set to 2.0.
+            // was already running on the host with defaultVersion set to 2.0.
             var expectedOutput = $"Orchestration: '1.0'; Sub-orchestration: '1.0'";
             Assert.Equal(expectedOutput, status.Output.ToString());
 
-            ITestHost GetJobHost(string taskHubName, string appVersion)
+            ITestHost GetJobHost(string taskHubName, string defaultVersion)
             {
                 return TestHelpers.GetJobHost(
                                 this.loggerProvider,
                                 nameof(this.OrchestrationVersionIsImmutable),
                                 enableExtendedSessions: false,
                                 exactTaskHubName: taskHubName,
-                                options: new DurableTaskOptions { AppVersion = appVersion });
+                                options: new DurableTaskOptions { DefaultVersion = defaultVersion });
             }
         }
     }

--- a/test/Common/OrchestrationVersionTests.cs
+++ b/test/Common/OrchestrationVersionTests.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
                 var expectedContextVersion = JsonSerializer.Serialize(defaultVersion);
                 Assert.Equal(OrchestrationRuntimeStatus.Completed, status.RuntimeStatus);
-                var expectedOutput = $"Orchestration: {expectedContextVersion}; Sub-orchestration: {expectedContextVersion}; Orchestration from entity: {expectedContextVersion}";
+                var expectedOutput = $"Orchestration: {expectedContextVersion}; Sub-orchestration: {expectedContextVersion}; Sub-orchestration from entity: {expectedContextVersion}";
                 Assert.Equal(expectedOutput, status.Output.ToString());
                 await host.StopAsync();
             }
@@ -73,7 +73,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             // The original orchestration version (1.0) persists. However, this version
             // is *not* propagated to the sub-orchestration started when this orchestration
             // was already running on the host with defaultVersion set to 2.0.
-            var expectedOutput = $"Orchestration: \"1.0\"; Sub-orchestration: \"2.0\"; Orchestration from entity: \"2.0\"";
+            var expectedOutput = $"Orchestration: \"1.0\"; Sub-orchestration: \"2.0\"; Sub-orchestration from entity: \"2.0\"";
             Assert.Equal(expectedOutput, status.Output.ToString());
 
             ITestHost GetJobHost(string taskHubName, string defaultVersion)

--- a/test/Common/OrchestrationVersionTests.cs
+++ b/test/Common/OrchestrationVersionTests.cs
@@ -39,8 +39,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 var status = await client.WaitForCompletionAsync(this.output, timeout: TimeSpan.FromMinutes(1));
 
                 Assert.Equal(OrchestrationRuntimeStatus.Completed, status.RuntimeStatus);
-                var expected = $"Orchestration: {expectedContextVersion}; Sub-orchestration: {expectedContextVersion}";
-                Assert.Equal(expected, status.Output.ToString());
+                var expectedOutput = $"Orchestration: {expectedContextVersion}; Sub-orchestration: {expectedContextVersion}";
+                Assert.Equal(expectedOutput, status.Output.ToString());
                 await host.StopAsync();
             }
         }
@@ -65,8 +65,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             Assert.Equal(OrchestrationRuntimeStatus.Completed, status.RuntimeStatus);
             await host2.StopAsync();
 
-            var expected = $"Orchestration: '1.0'; Sub-orchestration: '1.0'";
-            Assert.Equal(expected, status.Output.ToString());
+            var expectedOutput = $"Orchestration: '1.0'; Sub-orchestration: '1.0'";
+            Assert.Equal(expectedOutput, status.Output.ToString());
 
             ITestHost GetJobHost(string appVersion)
             {

--- a/test/Common/OrchestrationVersionTests.cs
+++ b/test/Common/OrchestrationVersionTests.cs
@@ -70,10 +70,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             Assert.Equal(OrchestrationRuntimeStatus.Completed, status.RuntimeStatus);
             await host2.StopAsync();
 
-            // The original orchestration version (1.0) persists. Furthermore, this version
-            // is propagated to the sub-orchestration started when this orchestration
+            // The original orchestration version (1.0) persists. However, this version
+            // is *not* propagated to the sub-orchestration started when this orchestration
             // was already running on the host with defaultVersion set to 2.0.
-            var expectedOutput = $"Orchestration: \"1.0\"; Sub-orchestration: \"1.0\"; Orchestration from entity: \"2.0\"";
+            var expectedOutput = $"Orchestration: \"1.0\"; Sub-orchestration: \"2.0\"; Orchestration from entity: \"2.0\"";
             Assert.Equal(expectedOutput, status.Output.ToString());
 
             ITestHost GetJobHost(string taskHubName, string defaultVersion)

--- a/test/Common/OrchestrationVersionTests.cs
+++ b/test/Common/OrchestrationVersionTests.cs
@@ -26,11 +26,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         [InlineData("", "''")]
         [InlineData("1.0", "'1.0'")]
         [InlineData("4.5.6-preview", "'4.5.6-preview'")]
-        public async Task OrchestrationVersionIsDeterminedByHostAppVersion(string defaultVersion, string expectedContextVersion)
+        public async Task OrchestrationVersionIsDeterminedByHostDefaultVersion(string defaultVersion, string expectedContextVersion)
         {
             using (ITestHost host = TestHelpers.GetJobHost(
                 this.loggerProvider,
-                nameof(this.OrchestrationVersionIsDeterminedByHostAppVersion),
+                nameof(this.OrchestrationVersionIsDeterminedByHostDefaultVersion),
                 enableExtendedSessions: false,
                 options: new DurableTaskOptions { DefaultVersion = defaultVersion }))
             {

--- a/test/Common/OrchestrationVersionTests.cs
+++ b/test/Common/OrchestrationVersionTests.cs
@@ -51,24 +51,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         {
             var taskHubName = TestHelpers.GetTaskHubNameFromTestName(nameof(this.OriginalOrchestrationVersionPersists), false);
 
-            using ITestHost host1 = TestHelpers.GetJobHost(
-                this.loggerProvider,
-                nameof(this.OriginalOrchestrationVersionPersists),
-                enableExtendedSessions: false,
-                exactTaskHubName: taskHubName,
-                options: new DurableTaskOptions { AppVersion = "1.0" });
+            using ITestHost host1 = GetJobHost(appVersion: "1.0");
             await host1.StartAsync();
             var client = await host1.StartOrchestratorAsync(nameof(TestOrchestrations.GetOrchestrationVersion_AfterExternalEvent), null, this.output);
             var status = await client.WaitForCustomStatusAsync(TimeSpan.FromMinutes(1), this.output, "Waiting");
             Assert.Equal(OrchestrationRuntimeStatus.Running, status.RuntimeStatus);
             await host1.StopAsync();
 
-            using ITestHost host2 = TestHelpers.GetJobHost(
-                this.loggerProvider,
-                nameof(this.OriginalOrchestrationVersionPersists),
-                enableExtendedSessions: false,
-                exactTaskHubName: taskHubName,
-                options: new DurableTaskOptions { AppVersion = "2.0" });
+            using ITestHost host2 = GetJobHost(appVersion: "2.0");
             await host2.StartAsync();
             await client.RaiseEventAsync("Resume", this.output);
             status = await client.WaitForCompletionAsync(this.output, timeout: TimeSpan.FromMinutes(1));
@@ -77,6 +67,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
             var expected = $"Orchestration: '1.0'; Sub-orchestration: '1.0'";
             Assert.Equal(expected, status.Output.ToString());
+
+            ITestHost GetJobHost(string appVersion)
+            {
+                return TestHelpers.GetJobHost(
+                                this.loggerProvider,
+                                nameof(this.OriginalOrchestrationVersionPersists),
+                                enableExtendedSessions: false,
+                                exactTaskHubName: taskHubName,
+                                options: new DurableTaskOptions { AppVersion = appVersion });
+            }
         }
     }
 }

--- a/test/Common/OrchestrationVersionTests.cs
+++ b/test/Common/OrchestrationVersionTests.cs
@@ -3,13 +3,11 @@
 
 using System;
 using System.Threading.Tasks;
-using Microsoft.Azure.WebJobs.Extensions.DurableTask;
-using Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests;
 using Microsoft.Azure.WebJobs.Host.TestCommon;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace WebJobs.Extensions.DurableTask.Tests.V2
+namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 {
     public class OrchestrationVersionTests
     {

--- a/test/Common/OrchestrationVersionTests.cs
+++ b/test/Common/OrchestrationVersionTests.cs
@@ -51,24 +51,29 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         {
             var taskHubName = TestHelpers.GetTaskHubNameFromTestName(nameof(this.OrchestrationVersionIsImmutable), false);
 
-            using ITestHost host1 = GetJobHost(appVersion: "1.0");
+            // Start an orchestration on a host with appVersion set to 1.0, and wait until it's paused.
+            using ITestHost host1 = GetJobHost(taskHubName, appVersion: "1.0");
             await host1.StartAsync();
             var client = await host1.StartOrchestratorAsync(nameof(TestOrchestrations.GetOrchestrationVersion_AfterExternalEvent), null, this.output);
             var status = await client.WaitForCustomStatusAsync(TimeSpan.FromMinutes(1), this.output, "Waiting");
             Assert.Equal(OrchestrationRuntimeStatus.Running, status.RuntimeStatus);
             await host1.StopAsync();
 
-            using ITestHost host2 = GetJobHost(appVersion: "2.0");
+            // Resume the same orchestration on a host with appVersion set to 2.0.
+            using ITestHost host2 = GetJobHost(taskHubName, appVersion: "2.0");
             await host2.StartAsync();
             await client.RaiseEventAsync("Resume", this.output);
             status = await client.WaitForCompletionAsync(this.output, timeout: TimeSpan.FromMinutes(1));
             Assert.Equal(OrchestrationRuntimeStatus.Completed, status.RuntimeStatus);
             await host2.StopAsync();
 
+            // The original orchestration version (1.0) persists. Furthermore, this version
+            // is propagated to the sub-orchestration started when this orchestration
+            // was already running on the host with appVersion set to 2.0.
             var expectedOutput = $"Orchestration: '1.0'; Sub-orchestration: '1.0'";
             Assert.Equal(expectedOutput, status.Output.ToString());
 
-            ITestHost GetJobHost(string appVersion)
+            ITestHost GetJobHost(string taskHubName, string appVersion)
             {
                 return TestHelpers.GetJobHost(
                                 this.loggerProvider,

--- a/test/Common/OrchestrationVersionTests.cs
+++ b/test/Common/OrchestrationVersionTests.cs
@@ -48,9 +48,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
         [Fact]
         [Trait("Category", PlatformSpecificHelpers.TestCategory)]
-        public async Task OrchestrationVersionIsImmutable()
+        public async Task ExistingOrchestrationVersionIsImmutable()
         {
-            var taskHubName = TestHelpers.GetTaskHubNameFromTestName(nameof(this.OrchestrationVersionIsImmutable), false);
+            var taskHubName = TestHelpers.GetTaskHubNameFromTestName(nameof(this.ExistingOrchestrationVersionIsImmutable), false);
 
             // Start an orchestration on a host with defaultVersion set to 1.0, and wait until it's paused.
             using ITestHost host1 = GetJobHost(taskHubName, defaultVersion: "1.0");
@@ -78,7 +78,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             {
                 return TestHelpers.GetJobHost(
                                 this.loggerProvider,
-                                nameof(this.OrchestrationVersionIsImmutable),
+                                nameof(this.ExistingOrchestrationVersionIsImmutable),
                                 enableExtendedSessions: false,
                                 exactTaskHubName: taskHubName,
                                 options: new DurableTaskOptions { DefaultVersion = defaultVersion });

--- a/test/Common/TestEntities.cs
+++ b/test/Common/TestEntities.cs
@@ -375,5 +375,39 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
             return Task.CompletedTask;
         }
+
+        //-------------- An entity that launches an orchestration and stores its output -----------------
+
+        public static void LauncherEntity2([EntityTrigger(EntityName = "Launcher2")] IDurableEntityContext context)
+        {
+            var (output, done) = context.HasState ? context.GetState<(string, bool)>() : (null, false);
+
+            switch (context.OperationName)
+            {
+                case "launch":
+                    {
+                        context.StartNewOrchestration(nameof(TestOrchestrations.ScheduledByEntity), context.EntityId);
+                        break;
+                    }
+
+                case "done":
+                    {
+                        output = context.GetInput<string>();
+                        done = true;
+                        break;
+                    }
+
+                case "get":
+                    {
+                        context.Return(done ? output : null);
+                        break;
+                    }
+
+                default:
+                    throw new NotImplementedException("no such entity operation");
+            }
+
+            context.SetState((output, done));
+        }
     }
 }

--- a/test/Common/TestEntities.cs
+++ b/test/Common/TestEntities.cs
@@ -378,7 +378,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
         //-------------- An entity that launches an orchestration and stores its output -----------------
 
-        public static void LauncherEntity2([EntityTrigger(EntityName = "Launcher2")] IDurableEntityContext context)
+        public static void LauncherStoringOrchestrationOutputEntity([EntityTrigger(EntityName = "LauncherStoringOrchestrationOutput")] IDurableEntityContext context)
         {
             var (output, done) = context.HasState ? context.GetState<(string, bool)>() : (null, false);
 

--- a/test/Common/TestOrchestrations.cs
+++ b/test/Common/TestOrchestrations.cs
@@ -1552,13 +1552,19 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
         public static async Task<string> GetOrchestrationVersion([OrchestrationTrigger] IDurableOrchestrationContext ctx, ILogger log)
         {
-            string version = ctx.Version;
-            return await Task.FromResult(version == null ? "null" : $"'{version}'");
+            string orchVersion = VersionToString(ctx.Version);
+            string subOrchVersion = await ctx.CallSubOrchestratorAsync<string>(nameof(GetOrchestrationVersion_SubOrchestrator), null);
+            return $"Orchestration: {orchVersion}; Sub-orchestration: {subOrchVersion}";
         }
 
-        public static async Task<string> GetOrchestrationVersion_WithSubOrchestrator([OrchestrationTrigger] IDurableOrchestrationContext ctx, ILogger log)
+        public static async Task<string> GetOrchestrationVersion_SubOrchestrator([OrchestrationTrigger] IDurableOrchestrationContext ctx, ILogger log)
         {
-            return await ctx.CallSubOrchestratorAsync<string>(nameof(GetOrchestrationVersion), null);
+            return await Task.FromResult(VersionToString(ctx.Version));
+        }
+
+        private static string VersionToString(string version)
+        {
+            return version == null ? "null" : $"'{version}'";
         }
     }
 }

--- a/test/Common/TestOrchestrations.cs
+++ b/test/Common/TestOrchestrations.cs
@@ -1555,5 +1555,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             string version = ctx.Version;
             return await Task.FromResult(version == null ? "null" : $"'{version}'");
         }
+
+        public static async Task<string> GetOrchestrationVersion_WithSubOrchestrator([OrchestrationTrigger] IDurableOrchestrationContext ctx, ILogger log)
+        {
+            return await ctx.CallSubOrchestratorAsync<string>(nameof(GetOrchestrationVersion), null);
+        }
     }
 }

--- a/test/Common/TestOrchestrations.cs
+++ b/test/Common/TestOrchestrations.cs
@@ -1553,7 +1553,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         public static async Task<string> GetOrchestrationVersion([OrchestrationTrigger] IDurableOrchestrationContext ctx, ILogger log)
         {
             string version = ctx.Version;
-            return await Task.FromResult(version == null ? "null" : $"{version}");
+            return await Task.FromResult(version == null ? "null" : $"'{version}'");
         }
     }
 }

--- a/test/Common/TestOrchestrations.cs
+++ b/test/Common/TestOrchestrations.cs
@@ -1557,6 +1557,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             return $"Orchestration: {orchVersion}; Sub-orchestration: {subOrchVersion}";
         }
 
+        public static async Task<string> GetOrchestrationVersion_AfterExternalEvent([OrchestrationTrigger] IDurableOrchestrationContext ctx, ILogger log)
+        {
+            ctx.SetCustomStatus("Waiting");
+            await ctx.WaitForExternalEvent<object>("Resume");
+
+            string orchVersion = VersionToString(ctx.Version);
+            string subOrchVersion = await ctx.CallSubOrchestratorAsync<string>(nameof(GetOrchestrationVersion_SubOrchestrator), null);
+            return $"Orchestration: {orchVersion}; Sub-orchestration: {subOrchVersion}";
+        }
+
         public static async Task<string> GetOrchestrationVersion_SubOrchestrator([OrchestrationTrigger] IDurableOrchestrationContext ctx, ILogger log)
         {
             return await Task.FromResult(VersionToString(ctx.Version));

--- a/test/Common/TestOrchestrations.cs
+++ b/test/Common/TestOrchestrations.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -1552,7 +1553,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
         public static async Task<string> GetOrchestrationVersion([OrchestrationTrigger] IDurableOrchestrationContext ctx, ILogger log)
         {
-            string orchVersion = VersionToString(ctx.Version);
+            string orchVersion = JsonSerializer.Serialize(ctx.Version);
             string subOrchVersion = await ctx.CallSubOrchestratorAsync<string>(nameof(GetOrchestrationVersion_SubOrchestrator), null);
             return $"Orchestration: {orchVersion}; Sub-orchestration: {subOrchVersion}";
         }
@@ -1562,19 +1563,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             ctx.SetCustomStatus("Waiting");
             await ctx.WaitForExternalEvent<object>("Resume");
 
-            string orchVersion = VersionToString(ctx.Version);
+            string orchVersion = JsonSerializer.Serialize(ctx.Version);
             string subOrchVersion = await ctx.CallSubOrchestratorAsync<string>(nameof(GetOrchestrationVersion_SubOrchestrator), null);
             return $"Orchestration: {orchVersion}; Sub-orchestration: {subOrchVersion}";
         }
 
         public static async Task<string> GetOrchestrationVersion_SubOrchestrator([OrchestrationTrigger] IDurableOrchestrationContext ctx, ILogger log)
         {
-            return await Task.FromResult(VersionToString(ctx.Version));
-        }
-
-        private static string VersionToString(string version)
-        {
-            return version == null ? "null" : $"'{version}'";
+            return await Task.FromResult(JsonSerializer.Serialize(ctx.Version));
         }
     }
 }

--- a/test/Common/TestOrchestrations.cs
+++ b/test/Common/TestOrchestrations.cs
@@ -1549,5 +1549,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             string output = await ctx.CallActivityAsync<string>(nameof(TestActivities.Hello), input);
             return output;
         }
+
+        public static async Task<string> GetOrchestrationVersion([OrchestrationTrigger] IDurableOrchestrationContext ctx, ILogger log)
+        {
+            string version = ctx.Version;
+            return await Task.FromResult(version == null ? "null" : $"{version}");
+        }
     }
 }

--- a/test/Common/TestOrchestrations.cs
+++ b/test/Common/TestOrchestrations.cs
@@ -1581,7 +1581,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         public static async Task<string> GetOrchestrationVersion_SubOrchestrator([OrchestrationTrigger] IDurableOrchestrationContext ctx, ILogger log)
         {
             // Create an EntityId for a counter entity
-            var entityId = new EntityId("Launcher2", ctx.NewGuid().ToString());
+            var entityId = new EntityId("LauncherStoringOrchestrationOutput", ctx.NewGuid().ToString());
 
             await ctx.CallEntityAsync(entityId, "launch");
 

--- a/test/Common/TestOrchestrations.cs
+++ b/test/Common/TestOrchestrations.cs
@@ -1179,6 +1179,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             ctx.SignalEntity(entityId, "done");
         }
 
+        public static async Task ScheduledByEntity([OrchestrationTrigger] IDurableOrchestrationContext ctx)
+        {
+            var entityId = ctx.GetInput<EntityId>();
+
+            await ctx.CreateTimer(ctx.CurrentUtcDateTime + TimeSpan.FromSeconds(.2), CancellationToken.None);
+
+            var version = ctx.Version;
+            ctx.SignalEntity(entityId, "done", JsonSerializer.Serialize(version));
+        }
+
         public static async Task<string> LargeEntity([OrchestrationTrigger] IDurableOrchestrationContext ctx)
         {
             var entityId = ctx.GetInput<EntityId>();
@@ -1554,8 +1564,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         public static async Task<string> GetOrchestrationVersion([OrchestrationTrigger] IDurableOrchestrationContext ctx, ILogger log)
         {
             string orchVersion = JsonSerializer.Serialize(ctx.Version);
-            string subOrchVersion = await ctx.CallSubOrchestratorAsync<string>(nameof(GetOrchestrationVersion_SubOrchestrator), null);
-            return $"Orchestration: {orchVersion}; Sub-orchestration: {subOrchVersion}";
+            string subOrchOutput = await ctx.CallSubOrchestratorAsync<string>(nameof(GetOrchestrationVersion_SubOrchestrator), null);
+            return $"Orchestration: {orchVersion}; Sub-orchestration: {subOrchOutput}";
         }
 
         public static async Task<string> GetOrchestrationVersion_AfterExternalEvent([OrchestrationTrigger] IDurableOrchestrationContext ctx, ILogger log)
@@ -1564,11 +1574,34 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             await ctx.WaitForExternalEvent<object>("Resume");
 
             string orchVersion = JsonSerializer.Serialize(ctx.Version);
-            string subOrchVersion = await ctx.CallSubOrchestratorAsync<string>(nameof(GetOrchestrationVersion_SubOrchestrator), null);
-            return $"Orchestration: {orchVersion}; Sub-orchestration: {subOrchVersion}";
+            string subOrchOutput = await ctx.CallSubOrchestratorAsync<string>(nameof(GetOrchestrationVersion_SubOrchestrator), null);
+            return $"Orchestration: {orchVersion}; Sub-orchestration: {subOrchOutput}";
         }
 
         public static async Task<string> GetOrchestrationVersion_SubOrchestrator([OrchestrationTrigger] IDurableOrchestrationContext ctx, ILogger log)
+        {
+            // Create an EntityId for a counter entity
+            var entityId = new EntityId("Launcher2", ctx.NewGuid().ToString());
+
+            await ctx.CallEntityAsync(entityId, "launch");
+
+            string entityResult;
+            while (true)
+            {
+                entityResult = await ctx.CallEntityAsync<string>(entityId, "get");
+                if (entityResult != null)
+                {
+                    break;
+                }
+
+                await ctx.CreateTimer(ctx.CurrentUtcDateTime + TimeSpan.FromSeconds(1), CancellationToken.None);
+            }
+
+            // Return both the orchestration version and entity info
+            return await Task.FromResult($"{JsonSerializer.Serialize(ctx.Version)}; Orchestration from entity: {entityResult}");
+        }
+
+        public static async Task<string> GetOrchestrationVersion_SubOrchestrator2([OrchestrationTrigger] IDurableOrchestrationContext ctx, ILogger log)
         {
             return await Task.FromResult(JsonSerializer.Serialize(ctx.Version));
         }

--- a/test/Common/TestOrchestrations.cs
+++ b/test/Common/TestOrchestrations.cs
@@ -1580,7 +1580,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
         public static async Task<string> GetOrchestrationVersion_SubOrchestrator([OrchestrationTrigger] IDurableOrchestrationContext ctx, ILogger log)
         {
-            // Create an EntityId for a counter entity
             var entityId = new EntityId("LauncherStoringOrchestrationOutput", ctx.NewGuid().ToString());
 
             await ctx.CallEntityAsync(entityId, "launch");
@@ -1598,12 +1597,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             }
 
             // Return both the orchestration version and entity info
-            return await Task.FromResult($"{JsonSerializer.Serialize(ctx.Version)}; Orchestration from entity: {entityResult}");
-        }
-
-        public static async Task<string> GetOrchestrationVersion_SubOrchestrator2([OrchestrationTrigger] IDurableOrchestrationContext ctx, ILogger log)
-        {
-            return await Task.FromResult(JsonSerializer.Serialize(ctx.Version));
+            return await Task.FromResult($"{JsonSerializer.Serialize(ctx.Version)}; Sub-orchestration from entity: {entityResult}");
         }
     }
 }

--- a/test/FunctionsV2/OrchestrationVersionTests.cs
+++ b/test/FunctionsV2/OrchestrationVersionTests.cs
@@ -22,23 +22,26 @@ namespace WebJobs.Extensions.DurableTask.Tests.V2
             this.loggerProvider = new TestLoggerProvider(output);
         }
 
-        [Fact]
+        [Theory]
         [Trait("Category", PlatformSpecificHelpers.TestCategory)]
-        public async Task CanCheckOrchestrationVersion()
+        [InlineData(null, "null")]
+        [InlineData("", "''")]
+        [InlineData("4.5.6-preview", "'4.5.6-preview'")]
+        public async Task CanCheckOrchestrationVersion(string appVersion, string expectedContextVersion)
         {
             using (ITestHost host = TestHelpers.GetJobHost(
                 this.loggerProvider,
                 nameof(this.CanCheckOrchestrationVersion),
                 enableExtendedSessions: false,
-                options: new DurableTaskOptions()))
+                options: new DurableTaskOptions { AppVersion = appVersion }))
             {
                 await host.StartAsync();
 
                 var client = await host.StartOrchestratorAsync(nameof(TestOrchestrations.GetOrchestrationVersion), null, this.output);
-                var status = await client.WaitForCompletionAsync(this.output, timeout: TimeSpan.FromMinutes(3));
+                var status = await client.WaitForCompletionAsync(this.output, timeout: TimeSpan.FromMinutes(1));
 
                 Assert.Equal(OrchestrationRuntimeStatus.Completed, status.RuntimeStatus);
-                Assert.Equal("null", status.Output.ToString());
+                Assert.Equal(expectedContextVersion, status.Output.ToString());
                 await host.StopAsync();
             }
         }

--- a/test/FunctionsV2/OrchestrationVersionTests.cs
+++ b/test/FunctionsV2/OrchestrationVersionTests.cs
@@ -1,0 +1,46 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Extensions.DurableTask;
+using Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests;
+using Microsoft.Azure.WebJobs.Host.TestCommon;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace WebJobs.Extensions.DurableTask.Tests.V2
+{
+    public class OrchestrationVersionTests
+    {
+        private readonly ITestOutputHelper output;
+        private readonly TestLoggerProvider loggerProvider;
+
+        public OrchestrationVersionTests(ITestOutputHelper output)
+        {
+            this.output = output;
+            this.loggerProvider = new TestLoggerProvider(output);
+        }
+
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public async Task CanCheckOrchestrationVersion()
+        {
+            using (ITestHost host = TestHelpers.GetJobHost(
+                this.loggerProvider,
+                nameof(this.CanCheckOrchestrationVersion),
+                enableExtendedSessions: false,
+                options: new DurableTaskOptions()))
+            {
+                await host.StartAsync();
+
+                var client = await host.StartOrchestratorAsync(nameof(TestOrchestrations.GetOrchestrationVersion), null, this.output);
+                var status = await client.WaitForCompletionAsync(this.output, timeout: TimeSpan.FromMinutes(3));
+
+                Assert.Equal(OrchestrationRuntimeStatus.Completed, status.RuntimeStatus);
+                Assert.Equal("null", status.Output.ToString());
+                await host.StopAsync();
+            }
+        }
+    }
+}

--- a/test/FunctionsV2/OrchestrationVersionTests.cs
+++ b/test/FunctionsV2/OrchestrationVersionTests.cs
@@ -41,31 +41,8 @@ namespace WebJobs.Extensions.DurableTask.Tests.V2
                 var status = await client.WaitForCompletionAsync(this.output, timeout: TimeSpan.FromMinutes(1));
 
                 Assert.Equal(OrchestrationRuntimeStatus.Completed, status.RuntimeStatus);
-                Assert.Equal(expectedContextVersion, status.Output.ToString());
-                await host.StopAsync();
-            }
-        }
-
-        [Theory]
-        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
-        [InlineData(null, "null")]
-        [InlineData("", "''")]
-        [InlineData("4.5.6-preview", "'4.5.6-preview'")]
-        public async Task CanCheckOrchestrationVersion_WithSubOrchestrator(string appVersion, string expectedContextVersion)
-        {
-            using (ITestHost host = TestHelpers.GetJobHost(
-                this.loggerProvider,
-                nameof(this.CanCheckOrchestrationVersion),
-                enableExtendedSessions: false,
-                options: new DurableTaskOptions { AppVersion = appVersion }))
-            {
-                await host.StartAsync();
-
-                var client = await host.StartOrchestratorAsync(nameof(TestOrchestrations.GetOrchestrationVersion_WithSubOrchestrator), null, this.output);
-                var status = await client.WaitForCompletionAsync(this.output, timeout: TimeSpan.FromMinutes(1));
-
-                Assert.Equal(OrchestrationRuntimeStatus.Completed, status.RuntimeStatus);
-                Assert.Equal(expectedContextVersion, status.Output.ToString());
+                var expected = $"Orchestration: {expectedContextVersion}; Sub-orchestration: {expectedContextVersion}";
+                Assert.Equal(expected, status.Output.ToString());
                 await host.StopAsync();
             }
         }

--- a/test/FunctionsV2/OrchestrationVersionTests.cs
+++ b/test/FunctionsV2/OrchestrationVersionTests.cs
@@ -45,5 +45,29 @@ namespace WebJobs.Extensions.DurableTask.Tests.V2
                 await host.StopAsync();
             }
         }
+
+        [Theory]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        [InlineData(null, "null")]
+        [InlineData("", "''")]
+        [InlineData("4.5.6-preview", "'4.5.6-preview'")]
+        public async Task CanCheckOrchestrationVersion_WithSubOrchestrator(string appVersion, string expectedContextVersion)
+        {
+            using (ITestHost host = TestHelpers.GetJobHost(
+                this.loggerProvider,
+                nameof(this.CanCheckOrchestrationVersion),
+                enableExtendedSessions: false,
+                options: new DurableTaskOptions { AppVersion = appVersion }))
+            {
+                await host.StartAsync();
+
+                var client = await host.StartOrchestratorAsync(nameof(TestOrchestrations.GetOrchestrationVersion_WithSubOrchestrator), null, this.output);
+                var status = await client.WaitForCompletionAsync(this.output, timeout: TimeSpan.FromMinutes(1));
+
+                Assert.Equal(OrchestrationRuntimeStatus.Completed, status.RuntimeStatus);
+                Assert.Equal(expectedContextVersion, status.Output.ToString());
+                await host.StopAsync();
+            }
+        }
     }
 }

--- a/test/FunctionsV2/OrchestrationVersionTests.cs
+++ b/test/FunctionsV2/OrchestrationVersionTests.cs
@@ -46,5 +46,39 @@ namespace WebJobs.Extensions.DurableTask.Tests.V2
                 await host.StopAsync();
             }
         }
+
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public async Task OriginalOrchestrationVersionPersists()
+        {
+            var taskHubName = TestHelpers.GetTaskHubNameFromTestName(nameof(this.OriginalOrchestrationVersionPersists), false);
+
+            using ITestHost host1 = TestHelpers.GetJobHost(
+                this.loggerProvider,
+                nameof(this.OriginalOrchestrationVersionPersists),
+                enableExtendedSessions: false,
+                exactTaskHubName: taskHubName,
+                options: new DurableTaskOptions { AppVersion = "1.0" });
+            await host1.StartAsync();
+            var client = await host1.StartOrchestratorAsync(nameof(TestOrchestrations.GetOrchestrationVersion_AfterExternalEvent), null, this.output);
+            var status = await client.WaitForCustomStatusAsync(TimeSpan.FromMinutes(1), this.output, "Waiting");
+            Assert.Equal(OrchestrationRuntimeStatus.Running, status.RuntimeStatus);
+            await host1.StopAsync();
+
+            using ITestHost host2 = TestHelpers.GetJobHost(
+                this.loggerProvider,
+                nameof(this.OriginalOrchestrationVersionPersists),
+                enableExtendedSessions: false,
+                exactTaskHubName: taskHubName,
+                options: new DurableTaskOptions { AppVersion = "2.0" });
+            await host2.StartAsync();
+            await client.RaiseEventAsync("Resume", this.output);
+            status = await client.WaitForCompletionAsync(this.output, timeout: TimeSpan.FromMinutes(1));
+            Assert.Equal(OrchestrationRuntimeStatus.Completed, status.RuntimeStatus);
+            await host2.StopAsync();
+
+            var expected = $"Orchestration: '1.0'; Sub-orchestration: '1.0'";
+            Assert.Equal(expected, status.Output.ToString());
+        }
     }
 }


### PR DESCRIPTION
### Goal

The goal of this PR is to allow updating orchestration logic without requiring users to drain or abandon in-flight orchestration instances. Developers will be able to maintain backward compatibility in their orchestrator function code by checking which version of the app created the current orchestration instance and, based on that, executing either the new or old logic. This preserves the intent of the original orchestrator function and avoids non-determinism issues during function replay.

This PR enables this capability for .NET in-process Durable Function apps. Support for other runtimes is coming soon.

### Details

- The user will be able to assign a `defaultVersion` property to their durable app in `host.json`. All orchestration instances created by this app will automatically have this version value permanently associated with them.
- Orchestrator functions will have access to a `context.Version` property containing the version value that was set when the orchestration was created.

### Example

Suppose that the original app contains:

**host.json**
```json
{
  "extensions": {
    "durableTask": {
      "defaultVersion": "1.0"
    }
  }
}
```

**Orchestrator function**
```csharp
[FunctionName("MyOrchestration")]
public static async Task RunOrchestrator(
    [OrchestrationTrigger] IDurableOrchestrationContext context)
{
    await context.CallActivityAsync<string>("ActivityA", ...));
    await context.CallActivityAsync<string>("ActivityB", ...));
    await context.CallActivityAsync<string>("ActivityC", ...));
}
```

In the next version, we want to invoke `ActivityD` instead of `ActivityB`. However, we expect some orchestrations to be still running during the app upgrade, and some of them may have have already invoked `ActivityB`. Simply replacing `ActivityB` invocation with `ActivityD` could cause non-determinism issues when replaying history with the new orchestrator code.

Here is what we can do to keep our orchestrator backward compatible:

**host.json**
```json
{
  "extensions": {
    "durableTask": {
      "defaultVersion": "2.0"
    }
  }
}
```

**Orchestrator function**
```csharp
[FunctionName("MyOrchestration")]
public static async Task RunOrchestrator([OrchestrationTrigger] IDurableOrchestrationContext context)
{
    await context.CallActivityAsync<string>("ActivityA", ...));
    if (context.Version == "1.0") {
        // legacy code path
        await context.CallActivityAsync<string>("ActivityB", ...));
    } else {
        // new code path
        await context.CallActivityAsync<string>("ActivityD", ...));
    }
    await context.CallActivityAsync<string>("ActivityC", ...));
}
```

As a result, orchestrations created before the app upgrade will follow the old code path and invoke `ActivityB`, while new orchestrations will invoke `ActivityD` instead.

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)
* [x] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk
* [x] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
    * [ ] Otherwise: major or minor version updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
* [x] My changes **do not** add EventIds to our EventSource logs
    * [ ] Otherwise: Ensure the EventIds are within the supported range in our existing Windows infrastructure. You may validate this with a deployed app's telemetry. You may also extend the range by completing a PR such as [this one](https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files).
* [ ] My changes **should** be added to **v2.x** branch.
    * [x] Otherwise: This change applies exclusively to WebJobs.Extensions.DurableTask v3.x. It will be retained only in the `dev` and `main` branches and will not be merged into the `v2.x` branch.
