### PR TITLE
Fixing Null Reference Bug in TaskEntityShim

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/Correlation/TraceHelper.cs
+++ b/src/WebJobs.Extensions.DurableTask/Correlation/TraceHelper.cs
@@ -85,8 +85,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Correlation
             return newActivity;
         }
 
-        internal static Activity? StartActivityForProcessingEntityInvocation(string entityId, string entityName, string operationName, bool signalEntity, ActivityContext parentTraceContext, DateTimeOffset startTime)
+        internal static Activity? StartActivityForProcessingEntityInvocation(string entityId, string entityName, string operationName, bool signalEntity, ActivityContext? parentTraceContext, DateTimeOffset startTime)
         {
+            // We only want to create a trace activity for processing an entity invocation in the case that we can successfully get the parent trace context of the request.
+            // Otherwise, we will create an unlinked trace activity with no parent.
+            if (parentTraceContext == null)
+            {
+                return null;
+            }
+
             Activity? newActivity = ActivityTraceSource.StartActivity(
                 Schema.SpanNames.CallOrSignalEntity(entityName, operationName),
                 kind: signalEntity ? ActivityKind.Consumer : ActivityKind.Server,

--- a/src/WebJobs.Extensions.DurableTask/Correlation/TraceHelper.cs
+++ b/src/WebJobs.Extensions.DurableTask/Correlation/TraceHelper.cs
@@ -97,7 +97,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Correlation
             Activity? newActivity = ActivityTraceSource.StartActivity(
                 Schema.SpanNames.CallOrSignalEntity(entityName, operationName),
                 kind: signalEntity ? ActivityKind.Consumer : ActivityKind.Server,
-                parentContext: parentTraceContext,
+                parentContext: parentTraceContext.Value,
                 startTime: startTime);
 
             if (newActivity == null)

--- a/src/WebJobs.Extensions.DurableTask/Listener/TaskEntityShim.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/TaskEntityShim.cs
@@ -741,13 +741,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         {
             Activity processEntityInvocationActivity = null;
             Activity callEntityActivity = null;
-            ActivityContext? parentTraceContext;
 
             // We only want to create a trace activity for processing the entity invocation in the case that we can successfully parse the trace context of the request that led to this entity invocation.
             // Otherwise, we will create an unlinked trace activity with no parent.
             if (ActivityContext.TryParse(request.ParentTraceContext?.TraceParent, request.ParentTraceContext?.TraceState, out ActivityContext parentTraceContextFromRequest))
             {
-                parentTraceContext = parentTraceContextFromRequest;
+                ActivityContext? parentTraceContext = parentTraceContextFromRequest;
                 if (!request.IsSignal)
                 {
                     callEntityActivity = TraceHelper.StartActivityForCallingOrSignalingEntity(

--- a/src/WebJobs.Extensions.DurableTask/Listener/TaskEntityShim.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/TaskEntityShim.cs
@@ -741,11 +741,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         {
             Activity processEntityInvocationActivity = null;
             Activity callEntityActivity = null;
+            ActivityContext? parentTraceContext;
 
             // We only want to create a trace activity for processing the entity invocation in the case that we can successfully parse the trace context of the request that led to this entity invocation.
             // Otherwise, we will create an unlinked trace activity with no parent.
-            if (ActivityContext.TryParse(request.ParentTraceContext?.TraceParent, request.ParentTraceContext?.TraceState, out ActivityContext parentTraceContext))
+            if (ActivityContext.TryParse(request.ParentTraceContext?.TraceParent, request.ParentTraceContext?.TraceState, out ActivityContext parentTraceContextFromRequest))
             {
+                parentTraceContext = parentTraceContextFromRequest;
                 if (!request.IsSignal)
                 {
                     callEntityActivity = TraceHelper.StartActivityForCallingOrSignalingEntity(
@@ -756,7 +758,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                         request.ScheduledTime,
                         parentTraceContext,
                         request.RequestTime);
-                    parentTraceContext = callEntityActivity.Context;
+                    parentTraceContext = callEntityActivity?.Context;
                 }
 
                 processEntityInvocationActivity = TraceHelper.StartActivityForProcessingEntityInvocation(


### PR DESCRIPTION
There was a bug in my implementation of distributed tracing for entities leading to a null reference exception in the case that a `callEntityActivity` trace activity was not successfully created in `TaskEntityShim.StartCallEntityAndEntityInvocationActivities`. The null reference exception is thrown if `callEntityActivity` is null but we attempt to access its `Context` anyway. This PR fixes that bug by essentially changing this to a `callEntityActivity?.Context` call. 

Resolves #3167 

### Pull request checklist

* [ ] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)
* [ ] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk
* [ ] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
    * [ ] Otherwise: major or minor version updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
* [ ] My changes **do not** add EventIds to our EventSource logs
    * [ ] Otherwise: Ensure the EventIds are within the supported range in our existing Windows infrastructure. You may validate this with a deployed app's telemetry. You may also extend the range by completing a PR such as [this one](https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files).
* [ ] My changes **should** be added to **v2.x** branch.
    * [ ] Otherwise: This change applies exclusively to WebJobs.Extensions.DurableTask v3.x. It will be retained only in the `dev` and `main` branches and will not be merged into the `v2.x` branch.
