### PR TITLE
Fix the IOException on gRPC server close

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/LocalGrpcListener.cs
+++ b/src/WebJobs.Extensions.DurableTask/LocalGrpcListener.cs
@@ -5,8 +5,8 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using System.Reflection;
-using System.Reflection.Metadata.Ecma335;
+using System.Linq;
+using System.Net.NetworkInformation;
 using System.Threading;
 using System.Threading.Tasks;
 using DurableTask.Core;
@@ -17,10 +17,8 @@ using DurableTask.Core.Query;
 using DurableTask.Core.Serializing.Internal;
 using Google.Protobuf.WellKnownTypes;
 using Grpc.Core;
-using Microsoft.ApplicationInsights.Extensibility.Implementation;
 using Microsoft.Azure.WebJobs.Extensions.DurableTask.Correlation;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
 using DTCore = DurableTask.Core;
 using P = Microsoft.DurableTask.Protobuf;
 
@@ -65,15 +63,34 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     new ChannelOption(ChannelOptions.MaxSendMessageLength, int.MaxValue),
                 };
 
-                if (this.grpcServer != null)
+                if (this.grpcServer is not null)
                 {
-                    await this.grpcServer.ShutdownAsync();
+                    try
+                    {
+                        await this.grpcServer.ShutdownAsync();
+                    }
+                    catch (IOException)
+                    {
+                        // Do nothing, IOException is a known exception type when trying to shutdown a server
+                        // when its port was already in use
+                    }
+                    catch (Exception ex)
+                    {
+                        this.extension.TraceHelper.ExtensionWarningEvent(
+                            this.extension.Options.HubName,
+                            functionName: string.Empty,
+                            instanceId: string.Empty,
+                            message: $"Unexpected error when closing gRPC server. Exception details: {ex}");
+                    }
                 }
 
                 this.grpcServer = new Server(options);
                 this.grpcServer.Services.Add(P.TaskHubSidecarService.BindService(new TaskHubGrpcServer(this)));
 
-                int listeningPort = numAttempts == 1 ? DefaultPort : this.GetRandomPort();
+                // Attempt to get an unused port. Note that while unlikely, it is possible that the port returned by this method
+                // may be utilized by another process between this call and the gRPC server create below, hence we still need to
+                // guard against port conflicts.
+                int listeningPort = this.GetLikelyAvailablePort();
                 int portBindingResult = this.grpcServer.Ports.Add("localhost", listeningPort, ServerCredentials.Insecure);
                 if (portBindingResult != 0)
                 {
@@ -120,18 +137,28 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             }
         }
 
-        private int GetRandomPort()
+        private int GetLikelyAvailablePort()
         {
-            // Get a random port that has not already been attempted so we don't waste time trying
-            // to listen to a port we know is not free.
+            // Get an available port for use in the gRPC server. Try 4001 first, then select a random open port
+            // in the 30000-31000 range.
+            IPGlobalProperties ipGlobalProperties = IPGlobalProperties.GetIPGlobalProperties();
+            TcpConnectionInformation[] tcpConnInfoArray = ipGlobalProperties.GetActiveTcpConnections();
+            if (!tcpConnInfoArray.Where(x => x.LocalEndPoint.Port == DefaultPort).Any())
+            {
+                return DefaultPort;
+            }
+
             int randomPort;
-            do
+            for (int i = 0; i < 10; i++)
             {
                 randomPort = this.portGenerator.Next(MinPort, MaxPort);
+                if (!tcpConnInfoArray.Where(x => x.LocalEndPoint.Port == randomPort).Any())
+                {
+                    return randomPort;
+                }
             }
-            while (this.attemptedPorts.Contains(randomPort));
 
-            return randomPort;
+            return 0;
         }
 
         private class TaskHubGrpcServer : P.TaskHubSidecarService.TaskHubSidecarServiceBase

--- a/src/WebJobs.Extensions.DurableTask/LocalGrpcListener.cs
+++ b/src/WebJobs.Extensions.DurableTask/LocalGrpcListener.cs
@@ -90,7 +90,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 // Attempt to get an unused port. Note that while unlikely, it is possible that the port returned by this method
                 // may be utilized by another process between this call and the gRPC server create below, hence we still need to
                 // guard against port conflicts.
