### PR TITLE
Add Support for Customizing Maximum gRPC Message Size

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,7 +12,7 @@
     <PackageVersion Include="Azure.Identity" Version="1.12.1" />
     <PackageVersion Include="Grpc.Core" Version="2.46.6" /> 
     <PackageVersion Include="Grpc.Tools" Version="2.49.0"  />
-	<PackageVersion Include="Grpc.Net.Client" Version="2.67.0" />
+    <PackageVersion Include="Grpc.Net.Client" Version="2.67.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.WebApiCompatShim" Version="2.2.0" />
     <PackageVersion Include="Microsoft.Azure.DurableTask.ApplicationInsights" Version="0.2.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,7 +12,7 @@
     <PackageVersion Include="Azure.Identity" Version="1.12.1" />
     <PackageVersion Include="Grpc.Core" Version="2.46.6" /> 
     <PackageVersion Include="Grpc.Tools" Version="2.49.0"  />
-    <PackageVersion Include="Grpc.Net.Client" Version="2.67.0" />
+    <PackageVersion Include="Grpc.Net.Client" Version="2.70.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.WebApiCompatShim" Version="2.2.0" />
     <PackageVersion Include="Microsoft.Azure.DurableTask.ApplicationInsights" Version="0.2.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,6 +12,7 @@
     <PackageVersion Include="Azure.Identity" Version="1.12.1" />
     <PackageVersion Include="Grpc.Core" Version="2.46.6" /> 
     <PackageVersion Include="Grpc.Tools" Version="2.49.0"  />
+	<PackageVersion Include="Grpc.Net.Client" Version="2.67.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.WebApiCompatShim" Version="2.2.0" />
     <PackageVersion Include="Microsoft.Azure.DurableTask.ApplicationInsights" Version="0.2.0" />

--- a/src/WebJobs.Extensions.DurableTask/Bindings/BindingHelper.cs
+++ b/src/WebJobs.Extensions.DurableTask/Bindings/BindingHelper.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     RpcBaseUrl = localRpcAddress,
                     RequiredQueryStringParameters = this.config.HttpApiHandler.GetUniversalQueryStrings(),
                     HttpBaseUrl = this.config.HttpApiHandler.GetBaseUrl(),
-                    MaxGrpcMessageSize = this.config.Options.MaxGrpcMessageSize.ToString(),
+                    MaxGrpcMessageSizeInBytes = this.config.Options.MaxGrpcMessageSizeInBytes.ToString(),
                 });
             }
 
@@ -146,8 +146,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             /// Defaults to 4,194,304 bytes (4 MB).
             /// In .NET 6.0 or later, setting this value to <c>null</c> removes the receive message size limit.
             /// </summary>
-            [JsonProperty("maxGrpcMessageSize")]
-            public string? MaxGrpcMessageSize { get; set; }
+            [JsonProperty("maxGrpcMessageSizeInBytes")]
+            public string? MaxGrpcMessageSizeInBytes { get; set; }
         }
     }
 }

--- a/src/WebJobs.Extensions.DurableTask/Bindings/BindingHelper.cs
+++ b/src/WebJobs.Extensions.DurableTask/Bindings/BindingHelper.cs
@@ -144,7 +144,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             /// <summary>
             /// Optional setting that specifies the maximum gRPC receive message size (in bytes) for the DurableTaskClient.
             /// Defaults to 4,194,304 bytes (4 MB).
-            /// In .NET 6.0 or later, setting this value to <c>null</c> removes the receive message size limit.
             /// </summary>
             [JsonProperty("maxGrpcMessageSizeInBytes")]
             public string? MaxGrpcMessageSizeInBytes { get; set; }

--- a/src/WebJobs.Extensions.DurableTask/Bindings/BindingHelper.cs
+++ b/src/WebJobs.Extensions.DurableTask/Bindings/BindingHelper.cs
@@ -44,6 +44,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     RpcBaseUrl = localRpcAddress,
                     RequiredQueryStringParameters = this.config.HttpApiHandler.GetUniversalQueryStrings(),
                     HttpBaseUrl = this.config.HttpApiHandler.GetBaseUrl(),
+                    MaxGrpcMessageSize = this.config.Options.MaxGrpcMessageSize.ToString(),
                 });
             }
 
@@ -139,6 +140,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             /// </summary>
             [JsonProperty("httpBaseUrl")]
             public string? HttpBaseUrl { get; set; }
+
+            /// <summary>
+            /// Optional setting that specifies the maximum gRPC receive message size (in bytes) for the DurableTaskClient.
+            /// Defaults to 4,194,304 bytes (4 MB).
+            /// In .NET 6.0 or later, setting this value to <c>null</c> removes the receive message size limit.
+            /// </summary>
+            [JsonProperty("maxGrpcMessageSize")]
+            public string? MaxGrpcMessageSize { get; set; }
         }
     }
 }

--- a/src/WebJobs.Extensions.DurableTask/Bindings/BindingHelper.cs
+++ b/src/WebJobs.Extensions.DurableTask/Bindings/BindingHelper.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     RpcBaseUrl = localRpcAddress,
                     RequiredQueryStringParameters = this.config.HttpApiHandler.GetUniversalQueryStrings(),
                     HttpBaseUrl = this.config.HttpApiHandler.GetBaseUrl(),
-                    MaxGrpcMessageSizeInBytes = this.config.Options.MaxGrpcMessageSizeInBytes.ToString(),
+                    MaxGrpcMessageSizeInBytes = this.config.Options.MaxGrpcMessageSizeInBytes,
                 });
             }
 
@@ -146,7 +146,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             /// Defaults to 4,194,304 bytes (4 MB).
             /// </summary>
             [JsonProperty("maxGrpcMessageSizeInBytes")]
-            public string? MaxGrpcMessageSizeInBytes { get; set; }
+            public int? MaxGrpcMessageSizeInBytes { get; set; }
         }
     }
 }

--- a/src/WebJobs.Extensions.DurableTask/Options/DurableTaskOptions.cs
+++ b/src/WebJobs.Extensions.DurableTask/Options/DurableTaskOptions.cs
@@ -240,7 +240,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// Defaults to 4,194,304 (4 MB).
         /// The maximum allowable value is <see cref="int.MaxValue"/>, which corresponds to the durable grpc server's receive limit.
         /// </summary>
-        public int? MaxGrpcMessageSizeInBytes { get; set; } = 4194304;
+        public int MaxGrpcMessageSizeInBytes { get; set; } = 4194304;
 
         // Used for mocking the lifecycle notification helper.
         internal HttpMessageHandler NotificationHandler { get; set; }

--- a/src/WebJobs.Extensions.DurableTask/Options/DurableTaskOptions.cs
+++ b/src/WebJobs.Extensions.DurableTask/Options/DurableTaskOptions.cs
@@ -240,7 +240,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// Defaults to 4,194,304 (4 MB).
         /// In .NET 6.0 or later, setting this value to <c>null</c> removes the receive message size limit.
         /// </summary>
-        public int? MaxGrpcMessageSize { get; set; } = 4194304;
+        public int? MaxGrpcMessageSizeInBytes { get; set; } = 4194304;
 
         // Used for mocking the lifecycle notification helper.
         internal HttpMessageHandler NotificationHandler { get; set; }

--- a/src/WebJobs.Extensions.DurableTask/Options/DurableTaskOptions.cs
+++ b/src/WebJobs.Extensions.DurableTask/Options/DurableTaskOptions.cs
@@ -235,6 +235,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// </summary>
         public AppLeaseOptions AppLeaseOptions { get; set; } = AppLeaseOptions.DefaultOptions;
 
