### PR TITLE
Add New Configuration GrpcHttpClientTimeout for DurableTaskClient 

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/Bindings/BindingHelper.cs
+++ b/src/WebJobs.Extensions.DurableTask/Bindings/BindingHelper.cs
@@ -45,6 +45,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     RequiredQueryStringParameters = this.config.HttpApiHandler.GetUniversalQueryStrings(),
                     HttpBaseUrl = this.config.HttpApiHandler.GetBaseUrl(),
                     MaxGrpcMessageSizeInBytes = this.config.Options.MaxGrpcMessageSizeInBytes,
+                    GrpcHttpClientTimeout = JsonConvert.SerializeObject(this.config.Options.GrpcHttpClientTimeout),
                 });
             }
 
@@ -147,6 +148,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             /// </summary>
             [JsonProperty("maxGrpcMessageSizeInBytes")]
             public int? MaxGrpcMessageSizeInBytes { get; set; }
+
+            /// <summary>
+            /// Sets the timeout for the HTTP client used by the gRPC client. If the server does not respond
+            /// within this period, the HTTP request will time out. Default is 100 seconds.
+            /// </summary>
+            [JsonProperty("grpcHttpClientTimeout")]
+            public string? GrpcHttpClientTimeout { get; set; }
         }
     }
 }

--- a/src/WebJobs.Extensions.DurableTask/LocalGrpcListener.cs
+++ b/src/WebJobs.Extensions.DurableTask/LocalGrpcListener.cs
@@ -453,10 +453,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 }
                 catch (RpcException)
                 {
+                    // Rethrow RPC-related exceptions as-is.
                     throw;
                 }
                 catch (Exception ex)
                 {
+                    // Wrap all other exceptions in an RpcException.
                     throw new RpcException(new Status(StatusCode.Internal, $"Failed during purging instances: {ex.Message}"));
                 }
             }

--- a/src/WebJobs.Extensions.DurableTask/LocalGrpcListener.cs
+++ b/src/WebJobs.Extensions.DurableTask/LocalGrpcListener.cs
@@ -432,22 +432,33 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 var purgeClient = (IOrchestrationServicePurgeClient)this.GetDurabilityProvider(context);
 
                 PurgeResult result;
-                switch (request.RequestCase)
+                try
                 {
-                    case P.PurgeInstancesRequest.RequestOneofCase.InstanceId:
-                        result = await purgeClient.PurgeInstanceStateAsync(request.InstanceId);
-                        break;
+                    switch (request.RequestCase)
+                    {
+                        case P.PurgeInstancesRequest.RequestOneofCase.InstanceId:
+                            result = await purgeClient.PurgeInstanceStateAsync(request.InstanceId);
+                            break;
 
-                    case P.PurgeInstancesRequest.RequestOneofCase.PurgeInstanceFilter:
-                        var purgeInstanceFilter = ProtobufUtils.ToPurgeInstanceFilter(request);
-                        result = await purgeClient.PurgeInstanceStateAsync(purgeInstanceFilter);
-                        break;
+                        case P.PurgeInstancesRequest.RequestOneofCase.PurgeInstanceFilter:
+                            var purgeInstanceFilter = ProtobufUtils.ToPurgeInstanceFilter(request);
+                            result = await purgeClient.PurgeInstanceStateAsync(purgeInstanceFilter);
+                            break;
 
-                    default:
-                        throw new ArgumentException($"Unknown purge request type '{request.RequestCase}'.");
+                        default:
+                            throw new RpcException(new Status(StatusCode.InvalidArgument, $"Unknown purge request type '{request.RequestCase}'."));
+                    }
+
+                    return ProtobufUtils.CreatePurgeInstancesResponse(result);
                 }
-
-                return ProtobufUtils.CreatePurgeInstancesResponse(result);
+                catch (RpcException)
+                {
+                    throw;
+                }
+                catch (Exception ex)
+                {
+                    throw new RpcException(new Status(StatusCode.Internal, $"Failed during purging instances: {ex.Message}"));
+                }
             }
 
             public async override Task<P.GetInstanceResponse> WaitForInstanceStart(P.GetInstanceRequest request, ServerCallContext context)

