### PR TITLE
Cleanup warnings

### DIFF
--- a/src/Worker.Extensions.DurableTask/FunctionsWorkerApplicationBuilderExtensions.cs
+++ b/src/Worker.Extensions.DurableTask/FunctionsWorkerApplicationBuilderExtensions.cs
@@ -90,7 +90,7 @@ public static class FunctionsWorkerApplicationBuilderExtensions
             this.workerOptions = workerOptions;
         }
 
-        public void PostConfigure(string name, DurableTaskClientOptions options)
+        public void PostConfigure(string? name, DurableTaskClientOptions options)
         {
             if (this.workerOptions.Get(name).Serializer is { } serializer)
             {
@@ -116,7 +116,7 @@ public static class FunctionsWorkerApplicationBuilderExtensions
             this.workerOptions = workerOptions;
         }
 
-        public void PostConfigure(string name, DurableTaskWorkerOptions options)
+        public void PostConfigure(string? name, DurableTaskWorkerOptions options)
         {
             if (this.workerOptions.Get(name).Serializer is { } serializer)
             {

--- a/src/Worker.Extensions.DurableTask/TaskOrchestrationContextExtensionMethods.cs
+++ b/src/Worker.Extensions.DurableTask/TaskOrchestrationContextExtensionMethods.cs
@@ -69,7 +69,7 @@ public static class TaskOrchestrationContextExtensionMethods
 
             await context.CreateTimer(fireAt, CancellationToken.None);
 
-            string? locationUrl = response.Headers!["Location"];
+            string? locationUrl = response.Headers["Location"];
 
             if (locationUrl is null)
             {

--- a/src/Worker.Extensions.DurableTask/TaskOrchestrationContextExtensionMethods.cs
+++ b/src/Worker.Extensions.DurableTask/TaskOrchestrationContextExtensionMethods.cs
@@ -54,9 +54,9 @@ public static class TaskOrchestrationContextExtensionMethods
 
             DateTime fireAt = default(DateTime);
 
-            if (headersDictionary.TryGetValue("Retry-After", out StringValues retryAfter))
+            if (headersDictionary.TryGetValue("Retry-After", out StringValues retryAfterStr) && int.TryParse(retryAfterStr, out int retryAfter))
             {
-                fireAt = context.CurrentUtcDateTime.AddSeconds(int.Parse(retryAfter));
+                fireAt = context.CurrentUtcDateTime.AddSeconds(retryAfter);
             }
             else
             {
@@ -69,7 +69,13 @@ public static class TaskOrchestrationContextExtensionMethods
 
             await context.CreateTimer(fireAt, CancellationToken.None);
 
-            string locationUrl = response.Headers!["Location"];
+            string? locationUrl = response.Headers!["Location"];
+
+            if (locationUrl is null)
+            {
+                logger.LogWarning("HTTP response received but 'Location' header is missing; unable to poll for status.");
+                break;
+            }
 
             DurableHttpRequest newHttpRequest = CreateLocationPollRequest(request, locationUrl);
 

--- a/test/SmokeTests/OOProcSmokeTests/DotNetIsolated/FaultyOrchestrators.cs
+++ b/test/SmokeTests/OOProcSmokeTests/DotNetIsolated/FaultyOrchestrators.cs
@@ -3,7 +3,6 @@ using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.DurableTask;
 using Microsoft.DurableTask.Client;
 using Microsoft.Extensions.Logging;
-using System;
 
 namespace FaultOrchestrators
 {
@@ -20,11 +19,11 @@ namespace FaultOrchestrators
             // From experience, this code runs in `<sourceCodePath>/bin/output/`, so we store the file two directories above.
             // We do this because the /bin/output/ directory gets overridden during the build process, which happens automatically
             // when `func host start` is re-invoked.
-            string evidenceFile = System.IO.Path.Combine(System.IO.Directory.GetCurrentDirectory(), "..", "..", "replayEvidence");
-            bool isTheFirstReplay = !System.IO.File.Exists(evidenceFile);
+            string evidenceFile = Path.Combine(Directory.GetCurrentDirectory(), "..", "..", "replayEvidence");
+            bool isTheFirstReplay = !File.Exists(evidenceFile);
             if (isTheFirstReplay)
             {
-                System.IO.File.Create(evidenceFile).Close();
+                File.Create(evidenceFile).Close();
 
                 // force the process to run out of memory
                 List<byte[]> data = new List<byte[]>();
@@ -40,7 +39,7 @@ namespace FaultOrchestrators
             }
             else {
                 // if it's not the first replay, delete the evidence file and return
-                System.IO.File.Delete(evidenceFile);
+                File.Delete(evidenceFile);
                 return Task.CompletedTask;
             }
         }
@@ -56,11 +55,11 @@ namespace FaultOrchestrators
             // From experience, this code runs in `<sourceCodePath>/bin/output/`, so we store the file two directories above.
             // We do this because the /bin/output/ directory gets overridden during the build process, which happens automatically
             // when `func host start` is re-invoked.
-            string evidenceFile = System.IO.Path.Combine(System.IO.Directory.GetCurrentDirectory(), "..", "..", "replayEvidence");
-            bool isTheFirstReplay = !System.IO.File.Exists(evidenceFile);
+            string evidenceFile = Path.Combine(Directory.GetCurrentDirectory(), "..", "..", "replayEvidence");
+            bool isTheFirstReplay = !File.Exists(evidenceFile);
             if (isTheFirstReplay)
             {
-                System.IO.File.Create(evidenceFile).Close();
+                File.Create(evidenceFile).Close();
 
                 // force sudden crash
                 Environment.FailFast("Simulating crash!");
@@ -68,7 +67,7 @@ namespace FaultOrchestrators
             }
             else {
                 // if it's not the first replay, delete the evidence file and return
-                System.IO.File.Delete(evidenceFile);
+                File.Delete(evidenceFile);
                 return Task.CompletedTask;
             }
         }
@@ -84,23 +83,25 @@ namespace FaultOrchestrators
             // From experience, this code runs in `<sourceCodePath>/bin/output/`, so we store the file two directories above.
             // We do this because the /bin/output/ directory gets overridden during the build process, which happens automatically
             // when `func host start` is re-invoked.
-            string evidenceFile = System.IO.Path.Combine(System.IO.Directory.GetCurrentDirectory(), "..", "..", "replayEvidence");
-            bool isTheFirstReplay = !System.IO.File.Exists(evidenceFile);
+            string evidenceFile = Path.Combine(Directory.GetCurrentDirectory(), "..", "..", "replayEvidence");
+            bool isTheFirstReplay = !File.Exists(evidenceFile);
 
             if (isTheFirstReplay)
             {
-                System.IO.File.Create(evidenceFile).Close();
-                
+                File.Create(evidenceFile).Close();
+
                 // force the process to timeout after a 1 minute wait
-                System.Threading.Thread.Sleep(TimeSpan.FromMinutes(1));
-                
+#pragma warning disable DURABLE0003 // Thread.Sleep in orchestrator code - intentional here
+                Thread.Sleep(TimeSpan.FromMinutes(1));
+#pragma warning restore DURABLE0003
+
                 // we expect the code to never reach this statement, it should time out.
                 // we throw just in case the code does not time out. This should fail the test
                 throw new Exception("this should never be reached");
             }
             else {
                 // if it's not the first replay, delete the evidence file and return
-                System.IO.File.Delete(evidenceFile);
+                File.Delete(evidenceFile);
                 return Task.CompletedTask;
             }
         }

--- a/test/e2e/Apps/BasicDotNetIsolated/DistributedTracing.cs
+++ b/test/e2e/Apps/BasicDotNetIsolated/DistributedTracing.cs
@@ -13,13 +13,13 @@ public static class DistributedTracing
     public static async Task<string> RunOrchestrator(
         [OrchestrationTrigger] TaskOrchestrationContext context)
     {
-        string? activityTraceId = await context.CallActivityAsync<string>(nameof(GetDistributedTraceId));
+        string? activityTraceId = await context.CallActivityAsync<string>(nameof(GetDistributedTraceId), input: string.Empty);
 
         return activityTraceId;
     }
 
     [Function(nameof(GetDistributedTraceId))]
-    public static string? GetDistributedTraceId([ActivityTrigger]object? input, FunctionContext executionContext)
+    public static string? GetDistributedTraceId([ActivityTrigger]string input, FunctionContext executionContext)
     {
         return Activity.Current?.Id;
     }

--- a/test/e2e/Apps/BasicDotNetIsolated/DistributedTracing.cs
+++ b/test/e2e/Apps/BasicDotNetIsolated/DistributedTracing.cs
@@ -19,7 +19,7 @@ public static class DistributedTracing
     }
 
     [Function(nameof(GetDistributedTraceId))]
-    public static string? GetDistributedTraceId([ActivityTrigger] FunctionContext executionContext)
+    public static string? GetDistributedTraceId([ActivityTrigger]object? input, FunctionContext executionContext)
     {
         return Activity.Current?.Id;
     }

--- a/test/e2e/Apps/BasicDotNetIsolated/TimeoutOrchestration.cs
+++ b/test/e2e/Apps/BasicDotNetIsolated/TimeoutOrchestration.cs
@@ -38,7 +38,7 @@ public static class TimeoutOrchestration
 
         using (var cts = new CancellationTokenSource())
         {
-            Task<string> activityTask = context.CallActivityAsync<string>(nameof(LongActivity));
+            Task<string> activityTask = context.CallActivityAsync<string>(nameof(LongActivity), input: context.InstanceId);
             Task timeoutTask = context.CreateTimer(deadline, cts.Token);
 
             Task winner = await Task.WhenAny(activityTask, timeoutTask);


### PR DESCRIPTION
Cleans up various warnings from the CI, mostly nullability stuff


* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)
* [x] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk
* [x] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
    * [ ] Otherwise: major or minor version updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
* [x] My changes **do not** add EventIds to our EventSource logs
    * [ ] Otherwise: Ensure the EventIds are within the supported range in our existing Windows infrastructure. You may validate this with a deployed app's telemetry. You may also extend the range by completing a PR such as [this one](https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files).
* [ ] My changes **should** be added to **v2.x** branch.
    * [x] Otherwise: This change applies exclusively to WebJobs.Extensions.DurableTask v3.x. It will be retained only in the `dev` and `main` branches and will not be merged into the `v2.x` branch.
