### PR TITLE
Expand platform-level retry checking

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/OutOfProcMiddleware.cs
+++ b/src/WebJobs.Extensions.DurableTask/OutOfProcMiddleware.cs
@@ -176,8 +176,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 // - a timeout
                 // - an out of memory exception
                 // - a worker process exit
-                if (this.IsPlatformLevelError(functionResult))
-                { 
+                if (functionResult.Exception != null && this.IsPlatformLevelError(functionResult))
+                {
                     throw functionResult.Exception;
                 }
             }
@@ -432,7 +432,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     this.HostLifetimeService.OnStopping.ThrowIfCancellationRequested();
                 }
 
-                if (this.IsPlatformLevelError(functionResult))
+                if (functionResult.Exception != null && this.IsPlatformLevelError(functionResult))
                 {
                     throw functionResult.Exception;
                 }
@@ -479,7 +479,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                         errorType: "FunctionInvocationFailed",
                         errorMessage: $"Invocation of function '{functionName}' failed with an exception.",
                         stackTrace: null,
-                        innerFailure: new FailureDetails(functionResult.Exception),
+                        innerFailure: functionResult.Exception != null ? new FailureDetails(functionResult.Exception) : null,
                         isNonRetriable: true));
                 }
 
@@ -581,7 +581,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     this.HostLifetimeService.OnStopping.ThrowIfCancellationRequested();
                 }
 
-                if (this.IsPlatformLevelError(result))
+                if (result.Exception != null && this.IsPlatformLevelError(result))
                 {
                     throw result.Exception;
                 }
@@ -636,7 +636,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     isReplay: false,
                     scheduledEvent.EventId);
 
-                bool detailsParsedFromSerializedException;
+                bool detailsParsedFromSerializedException = false;
 
                 activityResult = new ActivityExecutionResult
                 {
@@ -645,7 +645,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                         taskScheduledId: scheduledEvent.EventId,
                         reason: $"Function '{functionName}' failed with an unhandled exception.",
                         details: null,
-                        GetFailureDetails(result.Exception, out detailsParsedFromSerializedException)),
+                        result.Exception != null ? GetFailureDetails(result.Exception, out detailsParsedFromSerializedException) : null),
                 };
 
                 if (!detailsParsedFromSerializedException && this.extension.PlatformInformationService.GetWorkerRuntimeType() == WorkerRuntimeType.DotNetIsolated)

--- a/src/WebJobs.Extensions.DurableTask/OutOfProcMiddleware.cs
+++ b/src/WebJobs.Extensions.DurableTask/OutOfProcMiddleware.cs
@@ -176,12 +176,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 // - a timeout
                 // - an out of memory exception
                 // - a worker process exit
-                if (functionResult.Exception is Host.FunctionTimeoutException
-                    || functionResult.Exception?.InnerException is SessionAbortedException // see RemoteOrchestrationContext.TrySetResultInternal for details on OOM-handling
-                    || (functionResult.Exception?.InnerException?.GetType().ToString().Contains("WorkerProcessExitException") ?? false))
-                {
-                    // TODO: the `WorkerProcessExitException` type is not exposed in our dependencies, it's part of WebJobs.Host.Script.
-                    // Should we add that dependency or should it be exposed in WebJobs.Host?
+                if (this.IsPlatformLevelError(functionResult))
+                { 
                     throw functionResult.Exception;
                 }
             }
@@ -295,6 +291,40 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             dispatchContext.SetProperty(orchestratorResult);
         }
 
+        private bool IsPlatformLevelError(FunctionResult functionResult)
+        {
+            if (this.ExceptionIsInstanceOrIsCausedBy(functionResult.Exception, checkType: typeof(Host.FunctionTimeoutException))
+                || this.ExceptionIsInstanceOrIsCausedBy(functionResult.Exception, checkType: typeof(SessionAbortedException)) // see RemoteOrchestrationContext.TrySetResultInternal for details on OOM-handling
+                || this.ExceptionIsInstanceOrIsCausedBy(functionResult.Exception, checkTypeString: "WorkerProcessExitException"))
+            {
+                // TODO: the `WorkerProcessExitException` type is not exposed in our dependencies, it's part of WebJobs.Host.Script.
+                // Should we add that dependency or should it be exposed in WebJobs.Host?
+                return true;
+            }
+
+            return false;
+        }
+
+        private bool ExceptionIsInstanceOrIsCausedBy(Exception? sourceException, Type? checkType = null, string? checkTypeString = null)
+        {
+            if (sourceException is null)
+            {
+                return false;
+            }
+
+            if (checkType != null && sourceException.GetType().IsAssignableFrom(checkType))
+            {
+                return true;
+            }
+
+            if (checkTypeString != null && sourceException.GetType().ToString().Contains(checkTypeString))
+            {
+                return true;
+            }
+
+            return this.ExceptionIsInstanceOrIsCausedBy(sourceException.InnerException, checkType, checkTypeString);
+        }
+
         /// <summary>
         /// Durable Task Framework entity middleware that invokes an out-of-process orchestrator function.
         /// </summary>