--- a/src/WebJobs.Extensions.DurableTask/Options/DurableTaskOptions.cs
+++ b/src/WebJobs.Extensions.DurableTask/Options/DurableTaskOptions.cs
@@ -249,6 +249,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// </summary>
         public int MaxGrpcMessageSizeInBytes { get; set; } = 4194304;
 
+        /// <summary>
+        /// Sets the timeout for the HTTP client used by the gRPC client, which is used by Durable Funsiont C# Isolated and Java.
+        /// If the server does not respond within this period, the HTTP request will time out.
+        /// Default is 100 seconds.
+        /// This settings only applies when .NET 6 or greater is used.
+        /// </summary>
+        public TimeSpan? GrpcHttpClientTimeout { get; set; } = TimeSpan.FromSeconds(100);
+
         // Used for mocking the lifecycle notification helper.
         internal HttpMessageHandler NotificationHandler { get; set; }
 

--- a/src/WebJobs.Extensions.DurableTask/Options/DurableTaskOptions.cs
+++ b/src/WebJobs.Extensions.DurableTask/Options/DurableTaskOptions.cs
@@ -243,14 +243,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         public AppLeaseOptions AppLeaseOptions { get; set; } = AppLeaseOptions.DefaultOptions;
 
         /// <summary>
-        /// Option to control the receive message size in bytes of the gRPC client, which is used by Durable Funsiont C# Isolated and Java.
+        /// Option to control the receive message size in bytes of the gRPC client, which is used by Durable Functions C# Isolated and Java (and potentially more languages in the future).
+        /// If the server does not respond within this period, the HTTP request will time out.
         /// Defaults to 4,194,304 (4 MB).
         /// The maximum allowable value is <see cref="int.MaxValue"/>, which corresponds to the durable grpc server's receive limit.
         /// </summary>
         public int MaxGrpcMessageSizeInBytes { get; set; } = 4194304;
 
         /// <summary>
-        /// Sets the timeout for the HTTP client used by the gRPC client, which is used by Durable Funsiont C# Isolated and Java.
+        /// Sets the timeout for the HTTP client used by the gRPC client, which is used by Durable Functions C# Isolated and Java (and potentially more languages in the future).
         /// If the server does not respond within this period, the HTTP request will time out.
         /// Default is 100 seconds.
         /// This settings only applies when .NET 6 or greater is used.

--- a/src/Worker.Extensions.DurableTask/DurableTaskClientConverter.cs
+++ b/src/Worker.Extensions.DurableTask/DurableTaskClientConverter.cs
@@ -48,7 +48,11 @@ internal sealed partial class DurableTaskClientConverter : IInputConverter
                     new InvalidOperationException("Failed to parse the input binding payload data")));
             }
 
-            DurableTaskClient client = this.clientProvider.GetClient(endpoint, inputData?.taskHubName, inputData?.connectionName, inputData?.maxGrpcMessageSizeInBytes);
+            // Deserialize the gRPC HTTP client timeout from inputData. If the value is null or missing, default to 100 seconds.
+            TimeSpan grpcHttpClientTimeout = inputData?.GrpcHttpClientTimeout != null
+                                                ? JsonSerializer.Deserialize<TimeSpan>(inputData.GrpcHttpClientTimeout) : TimeSpan.FromSeconds(100);
+
+            DurableTaskClient client = this.clientProvider.GetClient(endpoint, inputData?.taskHubName, inputData?.connectionName, inputData?.maxGrpcMessageSizeInBytes, grpcHttpClientTimeout);
             client = new FunctionsDurableTaskClient(client, inputData!.requiredQueryStringParameters, inputData!.httpBaseUrl);
             return new ValueTask<ConversionResult>(ConversionResult.Success(client));
         }
@@ -68,5 +72,6 @@ internal sealed partial class DurableTaskClientConverter : IInputConverter
         string connectionName,
         string requiredQueryStringParameters,
         string httpBaseUrl,
