### PR TITLE
Support X-Forwarded-Host and X-Forwarded-Proto headers in Durable Functions HTTP management APIs

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
+++ b/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
@@ -1177,11 +1177,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             if (useForwardedHost && request != null)
             {
                 if (request.Headers.TryGetValues("X-Forwarded-Host", out var forwardedHost))
-                {                    
+                {
                     baseUri = new UriBuilder(baseUri)
                     {
                         Host = forwardedHost.FirstOrDefault(),
-                    }.Uri;                
+                    }.Uri;
                 }
 
                 if (request.Headers.TryGetValues("X-Forwarded-Proto", out var forwardedProto))
@@ -1191,7 +1191,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                         Scheme = forwardedProto.FirstOrDefault(),
                     }.Uri;
                 }
-                
             }
 
             // e.g. http://{host}/runtime/webhooks/durabletask?code={systemKey}
@@ -1204,7 +1203,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             string connection = WebUtility.UrlEncode(connectionName ?? this.config.GetDefaultConnectionName());
 
             string querySuffix = $"{TaskHubParameter}={taskHub}&{ConnectionParameter}={connection}";
-if (!string.IsNullOrEmpty(notificationUri.Query))
+            if (!string.IsNullOrEmpty(notificationUri.Query))
             {
                 // This is expected to include the auto-generated system key for this extension.
                 querySuffix += "&" + notificationUri.Query.TrimStart('?');

--- a/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
+++ b/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
@@ -1204,14 +1204,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             string connection = WebUtility.UrlEncode(connectionName ?? this.config.GetDefaultConnectionName());
 
             string querySuffix = $"{TaskHubParameter}={taskHub}&{ConnectionParameter}={connection}";
-            if (!string.IsNullOrEmpty(notificationUri.Query))
+if (!string.IsNullOrEmpty(notificationUri.Query))
             {
                 // This is expected to include the auto-generated system key for this extension.
-                querySuffix += "&" + noti
-icationUri.Quer
-.TrimStart('?')
-
-   }
+                querySuffix += "&" + notificationUri.Query.TrimStart('?');
+            }
 
             var httpManagementPayload = new HttpManagementPayload
             {

--- a/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
+++ b/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
@@ -1176,18 +1176,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
             if (useForwardedHost && request != null)
             {
-                if (request.Headers.TryGetValues("X-Forwarded-Host", out var forwardedHost))
+                if (request.Headers.TryGetValues("X-Forwarded-Host", out var forwardedHost) &&
+                    request.Headers.TryGetValues("X-Forwarded-Proto", out var forwardedProto))
                 {
                     baseUri = new UriBuilder(baseUri)
                     {
                         Host = forwardedHost.FirstOrDefault(),
-                    }.Uri;
-                }
-
-                if (request.Headers.TryGetValues("X-Forwarded-Proto", out var forwardedProto))
-                {
-                    baseUri = new UriBuilder(baseUri)
-                    {
                         Scheme = forwardedProto.FirstOrDefault(),
                     }.Uri;
                 }

--- a/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
+++ b/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
@@ -1172,6 +1172,26 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             Uri notificationUri = this.GetWebhookUri();
             Uri baseUri = request?.RequestUri ?? notificationUri;
 
+            bool useForwardedHost = this.config.Options.HttpSettings.useForwardedHost;
+
+            if (useForwardedHost && request != null)
+            {
+                if (request.Headers.TryGetValues("X-Forwarded-Host", out var forwardedHost))
+                {
+                    baseUri = new UriBuilder(baseUri)
+                    {
+                        Host = forwardedHost.FirstOrDefault()
+                    }.Uri;
+                }
+                if (request.Headers.TryGetValues("X-Forwarded-Proto", out var forwardedProto))
+                {
+                    baseUri = new UriBuilder(baseUri)
+                    {
+                        Scheme = forwardedProto.FirstOrDefault()
+                    }.Uri;
+                }
+            }
+
             // e.g. http://{host}/runtime/webhooks/durabletask?code={systemKey}
             string hostUrl = baseUri.GetLeftPart(UriPartial.Authority);
             string baseUrl = hostUrl + notificationUri.AbsolutePath.TrimEnd('/');

--- a/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
+++ b/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
@@ -1177,19 +1177,21 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             if (useForwardedHost && request != null)
             {
                 if (request.Headers.TryGetValues("X-Forwarded-Host", out var forwardedHost))
-                {
+                {                    
                     baseUri = new UriBuilder(baseUri)
                     {
-                        Host = forwardedHost.FirstOrDefault()
-                    }.Uri;
+                        Host = forwardedHost.FirstOrDefault(),
+                    }.Uri;                
                 }
+
                 if (request.Headers.TryGetValues("X-Forwarded-Proto", out var forwardedProto))
                 {
                     baseUri = new UriBuilder(baseUri)
                     {
-                        Scheme = forwardedProto.FirstOrDefault()
+                        Scheme = forwardedProto.FirstOrDefault(),
                     }.Uri;
                 }
+                
             }
 
             // e.g. http://{host}/runtime/webhooks/durabletask?code={systemKey}
@@ -1205,8 +1207,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             if (!string.IsNullOrEmpty(notificationUri.Query))
             {
                 // This is expected to include the auto-generated system key for this extension.
-                querySuffix += "&" + notificationUri.Query.TrimStart('?');
-            }
+                querySuffix += "&" + noti
+icationUri.Quer
+.TrimStart('?')
+
+   }
 
             var httpManagementPayload = new HttpManagementPayload
             {

--- a/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
+++ b/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
@@ -1172,7 +1172,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             Uri notificationUri = this.GetWebhookUri();
             Uri baseUri = request?.RequestUri ?? notificationUri;
 
-            bool useForwardedHost = this.config.Options.HttpSettings.useForwardedHost;
+            bool useForwardedHost = this.config.Options.HttpSettings.UseForwardedHost;
 
             if (useForwardedHost && request != null)
             {

--- a/src/WebJobs.Extensions.DurableTask/Options/HttpOptions.cs
+++ b/src/WebJobs.Extensions.DurableTask/Options/HttpOptions.cs
@@ -17,5 +17,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// Gets or sets the default number of milliseconds between async HTTP status poll requests.
         /// </summary>
         public int DefaultAsyncRequestSleepTimeMilliseconds { get; set; } = 30000;
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to use forwarded headers for URL construction.
+        /// </summary>
+        public bool UseForwardedHost { get; set; } = false;
     }
 }

--- a/test/Common/HttpApiHandlerTests.cs
+++ b/test/Common/HttpApiHandlerTests.cs
@@ -1592,12 +1592,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             Assert.Equal(HttpStatusCode.Accepted, actualResponse.StatusCode);
         }
 
