### PR TITLE
bugfix: ScheduledStartTime + start orch. actions

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/ProtobufUtils.cs
+++ b/src/WebJobs.Extensions.DurableTask/ProtobufUtils.cs
@@ -573,6 +573,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                         InstanceId = operationAction.StartNewOrchestration.InstanceId,
                         Version = operationAction.StartNewOrchestration.Version,
                         RequestTime = operationAction.StartNewOrchestration.RequestTime?.ToDateTimeOffset(),
+                        ScheduledStartTime = operationAction.StartNewOrchestration.ScheduledTime?.ToDateTime(),
                         ParentTraceContext = operationAction.StartNewOrchestration.ParentTraceContext != null ?
                             new DistributedTraceContext(
                                 operationAction.StartNewOrchestration.ParentTraceContext.TraceParent,

--- a/test/e2e/Apps/BasicDotNetIsolated/EntityCreatesScheduledOrchestration.cs
+++ b/test/e2e/Apps/BasicDotNetIsolated/EntityCreatesScheduledOrchestration.cs
@@ -1,0 +1,72 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.DurableTask;
+using Microsoft.DurableTask.Entities;
+
+using Microsoft.Azure.Functions.Worker.Http;
+using Microsoft.DurableTask.Client;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Azure.Durable.Tests.E2E;
+
+public class EntityCreatesScheduledOrchestration
+{
+    [Function("EntityCreatesScheduledOrchestrationOrchestrator_HttpStart")]
+    public static async Task<HttpResponseData> HttpStartScheduled(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", "post")] HttpRequestData req,
+        [DurableClient] DurableTaskClient client,
+        FunctionContext executionContext,
+        int scheduledStartDelaySeconds)
+    {
+        ILogger logger = executionContext.GetLogger("EntityCreatesScheduledOrchestrationOrchestrator_HttpStart");
+
+        // Function input comes from the request content.
+        string instanceId = await client.ScheduleNewOrchestrationInstanceAsync(
+            nameof(EntityCreatesScheduledOrchestrationOrchestrator), input: scheduledStartDelaySeconds);
+
+        logger.LogInformation("Started orchestration with ID = '{instanceId}'.", instanceId);
+
+        // Returns an HTTP 202 response with an instance management payload.
+        // See https://learn.microsoft.com/azure/azure-functions/durable/durable-functions-http-api#start-orchestration
+        return await client.CreateCheckStatusResponseAsync(req, instanceId);
+    }
+
+    [Function(nameof(EntityCreatesScheduledOrchestrationOrchestrator))]
+    public static async Task<string> EntityCreatesScheduledOrchestrationOrchestrator(
+        [OrchestrationTrigger] TaskOrchestrationContext context)
+    {
+        var entityId = new EntityInstanceId(nameof(SubOrchestratorTriggerEntity), "singleton");
+        var scheduledOrchestrationInstanceId = await context.Entities.CallEntityAsync<string>(entityId, nameof(SubOrchestratorTriggerEntity.Call), context.GetInput<int>());
+        return scheduledOrchestrationInstanceId;
+    }
+
+    [Function(nameof(ScheduledOrchestrationSubOrchestrator))]
+    public static string ScheduledOrchestrationSubOrchestrator([OrchestrationTrigger] TaskOrchestrationContext context, string? _)
+    {
+        return "Success";
+    }
+}
+
+
+public class SubOrchestratorTriggerEntity: TaskEntity<string>
+{
+    public string Call(int delaySeconds)
+    {
+        var options = new StartOrchestrationOptions(null, DateTime.UtcNow.AddSeconds(delaySeconds));
+        var instanceId = this.Context.ScheduleNewOrchestration(nameof(EntityCreatesScheduledOrchestration.ScheduledOrchestrationSubOrchestrator), null, options);
+        return instanceId;
+    }
+
+    protected override string InitializeState(TaskEntityOperation entityOperation)
+    {
+        return string.Empty;
+    }
+    
+    [Function(nameof(SubOrchestratorTriggerEntity))]
+    public Task RunEntityAsync([EntityTrigger] TaskEntityDispatcher dispatcher)
+    {
+        return dispatcher.DispatchAsync(this);
+    }
+}

--- a/test/e2e/Tests/Fixtures/FunctionAppFixture.cs
+++ b/test/e2e/Tests/Fixtures/FunctionAppFixture.cs
@@ -15,6 +15,13 @@ public class FunctionAppFixture : IAsyncLifetime
     internal FunctionAppProcess functionAppProcess;
     internal ITestLanguageLocalizer functionLanguageLocalizer;
 
+    internal enum ConfiguredDurabilityProviderType
+    {
+        AzureStorage,
+        MSSQL,
+        AzureManaged
+    }
+
     public FunctionAppFixture(IMessageSink messageSink)
     {
         ILoggerFactory loggerFactory = new LoggerFactory();
@@ -48,6 +55,23 @@ public class FunctionAppFixture : IAsyncLifetime
         }
 
         this.functionAppProcess = new FunctionAppProcess(this.logger, this.TestLogs, this.functionLanguageLocalizer.GetLanguageType());
+    }
+
+    internal ConfiguredDurabilityProviderType GetDurabilityProvider()
+    {
+        string? e2eTestDurableBackendEnvVarValue = Environment.GetEnvironmentVariable("E2E_TEST_DURABLE_BACKEND");
+        switch (e2eTestDurableBackendEnvVarValue)
+        {
+            case "mssql":
+                return ConfiguredDurabilityProviderType.MSSQL;
+            case "azuremanaged":
+                return ConfiguredDurabilityProviderType.AzureManaged;
+            case "azurestorage":
+                return ConfiguredDurabilityProviderType.AzureStorage;
+            default:
+                this.logger.LogWarning("Environment variable E2E_TEST_DURABLE_BACKEND not set, test code will assume Azure Storage backend");
+                return ConfiguredDurabilityProviderType.AzureStorage;
+        }
     }
 
     public Task InitializeAsync()