+        /// <summary>
+        /// Option to control the receive message size  in bytes of the grpc client, which is used by Durable Funsiont c# Isolated and Java.
+        /// Defaults to 4,194,304 (4 MB).
+        /// In .NET 6.0 or later, setting this value to <c>null</c> removes the receive message size limit.
+        /// </summary>
+        public int? MaxGrpcMessageSize { get; set; } = 4194304;
+
         // Used for mocking the lifecycle notification helper.
         internal HttpMessageHandler NotificationHandler { get; set; }
 

--- a/src/WebJobs.Extensions.DurableTask/Options/DurableTaskOptions.cs
+++ b/src/WebJobs.Extensions.DurableTask/Options/DurableTaskOptions.cs
@@ -238,7 +238,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// <summary>
         /// Option to control the receive message size in bytes of the grpc client, which is used by Durable Funsiont c# Isolated and Java.
         /// Defaults to 4,194,304 (4 MB).
-        /// In .NET 6.0 or later, setting this value to <c>null</c> removes the receive message size limit.
+        /// The maximum allowable value is <see cref="int.MaxValue"/>, which corresponds to the durable grpc server's receive limit.
         /// </summary>
         public int? MaxGrpcMessageSizeInBytes { get; set; } = 4194304;
 

--- a/src/WebJobs.Extensions.DurableTask/Options/DurableTaskOptions.cs
+++ b/src/WebJobs.Extensions.DurableTask/Options/DurableTaskOptions.cs
@@ -236,7 +236,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         public AppLeaseOptions AppLeaseOptions { get; set; } = AppLeaseOptions.DefaultOptions;
 
         /// <summary>
-        /// Option to control the receive message size  in bytes of the grpc client, which is used by Durable Funsiont c# Isolated and Java.
+        /// Option to control the receive message size in bytes of the grpc client, which is used by Durable Funsiont c# Isolated and Java.
         /// Defaults to 4,194,304 (4 MB).
         /// In .NET 6.0 or later, setting this value to <c>null</c> removes the receive message size limit.
         /// </summary>

--- a/src/WebJobs.Extensions.DurableTask/Options/DurableTaskOptions.cs
+++ b/src/WebJobs.Extensions.DurableTask/Options/DurableTaskOptions.cs
@@ -236,7 +236,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         public AppLeaseOptions AppLeaseOptions { get; set; } = AppLeaseOptions.DefaultOptions;
 
         /// <summary>
-        /// Option to control the receive message size in bytes of the grpc client, which is used by Durable Funsiont c# Isolated and Java.
+        /// Option to control the receive message size in bytes of the gRPC client, which is used by Durable Funsiont C# Isolated and Java.
         /// Defaults to 4,194,304 (4 MB).
         /// The maximum allowable value is <see cref="int.MaxValue"/>, which corresponds to the durable grpc server's receive limit.
         /// </summary>

--- a/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
+++ b/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
@@ -5,8 +5,8 @@
     <AssemblyName>Microsoft.Azure.WebJobs.Extensions.DurableTask</AssemblyName>
     <RootNamespace>Microsoft.Azure.WebJobs.Extensions.DurableTask</RootNamespace>
     <MajorVersion>3</MajorVersion>
-    <MinorVersion>0</MinorVersion>
-    <PatchVersion>4</PatchVersion>
+    <MinorVersion>1</MinorVersion>
+    <PatchVersion>0</PatchVersion>
     <VersionPrefix>$(MajorVersion).$(MinorVersion).$(PatchVersion)</VersionPrefix>
     <FileVersion>$(MajorVersion).$(MinorVersion).$(PatchVersion)</FileVersion>
     <AssemblyVersion>$(MajorVersion).0.0.0</AssemblyVersion>

--- a/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
+++ b/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
@@ -5,8 +5,8 @@
     <AssemblyName>Microsoft.Azure.WebJobs.Extensions.DurableTask</AssemblyName>
     <RootNamespace>Microsoft.Azure.WebJobs.Extensions.DurableTask</RootNamespace>
     <MajorVersion>3</MajorVersion>
-    <MinorVersion>1</MinorVersion>
-    <PatchVersion>0</PatchVersion>
+    <MinorVersion>0</MinorVersion>
+    <PatchVersion>4</PatchVersion>
     <VersionPrefix>$(MajorVersion).$(MinorVersion).$(PatchVersion)</VersionPrefix>
     <FileVersion>$(MajorVersion).$(MinorVersion).$(PatchVersion)</FileVersion>
     <AssemblyVersion>$(MajorVersion).0.0.0</AssemblyVersion>

--- a/src/Worker.Extensions.DurableTask/AssemblyInfo.cs
+++ b/src/Worker.Extensions.DurableTask/AssemblyInfo.cs
@@ -5,5 +5,5 @@ using System.Runtime.CompilerServices;
 using Microsoft.Azure.Functions.Worker.Extensions.Abstractions;
 
 // TODO: Find a way to generate this dynamically at build-time
-[assembly: ExtensionInformation("Microsoft.Azure.WebJobs.Extensions.DurableTask", "3.0.4")]
+[assembly: ExtensionInformation("Microsoft.Azure.WebJobs.Extensions.DurableTask", "3.1.0")]
 [assembly: InternalsVisibleTo("Worker.Extensions.DurableTask.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100cd1dabd5a893b40e75dc901fe7293db4a3caf9cd4d3e3ed6178d49cd476969abe74a9e0b7f4a0bb15edca48758155d35a4f05e6e852fff1b319d103b39ba04acbadd278c2753627c95e1f6f6582425374b92f51cca3deb0d2aab9de3ecda7753900a31f70a236f163006beefffe282888f85e3c76d1205ec7dfef7fa472a17b1")]

--- a/src/Worker.Extensions.DurableTask/AssemblyInfo.cs
+++ b/src/Worker.Extensions.DurableTask/AssemblyInfo.cs
@@ -5,5 +5,5 @@ using System.Runtime.CompilerServices;
 using Microsoft.Azure.Functions.Worker.Extensions.Abstractions;
 
 // TODO: Find a way to generate this dynamically at build-time
-[assembly: ExtensionInformation("Microsoft.Azure.WebJobs.Extensions.DurableTask", "3.1.0")]
+[assembly: ExtensionInformation("Microsoft.Azure.WebJobs.Extensions.DurableTask", "3.0.4")]
 [assembly: InternalsVisibleTo("Worker.Extensions.DurableTask.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100cd1dabd5a893b40e75dc901fe7293db4a3caf9cd4d3e3ed6178d49cd476969abe74a9e0b7f4a0bb15edca48758155d35a4f05e6e852fff1b319d103b39ba04acbadd278c2753627c95e1f6f6582425374b92f51cca3deb0d2aab9de3ecda7753900a31f70a236f163006beefffe282888f85e3c76d1205ec7dfef7fa472a17b1")]

--- a/src/Worker.Extensions.DurableTask/DurableTaskClientConverter.cs
+++ b/src/Worker.Extensions.DurableTask/DurableTaskClientConverter.cs
@@ -47,20 +47,11 @@ internal sealed partial class DurableTaskClientConverter : IInputConverter
                 return new ValueTask<ConversionResult>(ConversionResult.Failed(
                     new InvalidOperationException("Failed to parse the input binding payload data")));
             }
