### PR TITLE
Update warning message for Distributed Tracing V2

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/Correlation/TelemetryActivator.cs
+++ b/src/WebJobs.Extensions.DurableTask/Correlation/TelemetryActivator.cs
@@ -128,7 +128,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Correlation
             this.endToEndTraceHelper.ExtensionWarningAnnouncement(
                 "Durable Functions Distributed Tracing V2 is GA now! Learn how to enable the feature by visiting "
                 + "aka.ms/durable-distributed-tracing. "
-                + "To disable this message, you can configure your distributed trace version to \"V2\" or \"None\".");
+                + "To disable this message, you can configure distributedTracingEnabled to \"true\" and version to \"V2\" or \"None\". Setting it to \"None\" would in effect disable the feature.");
         }
 
         private void SetUpV1DistributedTracing()


### PR DESCRIPTION
This pull request updates the announcement message shown when Durable Functions Distributed Tracing V2 is available. The revised message provides clearer instructions on how to disable the announcement and clarifies the configuration options for distributed tracing.

Announcement message improvement:

* Updated the message in `EmitDTV2Announcement()` (`TelemetryActivator.cs`) to clarify that users should set `distributedTracingEnabled` to `"true"` and `version` to `"V2"` or `"None"` to disable the announcement, with `"None"` disabling the feature.

Resolves #3200

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)
* [ x My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk
* [x] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
    * [ ] Otherwise: major or minor version updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
* [x] My changes **do not** add EventIds to our EventSource logs
    * [ ] Otherwise: Ensure the EventIds are within the supported range in our existing Windows infrastructure. You may validate this with a deployed app's telemetry. You may also extend the range by completing a PR such as [this one](https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files).
* [ ] My changes **should** be added to **v2.x** branch.
    * [x] Otherwise: This change applies exclusively to WebJobs.Extensions.DurableTask v3.x. It will be retained only in the `dev` and `main` branches and will not be merged into the `v2.x` branch.
