### PR TITLE
Fix byte[] Input Handling in Activity Functions at .NET Isolated 

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableActivityContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableActivityContext.cs
@@ -131,9 +131,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 return jToken.ToObject(destinationType);
             }
 
-            string serializedValue;
-
-            serializedValue = jToken.ToString(Formatting.None);
+            string serializedValue = jToken.ToString(Formatting.None);
 
             if (this.rawInput) // the "modern" OOProc protocol case
             {

--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableActivityContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableActivityContext.cs
@@ -125,7 +125,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 return value.ToObject(destinationType);
             }
 
-            string serializedValue = jToken.ToString(Formatting.None);
+            // Special case for byte[] inputs in the "modern" OOProc protocol case
+            if (this.rawInput && destinationType.Equals(typeof(byte[])) && jToken is JValue)
+            {
+                return jToken.ToObject(destinationType);
+            }
+
+            string serializedValue;
+
+            serializedValue = jToken.ToString(Formatting.None);
 
             if (this.rawInput) // the "modern" OOProc protocol case
             {

--- a/src/Worker.Extensions.DurableTask/ActivityInputConverter.cs
+++ b/src/Worker.Extensions.DurableTask/ActivityInputConverter.cs
@@ -39,6 +39,11 @@ internal class ActivityInputConverter : IInputConverter
 
         if (context.Source is not string source)
         {
+            if (context.Source is ReadOnlyMemory<byte> memory && context.TargetType == typeof(byte[]))
+            {
+                return new(ConversionResult.Success(memory.ToArray()));
+            }
+
             throw new InvalidOperationException($"Expected converter source to be a string, received {context.Source?.GetType()}.");
         }
 

--- a/test/e2e/Apps/BasicDotNetIsolated/ActivityInputType.cs
+++ b/test/e2e/Apps/BasicDotNetIsolated/ActivityInputType.cs
@@ -93,7 +93,7 @@ public static class ActivityInputType
     {
         if (input.Data?.GetType() != typeof(byte[]))
         {
-            return $"Error: Expected Data to be byte[] but got {input.Data.GetType().Name}";
+            return $"Error: Expected Data to be byte[] but got {input.Data!.GetType().Name}";
         }
 
         return $"Received CustomClass: {{Name: {input.Name}, Age: {input.Age}, Duration: {input.Duration}, Data: [{string.Join(", ", input.Data)}]}}";
@@ -116,22 +116,22 @@ public static class ActivityInputType
     {
         for (int i = 0; i < input.Length; i++)
         {
-            if (input[i].Data.GetType() != typeof(byte[]))
+            if (input[i].Data!.GetType() != typeof(byte[]))
             {
-                return $"Error: Expected Data to be byte[] but got {input[i].Data.GetType().Name}";
+                return $"Error: Expected Data to be byte[] but got {input[i].Data!.GetType().Name}";
             }
         }
 
         var items = input.Select(item => 
-            $"{{Name: {item.Name}, Age: {item.Age}, Duration: {item.Duration}, Data: [{string.Join(", ", item.Data)}]}}");
+            $"{{Name: {item.Name}, Age: {item.Age}, Duration: {item.Duration}, Data: [{string.Join(", ", item.Data!)}]}}");
         return $"Received CustomClass[]: [{string.Join(", ", items)}]";
     }
 }
 
 public class CustomClass
 {
-    public string Name { get; set; }
+    public string? Name { get; set; }
     public int Age { get; set; }
-    public byte[] Data { get; set; }
+    public byte[]? Data { get; set; }
     public TimeSpan Duration { get; set; }
 }