-
-            int? maxGrpcMessageSizeInBytes = null;
-
-            // If maxGrpcMessageSizeInBytes is explicitly set to "null", we preserve it as null.
-            if (!string.Equals(inputData?.maxGrpcMessageSizeInBytes, "null", StringComparison.OrdinalIgnoreCase))
+            
+            if (!int.TryParse(inputData?.maxGrpcMessageSizeInBytes, out int maxGrpcMessageSizeInBytes))
             {
-                // If maxGrpcMessageSizeInBytes is provided but cannot be parsed as an int, the format is invalid.
-                if (!int.TryParse(inputData?.maxGrpcMessageSizeInBytes, out int parsedSize))
-                {
-                    return new ValueTask<ConversionResult>(ConversionResult.Failed(
-                        new InvalidOperationException("Failed to parse maxGrpcMessageSizeInBytes from input binding payload")));
-                }
-
-                maxGrpcMessageSizeInBytes = parsedSize;
+                return new ValueTask<ConversionResult>(ConversionResult.Failed(
+                    new InvalidOperationException("Failed to parse maxGrpcMessageSizeInBytes from input binding payload")));
             }
 
             DurableTaskClient client = this.clientProvider.GetClient(endpoint, inputData?.taskHubName, inputData?.connectionName, maxGrpcMessageSizeInBytes);

--- a/src/Worker.Extensions.DurableTask/DurableTaskClientConverter.cs
+++ b/src/Worker.Extensions.DurableTask/DurableTaskClientConverter.cs
@@ -47,14 +47,8 @@ internal sealed partial class DurableTaskClientConverter : IInputConverter
                 return new ValueTask<ConversionResult>(ConversionResult.Failed(
                     new InvalidOperationException("Failed to parse the input binding payload data")));
             }
-            
-            if (!int.TryParse(inputData?.maxGrpcMessageSizeInBytes, out int maxGrpcMessageSizeInBytes))
-            {
-                return new ValueTask<ConversionResult>(ConversionResult.Failed(
-                    new InvalidOperationException("Failed to parse maxGrpcMessageSizeInBytes from input binding payload")));
-            }
 
-            DurableTaskClient client = this.clientProvider.GetClient(endpoint, inputData?.taskHubName, inputData?.connectionName, maxGrpcMessageSizeInBytes);
+            DurableTaskClient client = this.clientProvider.GetClient(endpoint, inputData?.taskHubName, inputData?.connectionName, inputData?.maxGrpcMessageSizeInBytes);
             client = new FunctionsDurableTaskClient(client, inputData!.requiredQueryStringParameters, inputData!.httpBaseUrl);
             return new ValueTask<ConversionResult>(ConversionResult.Success(client));
         }
@@ -68,5 +62,5 @@ internal sealed partial class DurableTaskClientConverter : IInputConverter
     }
 
     // Serializer is case-sensitive and incoming JSON properties are camel-cased.
-    private record DurableClientInputData(string rpcBaseUrl, string taskHubName, string connectionName, string requiredQueryStringParameters, string httpBaseUrl, string maxGrpcMessageSizeInBytes);
+    private record DurableClientInputData(string rpcBaseUrl, string taskHubName, string connectionName, string requiredQueryStringParameters, string httpBaseUrl, int maxGrpcMessageSizeInBytes);
 }

--- a/src/Worker.Extensions.DurableTask/DurableTaskClientConverter.cs
+++ b/src/Worker.Extensions.DurableTask/DurableTaskClientConverter.cs
@@ -48,7 +48,22 @@ internal sealed partial class DurableTaskClientConverter : IInputConverter
                     new InvalidOperationException("Failed to parse the input binding payload data")));
             }
 
-            DurableTaskClient client = this.clientProvider.GetClient(endpoint, inputData?.taskHubName, inputData?.connectionName);
+            int? maxGrpcMessageSize = null;
+
+            // If maxGrpcMessageSize is explicitly set to "null", we preserve it as null.
+            if (!string.Equals(inputData?.maxGrpcMessageSize, "null", StringComparison.OrdinalIgnoreCase))
+            {
+                // If maxGrpcMessageSize is provided but cannot be parsed as an int, the format is invalid.
+                if (!int.TryParse(inputData?.maxGrpcMessageSize, out int parsedSize))
+                {
+                    return new ValueTask<ConversionResult>(ConversionResult.Failed(
+                        new InvalidOperationException("Failed to parse maxGrpcMessageSize from input binding payload")));
+                }
+
+                maxGrpcMessageSize = parsedSize;
+            }
+
+            DurableTaskClient client = this.clientProvider.GetClient(endpoint, inputData?.taskHubName, inputData?.connectionName, maxGrpcMessageSize);
             client = new FunctionsDurableTaskClient(client, inputData!.requiredQueryStringParameters, inputData!.httpBaseUrl);
             return new ValueTask<ConversionResult>(ConversionResult.Success(client));
         }
@@ -62,5 +77,5 @@ internal sealed partial class DurableTaskClientConverter : IInputConverter
     }
 
     // Serializer is case-sensitive and incoming JSON properties are camel-cased.
-    private record DurableClientInputData(string rpcBaseUrl, string taskHubName, string connectionName, string requiredQueryStringParameters, string httpBaseUrl);
+    private record DurableClientInputData(string rpcBaseUrl, string taskHubName, string connectionName, string requiredQueryStringParameters, string httpBaseUrl, string maxGrpcMessageSize);
 }

--- a/src/Worker.Extensions.DurableTask/DurableTaskClientConverter.cs
+++ b/src/Worker.Extensions.DurableTask/DurableTaskClientConverter.cs
@@ -48,22 +48,22 @@ internal sealed partial class DurableTaskClientConverter : IInputConverter
                     new InvalidOperationException("Failed to parse the input binding payload data")));
             }
 
-            int? maxGrpcMessageSize = null;
+            int? maxGrpcMessageSizeInBytes = null;
 
-            // If maxGrpcMessageSize is explicitly set to "null", we preserve it as null.
-            if (!string.Equals(inputData?.maxGrpcMessageSize, "null", StringComparison.OrdinalIgnoreCase))
+            // If maxGrpcMessageSizeInBytes is explicitly set to "null", we preserve it as null.
+            if (!string.Equals(inputData?.maxGrpcMessageSizeInBytes, "null", StringComparison.OrdinalIgnoreCase))
             {
-                // If maxGrpcMessageSize is provided but cannot be parsed as an int, the format is invalid.
-                if (!int.TryParse(inputData?.maxGrpcMessageSize, out int parsedSize))
+                // If maxGrpcMessageSizeInBytes is provided but cannot be parsed as an int, the format is invalid.
+                if (!int.TryParse(inputData?.maxGrpcMessageSizeInBytes, out int parsedSize))
                 {
                     return new ValueTask<ConversionResult>(ConversionResult.Failed(
-                        new InvalidOperationException("Failed to parse maxGrpcMessageSize from input binding payload")));
+                        new InvalidOperationException("Failed to parse maxGrpcMessageSizeInBytes from input binding payload")));
                 }
 
-                maxGrpcMessageSize = parsedSize;
+                maxGrpcMessageSizeInBytes = parsedSize;
             }
 
