### PR TITLE
Update the extensions.csprojs for the E2E tests

### DIFF
--- a/eng/templates/build.yml
+++ b/eng/templates/build.yml
@@ -35,20 +35,6 @@ jobs:
         inputs:
             packageType: 'sdk'
             version: '8.0.x'
-            
-      - task: UsePythonVersion@0
-        inputs:
-          versionSpec: '3.11.x'
-          addToPath: true
-          architecture: 'x64'
-
-      # Required to run this first to set up the local NuGet cache for dotnet restore
-      - task: PowerShell@2
-        displayName: 'Build E2E test apps'
-        inputs:
-          filePath: 'test/e2e/tests/build-e2e-test.ps1'
-          arguments: '-SkipStorageEmulator -SkipCoreTools'
-          pwsh: true
       
       # Start by restoring all the dependencies.
       - task: DotNetCoreCLI@2
@@ -58,6 +44,19 @@ jobs:
             projects: '**/**/*.csproj'
             feedsToUse: config
             nugetConfigPath: 'nuget.config'
+            
+      - task: UsePythonVersion@0
+        inputs:
+          versionSpec: '3.11.x'
+          addToPath: true
+          architecture: 'x64'
+
+      - task: PowerShell@2
+        displayName: 'Build E2E test apps'
+        inputs:
+          filePath: 'test/e2e/tests/build-e2e-test.ps1'
+          arguments: '-SkipStorageEmulator -SkipCoreTools'
+          pwsh: true
 
       # Build durable-extension
       - task: VSBuild@1

--- a/test/e2e/Apps/BasicJava/extensions.csproj
+++ b/test/e2e/Apps/BasicJava/extensions.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <!-- This reference will be dynamically updated by build-e2e-tests.ps1 as part of test setup. -->
     <!-- Do not commit changes to this line unless necessary -->
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="3.5.0" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="3.4.1" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator" Version="1.1.3" />
     <PackageReference Include="Microsoft.DurableTask.SqlServer.AzureFunctions" Version="1.5.1" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.2" />

--- a/test/e2e/Apps/BasicNode/extensions.csproj
+++ b/test/e2e/Apps/BasicNode/extensions.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <!-- This reference will be dynamically updated by build-e2e-tests.ps1 as part of test setup. -->
     <!-- Do not commit changes to this line unless necessary -->
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="3.5.0" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="3.4.1" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator" Version="1.1.3" />
     <PackageReference Include="Microsoft.DurableTask.SqlServer.AzureFunctions" Version="1.5.1" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.2" />

--- a/test/e2e/Apps/BasicPowerShell/extensions.csproj
+++ b/test/e2e/Apps/BasicPowerShell/extensions.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <!-- This reference will be dynamically updated by build-e2e-tests.ps1 as part of test setup. -->
     <!-- Do not commit changes to this line unless necessary -->
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="3.5.0" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="3.4.1" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator" Version="1.1.3" />
     <PackageReference Include="Microsoft.DurableTask.SqlServer.AzureFunctions" Version="1.5.1" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.2" />

--- a/test/e2e/Apps/BasicPython/extensions.csproj
+++ b/test/e2e/Apps/BasicPython/extensions.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <!-- This reference will be dynamically updated by build-e2e-tests.ps1 as part of test setup. -->
     <!-- Do not commit changes to this line unless necessary -->
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="3.5.0" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="3.4.1" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator" Version="1.1.3" />
     <PackageReference Include="Microsoft.DurableTask.SqlServer.AzureFunctions" Version="1.5.1" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.2" />


### PR DESCRIPTION
<!-- Start the PR description with some context for the change. -->
Update the extensions.csprojs to revert to the WebJobs package version in nuget because the official build pipeline is failing because of this.