-        [Theory]
-        [InlineData("example.com", "https")]
+        [Fact]
         [Trait("Category", PlatformSpecificHelpers.TestCategory)]
-        public void GetClientResponseLinks_Uses_Forwarded_Headers_When_Enabled(
-            string forwardedHost,
-            string forwardedProto)
+        public async void GetClientResponseLinks_Uses_Forwarded_Headers_When_Enabled()
         {
             // Arrange
             var options = new DurableTaskOptions
@@ -1612,28 +1609,33 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 RequestUri = new Uri(TestConstants.RequestUri),
             };
 
-            if (forwardedHost != null)
-            {
-                request.Headers.Add("X-Forwarded-Host", forwardedHost);
-            }
-
-            if (forwardedProto != null)
-            {
-                request.Headers.Add("X-Forwarded-Proto", forwardedProto);
-            }
+            // Add headers that should be used
+            string forwardedHost = "example.com";
+            string forwardedProto = "https";
+            request.Headers.Add("X-Forwarded-Host", forwardedHost);
+            request.Headers.Add("X-Forwarded-Proto", forwardedProto);
 
             // Act
-            var payload = httpApiHandler.CreateHttpManagementPayload(TestConstants.InstanceId, null, null);
+            var httpResponseMessage = httpApiHandler.CreateCheckStatusResponse(
+                request,
+                TestConstants.InstanceId,
+                new DurableClientAttribute
+                {
+                    TaskHub = TestConstants.TaskHub,
+                    ConnectionName = TestConstants.ConnectionName,
+                });
 
             // Assert