--- a/test/e2e/Apps/BasicDotNetIsolated/ActivityInputType.cs
+++ b/test/e2e/Apps/BasicDotNetIsolated/ActivityInputType.cs
@@ -1,0 +1,137 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Grpc.Core;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
+using Microsoft.DurableTask;
+using Microsoft.DurableTask.Client;
+using Microsoft.Extensions.Logging;
+using System.Net;
+using System.Text;
+using System.Linq;
+
+namespace Microsoft.Azure.Durable.Tests.E2E;
+
+public static class ActivityInputType
+{
+    [Function("ActivityInputType_HttpStart")]
+    public static async Task<HttpResponseData> ActivityInputType_HttpStart(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", "post")] HttpRequestData req,
+        [DurableClient] DurableTaskClient client,
+        FunctionContext executionContext)
+    {
+        ILogger logger = executionContext.GetLogger("ActivityInputType_HttpStart");
+
+        string instanceId = await client.ScheduleNewOrchestrationInstanceAsync(
+            nameof(ActivityInputTypeOrchestrator));
+
+        return await client.CreateCheckStatusResponseAsync(req, instanceId);
+    }
+
+    [Function(nameof(ActivityInputTypeOrchestrator))]
+    public static async Task<List<string>> ActivityInputTypeOrchestrator(
+        [OrchestrationTrigger] TaskOrchestrationContext context)
+    {
+        var output = new List<string>();
+
+        // Test byte array input
+        byte[] byteArrayInput = new byte[] { 1, 2, 3, 4, 5 };
+        output.Add(await context.CallActivityAsync<string>(nameof(ByteArrayInput), byteArrayInput));
+
+        // Test empty byte array input
+        byte[] emptyByteArray = new byte[0];
+        output.Add(await context.CallActivityAsync<string>(nameof(ByteArrayInput), emptyByteArray));
+
+        // Test single byte input
+        byte singleByteInput = 42;
+        output.Add(await context.CallActivityAsync<string>(nameof(SingleByteInput), singleByteInput));
+
+        // Test custom class input
+        var customClassInput = new CustomClass
+        {
+            Name = "Test",
+            Age = 25,
+            Data = new byte[] { 1, 2, 3 },
+            Duration = TimeSpan.FromHours(1)
+        };
+        output.Add(await context.CallActivityAsync<string>(nameof(CustomClassInput), customClassInput));
+
+        // Test int array input
+        int[] intArrayInput = new int[] { 1, 2, 3, 4, 5 };
+        output.Add(await context.CallActivityAsync<string>(nameof(IntArrayInput), intArrayInput));
+
+        // Test string input
+        string stringInput = "Test string input";
+        output.Add(await context.CallActivityAsync<string>(nameof(StringInput), stringInput));
+
+        // Test array of custom class input
+        var complexInput = new CustomClass[]
+        {
+            new CustomClass { Name = "Test1", Age = 25, Data = new byte[] { 1, 2, 3 }, Duration = TimeSpan.FromMinutes(30) },
+            new CustomClass { Name = "Test2", Age = 30, Data = new byte[0], Duration = TimeSpan.FromMinutes(45) }
+        };
+        output.Add(await context.CallActivityAsync<string>(nameof(CustomClassArrayInput), complexInput));
+
+        return output;
+    }
+
+    [Function(nameof(ByteArrayInput))]
+    public static string ByteArrayInput([ActivityTrigger] byte[] input, FunctionContext executionContext)
+    {
+        return $"Received byte[]: [{string.Join(", ", input)}]";
+    }
+
+    [Function(nameof(SingleByteInput))]
+    public static string SingleByteInput([ActivityTrigger] byte input, FunctionContext executionContext)
+    {
+        return $"Received byte: {input}";
+    }
+
+    [Function(nameof(CustomClassInput))]
+    public static string CustomClassInput([ActivityTrigger] CustomClass input, FunctionContext executionContext)
+    {
+        if (input.Data?.GetType() != typeof(byte[]))
+        {
+            return $"Error: Expected Data to be byte[] but got {input.Data.GetType().Name}";
+        }
+
+        return $"Received CustomClass: {{Name: {input.Name}, Age: {input.Age}, Duration: {input.Duration}, Data: [{string.Join(", ", input.Data)}]}}";
+    }
+
+    [Function(nameof(IntArrayInput))]
+    public static string IntArrayInput([ActivityTrigger] int[] input, FunctionContext executionContext)
+    {
+        return $"Received int[]: [{string.Join(", ", input)}]";
+    }
+
+    [Function(nameof(StringInput))]
+    public static string StringInput([ActivityTrigger] string input, FunctionContext executionContext)
+    {
+        return $"Received string: {input}";
+    }
+
+    [Function(nameof(CustomClassArrayInput))]
+    public static string CustomClassArrayInput([ActivityTrigger] CustomClass[] input, FunctionContext executionContext)
+    {
+        for (int i = 0; i < input.Length; i++)
+        {
+            if (input[i].Data.GetType() != typeof(byte[]))
+            {
+                return $"Error: Expected Data to be byte[] but got {input[i].Data.GetType().Name}";
+            }
+        }
+
+        var items = input.Select(item => 
+            $"{{Name: {item.Name}, Age: {item.Age}, Duration: {item.Duration}, Data: [{string.Join(", ", item.Data)}]}}");
+        return $"Received CustomClass[]: [{string.Join(", ", items)}]";
+    }
+}
+
+public class CustomClass
+{
+    public string Name { get; set; }
+    public int Age { get; set; }
+    public byte[] Data { get; set; }
+    public TimeSpan Duration { get; set; }
+}