--- a/test/e2e/Tests/Helpers/DurableHelpers.cs
+++ b/test/e2e/Tests/Helpers/DurableHelpers.cs
@@ -18,6 +18,7 @@ internal class DurableHelpers
 
     internal class OrchestrationStatusDetails
     {
+        public string InstanceId { get; set; } = string.Empty;
         public string RuntimeStatus { get; set; } = string.Empty;
         public string Input { get; set; } = string.Empty;
         public string Output { get; set; } = string.Empty;
@@ -25,11 +26,16 @@ internal class DurableHelpers
         public DateTime LastUpdatedTime { get; set; }
         public OrchestrationStatusDetails(string statusQueryResponse)
         {
+            if (string.IsNullOrEmpty(statusQueryResponse))
+            {
+                return;
+            }
             JsonNode? statusQueryJsonNode = JsonNode.Parse(statusQueryResponse);
             if (statusQueryJsonNode == null)
             {
                 return;
             }
+            this.InstanceId = statusQueryJsonNode["instanceId"]?.GetValue<string>() ?? string.Empty;
             this.RuntimeStatus = statusQueryJsonNode["runtimeStatus"]?.GetValue<string>() ?? string.Empty;
             this.Input = statusQueryJsonNode["input"]?.ToString() ?? string.Empty;
             this.Output = statusQueryJsonNode["output"]?.ToString() ?? string.Empty;

--- a/test/e2e/Tests/Tests/ScheduledOrchestrationTests.cs
+++ b/test/e2e/Tests/Tests/ScheduledOrchestrationTests.cs
@@ -35,7 +35,7 @@ public class ScheduledOrchestrationTests
     }
 
     [Theory]
-    [InlineData("HelloCities_HttpStart_Scheduled", 5, HttpStatusCode.Accepted)]
+    [InlineData("HelloCities_HttpStart_Scheduled", 10, HttpStatusCode.Accepted)]
     [InlineData("HelloCities_HttpStart_Scheduled", -5, HttpStatusCode.Accepted)]
     [Trait("PowerShell", "Skip")] // Scheduled orchestrations not implemented in PowerShell
     public async Task ScheduledStartTests(string functionName, int startDelaySeconds, HttpStatusCode expectedStatusCode)
@@ -80,7 +80,7 @@ public class ScheduledOrchestrationTests
     }
 
     [Theory]
-    [InlineData("EntityCreatesScheduledOrchestrationOrchestrator_HttpStart", 5, HttpStatusCode.Accepted)]
+    [InlineData("EntityCreatesScheduledOrchestrationOrchestrator_HttpStart", 10, HttpStatusCode.Accepted)]
     [InlineData("EntityCreatesScheduledOrchestrationOrchestrator_HttpStart", -5, HttpStatusCode.Accepted)]
     [Trait("PowerShell", "Skip")] // Durable Entities not yet implemented in PowerShell
     [Trait("Java", "Skip")] // Durable Entities not yet implemented in Java
@@ -104,7 +104,12 @@ public class ScheduledOrchestrationTests
 
         string subOrchestratorStatusQueryGetUri = statusQueryGetUri.ToLower().Replace(schedulerOrchestrationDetails.InstanceId.ToLower(), subOrchestratorInstanceId);
 
