### PR TITLE
Build e2e apps before dotnet restore

### DIFF
--- a/eng/templates/build.yml
+++ b/eng/templates/build.yml
@@ -35,6 +35,12 @@ jobs:
         inputs:
             packageType: 'sdk'
             version: '8.0.x'
+            
+      - task: UsePythonVersion@0
+        inputs:
+          versionSpec: '3.11.x'
+          addToPath: true
+          architecture: 'x64'
 
       # Required to run this first to set up the local NuGet cache for dotnet restore
       - task: PowerShell@2
@@ -52,12 +58,6 @@ jobs:
             projects: '**/**/*.csproj'
             feedsToUse: config
             nugetConfigPath: 'nuget.config'
-            
-      - task: UsePythonVersion@0
-        inputs:
-          versionSpec: '3.11.x'
-          addToPath: true
-          architecture: 'x64'
 
       # Build durable-extension
       - task: VSBuild@1

--- a/eng/templates/build.yml
+++ b/eng/templates/build.yml
@@ -35,6 +35,14 @@ jobs:
         inputs:
             packageType: 'sdk'
             version: '8.0.x'
+
+      # Required to run this first to set up the local NuGet cache for dotnet restore
+      - task: PowerShell@2
+        displayName: 'Build E2E test apps'
+        inputs:
+          filePath: 'test/e2e/tests/build-e2e-test.ps1'
+          arguments: '-SkipStorageEmulator -SkipCoreTools'
+          pwsh: true
       
       # Start by restoring all the dependencies.
       - task: DotNetCoreCLI@2
@@ -50,13 +58,6 @@ jobs:
           versionSpec: '3.11.x'
           addToPath: true
           architecture: 'x64'
-
-      - task: PowerShell@2
-        displayName: 'Build E2E test apps'
-        inputs:
-          filePath: 'test/e2e/tests/build-e2e-test.ps1'
-          arguments: '-SkipStorageEmulator -SkipCoreTools'
-          pwsh: true
 
       # Build durable-extension
       - task: VSBuild@1


### PR DESCRIPTION
The official build is failing because it tries to run "dotnet restore" before build-e2e-test.ps1 which causes the restore to fail as the local NuGet cache for the ooproc extensions.csproj is not set up yet. This PR changes the order.

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)
* [x] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk
* [x] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
    * [ ] Otherwise: major or minor version updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
* [x] My changes **do not** add EventIds to our EventSource logs
    * [ ] Otherwise: Ensure the EventIds are within the supported range in our existing Windows infrastructure. You may validate this with a deployed app's telemetry. You may also extend the range by completing a PR such as [this one](https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files).
* [ ] My changes **should** be added to **v2.x** branch.
    * [x] Otherwise: This change applies exclusively to WebJobs.Extensions.DurableTask v3.x. It will be retained only in the `dev` and `main` branches and will not be merged into the `v2.x` branch.
