### PR TITLE
Fix for the default TaskHub name bug

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/Options/DurableTaskOptions.cs
+++ b/src/WebJobs.Extensions.DurableTask/Options/DurableTaskOptions.cs
@@ -60,24 +60,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         {
             get
             {
-                if (this.resolvedHubName == null)
-                {
-                    // "WEBSITE_SITE_NAME" is an environment variable used in Azure functions infrastructure. When running locally, this can be
-                    // specified in local.settings.json file to avoid being defaulted to "TestHubName"
-                    this.resolvedHubName = Environment.GetEnvironmentVariable("WEBSITE_SITE_NAME") ?? DefaultHubName;
-                    this.defaultHubName = this.resolvedHubName;
-                }
-
+                // "WEBSITE_SITE_NAME" is an environment variable used in Azure functions infrastructure. When running locally, this can be
+                // specified in local.settings.json file to avoid being defaulted to "TestHubName"
+                this.defaultHubName ??= Environment.GetEnvironmentVariable("WEBSITE_SITE_NAME") ?? DefaultHubName;
+                this.resolvedHubName ??= this.defaultHubName;
                 return this.resolvedHubName;
             }
 
             set
             {
-                if (this.originalHubName == null)
-                {
-                    this.originalHubName = value;
-                }
-
+                this.originalHubName ??= value;
                 this.resolvedHubName = value;
             }
         }


### PR DESCRIPTION
We seem to have a bug in `DurableTaskOptions` where `this.defaultHubName` is not set correctly in the case that the user specified the TaskHub name manually. `this.defaultHubName` gets set in two places:

1.  A call to get the [HubName](https://github.com/Azure/azure-functions-durable-extension/blob/1d35ccf24f1236e0bfe51c5686a617f0f07a61cd/src/WebJobs.Extensions.DurableTask/Options/DurableTaskOptions.cs#L68), which is only happens if the `this.resolvedHubName` is null (which is not true in the case of a user-specified hub name), and
2. And in [SetDefaultHubName](https://github.com/Azure/azure-functions-durable-extension/blob/1d35ccf24f1236e0bfe51c5686a617f0f07a61cd/src/WebJobs.Extensions.DurableTask/Options/DurableTaskOptions.cs#L308), which is called by the [AzureStorageDurabilityProviderFactory](https://github.com/Azure/azure-functions-durable-extension/blob/1d35ccf24f1236e0bfe51c5686a617f0f07a61cd/src/WebJobs.Extensions.DurableTask/AzureStorageDurabilityProviderFactory.cs#L117) only if `this.options.IsDefaultHubName` is true to sanitize the hub name. However, in the case of a user-specified hub name, `this.options.IsDefaultHubName` will always evaluate to false, even if the specified name is in fact the default task hub name. This is due to the logic in point 1. 

This can allow customers to basically "evade" the check we have in our [`Validate`](https://github.com/Azure/azure-functions-durable-extension/blob/1d35ccf24f1236e0bfe51c5686a617f0f07a61cd/src/WebJobs.Extensions.DurableTask/Options/DurableTaskOptions.cs#L352) code to check whether or not the taskhub name used for a non-production slot is the default. This check does not work since `this.IsDefaultHubName` will always evaluate to false in the case of a user-specified hub name, even if the user-specified hub name is in fact the default (as discussed in point 2), since `this.defaultHubName` is not set in this case and remains null (as discussed in point 1). 

### Pull request checklist

* [ ] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)
* [ ] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk
* [ ] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
    * [ ] Otherwise: major or minor version updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
* [ ] My changes **do not** add EventIds to our EventSource logs
    * [ ] Otherwise: Ensure the EventIds are within the supported range in our existing Windows infrastructure. You may validate this with a deployed app's telemetry. You may also extend the range by completing a PR such as [this one](https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files).
* [ ] My changes **should** be added to **v2.x** branch.
    * [ ] Otherwise: This change applies exclusively to WebJobs.Extensions.DurableTask v3.x. It will be retained only in the `dev` and `main` branches and will not be merged into the `v2.x` branch.