-        if (scheduledStartTime > DateTime.UtcNow + TimeSpan.FromSeconds(1))
+        // Azure Storage backend has a quirk where creating an orchestration from an entity creates the OrchestrationStarted event in the History table
+        // but doesn't initialize the orchestration state in the Instances table until the orchestration starts running. Since the implementation for
+        // GetOrchestrationStateAsync in AzureStorage only queries the Instances table, this will 404 until the orchestration state becomes "running",
+        // so we can't check for "Pending".
+        // The checks below should still suffice to prove that the orchestration did not run until the scheduled time.
+        if (scheduledStartTime > DateTime.UtcNow + TimeSpan.FromSeconds(1) && this.fixture.GetDurabilityProvider() != FunctionAppFixture.ConfiguredDurabilityProviderType.AzureStorage)
         {
             // This line will throw if the orchestration goes to a terminal state before reaching "Pending",
             // ensuring that any scheduled orchestrations that run immediately fail the test.

--- a/test/e2e/Tests/Tests/ScheduledOrchestrationTests.cs
+++ b/test/e2e/Tests/Tests/ScheduledOrchestrationTests.cs
@@ -35,7 +35,7 @@ public class ScheduledOrchestrationTests
     }
 
     [Theory]
-    [InlineData("HelloCities_HttpStart_Scheduled", 10, HttpStatusCode.Accepted)]
+    [InlineData("HelloCities_HttpStart_Scheduled", 5, HttpStatusCode.Accepted)]
     [InlineData("HelloCities_HttpStart_Scheduled", -5, HttpStatusCode.Accepted)]
     [Trait("PowerShell", "Skip")] // Scheduled orchestrations not implemented in PowerShell
     public async Task ScheduledStartTests(string functionName, int startDelaySeconds, HttpStatusCode expectedStatusCode)
@@ -55,6 +55,8 @@ public class ScheduledOrchestrationTests
             if (this.fixture.functionLanguageLocalizer.GetLanguageType() == LanguageType.DotnetIsolated ||
                 this.fixture.functionLanguageLocalizer.GetLanguageType() == LanguageType.Java)
             {
+                // This line will throw if the orchestration goes to a terminal state before reaching "Pending",
+                // ensuring that any scheduled orchestrations that run immediately fail the test.
                 await DurableHelpers.WaitForOrchestrationStateAsync(statusQueryGetUri, "Pending", 30);
             }
             else
@@ -78,7 +80,7 @@ public class ScheduledOrchestrationTests
     }
 
     [Theory]
-    [InlineData("EntityCreatesScheduledOrchestrationOrchestrator_HttpStart", 10, HttpStatusCode.Accepted)]
+    [InlineData("EntityCreatesScheduledOrchestrationOrchestrator_HttpStart", 5, HttpStatusCode.Accepted)]
     [InlineData("EntityCreatesScheduledOrchestrationOrchestrator_HttpStart", -5, HttpStatusCode.Accepted)]
     [Trait("PowerShell", "Skip")] // Durable Entities not yet implemented in PowerShell
     [Trait("Java", "Skip")] // Durable Entities not yet implemented in Java
@@ -104,6 +106,8 @@ public class ScheduledOrchestrationTests
 
         if (scheduledStartTime > DateTime.UtcNow + TimeSpan.FromSeconds(1))
         {
+            // This line will throw if the orchestration goes to a terminal state before reaching "Pending",
+            // ensuring that any scheduled orchestrations that run immediately fail the test.
             await DurableHelpers.WaitForOrchestrationStateAsync(subOrchestratorStatusQueryGetUri, "Pending", 30);
         }
 

