### PR TITLE
Add support to correlate traces from DF Python and JS SDKs

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
+++ b/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
@@ -966,7 +966,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 kind: ActivityKind.Producer,
                 parentContext: parentTraceContext);
 
-            newActivity.Start();
+            if (newActivity != null)
+            {
+                newActivity.Start();
+            }
 
             if (newActivity != null && !string.IsNullOrEmpty(newActivity.Id))
             {

--- a/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
+++ b/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
@@ -893,13 +893,17 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                         OrchestrationInstance = instance,
                     };
 
-                    string traceParent = GetHeaderValueFromHeaders("traceparent", request.Headers);
-                    string traceState = GetHeaderValueFromHeaders("tracestate", request.Headers);
+                    string traceParent = GetHeaderValueFromHeaders("x-client-traceparent", request.Headers);
+                    string traceState = GetHeaderValueFromHeaders("x-client-tracestate", request.Headers);
 
                     if (traceParent != null)
                     {
                         ActivityContext.TryParse(traceParent, traceState, out ActivityContext parentActivityContext);
                         using Activity scheduleOrchestrationActivity = StartActivityForNewOrchestration(executionStartedEvent, parentActivityContext);
+                    }
+                    else
+                    {
+                        using Activity scheduleOrchestrationActivity = StartActivityForNewOrchestration(executionStartedEvent, default);
                     }
 
                     await durableClient.DurabilityProvider.CreateTaskOrchestrationAsync(

--- a/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
+++ b/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
@@ -868,8 +868,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
                 var queryNameValuePairs = request.GetQueryNameValuePairs();
 
-                object input = null;
                 string json = null;
+                object input = null;
 
                 if (request.Content != null && request.Content.Headers?.ContentLength != 0)
                 {
@@ -877,9 +877,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     input = JsonConvert.DeserializeObject(json, this.messageDataConverter.JsonSettings);
                 }
 
-                // string id = await client.StartNewAsync(functionName, instanceId, input);
                 string id = "";
-                if (client is DurableClient durableClient1)
+                if (client is DurableClient durableClient)
                 {
                     var instance = new OrchestrationInstance
                     {
@@ -891,7 +890,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     ExecutionStartedEvent executionStartedEvent = new ExecutionStartedEvent(-1, json)
                     {
                         Name = functionName,
-                        Version = "",
                         OrchestrationInstance = instance,
                     };
 
@@ -904,13 +902,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                         using Activity scheduleOrchestrationActivity = StartActivityForNewOrchestration(executionStartedEvent, parentActivityContext);
                     }
 
-                    await durableClient1.DurabilityProvider.CreateTaskOrchestrationAsync(
+                    await durableClient.DurabilityProvider.CreateTaskOrchestrationAsync(
                         new TaskMessage
                         {
                             Event = executionStartedEvent,
                             OrchestrationInstance = instance,
                         },
                         this.config.Options.OverridableExistingInstanceStates.ToDedupeStatuses());
+
+                    id = instance.InstanceId;
                 }
                 else
                 {
@@ -921,7 +921,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 TryGetTimeSpanQueryParameterValue(queryNameValuePairs, PollingInterval, out TimeSpan? pollingInterval);
 
                 // for durability providers that support poll-free waiting, we override the specified polling interval
-                if (client is DurableClient durableClient && durableClient.DurabilityProvider.SupportsPollFreeWait)
+                if (client is DurableClient pollFreeDurableClient && pollFreeDurableClient.DurabilityProvider.SupportsPollFreeWait)
                 {
                     pollingInterval = timeout;
                 }

--- a/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
+++ b/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
@@ -11,13 +11,15 @@ using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Web;
 using DurableTask.Core;
+using DurableTask.Core.History;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.Routing.Template;
+using Microsoft.Azure.WebJobs.Extensions.DurableTask.Correlation;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using DTCore = DurableTask.Core;
 
 namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 {
@@ -867,13 +869,53 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 var queryNameValuePairs = request.GetQueryNameValuePairs();
 
                 object input = null;
+                string json = null;
+
                 if (request.Content != null && request.Content.Headers?.ContentLength != 0)
                 {
-                    string json = await request.Content.ReadAsStringAsync();
+                    json = await request.Content.ReadAsStringAsync();
                     input = JsonConvert.DeserializeObject(json, this.messageDataConverter.JsonSettings);
                 }
 
-                string id = await client.StartNewAsync(functionName, instanceId, input);
+                // string id = await client.StartNewAsync(functionName, instanceId, input);
+                string id = "";
+                if (client is DurableClient durableClient1)
+                {
+                    var instance = new OrchestrationInstance
+                    {
+                        InstanceId = Guid.NewGuid().ToString("N"),
+                        ExecutionId = Guid.NewGuid().ToString(),
+                    };
+
+                    // Create the ExecutionStartedEvent
+                    ExecutionStartedEvent executionStartedEvent = new ExecutionStartedEvent(-1, json)
+                    {
+                        Name = functionName,
+                        Version = "",
+                        OrchestrationInstance = instance,
+                    };
+
+                    string traceParent = GetHeaderValueFromHeaders("traceparent", request.Headers);
+                    string traceState = GetHeaderValueFromHeaders("tracestate", request.Headers);
+
+                    if (traceParent != null)
+                    {
+                        ActivityContext.TryParse(traceParent, traceState, out ActivityContext parentActivityContext);
+                        using Activity scheduleOrchestrationActivity = StartActivityForNewOrchestration(executionStartedEvent, parentActivityContext);
+                    }
+
+                    await durableClient1.DurabilityProvider.CreateTaskOrchestrationAsync(
+                        new TaskMessage
+                        {
+                            Event = executionStartedEvent,
+                            OrchestrationInstance = instance,
+                        },
+                        this.config.Options.OverridableExistingInstanceStates.ToDedupeStatuses());
+                }
+                else
+                {
+                    id = await client.StartNewAsync(functionName, instanceId, input);
+                }
 
                 TryGetTimeSpanQueryParameterValue(queryNameValuePairs, TimeoutParameter, out TimeSpan? timeout);
                 TryGetTimeSpanQueryParameterValue(queryNameValuePairs, PollingInterval, out TimeSpan? pollingInterval);
@@ -897,6 +939,48 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             {
                 return request.CreateErrorResponse(HttpStatusCode.BadRequest, "Invalid JSON content", e);
             }
+        }
+
+        private static string GetHeaderValueFromHeaders(string header, HttpRequestHeaders headers)
+        {
+            if (headers.TryGetValues(header, out IEnumerable<string> values))
+            {
+                return values.FirstOrDefault();
+            }
+
+            return null;
+        }
+
+        internal static Activity? StartActivityForNewOrchestration(ExecutionStartedEvent startEvent, ActivityContext parentTraceContext)
+        {
+            // Create the Activity Source for the WebJobs extension
+            ActivitySource activitySource = new ActivitySource("WebJobs.Extensions.DurableTask");
+
+            // Start the new activity to represent scheduling the orchestration
+            Activity? newActivity = activitySource.CreateActivity(
+                name: Schema.SpanNames.CreateOrchestration(startEvent.Name, startEvent.Version),
+                kind: ActivityKind.Producer,
+                parentContext: parentTraceContext);
+
+            newActivity?.Start();
+
+            if (newActivity != null && !string.IsNullOrEmpty(newActivity.Id))
+            {
+                newActivity.SetTag(Schema.Task.Type, TraceActivityConstants.Orchestration);
+                newActivity.SetTag(Schema.Task.Name, startEvent.Name);
+                newActivity.SetTag(Schema.Task.InstanceId, startEvent.OrchestrationInstance.InstanceId);
+                newActivity.SetTag(Schema.Task.ExecutionId, startEvent.OrchestrationInstance.ExecutionId);
+
+                if (!string.IsNullOrEmpty(startEvent.Version))
+                {
+                    newActivity.SetTag(Schema.Task.Version, startEvent.Version);
+                }
+
+                // Set the parent trace context for the ExecutionStartedEvent
+                startEvent.ParentTraceContext = new DTCore.Tracing.DistributedTraceContext(newActivity?.Id!, newActivity?.TraceStateString);
+            }
+
+            return newActivity;
         }
 
         private async Task<HttpResponseMessage> HandleRestartInstanceRequestAsync(

--- a/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
+++ b/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
@@ -893,8 +893,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                         OrchestrationInstance = instance,
                     };
 
-                    string traceParent = GetHeaderValueFromHeaders("x-client-traceparent", request.Headers);
-                    string traceState = GetHeaderValueFromHeaders("x-client-tracestate", request.Headers);
+                    string traceParent = GetHeaderValueFromHeaders("traceparent", request.Headers);
+                    string traceState = GetHeaderValueFromHeaders("tracestate", request.Headers);
 
                     if (traceParent != null)
                     {

--- a/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
+++ b/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
@@ -951,18 +951,18 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             return null;
         }
 
-        internal static Activity? StartActivityForNewOrchestration(ExecutionStartedEvent startEvent, ActivityContext parentTraceContext)
+        internal static Activity StartActivityForNewOrchestration(ExecutionStartedEvent startEvent, ActivityContext parentTraceContext)
         {
             // Create the Activity Source for the WebJobs extension
             ActivitySource activitySource = new ActivitySource("WebJobs.Extensions.DurableTask");
 
             // Start the new activity to represent scheduling the orchestration
-            Activity? newActivity = activitySource.CreateActivity(
+            Activity newActivity = activitySource.CreateActivity(
                 name: Schema.SpanNames.CreateOrchestration(startEvent.Name, startEvent.Version),
                 kind: ActivityKind.Producer,
                 parentContext: parentTraceContext);
 
-            newActivity?.Start();
+            newActivity.Start();
 
             if (newActivity != null && !string.IsNullOrEmpty(newActivity.Id))
             {


### PR DESCRIPTION
This PR adds support to consume `traceparent` and `tracestate` header values from the Python and JS OOProc SDKs and then start an orchestration with that information so we can correlate traces from SDKs to DTFx.


### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)
* [ ] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk
* [x] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
    * [ ] Otherwise: major or minor version updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
* [x] My changes **do not** add EventIds to our EventSource logs
    * [ ] Otherwise: Ensure the EventIds are within the supported range in our existing Windows infrastructure. You may validate this with a deployed app's telemetry. You may also extend the range by completing a PR such as [this one](https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files).
* [ ] My changes **should** be added to **v2.x** branch.
    * [ ] Otherwise: This change applies exclusively to WebJobs.Extensions.DurableTask v3.x. It will be retained only in the `dev` and `main` branches and will not be merged into the `v2.x` branch.
