### PR TITLE
Add E2E run for Azure Storage on Windows

### DIFF
--- a/.github/workflows/E2ETest.yml
+++ b/.github/workflows/E2ETest.yml
@@ -3,19 +3,54 @@ name: End to End Test - .NET Isolated/Func V4
 on:
   workflow_dispatch:
   push:
-    branches: [ main, dev, andystaples/add-gh-action-for-e2e-tests ]
+    branches: [ main, dev ]
     paths:
       - 'src/**'
       - 'test/e2e/**'
   pull_request:
-    branches: [ main, dev, andystaples/add-gh-action-for-e2e-tests ]
+    branches: [ main, dev ]
     paths:
       - 'src/**'
       - 'test/e2e/**'
 
 jobs:
-  e2e-azurestorage:
+  e2e-azurestorage-linux:
     runs-on: ubuntu-latest
+    env:
+      E2E_TEST_DURABLE_BACKEND: 'AzureStorage'
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET Core
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: 6.0.x
+
+      - name: Setup .NET Core
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: 8.0.x
+
+      - name: Set up Node.js (needed for Azurite)
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18.x' # Azurite requires at least Node 18
+
+      - name: Setup E2E tests
+        shell: pwsh
+        run: |
+          .\test\e2e\Tests\build-e2e-test.ps1
+
+      - name: Build
+        working-directory: test/e2e/Tests
+        run: dotnet build
+
+      - name: Run E2E tests
+        working-directory: test/e2e/Tests
+        run: dotnet test --filter AzureStorage!=Skip
+
+  e2e-azurestorage-windows:
+    runs-on: windows-latest
     env:
       E2E_TEST_DURABLE_BACKEND: 'AzureStorage'
     steps:


### PR DESCRIPTION
Adds another workflow item to run the E2E suite on Windows for Azure Storage. 
This will help catch platform-specific issues. The reason we cannot immediately add the DTS/MSSQL tests on Windows is due to a known issue with the GitHub Windows runners being incompatible with Linux Docker images. 

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)
* [x] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk
* [x] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
    * [ ] Otherwise: major or minor version updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
* [x] My changes **do not** add EventIds to our EventSource logs
    * [ ] Otherwise: Ensure the EventIds are within the supported range in our existing Windows infrastructure. You may validate this with a deployed app's telemetry. You may also extend the range by completing a PR such as [this one](https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files).
* [ ] My changes **should** be added to **v2.x** branch.
    * [x] Otherwise: This change applies exclusively to WebJobs.Extensions.DurableTask v3.x. It will be retained only in the `dev` and `main` branches and will not be merged into the `v2.x` branch.
