### PR TITLE
Update durabletask dependencies and Azurite docker image to latest

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -15,9 +15,9 @@
     <PackageVersion Include="Grpc.Net.Client" Version="2.70.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.WebApiCompatShim" Version="2.2.0" />
-    <PackageVersion Include="Microsoft.Azure.DurableTask.ApplicationInsights" Version="0.4.0" />
-    <PackageVersion Include="Microsoft.Azure.DurableTask.AzureStorage" Version="2.2.0" />
-    <PackageVersion Include="Microsoft.Azure.DurableTask.Core" Version="3.2.0" />
+    <PackageVersion Include="Microsoft.Azure.DurableTask.ApplicationInsights" Version="0.5.0" />
+    <PackageVersion Include="Microsoft.Azure.DurableTask.AzureStorage" Version="2.3.0" />
+    <PackageVersion Include="Microsoft.Azure.DurableTask.Core" Version="3.3.0" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Core" Version="1.16.0" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Abstractions" Version="1.3.0" />
     <PackageVersion Include="Microsoft.Azure.WebJobs" Version="3.0.39" />

--- a/test/SmokeTests/e2e-test.ps1
+++ b/test/SmokeTests/e2e-test.ps1
@@ -70,7 +70,7 @@ function Start-And-Wait-Orchestration {
 }
 
 $ErrorActionPreference = "Stop"
-$AzuriteVersion = "3.32.0"
+$AzuriteVersion = "3.34.0"
 
 if ($NoSetup -eq $false) {
 	# Build the docker image first, since that's the most critical step


### PR DESCRIPTION
* Update DurableTask.Core to 3.3.0
* Update DurableTask.AzureStorage to 2.3.0
* Update DurableTask.ApplicationInsights to 0.5.0
* Fix dependency issue with azurite Docker image by updating to 3.34.0

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)
* [x] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk
* [x] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
    * [ ] Otherwise: major or minor version updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
* [x] My changes **do not** add EventIds to our EventSource logs
    * [ ] Otherwise: Ensure the EventIds are within the supported range in our existing Windows infrastructure. You may validate this with a deployed app's telemetry. You may also extend the range by completing a PR such as [this one](https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files).
* [ ] My changes **should** be added to **v2.x** branch.
    * [x] Otherwise: This change applies exclusively to WebJobs.Extensions.DurableTask v3.x. It will be retained only in the `dev` and `main` branches and will not be merged into the `v2.x` branch.