--- a/test/e2e/Tests/Tests/ScheduledOrchestrationTests.cs
+++ b/test/e2e/Tests/Tests/ScheduledOrchestrationTests.cs
@@ -1,0 +1,121 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Net;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.Azure.Durable.Tests.DotnetIsolatedE2E;
+
+[Collection(Constants.FunctionAppCollectionName)]
+public class ScheduledOrchestrationTests
+{
+    private readonly FunctionAppFixture fixture;
+    private readonly ITestOutputHelper output;
+
+    public ScheduledOrchestrationTests(FunctionAppFixture fixture, ITestOutputHelper testOutputHelper)
+    {
+        this.fixture = fixture;
+        this.fixture.TestLogs.UseTestLogger(testOutputHelper);
+        this.output = testOutputHelper;
+    }
+
+    // Due to some kind of asynchronous race condition in XUnit, when running these tests in pipelines,
+    // the output may be disposed before the message is written. Just ignore these types of errors for now. 
+    private void WriteOutput(string message)
+    {
+        try
+        {
+            this.output.WriteLine(message);
+        }
+        catch
+        {
+            // Ignore
+        }
+    }
+
+    [Theory]
+    [InlineData("HelloCities_HttpStart_Scheduled", 5, HttpStatusCode.Accepted)]
+    [InlineData("HelloCities_HttpStart_Scheduled", -5, HttpStatusCode.Accepted)]
+    [Trait("PowerShell", "Skip")] // Scheduled orchestrations not implemented in PowerShell
+    public async Task ScheduledStartTests(string functionName, int startDelaySeconds, HttpStatusCode expectedStatusCode)
+    {
+        var testStartTime = DateTime.UtcNow;
+        var scheduledStartTime = testStartTime + TimeSpan.FromSeconds(startDelaySeconds);
+        string urlQueryString = $"?ScheduledStartTime={scheduledStartTime.ToString("o")}";
+
+        using HttpResponseMessage response = await HttpHelpers.InvokeHttpTrigger(functionName, urlQueryString);
+
+        string statusQueryGetUri = await DurableHelpers.ParseStatusQueryGetUriAsync(response);
+
+        Assert.Equal(expectedStatusCode, response.StatusCode);
+
+        if (scheduledStartTime > DateTime.UtcNow + TimeSpan.FromSeconds(1))
+        {
+            if (this.fixture.functionLanguageLocalizer.GetLanguageType() == LanguageType.DotnetIsolated ||
+                this.fixture.functionLanguageLocalizer.GetLanguageType() == LanguageType.Java)
+            {
+                await DurableHelpers.WaitForOrchestrationStateAsync(statusQueryGetUri, "Pending", 30);
+            }
+            else
+            {
+                // Scheduled orchestrations are not properly implemented in the other languages - however, 
+                // this test has been implemented using timers in the orchestration instead.
+                await DurableHelpers.WaitForOrchestrationStateAsync(statusQueryGetUri, "Running", 30);
+            }
+        }
+
+        await DurableHelpers.WaitForOrchestrationStateAsync(statusQueryGetUri, "Completed", Math.Max(startDelaySeconds, 0) + 30);
+
+        // This +2s should not be necessary - however, experimentally the orchestration may run up to ~1 second before the scheduled time.
+        // It is unclear currently whether this is a bug where orchestrations run early, or a clock difference/error,
+        // but leaving this logic in for now until further investigation.
+        Assert.True(DateTime.UtcNow + TimeSpan.FromSeconds(2) >= scheduledStartTime);
+
+        var finalOrchestrationDetails = await DurableHelpers.GetRunningOrchestrationDetailsAsync(statusQueryGetUri);
+        WriteOutput($"Last updated at {finalOrchestrationDetails.LastUpdatedTime}, scheduled to complete at {scheduledStartTime}");
+        Assert.True(finalOrchestrationDetails.LastUpdatedTime + TimeSpan.FromSeconds(2) >= scheduledStartTime);
+    }
+
+    [Theory]
+    [InlineData("EntityCreatesScheduledOrchestrationOrchestrator_HttpStart", 5, HttpStatusCode.Accepted)]
+    [InlineData("EntityCreatesScheduledOrchestrationOrchestrator_HttpStart", -5, HttpStatusCode.Accepted)]
+    [Trait("PowerShell", "Skip")] // Durable Entities not yet implemented in PowerShell
+    [Trait("Java", "Skip")] // Durable Entities not yet implemented in Java
+    [Trait("Python", "Skip")] // Durable Entities do not support the "schedule new orchestration" action in Python
+    [Trait("Node", "Skip")] // Durable Entities do not support the "schedule new orchestration" action in Node
+    [Trait("MSSQL", "Skip")] // Durable Entities are not supported in MSSQL for out-of-proc (see https://github.com/microsoft/durabletask-mssql/issues/205)
+    public async Task ScheduledStartFromEntitiesTests(string functionName, int startDelaySeconds, HttpStatusCode expectedStatusCode)
+    {
+        var testStartTime = DateTime.UtcNow;
+        var scheduledStartTime = testStartTime + TimeSpan.FromSeconds(startDelaySeconds);
+        string urlQueryString = $"?scheduledStartDelaySeconds={startDelaySeconds}";
+
+        using HttpResponseMessage response = await HttpHelpers.InvokeHttpTrigger(functionName, urlQueryString);
+
+        string statusQueryGetUri = await DurableHelpers.ParseStatusQueryGetUriAsync(response);
+
+        Assert.Equal(expectedStatusCode, response.StatusCode);
+        await DurableHelpers.WaitForOrchestrationStateAsync(statusQueryGetUri, "Completed", Math.Max(startDelaySeconds, 0) + 30);
+        var schedulerOrchestrationDetails = await DurableHelpers.GetRunningOrchestrationDetailsAsync(statusQueryGetUri);
+        string subOrchestratorInstanceId = schedulerOrchestrationDetails.Output;
+
+        string subOrchestratorStatusQueryGetUri = statusQueryGetUri.ToLower().Replace(schedulerOrchestrationDetails.InstanceId.ToLower(), subOrchestratorInstanceId);
+
+        if (scheduledStartTime > DateTime.UtcNow + TimeSpan.FromSeconds(1))
+        {
+            await DurableHelpers.WaitForOrchestrationStateAsync(subOrchestratorStatusQueryGetUri, "Pending", 30);
+        }
+
+        await DurableHelpers.WaitForOrchestrationStateAsync(subOrchestratorStatusQueryGetUri, "Completed", Math.Max(startDelaySeconds, 0) + 30);
+
+        // This +2s should not be necessary - however, experimentally the orchestration may run up to ~1 second before the scheduled time.
+        // It is unclear currently whether this is a bug where orchestrations run early, or a clock difference/error,
+        // but leaving this logic in for now until further investigation.
+        Assert.True(DateTime.UtcNow + TimeSpan.FromSeconds(2) >= scheduledStartTime);
+
+        var subOrchestrationDetails = await DurableHelpers.GetRunningOrchestrationDetailsAsync(subOrchestratorStatusQueryGetUri);
+        Assert.True(subOrchestrationDetails.LastUpdatedTime + TimeSpan.FromSeconds(2) >= scheduledStartTime);
+        Assert.Equal("Success", subOrchestrationDetails.Output);
+    }
+}