-            DurableTaskClient client = this.clientProvider.GetClient(endpoint, inputData?.taskHubName, inputData?.connectionName, maxGrpcMessageSize);
+            DurableTaskClient client = this.clientProvider.GetClient(endpoint, inputData?.taskHubName, inputData?.connectionName, maxGrpcMessageSizeInBytes);
             client = new FunctionsDurableTaskClient(client, inputData!.requiredQueryStringParameters, inputData!.httpBaseUrl);
             return new ValueTask<ConversionResult>(ConversionResult.Success(client));
         }
@@ -77,5 +77,5 @@ internal sealed partial class DurableTaskClientConverter : IInputConverter
     }
 
     // Serializer is case-sensitive and incoming JSON properties are camel-cased.
-    private record DurableClientInputData(string rpcBaseUrl, string taskHubName, string connectionName, string requiredQueryStringParameters, string httpBaseUrl, string maxGrpcMessageSize);
+    private record DurableClientInputData(string rpcBaseUrl, string taskHubName, string connectionName, string requiredQueryStringParameters, string httpBaseUrl, string maxGrpcMessageSizeInBytes);
 }

--- a/src/Worker.Extensions.DurableTask/FunctionsDurableClientProvider.cs
+++ b/src/Worker.Extensions.DurableTask/FunctionsDurableClientProvider.cs
@@ -93,9 +93,9 @@ internal partial class FunctionsDurableClientProvider : IAsyncDisposable
     /// <param name="endpoint">The gRPC endpoint this client should connect to.</param>
     /// <param name="taskHub">The name of the task hub this client is for.</param>
     /// <param name="connectionName">The name of the connection to use for the task-hub.</param>
-    /// <param name="maxGrpcMessageSize">Max message size in bytes grpc channel can receive.</param>
+    /// <param name="maxGrpcMessageSizeInBytes">Max message size in bytes grpc channel can receive.</param>
     /// <returns>A <see cref="DurableTaskClient" />.</returns>
-    public DurableTaskClient GetClient(Uri endpoint, string? taskHub, string? connectionName, int? maxGrpcMessageSize)
+    public DurableTaskClient GetClient(Uri endpoint, string? taskHub, string? connectionName, int? maxGrpcMessageSizeInBytes)
     {
         this.VerifyNotDisposed();
         this.sync.EnterReadLock();
@@ -133,7 +133,7 @@ internal partial class FunctionsDurableClientProvider : IAsyncDisposable
                 taskHub,
                 connectionName);
 
-            GrpcChannel channel = CreateChannel(key, maxGrpcMessageSize);
+            GrpcChannel channel = CreateChannel(key, maxGrpcMessageSizeInBytes);
             GrpcDurableTaskClientOptions options = new()
             {
                 Channel = channel,

--- a/src/Worker.Extensions.DurableTask/FunctionsDurableClientProvider.cs
+++ b/src/Worker.Extensions.DurableTask/FunctionsDurableClientProvider.cs
@@ -93,8 +93,9 @@ internal partial class FunctionsDurableClientProvider : IAsyncDisposable
     /// <param name="endpoint">The gRPC endpoint this client should connect to.</param>
     /// <param name="taskHub">The name of the task hub this client is for.</param>
     /// <param name="connectionName">The name of the connection to use for the task-hub.</param>
+    /// <param name="maxGrpcMessageSize">Max message size in bytes grpc channel can receive.</param>
     /// <returns>A <see cref="DurableTaskClient" />.</returns>
-    public DurableTaskClient GetClient(Uri endpoint, string? taskHub, string? connectionName)
+    public DurableTaskClient GetClient(Uri endpoint, string? taskHub, string? connectionName, int? maxGrpcMessageSize)
     {
         this.VerifyNotDisposed();
         this.sync.EnterReadLock();
@@ -131,7 +132,8 @@ internal partial class FunctionsDurableClientProvider : IAsyncDisposable
                 endpoint,
                 taskHub,
                 connectionName);
-            GrpcChannel channel = CreateChannel(key);
+
+            GrpcChannel channel = CreateChannel(key, maxGrpcMessageSize);
             GrpcDurableTaskClientOptions options = new()
             {
                 Channel = channel,

--- a/src/Worker.Extensions.DurableTask/FunctionsDurableClientProvider.net6.cs
+++ b/src/Worker.Extensions.DurableTask/FunctionsDurableClientProvider.net6.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.DurableTask;
 
 internal partial class FunctionsDurableClientProvider
 {
-    private static GrpcChannel CreateChannel(ClientKey key)
+    private static GrpcChannel CreateChannel(ClientKey key, int? maxGrpcMessageSize)
     {
         IReadOnlyDictionary<string, string> headers = key.GetHeaders();
         if (headers.Count == 0)
@@ -29,6 +29,7 @@ internal partial class FunctionsDurableClientProvider
         {
             HttpClient = httpClient,
             DisposeHttpClient = true,
+            MaxReceiveMessageSize = maxGrpcMessageSize
         };
 
         return GrpcChannel.ForAddress(key.Address, options);

--- a/src/Worker.Extensions.DurableTask/Worker.Extensions.DurableTask.csproj
+++ b/src/Worker.Extensions.DurableTask/Worker.Extensions.DurableTask.csproj
@@ -29,8 +29,8 @@
     <AssemblyOriginatorKeyFile>..\..\sign.snk</AssemblyOriginatorKeyFile>
 
     <!-- Version information -->
-    <VersionPrefix>1.2.3</VersionPrefix>
-    <VersionSuffix></VersionSuffix>
+    <VersionPrefix>1.3.0</VersionPrefix>
+    <VersionSuffix>grpc0</VersionSuffix>
     <AssemblyVersion>$(VersionPrefix).0</AssemblyVersion>
     <!-- FileVersionRevision is expected to be set by the CI.  -->
     <FileVersion Condition="'$(FileVersionRevision)' != ''">$(VersionPrefix).$(FileVersionRevision)</FileVersion>
@@ -41,6 +41,7 @@
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Abstractions" />
     <PackageReference Include="Microsoft.DurableTask.Client.Grpc" />
     <PackageReference Include="Microsoft.DurableTask.Worker.Grpc" />
+	<PackageReference Include="Grpc.Net.Client" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Worker.Extensions.DurableTask/Worker.Extensions.DurableTask.csproj
+++ b/src/Worker.Extensions.DurableTask/Worker.Extensions.DurableTask.csproj
@@ -29,8 +29,8 @@
     <AssemblyOriginatorKeyFile>..\..\sign.snk</AssemblyOriginatorKeyFile>
 
     <!-- Version information -->
-    <VersionPrefix>1.3.0</VersionPrefix>
-    <VersionSuffix>grpc0</VersionSuffix>
+    <VersionPrefix>1.2.3</VersionPrefix>
+    <VersionSuffix></VersionSuffix>
     <AssemblyVersion>$(VersionPrefix).0</AssemblyVersion>
     <!-- FileVersionRevision is expected to be set by the CI.  -->
     <FileVersion Condition="'$(FileVersionRevision)' != ''">$(VersionPrefix).$(FileVersionRevision)</FileVersion>

--- a/src/Worker.Extensions.DurableTask/Worker.Extensions.DurableTask.csproj
+++ b/src/Worker.Extensions.DurableTask/Worker.Extensions.DurableTask.csproj
@@ -29,7 +29,7 @@
     <AssemblyOriginatorKeyFile>..\..\sign.snk</AssemblyOriginatorKeyFile>
 
     <!-- Version information -->
-    <VersionPrefix>1.2.3</VersionPrefix>
+    <VersionPrefix>1.3.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <AssemblyVersion>$(VersionPrefix).0</AssemblyVersion>
     <!-- FileVersionRevision is expected to be set by the CI.  -->

--- a/src/Worker.Extensions.DurableTask/Worker.Extensions.DurableTask.csproj
+++ b/src/Worker.Extensions.DurableTask/Worker.Extensions.DurableTask.csproj
@@ -41,7 +41,7 @@
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Abstractions" />
     <PackageReference Include="Microsoft.DurableTask.Client.Grpc" />
     <PackageReference Include="Microsoft.DurableTask.Worker.Grpc" />
-	<PackageReference Include="Grpc.Net.Client" />
+    <PackageReference Include="Grpc.Net.Client" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/e2e/Apps/BasicDotNetIsolated/LargeOutputOrchestrator.cs
+++ b/test/e2e/Apps/BasicDotNetIsolated/LargeOutputOrchestrator.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.DurableTask;
@@ -15,7 +18,7 @@ public static class LargeOutputOrchestrator
         [OrchestrationTrigger] TaskOrchestrationContext context)
     {
         ILogger logger = context.CreateReplaySafeLogger(nameof(HelloCities));
-        int size = context.GetInput<int>();
+        int sizeInKB = context.GetInput<int>();
 
         logger.LogInformation("Saying hello.");
         var outputs = new List<string>();
@@ -24,7 +27,7 @@ public static class LargeOutputOrchestrator
 
         // Add a large message to the outputs that exceeds the Azure Storage Queue message size limit (64 KB),
         // so that blobs will be used instead. 
-        outputs.Add(GenerateLargeString(size)); 
+        outputs.Add(GenerateLargeString(sizeInKB));
 
         return outputs;
     }
@@ -44,11 +47,11 @@ public static class LargeOutputOrchestrator
         FunctionContext executionContext)
     {
         ILogger logger = executionContext.GetLogger("LargeOutputOrchestrator_HttpStart");
-        int size = await req.ReadFromJsonAsync<int>();
+        int sizeInKB = await req.ReadFromJsonAsync<int>();
         
         // Function input comes from the request content.
         string instanceId = await client.ScheduleNewOrchestrationInstanceAsync(
-            nameof(LargeOutputOrchestrator), size);
+            nameof(LargeOutputOrchestrator), input: sizeInKB);
 
         logger.LogInformation("Started orchestration with ID = '{instanceId}'.", instanceId);
 
@@ -82,8 +85,8 @@ public static class LargeOutputOrchestrator
         return response;
     }
 
-    static string GenerateLargeString(int size)
+    static string GenerateLargeString(int sizeInKB)
     {
-        return new string('A', size * 1024);
+        return new string('A', sizeInKB * 1024);
     }
 }