-        int maxGrpcMessageSizeInBytes);
+        int maxGrpcMessageSizeInBytes,
+        string GrpcHttpClientTimeout);
 }

--- a/src/Worker.Extensions.DurableTask/DurableTaskClientConverter.cs
+++ b/src/Worker.Extensions.DurableTask/DurableTaskClientConverter.cs
@@ -49,8 +49,8 @@ internal sealed partial class DurableTaskClientConverter : IInputConverter
             }
 
             // Deserialize the gRPC HTTP client timeout from inputData. If the value is null or missing, default to 100 seconds.
-            TimeSpan grpcHttpClientTimeout = inputData?.GrpcHttpClientTimeout != null
-                                                ? JsonSerializer.Deserialize<TimeSpan>(inputData.GrpcHttpClientTimeout) : TimeSpan.FromSeconds(100);
+            TimeSpan grpcHttpClientTimeout = inputData?.grpcHttpClientTimeout != null
+                                                ? JsonSerializer.Deserialize<TimeSpan>(inputData.grpcHttpClientTimeout) : TimeSpan.FromSeconds(100);
 
             DurableTaskClient client = this.clientProvider.GetClient(endpoint, inputData?.taskHubName, inputData?.connectionName, inputData?.maxGrpcMessageSizeInBytes, grpcHttpClientTimeout);
             client = new FunctionsDurableTaskClient(client, inputData!.requiredQueryStringParameters, inputData!.httpBaseUrl);
@@ -73,5 +73,5 @@ internal sealed partial class DurableTaskClientConverter : IInputConverter
         string requiredQueryStringParameters,
         string httpBaseUrl,
         int maxGrpcMessageSizeInBytes,
-        string GrpcHttpClientTimeout);
+        string grpcHttpClientTimeout);
 }

--- a/src/Worker.Extensions.DurableTask/FunctionsDurableClientProvider.cs
+++ b/src/Worker.Extensions.DurableTask/FunctionsDurableClientProvider.cs
@@ -94,7 +94,7 @@ internal partial class FunctionsDurableClientProvider : IAsyncDisposable
     /// <param name="taskHub">The name of the task hub this client is for.</param>
     /// <param name="connectionName">The name of the connection to use for the task-hub.</param>
     /// <param name="maxGrpcMessageSizeInBytes">Max message size in bytes grpc channel can receive.</param>
