### PR TITLE
Add check for ACA for Linux logging

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -4,17 +4,7 @@
 
 ### New Features
 
-- Fail fast if extendedSessionsEnabled set to 'true' for the worker type that doesn't support extended sessions (https://github.com/Azure/azure-functions-durable-extension/pull/2732).
-- Added an `IFunctionsWorkerApplicationBuilder.ConfigureDurableExtension()` extension method for cases where auto-registration does not work (no source gen running). (#2950)
-- Enable version-aware orchestrations (.NET in-proc) (https://github.com/Azure/azure-functions-durable-extension/pull/3072).
-- Fix scaling when using a non-default Azure Storage account (https://github.com/Azure/azure-functions-durable-extension/pull/3084).
-
 ### Bug Fixes
-
-- Fix custom connection name not working when using IDurableClientFactory.CreateClient() - contributed by [@hctan](https://github.com/hctan)
-- Made durable extension for isolated worker configuration idempotent, allowing multiple calls safely. (#2950)
-- Fixes a bug with Out of Memory exception handling in Isolated, improving reliability of retries for this case. (part of #3020)
-- Fixed issue with passing null CreatedFrom date in PurgeInstancesFilter to client.PurgeAllInstancesAsync (#3021)
 
 ### Breaking Changes
 
@@ -24,12 +14,10 @@
 
 ### New Features
 
-- Update MaxQueuePollingInterval default for Flex Consumption apps #2953
+- Initialize linux logging in Managed Environment (Azure Container Apps) scenarios. Emit MS_DURABLE_FUNCTION_EVENTS_LOGS in these environments.
 
 ### Bug Fixes
 
 ### Breaking Changes
 
 ### Dependency Updates
-
-- Microsoft.DurableTask.Grpc to 1.3.0

--- a/src/WebJobs.Extensions.DurableTask/DefaultPlatformInformation.cs
+++ b/src/WebJobs.Extensions.DurableTask/DefaultPlatformInformation.cs
@@ -64,9 +64,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             return inLinuxDedicated;
         }
 
+        private bool IsInAzureContainerApps()
+        {
+            string? managedEnvironmentValue = this.ReadEnviromentVariable("MANAGED_ENVIRONMENT");
+            return !string.IsNullOrEmpty(managedEnvironmentValue);
+        }
+
         public OperatingSystem GetOperatingSystem()
         {
-            if (this.IsInLinuxConsumption() || this.IsInLinuxAppService())
+            if (this.IsInLinuxConsumption() || this.IsInLinuxAppService() || this.IsInAzureContainerApps())
             {
                 return OperatingSystem.Linux;
             }

--- a/src/WebJobs.Extensions.DurableTask/DefaultPlatformInformation.cs
+++ b/src/WebJobs.Extensions.DurableTask/DefaultPlatformInformation.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             return inLinuxDedicated;
         }
 
-        private bool IsManagedAppEnvironment()
+        public bool IsManagedAppEnvironment()
         {
             string? managedEnvironmentValue = this.ReadEnviromentVariable("MANAGED_ENVIRONMENT");
             return !string.IsNullOrEmpty(managedEnvironmentValue);

--- a/src/WebJobs.Extensions.DurableTask/DefaultPlatformInformation.cs
+++ b/src/WebJobs.Extensions.DurableTask/DefaultPlatformInformation.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             return inLinuxDedicated;
         }
 
-        private bool IsInAzureContainerApps()
+        private bool IsManagedAppEnvironment()
         {
             string? managedEnvironmentValue = this.ReadEnviromentVariable("MANAGED_ENVIRONMENT");
             return !string.IsNullOrEmpty(managedEnvironmentValue);
@@ -72,7 +72,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
         public OperatingSystem GetOperatingSystem()
         {
-            if (this.IsInLinuxConsumption() || this.IsInLinuxAppService() || this.IsInAzureContainerApps())
+            if (this.IsInLinuxConsumption() || this.IsInLinuxAppService() || this.IsManagedAppEnvironment())
             {
                 return OperatingSystem.Linux;
             }

--- a/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
@@ -415,6 +415,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         {
             // Determine host platform
             bool inConsumption = this.PlatformInformationService.IsInConsumptionPlan();
+            bool isManagedAppEnvironment = this.PlatformInformationService.IsManagedAppEnvironment();
 
             string tenant = this.PlatformInformationService.GetLinuxTenant();
             string stampName = this.PlatformInformationService.GetLinuxStampName();
@@ -422,7 +423,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
             // in linux consumption, logs are emitted to the console.
             // In other linux plans, they are emitted to a logfile.
-            var linuxLogger = new LinuxAppServiceLogger(writeToConsole: inConsumption, containerName, tenant, stampName);
+            var linuxLogger = new LinuxAppServiceLogger(writeToConsole: inConsumption || isManagedAppEnvironment, containerName, tenant, stampName);
 
             // The logging service for linux works by capturing EventSource messages,
             // which our linux platform does not recognize, and logging them via a

--- a/src/WebJobs.Extensions.DurableTask/IPlatformInformation.cs
+++ b/src/WebJobs.Extensions.DurableTask/IPlatformInformation.cs
@@ -84,9 +84,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         bool IsInConsumptionPlan();
 
         /// <summary>
-        /// Determine the underlying plan is Consumption or not.
+        /// Gets a value indicating whether the application is running in Managed App environment.
         /// </summary>
-        /// <returns> True if the plan is Consumption. Otherwise, False.</returns>
+        /// <returns><see cref="true"/> if running in Managed App environment; otherwise, false.</returns>
         bool IsManagedAppEnvironment();
 
         /// <summary>

--- a/src/WebJobs.Extensions.DurableTask/IPlatformInformation.cs
+++ b/src/WebJobs.Extensions.DurableTask/IPlatformInformation.cs
@@ -84,6 +84,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         bool IsInConsumptionPlan();
 
         /// <summary>
+        /// Determine the underlying plan is Consumption or not.
+        /// </summary>
+        /// <returns> True if the plan is Consumption. Otherwise, False.</returns>
+        bool IsManagedAppEnvironment();
+
+        /// <summary>
         /// Determine the underlying operating system.
         /// </summary>
         /// <returns>An OperatingSystem enum.</returns>

--- a/src/WebJobs.Extensions.DurableTask/LinuxAppServiceLogger.cs
+++ b/src/WebJobs.Extensions.DurableTask/LinuxAppServiceLogger.cs
@@ -62,7 +62,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 this.roleInstance = "App-" + containerName;
             }
 
-            this.tenant = tenant;
+            if (!string.IsNullOrEmpty(tenant))
+            {
+                this.tenant = tenant;
+            }
 
             if (!string.IsNullOrEmpty(stampName))
             {


### PR DESCRIPTION
<!-- Start the PR description with some context for the change. -->
Adds a check that will initialize Linux logging if the environment is detected as Managed Environment (Azure Container Apps). This will lead to telemetry being emitted with the prefix MS_DURABLE_FUNCTION_EVENTS_LOGS for consumption by ACA logging pipelines that will ultimately land in the DurableFunctionsEvents table for internal diagnostics. 

<!-- Make sure to delete the markdown comments and the below sections when squash merging -->
### Issue describing the changes in this PR

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)
* [x] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk
* [x] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
    * [ ] Otherwise: major or minor version updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
* [x] My changes **do not** add EventIds to our EventSource logs
    * [ ] Otherwise: Ensure the EventIds are within the supported range in our existing Windows infrastructure. You may validate this with a deployed app's telemetry. You may also extend the range by completing a PR such as [this one](https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files).
* [ ] My changes **should** be added to **v2.x** branch.
    * [x] Otherwise: This change applies exclusively to WebJobs.Extensions.DurableTask v3.x. It will be retained only in the `dev` and `main` branches and will not be merged into the `v2.x` branch.