-            Assert.StartsWith($"{forwardedProto}://{forwardedHost}", payload.StatusQueryGetUri);
-            Assert.StartsWith($"{forwardedProto}://{forwardedHost}", payload.SendEventPostUri);
-            Assert.StartsWith($"{forwardedProto}://{forwardedHost}", payload.TerminatePostUri);
+            var content = await httpResponseMessage.Content.ReadAsStringAsync();
+            var status = JsonConvert.DeserializeObject<JObject>(content);
+            Assert.StartsWith($"{forwardedProto}://{forwardedHost}", (string)status["statusQueryGetUri"]);
+            Assert.StartsWith($"{forwardedProto}://{forwardedHost}", (string)status["sendEventPostUri"]);
+            Assert.StartsWith($"{forwardedProto}://{forwardedHost}", (string)status["terminatePostUri"]);
         }
 
         [Fact]
         [Trait("Category", PlatformSpecificHelpers.TestCategory)]
-        public void GetClientResponseLinks_Ignores_Forwarded_Headers_When_Disabled()
+        public async void GetClientResponseLinks_Ignores_Forwarded_Headers_When_Disabled()
         {
             // Arrange
             var options = new DurableTaskOptions
@@ -1653,12 +1655,21 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             request.Headers.Add("X-Forwarded-Proto", "https");
 
             // Act
-            var payload = httpApiHandler.CreateHttpManagementPayload(TestConstants.InstanceId, null, null);
+            var httpResponseMessage = httpApiHandler.CreateCheckStatusResponse(
+                request,
+                TestConstants.InstanceId,
+                new DurableClientAttribute
+                {
+                    TaskHub = TestConstants.TaskHub,
+                    ConnectionName = TestConstants.ConnectionName,
+                });
 
             // Assert
-            Assert.StartsWith(TestConstants.RequestUri, payload.StatusQueryGetUri);
-            Assert.StartsWith(TestConstants.RequestUri, payload.SendEventPostUri);
-            Assert.StartsWith(TestConstants.RequestUri, payload.TerminatePostUri);
+            var content = await httpResponseMessage.Content.ReadAsStringAsync();
+            var status = JsonConvert.DeserializeObject<JObject>(content);
+            Assert.StartsWith("http://localhost:7071", (string)status["statusQueryGetUri"]);
+            Assert.StartsWith("http://localhost:7071", (string)status["sendEventPostUri"]);
+            Assert.StartsWith("http://localhost:7071", (string)status["terminatePostUri"]);
         }
 
         private static DurableTaskExtension GetTestExtension()

--- a/test/Common/HttpApiHandlerTests.cs
+++ b/test/Common/HttpApiHandlerTests.cs
@@ -1604,6 +1604,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             var options = new DurableTaskOptions
             {
                 HttpSettings = new HttpOptions { UseForwardedHost = true },
+                WebhookUriProviderOverride = () => new Uri(TestConstants.NotificationUrl),
             };
 
             var httpApiHandler = new HttpApiHandler(GetTestExtension(options), null);
@@ -1623,7 +1624,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             }
 
             // Act
-            var payload = httpApiHandler.CreateHttpManagementPayload("test-instance", null, null);
+            var payload = httpApiHandler.CreateHttpManagementPayload(TestConstants.InstanceId, null, null);
 
             // Assert
             Assert.StartsWith($"{forwardedProto}://{forwardedHost}", payload.StatusQueryGetUri);
@@ -1639,6 +1640,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             var options = new DurableTaskOptions
             {
                 HttpSettings = new HttpOptions { UseForwardedHost = false },
+                WebhookUriProviderOverride = () => new Uri(TestConstants.NotificationUrl),
             };
 
             var httpApiHandler = new HttpApiHandler(GetTestExtension(options), null);