--- a/test/e2e/Apps/BasicDotNetIsolated/LargeOutputOrchestrator.cs
+++ b/test/e2e/Apps/BasicDotNetIsolated/LargeOutputOrchestrator.cs
@@ -15,6 +15,8 @@ public static class LargeOutputOrchestrator
         [OrchestrationTrigger] TaskOrchestrationContext context)
     {
         ILogger logger = context.CreateReplaySafeLogger(nameof(HelloCities));
+        int size = context.GetInput<int>();
+
         logger.LogInformation("Saying hello.");
         var outputs = new List<string>();
 
@@ -22,7 +24,7 @@ public static class LargeOutputOrchestrator
 
         // Add a large message to the outputs that exceeds the Azure Storage Queue message size limit (64 KB),
         // so that blobs will be used instead. 
-        outputs.Add(GenerateLargeString(65)); 
+        outputs.Add(GenerateLargeString(size)); 
 
         return outputs;
     }
@@ -42,10 +44,11 @@ public static class LargeOutputOrchestrator
         FunctionContext executionContext)
     {
         ILogger logger = executionContext.GetLogger("LargeOutputOrchestrator_HttpStart");
-
+        int size = await req.ReadFromJsonAsync<int>();
+        
         // Function input comes from the request content.
         string instanceId = await client.ScheduleNewOrchestrationInstanceAsync(
-            nameof(LargeOutputOrchestrator));
+            nameof(LargeOutputOrchestrator), size);
 
         logger.LogInformation("Started orchestration with ID = '{instanceId}'.", instanceId);
 
@@ -61,7 +64,7 @@ public static class LargeOutputOrchestrator
         string id)
     {
         OrchestrationMetadata? metadata = await client.GetInstancesAsync(instanceId: id, getInputsAndOutputs:true);
-        
+   
         HttpResponseData response;
         if (metadata == null)
         {

--- a/test/e2e/Apps/BasicDotNetIsolated/LargeOutputOrchestrator.cs
+++ b/test/e2e/Apps/BasicDotNetIsolated/LargeOutputOrchestrator.cs
@@ -74,7 +74,7 @@ public static class LargeOutputOrchestrator
 
         response = req.CreateResponse(HttpStatusCode.OK);
         response.Headers.Add("Content-Type", "application/json");
-        await response.WriteStringAsync(output.ToString());
+        await response.WriteStringAsync(output!.ToString());
 
         return response;
     }

--- a/test/e2e/Apps/BasicDotNetIsolated/LargeOutputOrchestrator.cs
+++ b/test/e2e/Apps/BasicDotNetIsolated/LargeOutputOrchestrator.cs
@@ -22,7 +22,7 @@ public static class LargeOutputOrchestrator
 
         // Add a large message to the outputs that exceeds the Azure Storage Queue message size limit (64 KB),
         // so that blobs will be used instead. 
-        outputs.Add(new string('A', 65 * 1024));
+        outputs.Add(GenerateLargeString(65)); 
 
         return outputs;
     }
@@ -77,5 +77,10 @@ public static class LargeOutputOrchestrator
         await response.WriteStringAsync(output.ToString());
 
         return response;
+    }
+
+    static string GenerateLargeString(int size)
+    {
+        return new string('A', size * 1024);
     }
 }