-    /// <param name="grpcHttpClientTimeout">Timeout for the underlying HTTP client used by the gRPC channel.Only applies when .NET 6 or greater is used.</param>
+    /// <param name="grpcHttpClientTimeout">Timeout for the underlying HTTP client used by the gRPC channel. Only applies when .NET 6 or greater is used.</param>
     /// <returns>A <see cref="DurableTaskClient" />.</returns>
     public DurableTaskClient GetClient(Uri endpoint, string? taskHub, string? connectionName, int? maxGrpcMessageSizeInBytes, TimeSpan grpcHttpClientTimeout)
     {

--- a/src/Worker.Extensions.DurableTask/FunctionsDurableClientProvider.cs
+++ b/src/Worker.Extensions.DurableTask/FunctionsDurableClientProvider.cs
@@ -94,8 +94,9 @@ internal partial class FunctionsDurableClientProvider : IAsyncDisposable
     /// <param name="taskHub">The name of the task hub this client is for.</param>
     /// <param name="connectionName">The name of the connection to use for the task-hub.</param>
     /// <param name="maxGrpcMessageSizeInBytes">Max message size in bytes grpc channel can receive.</param>
+    /// <param name="grpcHttpClientTimeout">Timeout for the underlying HTTP client used by the gRPC channel.Only applies when .NET 6 or greater is used.</param>
     /// <returns>A <see cref="DurableTaskClient" />.</returns>
-    public DurableTaskClient GetClient(Uri endpoint, string? taskHub, string? connectionName, int? maxGrpcMessageSizeInBytes)
+    public DurableTaskClient GetClient(Uri endpoint, string? taskHub, string? connectionName, int? maxGrpcMessageSizeInBytes, TimeSpan grpcHttpClientTimeout)
     {
         this.VerifyNotDisposed();
         this.sync.EnterReadLock();
@@ -133,7 +134,7 @@ internal partial class FunctionsDurableClientProvider : IAsyncDisposable
                 taskHub,
                 connectionName);
 
-            GrpcChannel channel = CreateChannel(key, maxGrpcMessageSizeInBytes);
+            GrpcChannel channel = CreateChannel(key, maxGrpcMessageSizeInBytes, grpcHttpClientTimeout);
             GrpcDurableTaskClientOptions options = new()
             {
                 Channel = channel,

--- a/src/Worker.Extensions.DurableTask/FunctionsDurableClientProvider.net6.cs
+++ b/src/Worker.Extensions.DurableTask/FunctionsDurableClientProvider.net6.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 #if NET6_0_OR_GREATER
+using System;
 using System.Collections.Generic;
 using System.Net.Http;
 using Grpc.Net.Client;
@@ -10,7 +11,7 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.DurableTask;
 
 internal partial class FunctionsDurableClientProvider
 {
-    private static GrpcChannel CreateChannel(ClientKey key, int? maxGrpcMessageSize)
+    private static GrpcChannel CreateChannel(ClientKey key, int? maxGrpcMessageSize, TimeSpan grpcHttpClientTimeout)
     {
         IReadOnlyDictionary<string, string> headers = key.GetHeaders();
         if (headers.Count == 0)
@@ -18,8 +19,11 @@ internal partial class FunctionsDurableClientProvider
             return GrpcChannel.ForAddress(key.Address);
         }
 
+        HttpClient httpClient = new()
+        {
+            Timeout = grpcHttpClientTimeout
+        };
 
-        HttpClient httpClient = new();
         foreach (KeyValuePair<string, string> header in headers)
         {
             httpClient.DefaultRequestHeaders.Add(header.Key, header.Value);

--- a/src/Worker.Extensions.DurableTask/FunctionsDurableClientProvider.netstandard.cs
+++ b/src/Worker.Extensions.DurableTask/FunctionsDurableClientProvider.netstandard.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 #if NETSTANDARD
+using System;
 using System.Collections.Generic;
 using Grpc.Core;
 using Grpc.Core.Interceptors;
@@ -10,7 +11,7 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.DurableTask;
 
 internal partial class FunctionsDurableClientProvider
 {
-    private static Channel CreateChannel(ClientKey key, int? maxGrpcMessageSize)
+    private static Channel CreateChannel(ClientKey key, int? maxGrpcMessageSize, TimeSpan grpcHttpClientTimeout)
     {
         IReadOnlyDictionary<string, string> headers = key.GetHeaders();
         string address = $"{key.Address.Host}:{key.Address.Port}";


### PR DESCRIPTION
<!-- Start the PR description with some context for the change. -->


<!-- Make sure to delete the markdown comments and the below sections when squash merging -->
### Issue describing the changes in this PR

resolves https://github.com/orgs/Azure/projects/745/views/1?pane=issue&itemId=99899741&issue=microsoft%7Cdurabletask-dotnet%7C268

Main changes at this PR 
1. Add new configuration `GrpcHttpClientTimeout` which can set the HTTP client timeout at DurableTaskClient. Note that this only applies to .NET 6 or higher
2. Update DurableTaskClient.PurgeInstaceAsync for better grpc exception handling

### Pull request checklist

* [ ] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)
* [ ] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk
* [ ] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
    * [ ] Otherwise: major or minor version updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
* [ ] My changes **do not** add EventIds to our EventSource logs
    * [ ] Otherwise: Ensure the EventIds are within the supported range in our existing Windows infrastructure. You may validate this with a deployed app's telemetry. You may also extend the range by completing a PR such as [this one](https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files).
* [ ] My changes **should** be added to **v2.x** branch.
    * [ ] Otherwise: This change applies exclusively to WebJobs.Extensions.DurableTask v3.x. It will be retained only in the `dev` and `main` branches and will not be merged into the `v2.x` branch.
