### PR TITLE
Add build-e2e-test to official pipeline

### DIFF
--- a/.github/workflows/E2ETest.yml
+++ b/.github/workflows/E2ETest.yml
@@ -7,11 +7,15 @@ on:
     paths:
       - 'src/**'
       - 'test/e2e/**'
+      - 'Directory.Build.targets'
+      - 'Directory.Packages.props'
   pull_request:
     branches: [ main, dev ]
     paths:
       - 'src/**'
       - 'test/e2e/**'
+      - 'Directory.Build.targets'
+      - 'Directory.Packages.props'
 
 jobs:
   e2e-azurestorage-linux:

--- a/eng/templates/build.yml
+++ b/eng/templates/build.yml
@@ -44,7 +44,19 @@ jobs:
             projects: '**/**/*.csproj'
             feedsToUse: config
             nugetConfigPath: 'nuget.config'
-    
+            
+      - task: UsePythonVersion@0
+        inputs:
+          versionSpec: '3.11.x'
+          addToPath: true
+          architecture: 'x64'
+
+      - task: PowerShell@2
+        displayName: 'Build E2E test apps'
+        inputs:
+          filePath: 'test/e2e/tests/build-e2e-test.ps1'
+          arguments: '-SkipStorageEmulator -SkipCoreTools'
+
       # Build durable-extension
       - task: VSBuild@1
         displayName: 'Build Durable Extension'

--- a/eng/templates/build.yml
+++ b/eng/templates/build.yml
@@ -56,6 +56,7 @@ jobs:
         inputs:
           filePath: 'test/e2e/tests/build-e2e-test.ps1'
           arguments: '-SkipStorageEmulator -SkipCoreTools'
+          pwsh: true
 
       # Build durable-extension
       - task: VSBuild@1

--- a/test/e2e/Tests/build-e2e-test.ps1
+++ b/test/e2e/Tests/build-e2e-test.ps1
@@ -59,7 +59,7 @@ function StopOnFailedExecution {
 }
 
 $FUNC_CLI_DIRECTORY = Join-Path $ProjectTemporaryPath 'Azure.Functions.Cli'
-if($SkipCoreTool -or (Test-Path $FUNC_CLI_DIRECTORY))
+if($SkipCoreTools -or (Test-Path $FUNC_CLI_DIRECTORY))
 {
   Write-Host "---Skipping Core Tools download---"  
 }

--- a/test/e2e/Tests/build-e2e-test.ps1
+++ b/test/e2e/Tests/build-e2e-test.ps1
@@ -144,7 +144,7 @@ function InstallExtensionAndBuildTestApp($testAppDir) {
           dotnet add 'extensions.csproj' package 'Microsoft.Azure.WebJobs.Extensions.DurableTask' --version $webJobsExtensionVersion --source ".\packages" --no-restore
 
           Write-Host "Syncing extensions"
-          if (Test-Path (Join-Path $FUNC_CLI_DIRECTORY "func")) {
+          if ((Test-Path (Join-Path $FUNC_CLI_DIRECTORY "func")) -or (Test-Path (Join-Path $FUNC_CLI_DIRECTORY "func.exe"))) {
             .(Join-Path $FUNC_CLI_DIRECTORY "func") extensions sync
           }
           else {

--- a/test/e2e/Tests/build-e2e-test.ps1
+++ b/test/e2e/Tests/build-e2e-test.ps1
@@ -144,7 +144,12 @@ function InstallExtensionAndBuildTestApp($testAppDir) {
           dotnet add 'extensions.csproj' package 'Microsoft.Azure.WebJobs.Extensions.DurableTask' --version $webJobsExtensionVersion --source ".\packages" --no-restore
 
           Write-Host "Syncing extensions"
-          .(Join-Path $FUNC_CLI_DIRECTORY "func") extensions sync
+          if (Test-Path (Join-Path $FUNC_CLI_DIRECTORY "func")) {
+            .(Join-Path $FUNC_CLI_DIRECTORY "func") extensions sync
+          }
+          else {
+            Write-Warning "func command not found. Skipping extensions sync."
+          }
         }
 
         if (Test-Path ".\requirements.txt") {


### PR DESCRIPTION
Adds a step to the ADO official build pipeline that runs the build-e2e-test.ps1 script. This allows the pipeline build to succeed by adding the correct contents to the local NuGet sources in the e2e apps' nuget.config files. 
Also updates the E2E GH pipeline to run on changes to global deps files. 

Link to passing run: https://azfunc.visualstudio.com/internal/_build/results?buildId=229550&view=results

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)
* [x] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk
* [x] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
    * [ ] Otherwise: major or minor version updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
* [x] My changes **do not** add EventIds to our EventSource logs
    * [ ] Otherwise: Ensure the EventIds are within the supported range in our existing Windows infrastructure. You may validate this with a deployed app's telemetry. You may also extend the range by completing a PR such as [this one](https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files).
* [ ] My changes **should** be added to **v2.x** branch.
    * [x] Otherwise: This change applies exclusively to WebJobs.Extensions.DurableTask v3.x. It will be retained only in the `dev` and `main` branches and will not be merged into the `v2.x` branch.