--- a/test/e2e/Apps/BasicDotNetIsolated/LargeOutputOrchestrator.cs
+++ b/test/e2e/Apps/BasicDotNetIsolated/LargeOutputOrchestrator.cs
@@ -1,0 +1,81 @@
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
+using Microsoft.DurableTask;
+using Microsoft.DurableTask.Client;
+using Microsoft.Extensions.Logging;
+using System.Net;
+using System.Text.Json.Nodes;
+
+namespace Microsoft.Azure.Durable.Tests.E2E;
+
+public static class LargeOutputOrchestrator
+{
+    [Function(nameof(LargeOutputOrchestrator))]
+    public static async Task<List<string>> RunOrchestrator(
+        [OrchestrationTrigger] TaskOrchestrationContext context)
+    {
+        ILogger logger = context.CreateReplaySafeLogger(nameof(HelloCities));
+        logger.LogInformation("Saying hello.");
+        var outputs = new List<string>();
+
+        outputs.Add(await context.CallActivityAsync<string>(nameof(LargeOutputSayHello), "Tokyo"));
+
+        // Add a large message to the outputs that exceeds the Azure Storage Queue message size limit (64 KB),
+        // so that blobs will be used instead. 
+        outputs.Add(new string('A', 65 * 1024));
+
+        return outputs;
+    }
+
+    [Function(nameof(LargeOutputSayHello))]
+    public static string LargeOutputSayHello([ActivityTrigger] string name, FunctionContext executionContext)
+    {
+        ILogger logger = executionContext.GetLogger("SayHello");
+        logger.LogInformation("Saying hello to {name}.", name);
+        return $"Hello {name}!";
+    }
+
+    [Function("LargeOutputOrchestrator_HttpStart")]
+    public static async Task<HttpResponseData> HttpStart(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", "post")] HttpRequestData req,
+        [DurableClient] DurableTaskClient client,
+        FunctionContext executionContext)
+    {
+        ILogger logger = executionContext.GetLogger("LargeOutputOrchestrator_HttpStart");
+
+        // Function input comes from the request content.
+        string instanceId = await client.ScheduleNewOrchestrationInstanceAsync(
+            nameof(LargeOutputOrchestrator));
+
+        logger.LogInformation("Started orchestration with ID = '{instanceId}'.", instanceId);
+
+        // Returns an HTTP 202 response with an instance management payload.
+        // See https://learn.microsoft.com/azure/azure-functions/durable/durable-functions-http-api#start-orchestration
+        return await client.CreateCheckStatusResponseAsync(req, instanceId);
+    }
+
+    [Function("LargeOutputOrchestrator_Query_Output")]
+    public static async Task<HttpResponseData> QueryOutput(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", "post")] HttpRequestData req,
+        [DurableClient] DurableTaskClient client,
+        string id)
+    {
+        OrchestrationMetadata? metadata = await client.GetInstancesAsync(instanceId: id, getInputsAndOutputs:true);
+        
+        HttpResponseData response;
+        if (metadata == null)
+        {
+            response = req.CreateResponse(HttpStatusCode.NotFound);
+            await response.WriteStringAsync("Orchestration metadata not found.");
+            return response; // Return a 404 response if metadata is null
+        }
+
+        var output = metadata.ReadOutputAs<JsonArray>();
+
+        response = req.CreateResponse(HttpStatusCode.OK);
+        response.Headers.Add("Content-Type", "application/json");
+        await response.WriteStringAsync(output.ToString());
+
+        return response;
+    }
+}

--- a/test/e2e/Tests/E2ETests.csproj
+++ b/test/e2e/Tests/E2ETests.csproj
@@ -5,8 +5,7 @@
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <!-- Only add the following line when you want to locally debug
-    <RunSettingsFilePath>$(MSBuildProjectDirectory)\test.runsettings</RunSettingsFilePath> -->   
+    <RunSettingsFilePath>$(MSBuildProjectDirectory)\test.runsettings</RunSettingsFilePath>  
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/e2e/Tests/E2ETests.csproj
+++ b/test/e2e/Tests/E2ETests.csproj
@@ -5,7 +5,8 @@
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <RunSettingsFilePath>$(MSBuildProjectDirectory)\test.runsettings</RunSettingsFilePath>  
+    <!-- Only add the following line when you want to locally debug
+    <RunSettingsFilePath>$(MSBuildProjectDirectory)\test.runsettings</RunSettingsFilePath> -->
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/e2e/Tests/Fixtures/FixtureHelpers.cs
+++ b/test/e2e/Tests/Fixtures/FixtureHelpers.cs
@@ -106,7 +106,6 @@ public static class FixtureHelpers
                 funcProcess.StartInfo.EnvironmentVariables["AzureFunctionsJobHost__extensions__durableTask__storageProvider__type"] = "azureManaged";
                 funcProcess.StartInfo.EnvironmentVariables["AzureFunctionsJobHost__extensions__durableTask__storageProvider__connectionStringName"] = "DURABLE_TASK_SCHEDULER_CONNECTION_STRING";
                 funcProcess.StartInfo.EnvironmentVariables["DURABLE_TASK_SCHEDULER_CONNECTION_STRING"] = $"Endpoint=http://localhost:8080;Authentication=None";
-                funcProcess.StartInfo.EnvironmentVariables["AzureFunctionsJobHost__extensions__durableTask__MaxGrpcMessageSizeInBytes"] = "6291456";
                 return;
             default:
                 testLogger.LogWarning("Environment variable E2E_TEST_DURABLE_BACKEND not set, tests configured for Azure Storage");