@@ -1652,7 +1654,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             request.Headers.Add("X-Forwarded-Proto", "https");
 
             // Act
-            var payload = httpApiHandler.CreateHttpManagementPayload("test-instance", null, null);
+            var payload = httpApiHandler.CreateHttpManagementPayload(TestConstants.InstanceId, null, null);
 
             // Assert
             Assert.StartsWith(TestConstants.RequestUri, payload.StatusQueryGetUri);

--- a/test/Common/HttpApiHandlerTests.cs
+++ b/test/Common/HttpApiHandlerTests.cs
@@ -1593,21 +1593,17 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         }
 
         [Theory]
-        [InlineData("example.com", null, "example.com", null)]
-        [InlineData("example.com", "https", "example.com", "https")]
-        [InlineData("custom.domain.com", null, "custom.domain.com", null)]
-        [InlineData("custom.domain.com", "https", "custom.domain.com", "https")]
+        [InlineData("example.com", null)]
+        [InlineData("example.com", "https")]
         [Trait("Category", PlatformSpecificHelpers.TestCategory)]
         public void GetClientResponseLinks_Uses_Forwarded_Headers_When_Enabled(
             string forwardedHost,
-            string forwardedProto,
-            string expectedHost,
-            string expectedScheme)
+            string forwardedProto)
         {
             // Arrange
             var options = new DurableTaskOptions
             {
-                HttpSettings = new HttpOptions { UseForwardedHost = true }
+                HttpSettings = new HttpOptions { UseForwardedHost = true },
             };
 
             var httpApiHandler = new HttpApiHandler(GetTestExtension(options), null);
@@ -1627,25 +1623,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             }
 
             // Act
-            HttpManagementPayload payload = httpApiHandler.CreateHttpManagementPayload(
-                TestConstants.InstanceId,
-                TestConstants.TaskHub,
-                TestConstants.ConnectionName,
-                request);
-
-            // Parse the resulting URLs to check host and scheme
-            var statusUri = new Uri(payload.StatusQueryGetUri);
+            var payload = httpApiHandler.CreateHttpManagementPayload("test-instance", null, null);
 
             // Assert
-            if (expectedHost != null)
-            {
-                Assert.Equal(expectedHost, statusUri.Host);
-            }
-            
-            if (expectedScheme != null)
-            {
-                Assert.Equal(expectedScheme, statusUri.Scheme);
-            }
+            Assert.StartsWith($"{forwardedProto}://{forwardedHost}", payload.StatusQueryGetUri);
+            Assert.StartsWith($"{forwardedProto}://{forwardedHost}", payload.SendEventPostUri);
+            Assert.StartsWith($"{forwardedProto}://{forwardedHost}", payload.TerminatePostUri);
         }
 
         [Fact]
@@ -1655,7 +1638,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             // Arrange
             var options = new DurableTaskOptions
             {
-                HttpSettings = new HttpOptions { UseForwardedHost = false }
+                HttpSettings = new HttpOptions { UseForwardedHost = false },
             };
 
             var httpApiHandler = new HttpApiHandler(GetTestExtension(options), null);
@@ -1665,23 +1648,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             };
 
             // Add headers that should be ignored
-            request.Headers.Add("X-Forwarded-Host", "ignored.example.com");
+            request.Headers.Add("X-Forwarded-Host", "example.com");
             request.Headers.Add("X-Forwarded-Proto", "https");
 
             // Act
-            HttpManagementPayload payload = httpApiHandler.CreateHttpManagementPayload(
-                TestConstants.InstanceId,
-                TestConstants.TaskHub,
-                TestConstants.ConnectionName,
-                request);
+            var payload = httpApiHandler.CreateHttpManagementPayload("test-instance", null, null);
 