--- a/test/e2e/Tests/Tests/ActivityInputTypeTests.cs
+++ b/test/e2e/Tests/Tests/ActivityInputTypeTests.cs
@@ -1,0 +1,57 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Net;
+using System.Text.Json;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.Azure.Durable.Tests.DotnetIsolatedE2E;
+
+[Collection(Constants.FunctionAppCollectionName)]
+public class ActivityInputTypeTests
+{
+    private readonly FunctionAppFixture fixture;
+    private readonly ITestOutputHelper output;
+
+    public ActivityInputTypeTests(FunctionAppFixture fixture, ITestOutputHelper testOutputHelper)
+    {
+        this.fixture = fixture;
+        this.fixture.TestLogs.UseTestLogger(testOutputHelper);
+        this.output = testOutputHelper;
+    }
+
+    // This test verifies that different types of inputs can be properly serialized and passed to activity functions.
+    [Fact]
+    public async Task DifferentActivityInputTypeTests()
+    {
+        using HttpResponseMessage response = await HttpHelpers.InvokeHttpTrigger("ActivityInputType_HttpStart", "");
+
+        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
+        string statusQueryGetUri = await DurableHelpers.ParseStatusQueryGetUriAsync(response);
+
+        await DurableHelpers.WaitForOrchestrationStateAsync(statusQueryGetUri, "Completed", 30);
+
+        var orchestrationDetails = await DurableHelpers.GetRunningOrchestrationDetailsAsync(statusQueryGetUri);
+
+        // Verify that all activity functions can successfully receive their corresponding input types:
+        // - byte[]
+        // - empty byte[]
+        // - single byte
+        // - custom class (with byte[] property)
+        // - int[]
+        // - string
+        // - custom class array
+        // This especially verifies that byte[] serialization works correctly without any errors
+        Assert.Contains("Received byte[]: [1, 2, 3, 4, 5]", orchestrationDetails.Output);
+        Assert.Contains("Received byte[]: []", orchestrationDetails.Output);
+        Assert.Contains("Received byte: 42", orchestrationDetails.Output);
+        Assert.Contains("Received CustomClass: {Name: Test, Age: 25, Duration: 01:00:00, Data: [1, 2, 3]}", orchestrationDetails.Output);
+        Assert.Contains("Received int[]: [1, 2, 3, 4, 5]", orchestrationDetails.Output);
+        Assert.Contains("Received string: Test string input", orchestrationDetails.Output);
+        Assert.Contains("Received CustomClass[]: [{Name: Test1, Age: 25, Duration: 00:30:00, Data: [1, 2, 3]}, {Name: Test2, Age: 30, Duration: 00:45:00, Data: []}]", orchestrationDetails.Output);
+
+        // Verify there were no serialization errors, especially for byte[] types
+        Assert.DoesNotContain("Error:", orchestrationDetails.Output);
+    }
+}


### PR DESCRIPTION
<!-- Start the PR description with some context for the change. -->


<!-- Make sure to delete the markdown comments and the below sections when squash merging -->
### Issue describing the changes in this PR

- resolves #2746 by adding a special case when activity inputs are byte[]
- Add e2e test that cover different type inputs of activity functions. 

### Pull request checklist

* [ ] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)
* [ ] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk
* [ ] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
    * [ ] Otherwise: major or minor version updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
* [ ] My changes **do not** add EventIds to our EventSource logs
    * [ ] Otherwise: Ensure the EventIds are within the supported range in our existing Windows infrastructure. You may validate this with a deployed app's telemetry. You may also extend the range by completing a PR such as [this one](https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files).
* [ ] My changes **should** be added to **v2.x** branch.
    * [ ] Otherwise: This change applies exclusively to WebJobs.Extensions.DurableTask v3.x. It will be retained only in the `dev` and `main` branches and will not be merged into the `v2.x` branch.