-                int listeningPort = this.GetLikelyAvailablePort();
+                int listeningPort = this.GetAvailablePort();
                 int portBindingResult = this.grpcServer.Ports.Add("localhost", listeningPort, ServerCredentials.Insecure);
                 if (portBindingResult != 0)
                 {
@@ -137,7 +137,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             }
         }
 
-        private int GetLikelyAvailablePort()
+        private int GetAvailablePort()
         {
             // Get an available port for use in the gRPC server. Try 4001 first, then select a random open port
             // in the 30000-31000 range.
@@ -158,7 +158,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 }
             }
 
-            throw new Exception(string.Format("Failed to get free port for local gRPC server after {0} attempts", numAttempts));
+            throw new InvalidOperationException($"Failed to get free port for local gRPC server after {numAttempts} attempts");
         }
 
         private bool IsTcpPortFree(int port)
@@ -171,6 +171,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             }
             catch (SocketException)
             {
+                this.extension.TraceHelper.ExtensionWarningEvent(
+                    this.extension.Options.HubName,
+                    functionName: string.Empty,
+                    instanceId: string.Empty,
+                    message: $"Starting Durable gRPC server - Port {port} is already in use.");
                 return false;
             }
             finally

--- a/src/WebJobs.Extensions.DurableTask/LocalGrpcListener.cs
+++ b/src/WebJobs.Extensions.DurableTask/LocalGrpcListener.cs
@@ -5,8 +5,8 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using System.Linq;
-using System.Net.NetworkInformation;
+using System.Net;
+using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
 using DurableTask.Core;
@@ -141,24 +141,42 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         {
             // Get an available port for use in the gRPC server. Try 4001 first, then select a random open port
             // in the 30000-31000 range.
-            IPGlobalProperties ipGlobalProperties = IPGlobalProperties.GetIPGlobalProperties();
-            TcpConnectionInformation[] tcpConnInfoArray = ipGlobalProperties.GetActiveTcpConnections();
-            if (!tcpConnInfoArray.Where(x => x.LocalEndPoint.Port == DefaultPort).Any())
+            if (this.IsTcpPortFree(DefaultPort))
             {
                 return DefaultPort;
             }
 
+            int numAttempts = 50;
+
             int randomPort;
-            for (int i = 0; i < 10; i++)
+            for (int i = 0; i < numAttempts; i++)
             {
                 randomPort = this.portGenerator.Next(MinPort, MaxPort);
-                if (!tcpConnInfoArray.Where(x => x.LocalEndPoint.Port == randomPort).Any())
+                if (this.IsTcpPortFree(randomPort))
                 {
                     return randomPort;
                 }
             }
 
-            return 0;
+            throw new Exception(string.Format("Failed to get free port for local gRPC server after {0} attempts", numAttempts));
+        }
+
+        private bool IsTcpPortFree(int port)
+        {
+            var listener = new TcpListener(IPAddress.Loopback, port);
+            try
+            {
+                listener.Start();
+                return true;
+            }
+            catch (SocketException)
+            {
+                return false;
+            }
+            finally
+            {
+                listener.Stop();
+            }
         }
 
         private class TaskHubGrpcServer : P.TaskHubSidecarService.TaskHubSidecarServiceBase


### PR DESCRIPTION
Adds exception checking around the new gRPC server close logic. 
Also attempts to check if a port is in use before using it with the gRPC server, to further prevent issues stemming from opening multiple servers from the same process. 

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)
* [x] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk
* [x] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
    * [ ] Otherwise: major or minor version updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
* [x] My changes **do not** add EventIds to our EventSource logs
    * [ ] Otherwise: Ensure the EventIds are within the supported range in our existing Windows infrastructure. You may validate this with a deployed app's telemetry. You may also extend the range by completing a PR such as [this one](https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files).
* [ ] My changes **should** be added to **v2.x** branch.
    * [x] Otherwise: This change applies exclusively to WebJobs.Extensions.DurableTask v3.x. It will be retained only in the `dev` and `main` branches and will not be merged into the `v2.x` branch.