-            // Parse the resulting URL
-            var originalUri = new Uri(TestConstants.RequestUri);
-            var statusUri = new Uri(payload.StatusQueryGetUri);
-
-            // Assert - should maintain original host and scheme
-            Assert.Equal(originalUri.Host, statusUri.Host);
-            Assert.Equal(originalUri.Scheme, statusUri.Scheme);
+            // Assert
+            Assert.StartsWith(TestConstants.RequestUri, payload.StatusQueryGetUri);
+            Assert.StartsWith(TestConstants.RequestUri, payload.SendEventPostUri);
+            Assert.StartsWith(TestConstants.RequestUri, payload.TerminatePostUri);
         }
 
         private static DurableTaskExtension GetTestExtension()
@@ -1730,11 +1706,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                     new[]
                     {
                         new AzureStorageDurabilityProviderFactory(
-                        new OptionsWrapper<DurableTaskOptions>(options),
-                        new TestStorageServiceClientProviderFactory(),
-                        TestHelpers.GetTestNameResolver(),
-                        NullLoggerFactory.Instance,
-                        TestHelpers.GetMockPlatformInformationService()),
+                            new OptionsWrapper<DurableTaskOptions>(options),
+                            new TestStorageServiceClientProviderFactory(),
+                            TestHelpers.GetTestNameResolver(),
+                            NullLoggerFactory.Instance,
+                            TestHelpers.GetMockPlatformInformationService()),
                     },
                     new TestHostShutdownNotificationService(),
                     new DurableHttpMessageHandlerFactory(),

--- a/test/Common/HttpApiHandlerTests.cs
+++ b/test/Common/HttpApiHandlerTests.cs
@@ -1593,7 +1593,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         }
 
         [Theory]
-        [InlineData("example.com", null)]
         [InlineData("example.com", "https")]
         [Trait("Category", PlatformSpecificHelpers.TestCategory)]
         public void GetClientResponseLinks_Uses_Forwarded_Headers_When_Enabled(

--- a/test/Common/HttpApiHandlerTests.cs
+++ b/test/Common/HttpApiHandlerTests.cs
@@ -1592,6 +1592,98 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             Assert.Equal(HttpStatusCode.Accepted, actualResponse.StatusCode);
         }
 