--- a/test/e2e/Tests/Fixtures/FixtureHelpers.cs
+++ b/test/e2e/Tests/Fixtures/FixtureHelpers.cs
@@ -87,6 +87,7 @@ public static class FixtureHelpers
         switch ((durableBackendEnvVarValue ?? "").ToLowerInvariant())
         {
             case "azurestorage":
+                funcProcess.StartInfo.EnvironmentVariables["AzureFunctionsJobHost__extensions__durableTask__MaxGrpcMessageSizeInBytes"] = "5242880";
                 return;
             case "mssql":
                 string? sqlPassword = Environment.GetEnvironmentVariable("MSSQL_SA_PASSWORD");
@@ -98,12 +99,14 @@ public static class FixtureHelpers
                 funcProcess.StartInfo.EnvironmentVariables["AzureFunctionsJobHost__extensions__durableTask__storageProvider__type"] = "mssql";
                 funcProcess.StartInfo.EnvironmentVariables["AzureFunctionsJobHost__extensions__durableTask__storageProvider__connectionStringName"] = "SQLDB_Connection";
                 funcProcess.StartInfo.EnvironmentVariables["AzureFunctionsJobHost__extensions__durableTask__storageProvider__createDatabaseIfNotExists"] = "true";
+                funcProcess.StartInfo.EnvironmentVariables["AzureFunctionsJobHost__extensions__durableTask__MaxGrpcMessageSizeInBytes"] = "5242880";
                 return;
             case "azuremanaged":
                 funcProcess.StartInfo.EnvironmentVariables["AzureFunctionsJobHost__extensions__durableTask__hubName"] = "default";
                 funcProcess.StartInfo.EnvironmentVariables["AzureFunctionsJobHost__extensions__durableTask__storageProvider__type"] = "azureManaged";
                 funcProcess.StartInfo.EnvironmentVariables["AzureFunctionsJobHost__extensions__durableTask__storageProvider__connectionStringName"] = "DURABLE_TASK_SCHEDULER_CONNECTION_STRING";
                 funcProcess.StartInfo.EnvironmentVariables["DURABLE_TASK_SCHEDULER_CONNECTION_STRING"] = $"Endpoint=http://localhost:8080;Authentication=None";
+                funcProcess.StartInfo.EnvironmentVariables["AzureFunctionsJobHost__extensions__durableTask__MaxGrpcMessageSizeInBytes"] = "5242880";
                 return;
             default:
                 testLogger.LogWarning("Environment variable E2E_TEST_DURABLE_BACKEND not set, tests configured for Azure Storage");

--- a/test/e2e/Tests/Fixtures/FixtureHelpers.cs
+++ b/test/e2e/Tests/Fixtures/FixtureHelpers.cs
@@ -87,7 +87,7 @@ public static class FixtureHelpers
         switch ((durableBackendEnvVarValue ?? "").ToLowerInvariant())
         {
             case "azurestorage":
-                funcProcess.StartInfo.EnvironmentVariables["AzureFunctionsJobHost__extensions__durableTask__MaxGrpcMessageSizeInBytes"] = "5242880";
+                funcProcess.StartInfo.EnvironmentVariables["AzureFunctionsJobHost__extensions__durableTask__MaxGrpcMessageSizeInBytes"] = "6291456";
                 return;
             case "mssql":
                 string? sqlPassword = Environment.GetEnvironmentVariable("MSSQL_SA_PASSWORD");
@@ -99,14 +99,14 @@ public static class FixtureHelpers
                 funcProcess.StartInfo.EnvironmentVariables["AzureFunctionsJobHost__extensions__durableTask__storageProvider__type"] = "mssql";
                 funcProcess.StartInfo.EnvironmentVariables["AzureFunctionsJobHost__extensions__durableTask__storageProvider__connectionStringName"] = "SQLDB_Connection";
                 funcProcess.StartInfo.EnvironmentVariables["AzureFunctionsJobHost__extensions__durableTask__storageProvider__createDatabaseIfNotExists"] = "true";
-                funcProcess.StartInfo.EnvironmentVariables["AzureFunctionsJobHost__extensions__durableTask__MaxGrpcMessageSizeInBytes"] = "5242880";
+                funcProcess.StartInfo.EnvironmentVariables["AzureFunctionsJobHost__extensions__durableTask__MaxGrpcMessageSizeInBytes"] = "6291456";
                 return;
             case "azuremanaged":
                 funcProcess.StartInfo.EnvironmentVariables["AzureFunctionsJobHost__extensions__durableTask__hubName"] = "default";
                 funcProcess.StartInfo.EnvironmentVariables["AzureFunctionsJobHost__extensions__durableTask__storageProvider__type"] = "azureManaged";
                 funcProcess.StartInfo.EnvironmentVariables["AzureFunctionsJobHost__extensions__durableTask__storageProvider__connectionStringName"] = "DURABLE_TASK_SCHEDULER_CONNECTION_STRING";
                 funcProcess.StartInfo.EnvironmentVariables["DURABLE_TASK_SCHEDULER_CONNECTION_STRING"] = $"Endpoint=http://localhost:8080;Authentication=None";
-                funcProcess.StartInfo.EnvironmentVariables["AzureFunctionsJobHost__extensions__durableTask__MaxGrpcMessageSizeInBytes"] = "5242880";
+                funcProcess.StartInfo.EnvironmentVariables["AzureFunctionsJobHost__extensions__durableTask__MaxGrpcMessageSizeInBytes"] = "6291456";
                 return;
             default:
                 testLogger.LogWarning("Environment variable E2E_TEST_DURABLE_BACKEND not set, tests configured for Azure Storage");

--- a/test/e2e/Tests/Tests/LargeOutputOrchestratorTests.cs
+++ b/test/e2e/Tests/Tests/LargeOutputOrchestratorTests.cs
@@ -1,0 +1,60 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Net;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.Azure.Durable.Tests.DotnetIsolatedE2E;
+
+[Collection(Constants.FunctionAppCollectionName)]
+public class LargeOutputOrcehstratorTests
+{
+    private readonly FunctionAppFixture _fixture;
+    private readonly ITestOutputHelper _output;
+
+    public LargeOutputOrcehstratorTests(FunctionAppFixture fixture, ITestOutputHelper testOutputHelper)
+    {
+        _fixture = fixture;
+        _fixture.TestLogs.UseTestLogger(testOutputHelper);
+        _output = testOutputHelper;
+    }
+
+    [Fact] 
+    public async Task LargeOutputStatusQueryTests()
+    {
+        using HttpResponseMessage response = await HttpHelpers.InvokeHttpTrigger("LargeOutputOrchestrator_HttpStart", "");
+
+        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
+        string statusQueryGetUri = await DurableHelpers.ParseStatusQueryGetUriAsync(response);
+
+        await DurableHelpers.WaitForOrchestrationStateAsync(statusQueryGetUri, "Completed", 30);
+
+        string largeOutput = new string('A', 65 * 1024);
+
+        var orchestrationDetails = await DurableHelpers.GetRunningOrchestrationDetailsAsync(statusQueryGetUri);
+        
+        // Verify that large orchestrator outputs stored in blob storage are correctly returned via statusQueryGetUri
+        Assert.Contains(largeOutput, orchestrationDetails.Output);
+    }
+
+    [Fact]
+    public async Task DurableTaskClientWriteOutputTests()
+    {
+        using HttpResponseMessage response = await HttpHelpers.InvokeHttpTrigger("LargeOutputOrchestrator_HttpStart", "");
+
+        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
+        string instanceId = await DurableHelpers.ParseInstanceIdAsync(response);
+        string statusQueryGetUri = await DurableHelpers.ParseStatusQueryGetUriAsync(response);
+
+        await DurableHelpers.WaitForOrchestrationStateAsync(statusQueryGetUri, "Completed", 30);
+
+        HttpResponseMessage result = await HttpHelpers.InvokeHttpTrigger("LargeOutputOrchestrator_Query_Output", $"?id={instanceId}");
+        var expectedOutput = new string('A', 65 * 1024);
+
+        // Verify that large orchestrator outputs stored in blob storage are correctly returned when using OrchestrationMetada.ReadOutputAs()
+        Assert.Equal(HttpStatusCode.OK, result.StatusCode);
+        var content = await result.Content.ReadAsStringAsync();
+        Assert.Contains(expectedOutput, content);
+    }
+}

--- a/test/e2e/Tests/Tests/LargeOutputOrchestratorTests.cs
+++ b/test/e2e/Tests/Tests/LargeOutputOrchestratorTests.cs
@@ -21,7 +21,7 @@ public class LargeOutputOrcehstratorTests
     }
 
     [Theory]
-    [InlineData(4608)] // This value exceeds the default 4 MB, as the test sets the threshold to 5 MB.
+    [InlineData(65)] // Provide a value slightly exceeding the 64 KB Azure Queue Storage limit to trigger use of blob storage instead at Azure Storage backend.
     public async Task LargeOutputStatusQueryTests(int size)
     {
         using HttpResponseMessage response = await HttpHelpers.InvokeHttpTriggerWithBody("LargeOutputOrchestrator_HttpStart", size.ToString(), "application/json");
@@ -40,7 +40,8 @@ public class LargeOutputOrcehstratorTests
     }
 
     [Theory]
-    [InlineData(4608)]// This value exceeds the default 4 MB, as the test sets the threshold to 5 MB.
+    [InlineData(4608)]// This value exceeds the default 4 MB, as the test sets the threshold to 6 MB.
+    [Trait("DTS", "Skip")] 
     public async Task DurableTaskClientWriteOutputTests(int size)
     {
         using HttpResponseMessage response = await HttpHelpers.InvokeHttpTriggerWithBody("LargeOutputOrchestrator_HttpStart", size.ToString(), "application/json");

--- a/test/e2e/Tests/Tests/LargeOutputOrchestratorTests.cs
+++ b/test/e2e/Tests/Tests/LargeOutputOrchestratorTests.cs
@@ -22,16 +22,16 @@ public class LargeOutputOrcehstratorTests
 
     [Theory]
     [InlineData(65)] // Provide a value slightly exceeding the 64 KB Azure Queue Storage limit to trigger use of blob storage instead at Azure Storage backend.
-    public async Task LargeOutputStatusQueryTests(int size)
+    public async Task LargeOutputStatusQueryTests(int sizeInKB)
     {
-        using HttpResponseMessage response = await HttpHelpers.InvokeHttpTriggerWithBody("LargeOutputOrchestrator_HttpStart", size.ToString(), "application/json");
+        using HttpResponseMessage response = await HttpHelpers.InvokeHttpTriggerWithBody("LargeOutputOrchestrator_HttpStart", sizeInKB.ToString(), "application/json");
 
         Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
         string statusQueryGetUri = await DurableHelpers.ParseStatusQueryGetUriAsync(response);
 
         await DurableHelpers.WaitForOrchestrationStateAsync(statusQueryGetUri, "Completed", 30);
 
-        string largeOutput = GenerateLargeString(size);
+        string largeOutput = GenerateLargeString(sizeInKB);
 
         var orchestrationDetails = await DurableHelpers.GetRunningOrchestrationDetailsAsync(statusQueryGetUri);
         
@@ -42,9 +42,9 @@ public class LargeOutputOrcehstratorTests
     [Theory]
     [InlineData(4608)]// This value exceeds the default 4 MB, as the test sets the threshold to 6 MB.
     [Trait("DTS", "Skip")] 
-    public async Task DurableTaskClientWriteOutputTests(int size)
+    public async Task DurableTaskClientWriteOutputTests(int sizeInKB)
     {
-        using HttpResponseMessage response = await HttpHelpers.InvokeHttpTriggerWithBody("LargeOutputOrchestrator_HttpStart", size.ToString(), "application/json");
+        using HttpResponseMessage response = await HttpHelpers.InvokeHttpTriggerWithBody("LargeOutputOrchestrator_HttpStart", sizeInKB.ToString(), "application/json");
 
         Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
         string instanceId = await DurableHelpers.ParseInstanceIdAsync(response);
@@ -53,7 +53,7 @@ public class LargeOutputOrcehstratorTests
         await DurableHelpers.WaitForOrchestrationStateAsync(statusQueryGetUri, "Completed", 30);
 
         HttpResponseMessage result = await HttpHelpers.InvokeHttpTrigger("LargeOutputOrchestrator_Query_Output", $"?id={instanceId}");
-        var expectedOutput = GenerateLargeString(size);
+        var expectedOutput = GenerateLargeString(sizeInKB);
 
         // Verify that large orchestrator outputs stored in blob storage are correctly returned when using OrchestrationMetada.ReadOutputAs()
         Assert.Equal(HttpStatusCode.OK, result.StatusCode);
@@ -61,8 +61,8 @@ public class LargeOutputOrcehstratorTests
         Assert.Contains(expectedOutput, content);
     }
 
-    static string GenerateLargeString(int size)
+    static string GenerateLargeString(int sizeInKB)
     {
-        return new string('A', size * 1024);
+        return new string('A', sizeInKB * 1024);
     }
 }

--- a/test/e2e/Tests/Tests/LargeOutputOrchestratorTests.cs
+++ b/test/e2e/Tests/Tests/LargeOutputOrchestratorTests.cs
@@ -8,12 +8,12 @@ using Xunit.Abstractions;
 namespace Microsoft.Azure.Durable.Tests.DotnetIsolatedE2E;
 
 [Collection(Constants.FunctionAppCollectionName)]
-public class LargeOutputOrcehstratorTests
+public class LargeOutputOrchestratorTests
 {
     private readonly FunctionAppFixture _fixture;
     private readonly ITestOutputHelper _output;
 
-    public LargeOutputOrcehstratorTests(FunctionAppFixture fixture, ITestOutputHelper testOutputHelper)
+    public LargeOutputOrchestratorTests(FunctionAppFixture fixture, ITestOutputHelper testOutputHelper)
     {
         _fixture = fixture;
         _fixture.TestLogs.UseTestLogger(testOutputHelper);

--- a/test/e2e/Tests/Tests/LargeOutputOrchestratorTests.cs
+++ b/test/e2e/Tests/Tests/LargeOutputOrchestratorTests.cs
@@ -20,17 +20,18 @@ public class LargeOutputOrcehstratorTests
         _output = testOutputHelper;
     }
 
-    [Fact] 
-    public async Task LargeOutputStatusQueryTests()
+    [Theory]
+    [InlineData(4608)] // This value exceeds the default 4 MB, as the test sets the threshold to 5 MB.
+    public async Task LargeOutputStatusQueryTests(int size)
     {
-        using HttpResponseMessage response = await HttpHelpers.InvokeHttpTrigger("LargeOutputOrchestrator_HttpStart", "");
+        using HttpResponseMessage response = await HttpHelpers.InvokeHttpTriggerWithBody("LargeOutputOrchestrator_HttpStart", size.ToString(), "application/json");
 
         Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
         string statusQueryGetUri = await DurableHelpers.ParseStatusQueryGetUriAsync(response);
 
         await DurableHelpers.WaitForOrchestrationStateAsync(statusQueryGetUri, "Completed", 30);
 
-        string largeOutput = new string('A', 65 * 1024);
+        string largeOutput = GenerateLargeString(size);
 
         var orchestrationDetails = await DurableHelpers.GetRunningOrchestrationDetailsAsync(statusQueryGetUri);
         
@@ -38,10 +39,11 @@ public class LargeOutputOrcehstratorTests
         Assert.Contains(largeOutput, orchestrationDetails.Output);
     }
 
-    [Fact]
-    public async Task DurableTaskClientWriteOutputTests()
+    [Theory]
+    [InlineData(4608)]// This value exceeds the default 4 MB, as the test sets the threshold to 5 MB.
+    public async Task DurableTaskClientWriteOutputTests(int size)
     {
-        using HttpResponseMessage response = await HttpHelpers.InvokeHttpTrigger("LargeOutputOrchestrator_HttpStart", "");
+        using HttpResponseMessage response = await HttpHelpers.InvokeHttpTriggerWithBody("LargeOutputOrchestrator_HttpStart", size.ToString(), "application/json");
 
         Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
         string instanceId = await DurableHelpers.ParseInstanceIdAsync(response);
@@ -50,11 +52,16 @@ public class LargeOutputOrcehstratorTests
         await DurableHelpers.WaitForOrchestrationStateAsync(statusQueryGetUri, "Completed", 30);
 
         HttpResponseMessage result = await HttpHelpers.InvokeHttpTrigger("LargeOutputOrchestrator_Query_Output", $"?id={instanceId}");
-        var expectedOutput = new string('A', 65 * 1024);
+        var expectedOutput = GenerateLargeString(size);
 
         // Verify that large orchestrator outputs stored in blob storage are correctly returned when using OrchestrationMetada.ReadOutputAs()
         Assert.Equal(HttpStatusCode.OK, result.StatusCode);
         var content = await result.Content.ReadAsStringAsync();
         Assert.Contains(expectedOutput, content);
+    }
+
+    static string GenerateLargeString(int size)
+    {
+        return new string('A', size * 1024);
     }
 }


### PR DESCRIPTION
<!-- Start the PR description with some context for the change. -->


<!-- Make sure to delete the markdown comments and the below sections when squash merging -->
### Issue describing the changes in this PR

Fix issue #2831. Also related #3010 

This PR adds a new configuration option in `DurableTaskOptions` that allows customers to specify the gRPC receive message size when using DurableTaskClient in the .NET Isolated model. This provides flexibility when handling large payloads in gRPC responses.

This PR also adds a E2E test with this new configuration. 

### Pull request checklist

* [ ] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)
* [ ] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk
* [ ] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
    * [ ] Otherwise: major or minor version updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
* [ ] My changes **do not** add EventIds to our EventSource logs
    * [ ] Otherwise: Ensure the EventIds are within the supported range in our existing Windows infrastructure. You may validate this with a deployed app's telemetry. You may also extend the range by completing a PR such as [this one](https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files).
* [ ] My changes **should** be added to **v2.x** branch.
    * [ ] Otherwise: This change applies exclusively to WebJobs.Extensions.DurableTask v3.x. It will be retained only in the `dev` and `main` branches and will not be merged into the `v2.x` branch.
