### PR TITLE
Increase DurableTask Dependencies Version for v3.1.0 release

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -15,9 +15,9 @@
     <PackageVersion Include="Grpc.Net.Client" Version="2.70.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.WebApiCompatShim" Version="2.2.0" />
-    <PackageVersion Include="Microsoft.Azure.DurableTask.ApplicationInsights" Version="0.2.0" />
-    <PackageVersion Include="Microsoft.Azure.DurableTask.AzureStorage" Version="2.0.1" />
-    <PackageVersion Include="Microsoft.Azure.DurableTask.Core" Version="3.0.0" />
+    <PackageVersion Include="Microsoft.Azure.DurableTask.ApplicationInsights" Version="0.3.0" />
+    <PackageVersion Include="Microsoft.Azure.DurableTask.AzureStorage" Version="2.1.0" />
+    <PackageVersion Include="Microsoft.Azure.DurableTask.Core" Version="3.1.0" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Core" Version="1.16.0" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Abstractions" Version="1.3.0" />
     <PackageVersion Include="Microsoft.Azure.WebJobs" Version="3.0.39" />
@@ -28,8 +28,8 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="3.9.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.9.0"  />
     <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="3.9.0" />
-    <PackageVersion Include="Microsoft.DurableTask.Client.Grpc" Version="1.8.0" />
-    <PackageVersion Include="Microsoft.DurableTask.Worker.Grpc" Version="1.8.0" />
+    <PackageVersion Include="Microsoft.DurableTask.Client.Grpc" Version="1.10.0" />
+    <PackageVersion Include="Microsoft.DurableTask.Worker.Grpc" Version="1.10.0" />
     <PackageVersion Include="Microsoft.Extensions.Azure" Version="1.7.0" />
     <PackageVersion Include="Microsoft.Extensions.Http" Version="6.0.0" />
     <PackageVersion Include="Microsoft.NET.Sdk.Functions" Version="4.2.0" />
@@ -65,7 +65,7 @@
     <PackageVersion Include="Microsoft.CodeAnalysis" Version="3.9.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="3.9.0" />
     <PackageVersion Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.65" />
-    <PackageVersion Include="Microsoft.DurableTask.Abstractions" Version="1.8.1" />
+    <PackageVersion Include="Microsoft.DurableTask.Abstractions" Version="1.10.0" />
     <PackageVersion Include="Microsoft.DurableTask.Generators" Version="1.0.0-preview.1" />
     <PackageVersion Include="Microsoft.DurableTask.SqlServer.AzureFunctions" Version="1.5.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="9.0.0" />

--- a/src/WebJobs.Extensions.DurableTask/AzureStorageDurabilityProviderFactory.cs
+++ b/src/WebJobs.Extensions.DurableTask/AzureStorageDurabilityProviderFactory.cs
@@ -219,6 +219,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 EntityMessageReorderWindowInMinutes = this.options.EntityMessageReorderWindowInMinutes,
                 MaxEntityOperationBatchSize = this.options.MaxEntityOperationBatchSize,
                 AllowReplayingTerminalInstances = this.azureStorageOptions.AllowReplayingTerminalInstances,
+                PartitionTableOperationTimeout = this.azureStorageOptions.PartitionTableOperationTimeout,
             };
 
             if (this.inConsumption)

--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableOrchestrationContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableOrchestrationContext.cs
@@ -292,7 +292,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 }
 
                 this.IncrementActionsOrThrowException();
-                await this.InnerContext.CreateTimer(fireAt, CancellationToken.None);
+                await this.InnerContext.CreateTimer(fireAt: fireAt, state: true, cancelToken: CancellationToken.None);
 
                 DurableHttpRequest durableAsyncHttpRequest = this.CreateLocationPollRequest(
                     req,

--- a/src/WebJobs.Extensions.DurableTask/Options/AzureStorageOptions.cs
+++ b/src/WebJobs.Extensions.DurableTask/Options/AzureStorageOptions.cs
@@ -220,9 +220,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// the orchestrator in the "Instances table". To force a replay after enabling this configuration, just send any external event to the affected instanceId.
         /// </remarks>
         public bool AllowReplayingTerminalInstances { get; set; } = false;
-        
+
         /// Specifies the timeout (in seconds) for read and write operations on the partition table using PartitionManager V3 (TablePartitionManager) in Azure Storage.
-        /// This helps detect potential silent hangs caused by internal Azure Storage retries. 
+        /// This helps detect potential silent hangs caused by internal Azure Storage retries.
         /// If the timeout is exceeded, a PartitionManagerWarning is logged and the operation is retried.
         /// Default is 2 seconds.
         /// This setting is only effective when <see cref="UseTablePartitionManagement"/> is set to true.

--- a/src/WebJobs.Extensions.DurableTask/Options/AzureStorageOptions.cs
+++ b/src/WebJobs.Extensions.DurableTask/Options/AzureStorageOptions.cs
@@ -220,6 +220,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// the orchestrator in the "Instances table". To force a replay after enabling this configuration, just send any external event to the affected instanceId.
         /// </remarks>
         public bool AllowReplayingTerminalInstances { get; set; } = false;
+        
+        /// Specifies the timeout (in seconds) for read and write operations on the partition table using PartitionManager V3 (TablePartitionManager) in Azure Storage.
+        /// This helps detect potential silent hangs caused by internal Azure Storage retries. 
+        /// If the timeout is exceeded, a PartitionManagerWarning is logged and the operation is retried.
+        /// Default is 2 seconds.
+        /// This setting is only effective when <see cref="UseTablePartitionManagement"/> is set to true.
+        public TimeSpan PartitionTableOperationTimeout { get; set; } = TimeSpan.FromSeconds(2);
 
         /// <summary>
         /// Throws an exception if the provided hub name violates any naming conventions for the storage provider.


### PR DESCRIPTION
<!-- Start the PR description with some context for the change. -->


<!-- Make sure to delete the markdown comments and the below sections when squash merging -->
### Issue describing the changes in this PR

- Update DurabelTask dependencies for the WebJob.Extensions.DurableTask v3.1.0 and Worker.Extensions.DurableTask v1.3.0 release. 
`Microsoft.Azure.DurableTask.ApplicationInsights` from 0.2.0 to 0.3.0
`Microsoft.Azure.DurableTask.AzureStorage` from 2.0.1 to 2.1.0
`Microsoft.Azure.DurableTask.Core` from 3.0.0 to 3.1.0
`Microsoft.DurableTask.Client.Grpc` from 1.8.0 to 1.10.0
`Microsoft.DurableTask.Worker.Grpc` from 1.8.0 to 1.10.0
`Microsoft.DurableTask.Abstractions` from 1.8.1 to 1.10.0
- Add new settings `PartitionTableOperationTimeout` for Partition Managed v3 potential hangs, related PR https://github.com/Azure/durabletask/pull/1200
- Update the timer in `CallHttpAsync` due to our changes at https://github.com/Azure/durabletask/pull/1183

### Pull request checklist

* [ ] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)
* [ ] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk
* [ ] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
    * [ ] Otherwise: major or minor version updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
* [ ] My changes **do not** add EventIds to our EventSource logs
    * [ ] Otherwise: Ensure the EventIds are within the supported range in our existing Windows infrastructure. You may validate this with a deployed app's telemetry. You may also extend the range by completing a PR such as [this one](https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files).
* [ ] My changes **should** be added to **v2.x** branch.
    * [ ] Otherwise: This change applies exclusively to WebJobs.Extensions.DurableTask v3.x. It will be retained only in the `dev` and `main` branches and will not be merged into the `v2.x` branch.
