### PR TITLE
Update package versions to resolve component governance warnings

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -53,7 +53,7 @@
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.2.0" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="1.2.0" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.18.1"/>
-    <PackageVersion Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="2.6.0" />
+    <PackageVersion Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="2.13.7" />
     <PackageVersion Include="Microsoft.Azure.WebJobs.Extensions.Http" Version="3.2.0" />
     <PackageVersion Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="5.1.3" />
     <PackageVersion Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" Version="3.0.33" />

--- a/samples/Directory.Packages.props
+++ b/samples/Directory.Packages.props
@@ -4,7 +4,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageVersion Include="EntityFramework" Version="6.4.0" />
+    <PackageVersion Include="EntityFramework" Version="6.5.1" />
     <PackageVersion Include="Microsoft.AspNet.WebApi.Client" Version="5.2.7" />
     <PackageVersion Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
     <PackageVersion Include="Microsoft.Azure.WebJobs.Extensions.Http" Version="3.2.0" />

--- a/samples/entitites-csharp/RideSharing/RideSharing/RideSharing.csproj
+++ b/samples/entitites-csharp/RideSharing/RideSharing/RideSharing.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
-    <AzureFunctionsVersion>v2</AzureFunctionsVersion>
+    <TargetFramework>net8.0</TargetFramework>
+    <AzureFunctionsVersion>v4</AzureFunctionsVersion>
   </PropertyGroup>
 
   <!-- We use central package management. For version details, refer to `samples/Directory.packages.props`. -->
@@ -10,7 +10,7 @@
     <None Include="..\README.md" Link="README.md" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" VersionOverride = "2.4.0"/>
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Http" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" />
   </ItemGroup>

--- a/src/DurableFunctions.TypedInterfaces/Example/DurableFunctions.TypedInterfaces.Example.csproj
+++ b/src/DurableFunctions.TypedInterfaces/Example/DurableFunctions.TypedInterfaces.Example.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" />
     <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage" />
     <PackageReference Include="Microsoft.Azure.DurableTask.Core"  />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" VersionOverride = "2.4.3"/>
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions"  />
   </ItemGroup>
 

--- a/src/DurableFunctions.TypedInterfaces/SourceGenerator/DurableFunctions.TypedInterfaces.csproj
+++ b/src/DurableFunctions.TypedInterfaces/SourceGenerator/DurableFunctions.TypedInterfaces.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" VersionOverride="2.5.0" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" PrivateAssets="All">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/test/CodeGen.Example.Test/DurableFunctions.TypedInterfaces.Examples.Test.csproj
+++ b/test/CodeGen.Example.Test/DurableFunctions.TypedInterfaces.Examples.Test.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-	<PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Moq" />
     <PackageReference Include="xunit" />


### PR DESCRIPTION
This PR resolves several component governance issues by updating the package versions in the `Directory.Packages.props` file and updating various .csproj files to use the centrally managed versions instead of using overrides (something we intended to do anyways but I think we hadn't gotten around to doing it)

Reference: [Tracking Loop (Microsoft Internal)](https://microsoft.sharepoint.com/:fl:/r/sites/0b091fb5-5ea3-4b41-88aa-f16a04fde117/Shared%20Documents/LoopAppData/423%20-%20%5BSFI-ES5.2%5D%201ES%20Open%20Source%20Vulnerabilities%20(Operational).loop?d=wc6044128c2d94ec4a0f2a7a8f328baff&csf=1&web=1&e=gOoNIB&nav=cz0lMkZzaXRlcyUyRjBiMDkxZmI1LTVlYTMtNGI0MS04OGFhLWYxNmEwNGZkZTExNyZkPWIlMjFtQl9HamNIMmZVYWkyX2FYY3lYSGIxU3FDZDg0bnJ4Q2tpWnpYV3FmdFVFUnhEekVHOG15VGJvTk9LcDBJbnlhJmY9MDFJRERFVjZSSUlFQ01OV09DWVJIS0I0VkhWRFpTUk9YNyZjPSUyRiZhPUxvb3BBcHAmcD0lNDBmbHVpZHglMkZsb29wLXBhZ2UtY29udGFpbmVyJng9JTdCJTIydyUyMiUzQSUyMlQwUlRVSHh0YVdOeWIzTnZablF1YzJoaGNtVndiMmx1ZEM1amIyMThZaUZ0UWw5SGFtTklNbVpWWVdreVgyRllZM2xZU0dJeFUzRkRaRGcwYm5KNFEydHBXbnBZVjNGbWRGVkZVbmhFZWtWSE9HMTVWR0p2VGs5TGNEQkpibmxoZkRBeFNVUkVSVlkyVlVsU1MwOWFRVkJOUjBkV1ExbEJRelZPU1VOS1Uwb3lTMWclM0QlMjIlMkMlMjJpJTIyJTNBJTIyOTJiYWI0M2UtYWYxYS00MjU3LWExYmUtMjY2ODk0NmRjZDA0JTIyJTdE)

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)
* [x] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk
* [x] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
    * [ ] Otherwise: major or minor version updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
* [x] My changes **do not** add EventIds to our EventSource logs
    * [ ] Otherwise: Ensure the EventIds are within the supported range in our existing Windows infrastructure. You may validate this with a deployed app's telemetry. You may also extend the range by completing a PR such as [this one](https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files).
* [ ] My changes **should** be added to **v2.x** branch.
    * [x] Otherwise: This change applies exclusively to WebJobs.Extensions.DurableTask v3.x. It will be retained only in the `dev` and `main` branches and will not be merged into the `v2.x` branch.