@@ -400,6 +430,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     // Shutdown can surface as a completed invocation in a failed state.
                     // Re-throw so we can abort this invocation.
                     this.HostLifetimeService.OnStopping.ThrowIfCancellationRequested();
+                }
+
+                if (this.IsPlatformLevelError(functionResult))
+                {
+                    throw functionResult.Exception;
                 }
             }
             catch (Exception hostRuntimeException)
@@ -544,6 +579,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     // Shutdown can surface as a completed invocation in a failed state.
                     // Re-throw so we can abort this invocation.
                     this.HostLifetimeService.OnStopping.ThrowIfCancellationRequested();
+                }
+
+                if (this.IsPlatformLevelError(result))
+                {
+                    throw result.Exception;
                 }
             }
             catch (Exception hostRuntimeException)

--- a/src/WebJobs.Extensions.DurableTask/OutOfProcMiddleware.cs
+++ b/src/WebJobs.Extensions.DurableTask/OutOfProcMiddleware.cs
@@ -312,7 +312,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 return false;
             }
 
-            if (checkType != null && sourceException.GetType().IsAssignableFrom(checkType))
+            if (checkType != null && checkType.IsAssignableFrom(sourceException.GetType()))
             {
                 return true;
             }

--- a/test/e2e/Apps/BasicJava/extensions.csproj
+++ b/test/e2e/Apps/BasicJava/extensions.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <!-- This reference will be dynamically updated by build-e2e-tests.ps1 as part of test setup. -->
     <!-- Do not commit changes to this line unless necessary -->
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="3.4.1" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="3.5.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator" Version="1.1.3" />
     <PackageReference Include="Microsoft.DurableTask.SqlServer.AzureFunctions" Version="1.5.1" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.2" />

--- a/test/e2e/Apps/BasicNode/extensions.csproj
+++ b/test/e2e/Apps/BasicNode/extensions.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <!-- This reference will be dynamically updated by build-e2e-tests.ps1 as part of test setup. -->
     <!-- Do not commit changes to this line unless necessary -->
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="3.4.1" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="3.5.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator" Version="1.1.3" />
     <PackageReference Include="Microsoft.DurableTask.SqlServer.AzureFunctions" Version="1.5.1" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.2" />

--- a/test/e2e/Apps/BasicPowerShell/extensions.csproj
+++ b/test/e2e/Apps/BasicPowerShell/extensions.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <!-- This reference will be dynamically updated by build-e2e-tests.ps1 as part of test setup. -->
     <!-- Do not commit changes to this line unless necessary -->
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="3.4.1" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="3.5.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator" Version="1.1.3" />
     <PackageReference Include="Microsoft.DurableTask.SqlServer.AzureFunctions" Version="1.5.1" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.2" />

--- a/test/e2e/Apps/BasicPython/extensions.csproj
+++ b/test/e2e/Apps/BasicPython/extensions.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <!-- This reference will be dynamically updated by build-e2e-tests.ps1 as part of test setup. -->
     <!-- Do not commit changes to this line unless necessary -->
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="3.4.1" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="3.5.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator" Version="1.1.3" />
     <PackageReference Include="Microsoft.DurableTask.SqlServer.AzureFunctions" Version="1.5.1" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.2" />


### PR DESCRIPTION
Currently, we retry orchestrations if we detect a failure due to a platform-level exception, like OutOfMemory, WorkerProcessExit, etc. This PR expands this check to activities and entities as well, and also increases the robustness of the checking as experimentally we have seen cases where WorkerProcessExitException was the outer exception type, not the inner. 

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)
* [x] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk
* [x] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
    * [ ] Otherwise: major or minor version updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
* [x] My changes **do not** add EventIds to our EventSource logs
    * [ ] Otherwise: Ensure the EventIds are within the supported range in our existing Windows infrastructure. You may validate this with a deployed app's telemetry. You may also extend the range by completing a PR such as [this one](https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files).
* [ ] My changes **should** be added to **v2.x** branch.
    * [x] Otherwise: This change applies exclusively to WebJobs.Extensions.DurableTask v3.x. It will be retained only in the `dev` and `main` branches and will not be merged into the `v2.x` branch.
