### PR TITLE
Update e2e tests to use the latest core tools

### DIFF
--- a/test/Common/HttpApiHandlerTests.cs
+++ b/test/Common/HttpApiHandlerTests.cs
@@ -1594,7 +1594,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
         [Fact]
         [Trait("Category", PlatformSpecificHelpers.TestCategory)]
-        public async void GetClientResponseLinks_Uses_Forwarded_Headers_When_Enabled()
+        public async Task GetClientResponseLinks_Uses_Forwarded_Headers_When_Enabled()
         {
             // Arrange
             var options = new DurableTaskOptions
@@ -1635,7 +1635,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
         [Fact]
         [Trait("Category", PlatformSpecificHelpers.TestCategory)]
-        public async void GetClientResponseLinks_Ignores_Forwarded_Headers_When_Disabled()
+        public async Task GetClientResponseLinks_Ignores_Forwarded_Headers_When_Disabled()
         {
             // Arrange
             var options = new DurableTaskOptions

--- a/test/e2e/Apps/BasicDotNetIsolated/local.settings.json
+++ b/test/e2e/Apps/BasicDotNetIsolated/local.settings.json
@@ -1,6 +1,7 @@
 {
   "IsEncrypted": false,
   "Values": {
+    "FUNCTIONS_INPROC_NET8_ENABLED": "1",
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",
     "APPLICATIONINSIGHTS_CONNECTION_STRING": "InstrumentationKey=xxxx;IngestionEndpoint =https://xxxx.applicationinsights.azure.com/;LiveEndpoint=https://xxxx.livediagnostics.monitor.azure.com/"

--- a/test/e2e/Tests/Fixtures/FixtureHelpers.cs
+++ b/test/e2e/Tests/Fixtures/FixtureHelpers.cs
@@ -36,7 +36,6 @@ public static class FixtureHelpers
         funcProcess.StartInfo.FileName = cliPath;
         funcProcess.StartInfo.ArgumentList.Add("host");
         funcProcess.StartInfo.ArgumentList.Add("start");
-        funcProcess.StartInfo.ArgumentList.Add("--csharp");
         funcProcess.StartInfo.ArgumentList.Add("--verbose");
 
         if (enableAuth)

--- a/test/e2e/Tests/build-e2e-test.ps1
+++ b/test/e2e/Tests/build-e2e-test.ps1
@@ -32,6 +32,8 @@ if ($PSVersionTable.PSEdition -ne 'Core') {
 
 $ErrorActionPreference = "Stop"
 
+$CORE_TOOLS_VERSION = '4.0.7317'
+
 $ProjectBaseDirectory = "$PSScriptRoot\..\..\..\"
 $ProjectTemporaryPath = Join-Path ([System.IO.Path]::GetTempPath()) "DurableTaskExtensionE2ETests"
 New-Item -Path $ProjectTemporaryPath -ItemType Directory -ErrorAction SilentlyContinue
@@ -76,8 +78,7 @@ else
 
   if ([string]::IsNullOrWhiteSpace($coreToolsURL))
   {
-    $coreToolsURL = "https://functionsclibuilds.blob.core.windows.net/builds/$FunctionsRuntimeVersion/latest/Azure.Functions.Cli.$os-$arch.zip"
-    $versionUrl = "https://functionsclibuilds.blob.core.windows.net/builds/$FunctionsRuntimeVersion/latest/version.txt"
+    $coreToolsURL = "https://github.com/Azure/azure-functions-core-tools/releases/download/$CORE_TOOLS_VERSION/Azure.Functions.Cli.$os-$arch.$CORE_TOOLS_VERSION.zip"
   }
 
   Write-Host ""

--- a/test/e2e/Tests/build-e2e-test.ps1
+++ b/test/e2e/Tests/build-e2e-test.ps1
@@ -89,12 +89,6 @@ else
   Remove-Item -Force "$FUNC_CLI_DIRECTORY.zip" -ErrorAction Ignore
   Remove-Item -Recurse -Force $FUNC_CLI_DIRECTORY -ErrorAction Ignore
 
-  if ($versionUrl)
-  {
-    $version = Invoke-RestMethod -Uri $versionUrl
-    Write-Host "Downloading Functions Core Tools (Version: $version)..."
-  }
-
   $output = "$FUNC_CLI_DIRECTORY.zip"
   Invoke-RestMethod -Uri $coreToolsURL -OutFile $output
 


### PR DESCRIPTION
As stated - the previous links were no longer maintained and contained a very old Core Tools version. Also fixes warnings around test method types

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)
* [x] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk
* [x] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
    * [ ] Otherwise: major or minor version updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
* [x] My changes **do not** add EventIds to our EventSource logs
    * [ ] Otherwise: Ensure the EventIds are within the supported range in our existing Windows infrastructure. You may validate this with a deployed app's telemetry. You may also extend the range by completing a PR such as [this one](https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files).
* [ ] My changes **should** be added to **v2.x** branch.
    * [x] Otherwise: This change applies exclusively to WebJobs.Extensions.DurableTask v3.x. It will be retained only in the `dev` and `main` branches and will not be merged into the `v2.x` branch.
