### PR TITLE
Fix scaling when using a non-default Azure Storage account

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -7,6 +7,7 @@
 - Fail fast if extendedSessionsEnabled set to 'true' for the worker type that doesn't support extended sessions (https://github.com/Azure/azure-functions-durable-extension/pull/2732).
 - Added an `IFunctionsWorkerApplicationBuilder.ConfigureDurableExtension()` extension method for cases where auto-registration does not work (no source gen running). (#2950)
 - Enable version-aware orchestrations (.NET in-proc) (https://github.com/Azure/azure-functions-durable-extension/pull/3072).
+- Fix scaling when using a non-default Azure Storage account (https://github.com/Azure/azure-functions-durable-extension/pull/3084).
 
 ### Bug Fixes
 

--- a/src/WebJobs.Extensions.DurableTask/Scale/DurableTaskTriggersScaleProvider.cs
+++ b/src/WebJobs.Extensions.DurableTask/Scale/DurableTaskTriggersScaleProvider.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using Grpc.Core;
 using Microsoft.Azure.WebJobs.Host.Scale;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;

--- a/src/WebJobs.Extensions.DurableTask/Scale/DurableTaskTriggersScaleProvider.cs
+++ b/src/WebJobs.Extensions.DurableTask/Scale/DurableTaskTriggersScaleProvider.cs
@@ -42,9 +42,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Scale
             IDurabilityProviderFactory durabilityProviderFactory = this.GetDurabilityProviderFactory();
             DurabilityProvider defaultDurabilityProvider = durabilityProviderFactory.GetDurabilityProvider();
 
-            string? connectionName = durabilityProviderFactory is AzureStorageDurabilityProviderFactory azureStorageDurabilityProviderFactory
-                ? azureStorageDurabilityProviderFactory.DefaultConnectionName
-                : null;
+            string? connectionName = GetConnectionName(durabilityProviderFactory, this.options);
 
             this.targetScaler = ScaleUtils.GetTargetScaler(
                 defaultDurabilityProvider,
@@ -59,6 +57,24 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Scale
                 functionName,
                 connectionName,
                 this.options.HubName);
+        }
+
+        private static string? GetConnectionName(IDurabilityProviderFactory durabilityProviderFactory, DurableTaskOptions options)
+        {
+            if (durabilityProviderFactory is AzureStorageDurabilityProviderFactory azureStorageDurabilityProviderFactory)
+            {
+                var azureStorageOptions = new AzureStorageOptions();
+                if (options != null && options.StorageProvider != null)
+                {
+                    JsonConvert.PopulateObject(JsonConvert.SerializeObject(options.StorageProvider), azureStorageOptions);
+                }
+
+                return azureStorageOptions.ConnectionName ?? azureStorageDurabilityProviderFactory.DefaultConnectionName;
+            }
+            else
+            {
+                return null;
+            }
         }
 
         private void GetOptions(TriggerMetadata triggerMetadata)

--- a/src/WebJobs.Extensions.DurableTask/Scale/DurableTaskTriggersScaleProvider.cs
+++ b/src/WebJobs.Extensions.DurableTask/Scale/DurableTaskTriggersScaleProvider.cs
@@ -42,6 +42,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Scale
             IDurabilityProviderFactory durabilityProviderFactory = this.GetDurabilityProviderFactory();
             DurabilityProvider defaultDurabilityProvider = durabilityProviderFactory.GetDurabilityProvider();
 
+            // Note: `this.options` is populated from the trigger metadata above
             string? connectionName = GetConnectionName(durabilityProviderFactory, this.options);
 
             var logger = loggerFactory.CreateLogger<DurableTaskTriggersScaleProvider>();
@@ -69,7 +70,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Scale
         {
             if (durabilityProviderFactory is AzureStorageDurabilityProviderFactory azureStorageDurabilityProviderFactory)
             {
-                // First, look for the connection name in the options initialized from the trigger metadata
+                // First, look for the connection name in the options
                 var azureStorageOptions = new AzureStorageOptions();
                 if (options != null && options.StorageProvider != null)
                 {

--- a/src/WebJobs.Extensions.DurableTask/Scale/DurableTaskTriggersScaleProvider.cs
+++ b/src/WebJobs.Extensions.DurableTask/Scale/DurableTaskTriggersScaleProvider.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using Grpc.Core;
 using Microsoft.Azure.WebJobs.Host.Scale;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -37,12 +38,18 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Scale
             string functionId = triggerMetadata.FunctionName;
             FunctionName functionName = new FunctionName(functionId);
 
+            var logger = loggerFactory.CreateLogger<DurableTaskTriggersScaleProvider>();
+            var jsonStringMetadata = JsonConvert.SerializeObject(triggerMetadata);
+            logger.LogInformation("Creating DurableTaskTriggersScaleProvider for function {FunctionName}: jsonStringMetadata = '{jsonStringMetadata}'", triggerMetadata.FunctionName, jsonStringMetadata);
+
             this.GetOptions(triggerMetadata);
 
             IDurabilityProviderFactory durabilityProviderFactory = this.GetDurabilityProviderFactory();
             DurabilityProvider defaultDurabilityProvider = durabilityProviderFactory.GetDurabilityProvider();
 
             string? connectionName = GetConnectionName(durabilityProviderFactory, this.options);
+
+            logger.LogInformation("Creating DurableTaskTriggersScaleProvider for function {FunctionName}: connectionName = '{ConnectionName}'", triggerMetadata.FunctionName, connectionName);
 
             this.targetScaler = ScaleUtils.GetTargetScaler(
                 defaultDurabilityProvider,

--- a/src/WebJobs.Extensions.DurableTask/Scale/DurableTaskTriggersScaleProvider.cs
+++ b/src/WebJobs.Extensions.DurableTask/Scale/DurableTaskTriggersScaleProvider.cs
@@ -45,8 +45,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Scale
             string? connectionName = GetConnectionName(durabilityProviderFactory, this.options);
 
             var logger = loggerFactory.CreateLogger<DurableTaskTriggersScaleProvider>();
-            logger.LogInformation("Creating DurableTaskTriggersScaleProvider for function {FunctionName}: connectionName = '{ConnectionName}'",
-                                  triggerMetadata.FunctionName, connectionName);
+            logger.LogInformation(
+                "Creating DurableTaskTriggersScaleProvider for function {FunctionName}: connectionName = '{ConnectionName}'",
+                triggerMetadata.FunctionName,
+                connectionName);
 
             this.targetScaler = ScaleUtils.GetTargetScaler(
                 defaultDurabilityProvider,

--- a/src/WebJobs.Extensions.DurableTask/Scale/DurableTaskTriggersScaleProvider.cs
+++ b/src/WebJobs.Extensions.DurableTask/Scale/DurableTaskTriggersScaleProvider.cs
@@ -38,10 +38,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Scale
             string functionId = triggerMetadata.FunctionName;
             FunctionName functionName = new FunctionName(functionId);
 
-            var logger = loggerFactory.CreateLogger<DurableTaskTriggersScaleProvider>();
-            var jsonStringMetadata = JsonConvert.SerializeObject(triggerMetadata);
-            logger.LogInformation("Creating DurableTaskTriggersScaleProvider for function {FunctionName}: jsonStringMetadata = '{jsonStringMetadata}'", triggerMetadata.FunctionName, jsonStringMetadata);
-
             this.GetOptions(triggerMetadata);
 
             IDurabilityProviderFactory durabilityProviderFactory = this.GetDurabilityProviderFactory();
@@ -49,7 +45,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Scale
 
             string? connectionName = GetConnectionName(durabilityProviderFactory, this.options);
 
-            logger.LogInformation("Creating DurableTaskTriggersScaleProvider for function {FunctionName}: connectionName = '{ConnectionName}'", triggerMetadata.FunctionName, connectionName);
+            var logger = loggerFactory.CreateLogger<DurableTaskTriggersScaleProvider>();
+            logger.LogInformation("Creating DurableTaskTriggersScaleProvider for function {FunctionName}: connectionName = '{ConnectionName}'",
+                                  triggerMetadata.FunctionName, connectionName);
 
             this.targetScaler = ScaleUtils.GetTargetScaler(
                 defaultDurabilityProvider,

--- a/src/WebJobs.Extensions.DurableTask/Scale/DurableTaskTriggersScaleProvider.cs
+++ b/src/WebJobs.Extensions.DurableTask/Scale/DurableTaskTriggersScaleProvider.cs
@@ -68,12 +68,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Scale
         {
             if (durabilityProviderFactory is AzureStorageDurabilityProviderFactory azureStorageDurabilityProviderFactory)
             {
+                // First, look for the connection name in the options initialized from the trigger metadata
                 var azureStorageOptions = new AzureStorageOptions();
                 if (options != null && options.StorageProvider != null)
                 {
                     JsonConvert.PopulateObject(JsonConvert.SerializeObject(options.StorageProvider), azureStorageOptions);
                 }
 
+                // If the connection name is not found in the options, use the default connection name from the factory
                 return azureStorageOptions.ConnectionName ?? azureStorageDurabilityProviderFactory.DefaultConnectionName;
             }
             else


### PR DESCRIPTION
When using a non-default Azure Storage account (specified at `extensions/durableTask/storageProvider/connectionName` in `host.json`), Target-Based Scaling on Consumption and Elastic Premium plans does not work as expected because the Scale Controller tries to use the default Function App connection instead. As a result:

- Durable triggers are not considered when making scaling decisions.
- The default storage account may experience a high volume of transactions trying to find the non-existent task hub, which increases storage cost.

It turns out that, _when running in the Scale Controller context_, the `azureStorageDurabilityProviderFactory.DefaultConnectionName` property (that the `DurableTaskTriggersScaleProvider` constructor relies on to determine the connection name) does not contain the connection name configured in `host.json`, and instead contains the very generic `"Storage"` value. This PR fixes the problem by making the `DurableTaskTriggersScaleProvider` constructor look for this configuration in the `triggerMetadata` parameter instead.

Alternatively, we may want to figure out why `azureStorageDurabilityProviderFactory.DefaultConnectionName` does not contain the expected value to begin with. I don't have an answer or a working fix for that yet, though. The fix proposed in this PR is tested.

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)
* [x] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk
* [x] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
    * [ ] Otherwise: major or minor version updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
* [x] My changes **do not** add EventIds to our EventSource logs
    * [ ] Otherwise: Ensure the EventIds are within the supported range in our existing Windows infrastructure. You may validate this with a deployed app's telemetry. You may also extend the range by completing a PR such as [this one](https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files).
* [ ] My changes **should** be added to **v2.x** branch.
    * [x] Otherwise: This change applies exclusively to WebJobs.Extensions.DurableTask v3.x. It will be retained only in the `dev` and `main` branches and will not be merged into the `v2.x` branch.
