### PR TITLE
Add CustomStatus Size Check for OOP model

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/RemoteOrchestratorContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/RemoteOrchestratorContext.cs
@@ -74,8 +74,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
         internal void SetResult(IEnumerable<OrchestratorAction> actions, string customStatus)
         {
-            // Azure Table Storage enforces a 32 KB limit if a property value is a UTF016 encoded string.
-            // We apply a 16 KB limit here to align with the in-process model.
+            // Azure Table Storage enforces a 32 KB limit if a property value is a UTF-16 encoded string.
+            // We apply a 16 KB limit here to align with our in-process model.
             const int maxCustomStatusSizeInKB = 16;
             int? customStatusSizeInKB = customStatus != null ?
                 (int)(Encoding.Unicode.GetByteCount(customStatus) / 1024.0) : null;

--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/RemoteOrchestratorContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/RemoteOrchestratorContext.cs
@@ -186,7 +186,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             this.executionResult = result;
         }
 
-        private void ValidateCustomStatusSize(string customStatus)
+        private static void ValidateCustomStatusSize(string customStatus)
         {
             // Azure Table Storage enforces a 32 KB limit if a property value is a UTF-16 encoded string.
             // We apply a 16 KB limit here to align with our in-process model.

--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/RemoteOrchestratorContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/RemoteOrchestratorContext.cs
@@ -74,7 +74,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
         internal void SetResult(IEnumerable<OrchestratorAction> actions, string customStatus)
         {
-            this.ValidateCustomStatusSize(customStatus);
+            ValidateCustomStatusSize(customStatus);
 
             var result = new OrchestratorExecutionResult
             {

--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/RemoteOrchestratorContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/RemoteOrchestratorContext.cs
@@ -74,17 +74,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
         internal void SetResult(IEnumerable<OrchestratorAction> actions, string customStatus)
         {
-            // Azure Table Storage enforces a 32 KB limit if a property value is a UTF-16 encoded string.
-            // We apply a 16 KB limit here to align with our in-process model.
-            const int maxCustomStatusSizeInKB = 16;
-            int? customStatusSizeInKB = customStatus != null ?
-                (int)(Encoding.Unicode.GetByteCount(customStatus) / 1024.0) : null;
-
-            // If the provided custom status value exceeds 16KB in size, fail the orchestration.
-            if (customStatusSizeInKB.HasValue && customStatusSizeInKB > maxCustomStatusSizeInKB)
-            {
-                throw new ArgumentException($"CustomStatus too large: limit = {maxCustomStatusSizeInKB} KB (UTF-16), actual = {customStatusSizeInKB} KB.");
-            }
+            this.ValidateCustomStatusSize(customStatus);
 
             var result = new OrchestratorExecutionResult
             {
@@ -194,6 +184,21 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             }
 
             this.executionResult = result;
+        }
+
+        private void ValidateCustomStatusSize(string customStatus)
+        {
+            // Azure Table Storage enforces a 32 KB limit if a property value is a UTF-16 encoded string.
+            // We apply a 16 KB limit here to align with our in-process model.
+            const int MaxCustomStatusSizeInKB = 16;
+            double customStatusSizeInKB = customStatus != null ? Encoding.Unicode.GetByteCount(customStatus) / 1024.0 : 0;
+
+            // If the provided custom status value exceeds 16KB in size, fail the orchestration.
+            if (customStatusSizeInKB > MaxCustomStatusSizeInKB)
+            {
+                throw new ArgumentException(
+                    $"CustomStatus is too large: limit = {MaxCustomStatusSizeInKB} KB (UTF-16), actual = {customStatusSizeInKB:N2} KB.");
+            }
         }
     }
 }

--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/RemoteOrchestratorContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/RemoteOrchestratorContext.cs
@@ -3,6 +3,7 @@
 #nullable enable
 using System;
 using System.Collections.Generic;
+using System.Text;
 using DurableTask.Core;
 using DurableTask.Core.Command;
 using DurableTask.Core.Entities;
@@ -73,6 +74,19 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
         internal void SetResult(IEnumerable<OrchestratorAction> actions, string customStatus)
         {
+            // Azure Table Storage enforces a 32 KB limit if a property value is a UTF016 encoded string.
+            // We apply a 16 KB limit here to align with the in-process model.
+            const int maxCustomStatusSizeInKB = 16;
+            int customStatusSizeInKB = (int)(Encoding.Unicode.GetByteCount(customStatus) / 1024.0);
+
+            // If the provided custom status value exceeds 16KB in size, fail the orchestration.
+            if (customStatus != null && customStatusSizeInKB > maxCustomStatusSizeInKB)
+            {
+                string message = $"Custom Status exceeds the maximum allowed size of {maxCustomStatusSizeInKB} KB. Actual size: {customStatusSizeInKB} KB.";
+                this.failure = new OrchestrationFailureException(message);
+                return;
+            }
+
             var result = new OrchestratorExecutionResult
             {
                 CustomStatus = customStatus,

--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/RemoteOrchestratorContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/RemoteOrchestratorContext.cs
@@ -77,14 +77,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             // Azure Table Storage enforces a 32 KB limit if a property value is a UTF016 encoded string.
             // We apply a 16 KB limit here to align with the in-process model.
             const int maxCustomStatusSizeInKB = 16;
-            int customStatusSizeInKB = (int)(Encoding.Unicode.GetByteCount(customStatus) / 1024.0);
+            int? customStatusSizeInKB = customStatus != null ?
+                (int)(Encoding.Unicode.GetByteCount(customStatus) / 1024.0) : null;
 
             // If the provided custom status value exceeds 16KB in size, fail the orchestration.
-            if (customStatus != null && customStatusSizeInKB > maxCustomStatusSizeInKB)
+            if (customStatusSizeInKB.HasValue && customStatusSizeInKB > maxCustomStatusSizeInKB)
             {
-                string message = $"Custom Status exceeds the maximum allowed size of {maxCustomStatusSizeInKB} KB. Actual size: {customStatusSizeInKB} KB.";
-                this.failure = new OrchestrationFailureException(message);
-                return;
+                throw new ArgumentException($"CustomStatus too large: limit = {maxCustomStatusSizeInKB} KB (UTF-16), actual = {customStatusSizeInKB} KB.");
             }
 
             var result = new OrchestratorExecutionResult


### PR DESCRIPTION
<!-- Start the PR description with some context for the change. -->


<!-- Make sure to delete the markdown comments and the below sections when squash merging -->


Resolves #2918

Azure Storage has limit on Table Property, which is 64KB. For string value and UTF16 encoded, it should be 32 KB or less. Larger value will cause error. 

This PR adds a `CustomStatus` size check, so that when it's too large, fail the orchestration instead. The limit size is 16KB with UTF16 encoded to align with in-process model. 

### Pull request checklist

* [ ] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)
* [ ] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk
* [ ] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
    * [ ] Otherwise: major or minor version updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
* [ ] My changes **do not** add EventIds to our EventSource logs
    * [ ] Otherwise: Ensure the EventIds are within the supported range in our existing Windows infrastructure. You may validate this with a deployed app's telemetry. You may also extend the range by completing a PR such as [this one](https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files).
* [ ] My changes **should** be added to **v2.x** branch.
    * [ ] Otherwise: This change applies exclusively to WebJobs.Extensions.DurableTask v3.x. It will be retained only in the `dev` and `main` branches and will not be merged into the `v2.x` branch.