--- a/test/e2e/Tests/Tests/ScheduledOrchestrationTests.cs
+++ b/test/e2e/Tests/Tests/ScheduledOrchestrationTests.cs
@@ -35,7 +35,7 @@ public class ScheduledOrchestrationTests
     }
 
     [Theory]
-    [InlineData("HelloCities_HttpStart_Scheduled", 5, HttpStatusCode.Accepted)]
+    [InlineData("HelloCities_HttpStart_Scheduled", 10, HttpStatusCode.Accepted)]
     [InlineData("HelloCities_HttpStart_Scheduled", -5, HttpStatusCode.Accepted)]
     [Trait("PowerShell", "Skip")] // Scheduled orchestrations not implemented in PowerShell
     public async Task ScheduledStartTests(string functionName, int startDelaySeconds, HttpStatusCode expectedStatusCode)
@@ -78,7 +78,7 @@ public class ScheduledOrchestrationTests
     }
 
     [Theory]
-    [InlineData("EntityCreatesScheduledOrchestrationOrchestrator_HttpStart", 5, HttpStatusCode.Accepted)]
+    [InlineData("EntityCreatesScheduledOrchestrationOrchestrator_HttpStart", 10, HttpStatusCode.Accepted)]
     [InlineData("EntityCreatesScheduledOrchestrationOrchestrator_HttpStart", -5, HttpStatusCode.Accepted)]
     [Trait("PowerShell", "Skip")] // Durable Entities not yet implemented in PowerShell
     [Trait("Java", "Skip")] // Durable Entities not yet implemented in Java


### PR DESCRIPTION
Fixes an issue where the ScheduledStartTime for new orchestration actions from entities was dropped in conversion

<!-- Make sure to delete the markdown comments and the below sections when squash merging -->
### Issue describing the changes in this PR

resolves [#issue_for_this_pr](https://github.com/Azure/azure-functions-durable-extension/issues/2751)

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)
* [x] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk
* [x] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
    * [ ] Otherwise: major or minor version updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
* [x] My changes **do not** add EventIds to our EventSource logs
    * [ ] Otherwise: Ensure the EventIds are within the supported range in our existing Windows infrastructure. You may validate this with a deployed app's telemetry. You may also extend the range by completing a PR such as [this one](https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files).
* [ ] My changes **should** be added to **v2.x** branch.
    * [x] Otherwise: This change applies exclusively to WebJobs.Extensions.DurableTask v3.x. It will be retained only in the `dev` and `main` branches and will not be merged into the `v2.x` branch.
