### PR TITLE
Fix documentation warning about PartitionTableOperationTimeout comment

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/Options/AzureStorageOptions.cs
+++ b/src/WebJobs.Extensions.DurableTask/Options/AzureStorageOptions.cs
@@ -226,8 +226,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// This helps detect potential silent hangs caused by internal Azure Storage retries.
         /// If the timeout is exceeded, a PartitionManagerWarning is logged and the operation is retried.
         /// Default is 2 seconds.
-        /// This setting is only effective when <see cref="UseTablePartitionManagement"/> is set to true.
         /// </summary>
+        /// <remarks>
+        /// This setting is only effective when <see cref="UseTablePartitionManagement"/> is set to true.
+        /// </remarks>
         public TimeSpan PartitionTableOperationTimeout { get; set; } = TimeSpan.FromSeconds(2);
 
         /// <summary>

--- a/src/WebJobs.Extensions.DurableTask/Options/AzureStorageOptions.cs
+++ b/src/WebJobs.Extensions.DurableTask/Options/AzureStorageOptions.cs
@@ -221,11 +221,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// </remarks>
         public bool AllowReplayingTerminalInstances { get; set; } = false;
 
+        /// <summary>
         /// Specifies the timeout (in seconds) for read and write operations on the partition table using PartitionManager V3 (TablePartitionManager) in Azure Storage.
         /// This helps detect potential silent hangs caused by internal Azure Storage retries.
         /// If the timeout is exceeded, a PartitionManagerWarning is logged and the operation is retried.
         /// Default is 2 seconds.
         /// This setting is only effective when <see cref="UseTablePartitionManagement"/> is set to true.
+        /// </summary>
         public TimeSpan PartitionTableOperationTimeout { get; set; } = TimeSpan.FromSeconds(2);
 
         /// <summary>


### PR DESCRIPTION
Fixes a documentation warning (SA1604) about including comments in a `<summary>` tag.

### Pull request checklist

* [ ] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)
* [ ] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk
* [ ] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
    * [ ] Otherwise: major or minor version updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
* [ ] My changes **do not** add EventIds to our EventSource logs
    * [ ] Otherwise: Ensure the EventIds are within the supported range in our existing Windows infrastructure. You may validate this with a deployed app's telemetry. You may also extend the range by completing a PR such as [this one](https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files).
* [ ] My changes **should** be added to **v2.x** branch.
    * [ ] Otherwise: This change applies exclusively to WebJobs.Extensions.DurableTask v3.x. It will be retained only in the `dev` and `main` branches and will not be merged into the `v2.x` branch.