+        [Theory]
+        [InlineData("example.com", null, "example.com", null)]
+        [InlineData("example.com", "https", "example.com", "https")]
+        [InlineData("custom.domain.com", null, "custom.domain.com", null)]
+        [InlineData("custom.domain.com", "https", "custom.domain.com", "https")]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public void GetClientResponseLinks_Uses_Forwarded_Headers_When_Enabled(
+            string forwardedHost,
+            string forwardedProto,
+            string expectedHost,
+            string expectedScheme)
+        {
+            // Arrange
+            var options = new DurableTaskOptions
+            {
+                HttpSettings = new HttpOptions { UseForwardedHost = true }
+            };
+
+            var httpApiHandler = new HttpApiHandler(GetTestExtension(options), null);
+            var request = new HttpRequestMessage
+            {
+                RequestUri = new Uri(TestConstants.RequestUri),
+            };
+
+            if (forwardedHost != null)
+            {
+                request.Headers.Add("X-Forwarded-Host", forwardedHost);
+            }
+
+            if (forwardedProto != null)
+            {
+                request.Headers.Add("X-Forwarded-Proto", forwardedProto);
+            }
+
+            // Act
+            HttpManagementPayload payload = httpApiHandler.CreateHttpManagementPayload(
+                TestConstants.InstanceId,
+                TestConstants.TaskHub,
+                TestConstants.ConnectionName,
+                request);
+
+            // Parse the resulting URLs to check host and scheme
+            var statusUri = new Uri(payload.StatusQueryGetUri);
+
+            // Assert
+            if (expectedHost != null)
+            {
+                Assert.Equal(expectedHost, statusUri.Host);
+            }
+            
+            if (expectedScheme != null)
+            {
+                Assert.Equal(expectedScheme, statusUri.Scheme);
+            }
+        }
+
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public void GetClientResponseLinks_Ignores_Forwarded_Headers_When_Disabled()
+        {
+            // Arrange
+            var options = new DurableTaskOptions
+            {
+                HttpSettings = new HttpOptions { UseForwardedHost = false }
+            };
+
+            var httpApiHandler = new HttpApiHandler(GetTestExtension(options), null);
+            var request = new HttpRequestMessage
+            {
+                RequestUri = new Uri(TestConstants.RequestUri),
+            };
+
+            // Add headers that should be ignored
+            request.Headers.Add("X-Forwarded-Host", "ignored.example.com");
+            request.Headers.Add("X-Forwarded-Proto", "https");
+
+            // Act
+            HttpManagementPayload payload = httpApiHandler.CreateHttpManagementPayload(
+                TestConstants.InstanceId,
+                TestConstants.TaskHub,
+                TestConstants.ConnectionName,
+                request);
+
+            // Parse the resulting URL
+            var originalUri = new Uri(TestConstants.RequestUri);
+            var statusUri = new Uri(payload.StatusQueryGetUri);
+
+            // Assert - should maintain original host and scheme
+            Assert.Equal(originalUri.Host, statusUri.Host);
+            Assert.Equal(originalUri.Scheme, statusUri.Scheme);
+        }
+
         private static DurableTaskExtension GetTestExtension()
         {
             var options = new DurableTaskOptions();

--- a/test/Common/TestHelpers.cs
+++ b/test/Common/TestHelpers.cs
@@ -394,7 +394,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
         public static string GetStorageConnectionString()
         {
-            return Environment.GetEnvironmentVariable("AzureWebJobsStorage");
+            // Attempt to retrieve the connection string from the environment variable
+            string connectionString = Environment.GetEnvironmentVariable("AzureWebJobsStorage");
+
+            // Provide a fallback connection string for testing if the environment variable is not set
+            return connectionString ?? "UseDevelopmentStorage=true"; // Use Azurite or Azure Storage Emulator
         }
 
         public static Task DeleteTaskHubResources(string testName, bool enableExtendedSessions)


### PR DESCRIPTION
### Context

This PR addresses #1026, which requests proper support for Durable Functions being hosted behind a reverse proxy such as **Azure Front Door** or **Application Gateway**.

By default, Durable Functions generates management URLs (e.g., `statusQueryGetUri`) using the values from the incoming HTTP request. As a result, when Durable Functions is deployed behind a reverse proxy, the request received by Durable Functions often reflects the **internal routing address** (e.g., `myapp.azurewebsites.net`) rather than the **client-facing address** (e.g., `mycustomdomain.com`). This results in management URLs that are not usable by the client.

This PR adds support for honoring `X-Forwarded-Host` and `X-Forwarded-Proto` headers, allowing Durable Functions to return URLs that reflect what the client actually used when making the request.

Without this fix, developers must implement workarounds like [this one](https://github.com/rukasakurai/durable_test_app/pull/7/files) to rewrite management URLs manually.

---

### Issue describing the changes in this PR

Resolves #1026

---

### Description

This PR introduces support for the `X-Forwarded-Host` and `X-Forwarded-Proto` headers in Durable Functions' HTTP response URLs (e.g., `statusQueryGetUri`, `terminatePostUri`).

- A new config setting, `HttpOptions.HttpSettings.UseForwardedHost`, enables this feature.
- When enabled, the management URIs use values from `X-Forwarded-Host` and `X-Forwarded-Proto` instead of the default `Host` and scheme.
- Unit tests have been added to verify behavior under different header scenarios.

---

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)
* [x] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk
* [x] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
    * [ ] Otherwise: major or minor version updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
* [x] My changes **do not** add EventIds to our EventSource logs
    * [ ] Otherwise: Ensure the EventIds are within the supported range in our existing Windows infrastructure. You may validate this with a deployed app's telemetry. You may also extend the range by completing a PR such as [this one](https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files).
* [ ] My changes **should** be added to **v2.x** branch.
    * [x] Otherwise: This change applies exclusively to WebJobs.Extensions.DurableTask v3.x. It will be retained only in the `dev` and `main` branches and will not be merged into the `v2.x` branch.
