### PR TITLE
Support class-based durable function invocations

### DIFF
--- a/.github/workflows/smoketest-dotnet-isolated-v4.yml
+++ b/.github/workflows/smoketest-dotnet-isolated-v4.yml
@@ -73,15 +73,13 @@ jobs:
     # when building the smoke test app in docker, causing the build to fail. This is a temporary workaround until the
     # root cause is identified and fixed.
 
-    # Due to a known issue with class-based orchestrators, this test fails to discover the orchestrator definition. 
-    # Should re-enable once this bug is fixed: https://github.com/microsoft/durabletask-dotnet/issues/247
-    # - name: Run smoke tests (Hello Cities)
-    #   shell: pwsh
-    #   run: azurite --silent --blobPort 10000 --queuePort 10001 --tablePort 10002 &
-    #     cd ./test/SmokeTests/OOProcSmokeTests/DotNetIsolated && func host start --port 7071 &
-    #     ./test/SmokeTests/OOProcSmokeTests/DotNetIsolated/run-smoke-tests.ps1 -HttpStartPath api/StartHelloCitiesTyped
+    - name: Run smoke tests (Hello Cities (Typed))
+      shell: pwsh
+      run: azurite --silent --blobPort 10000 --queuePort 10001 --tablePort 10002 &
+        cd ./test/SmokeTests/OOProcSmokeTests/DotNetIsolated && func host start --port 7071 &
+        ./test/SmokeTests/OOProcSmokeTests/DotNetIsolated/run-smoke-tests.ps1 -HttpStartPath api/StartHelloCitiesTyped
         
-    - name: Run smoke tests (Hello Cities)
+    - name: Run smoke tests (Hello Cities (Untyped))
       shell: pwsh
       run: azurite --silent --blobPort 10000 --queuePort 10001 --tablePort 10002 &
         cd ./test/SmokeTests/OOProcSmokeTests/DotNetIsolated && func host start --port 7071 &
@@ -109,3 +107,9 @@ jobs:
       run: azurite --silent --blobPort 10000 --queuePort 10001 --tablePort 10002 &
         cd ./test/SmokeTests/OOProcSmokeTests/DotNetIsolated && func host start --port 7071 &
         ./test/SmokeTests/OOProcSmokeTests/DotNetIsolated/run-smoke-tests.ps1 -HttpStartPath api/durable_HttpStartOOMOrchestrator
+
+    - name: Run smoke tests (Entity Counting (Typed))
+      shell: pwsh
+      run: azurite --silent --blobPort 10000 --queuePort 10001 --tablePort 10002 &
+        cd ./test/SmokeTests/OOProcSmokeTests/DotNetIsolated && func host start --port 7071 &
+        ./test/SmokeTests/OOProcSmokeTests/DotNetIsolated/run-smoke-tests.ps1 -HttpStartPath api/StartEntityOrchestration

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -51,14 +51,16 @@
   <!-- Dependencies used by both tests and samples -->
   <ItemGroup>
     <PackageVersion Include="Microsoft.ApplicationInsights.WorkerService" Version="2.22.0" />
-    <PackageVersion Include="Microsoft.Azure.Functions.Worker" Version="2.0.0" />
-    <!-- TODO: Update this to Worker SDK 2.x -->
-    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.18.1" />
+    <PackageVersion Include="Microsoft.Azure.DurableTask.Emulator" Version="2.5.4" />
+    <PackageVersion Include="Microsoft.Azure.DurableTask.Netherite.AzureFunctions" Version="3.1.0" />
+    <PackageVersion Include="Microsoft.Azure.DurableTask.Redis" Version="0.1.9-alpha" />
+    <PackageVersion Include="Microsoft.Azure.Functions.Worker" Version="2.1.0" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="2.0.0" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask.AzureManaged" Version="0.4.2-alpha" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask.SqlServer" Version="1.5.2" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.3.0" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="2.0.2" />
+    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.5"/>
     <PackageVersion Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="2.13.7" />
     <PackageVersion Include="Microsoft.Azure.WebJobs.Extensions.Http" Version="3.2.0" />
     <PackageVersion Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="5.1.3" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -16,7 +16,7 @@
     <PackageVersion Include="Microsoft.Azure.DurableTask.ApplicationInsights" Version="0.8.0" />
     <PackageVersion Include="Microsoft.Azure.DurableTask.AzureStorage" Version="2.7.0" />
     <PackageVersion Include="Microsoft.Azure.DurableTask.Core" Version="3.6.0" />
-    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Core" Version="2.0.0" />
+    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Core" Version="2.2.0" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Abstractions" Version="1.3.0" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Storage.Blobs" Version="6.7.0" />
     <PackageVersion Include="Microsoft.Azure.WebJobs" Version="3.0.39" />
@@ -54,7 +54,7 @@
     <PackageVersion Include="Microsoft.Azure.DurableTask.Emulator" Version="2.5.4" />
     <PackageVersion Include="Microsoft.Azure.DurableTask.Netherite.AzureFunctions" Version="3.1.0" />
     <PackageVersion Include="Microsoft.Azure.DurableTask.Redis" Version="0.1.9-alpha" />
-    <PackageVersion Include="Microsoft.Azure.Functions.Worker" Version="2.1.0" />
+    <PackageVersion Include="Microsoft.Azure.Functions.Worker" Version="2.2.0" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="2.0.0" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask.AzureManaged" Version="0.4.2-alpha" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask.SqlServer" Version="1.5.2" />

--- a/src/Worker.Extensions.DurableTask/DurableTaskFunctionsMiddleware.cs
+++ b/src/Worker.Extensions.DurableTask/DurableTaskFunctionsMiddleware.cs
@@ -1,137 +1,28 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System;
-using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
-using Microsoft.Azure.Functions.Worker.Extensions.DurableTask.Exceptions;
+using Microsoft.Azure.Functions.Worker.Extensions.DurableTask.Execution;
+using Microsoft.Azure.Functions.Worker.Invocation;
 using Microsoft.Azure.Functions.Worker.Middleware;
-using Microsoft.DurableTask.Worker;
-using Microsoft.DurableTask.Worker.Grpc;
 
 namespace Microsoft.Azure.Functions.Worker.Extensions.DurableTask;
 
 /// <summary>
 /// A middleware to handle orchestration triggers.
 /// </summary>
-internal class DurableTaskFunctionsMiddleware(ExtendedSessionsCache extendedSessionsCache) : IFunctionsWorkerMiddleware
+internal class DurableTaskFunctionsMiddleware(DurableFunctionExecutor invoker) : IFunctionsWorkerMiddleware
 {
-    private readonly ExtendedSessionsCache extendedSessionsCache = extendedSessionsCache;
-
     /// <inheritdoc />
     public Task Invoke(FunctionContext functionContext, FunctionExecutionDelegate next)
     {
-        if (IsOrchestrationTrigger(functionContext, out BindingMetadata? triggerBinding))
+        if (functionContext.TryGetOrchestrationBinding(out _)
+            || functionContext.TryGetEntityBinding(out _)
+            || functionContext.TryGetActivityBinding(out _))
         {
-            return this.RunOrchestrationAsync(functionContext, triggerBinding, next);
-        }
-
-        if (IsEntityTrigger(functionContext, out triggerBinding))
-        {
-            return RunEntityAsync(functionContext, triggerBinding, next);
-        }
-
-        if (IsActivityTrigger(functionContext, out triggerBinding))
-        {
-            return RunActivityAsync(functionContext, triggerBinding, next);
+            functionContext.Features.Set<IFunctionExecutor>(invoker);
         }
 
         return next(functionContext);
-    }
-
-    private static bool IsOrchestrationTrigger(
-        FunctionContext context, [NotNullWhen(true)] out BindingMetadata? orchestrationTriggerBinding)
-    {
-        foreach (BindingMetadata binding in context.FunctionDefinition.InputBindings.Values)
-        {
-            if (string.Equals(binding.Type, "orchestrationTrigger", StringComparison.OrdinalIgnoreCase))
-            {
-                orchestrationTriggerBinding = binding;
-                return true;
-            }
-        }
-
-        orchestrationTriggerBinding = null;
-        return false;
-    }
-
-    async Task RunOrchestrationAsync(
-        FunctionContext context, BindingMetadata triggerBinding, FunctionExecutionDelegate next)
-    {
-        InputBindingData<object> triggerInputData = await context.BindInputAsync<object>(triggerBinding);
-        if (triggerInputData?.Value is not string encodedOrchestratorState)
-        {
-            throw new InvalidOperationException("Orchestration history state was either missing from the input or not a string value.");
-        }
-
-        FunctionsOrchestrator orchestrator = new(context, next, triggerInputData);
-        string orchestratorOutput = GrpcOrchestrationRunner.LoadAndRun(
-            encodedOrchestratorState, orchestrator, this.extendedSessionsCache, context.InstanceServices);
-
-        // Send the encoded orchestrator output as the return value seen by the functions host extension
-        context.GetInvocationResult().Value = orchestratorOutput;
-    }
-
-    private static bool IsEntityTrigger(
-        FunctionContext context, [NotNullWhen(true)] out BindingMetadata? entityTriggerBinding)
-    {
-        foreach (BindingMetadata binding in context.FunctionDefinition.InputBindings.Values)
-        {
-            if (string.Equals(binding.Type, "entityTrigger", StringComparison.OrdinalIgnoreCase))
-            {
-                entityTriggerBinding = binding;
-                return true;
-            }
-        }
-
-        entityTriggerBinding = null;
-        return false;
-    }
-
-    static async Task RunEntityAsync(
-        FunctionContext context, BindingMetadata triggerBinding, FunctionExecutionDelegate next)
-    {
-        InputBindingData<object> triggerInputData = await context.BindInputAsync<object>(triggerBinding);
-        if (triggerInputData?.Value is not string encodedEntityBatch)
-        {
-            throw new InvalidOperationException("Entity batch was either missing from the input or not a string value.");
-        }
-
-        TaskEntityDispatcher dispatcher = new(encodedEntityBatch, context.InstanceServices);
-        triggerInputData.Value = dispatcher;
-
-        await next(context);
-        context.GetInvocationResult().Value = dispatcher.Result;
-    }
-
-    private static bool IsActivityTrigger(
-        FunctionContext context, [NotNullWhen(true)] out BindingMetadata? activityTriggerBinding)
-    {
-        foreach (BindingMetadata binding in context.FunctionDefinition.InputBindings.Values)
-        {
-            if (string.Equals(binding.Type, "activityTrigger", StringComparison.OrdinalIgnoreCase))
-            {
-                activityTriggerBinding = binding;
-                return true;
-            }
-        }
-
-        activityTriggerBinding = null;
-        return false;
-    }
-
-    private static async Task RunActivityAsync(FunctionContext functionContext, BindingMetadata triggerBinding, FunctionExecutionDelegate next)
-    {
-        try
-        {
-            await next(functionContext);
-            return;
-        }
-        catch (Exception ex)
-        {
-            // Get the exception properties provider from the service provider if available
-            IExceptionPropertiesProvider? exceptionPropertiesProvider = functionContext.InstanceServices.GetService(typeof(IExceptionPropertiesProvider)) as IExceptionPropertiesProvider;
-            throw new DurableSerializationException(ex, exceptionPropertiesProvider);
-        }
     }
 }

--- a/src/Worker.Extensions.DurableTask/Execution/DurableFunctionExecutor.Activity.cs
+++ b/src/Worker.Extensions.DurableTask/Execution/DurableFunctionExecutor.Activity.cs
@@ -5,7 +5,6 @@ using System;
 using System.Threading.Tasks;
 using Microsoft.Azure.Functions.Worker.Extensions.DurableTask.Exceptions;
 using Microsoft.DurableTask;
-using Microsoft.DurableTask.Worker;
 
 namespace Microsoft.Azure.Functions.Worker.Extensions.DurableTask.Execution;
 
@@ -24,20 +23,19 @@ internal partial class DurableFunctionExecutor
 
     private async ValueTask RunActivityAsync(FunctionContext context, BindingMetadata triggerBinding)
     {
-        if (context.FunctionDefinition.EntryPoint == ActivityEntryPoint)
-        {
-            await this.RunDirectActivityAsync(context, triggerBinding);
-            return;
-        }
-
         try
         {
+            if (context.FunctionDefinition.EntryPoint == ActivityEntryPoint)
+            {
+                await this.RunDirectActivityAsync(context, triggerBinding);
+                return;
+            }
+
             await inner.ExecuteAsync(context);
             return;
         }
         catch (Exception ex)
         {
-            IExceptionPropertiesProvider? exceptionPropertiesProvider = context.InstanceServices.GetService(typeof(IExceptionPropertiesProvider)) as IExceptionPropertiesProvider;
             throw new DurableSerializationException(ex, exceptionPropertiesProvider);
         }
     }

--- a/src/Worker.Extensions.DurableTask/Execution/DurableFunctionExecutor.Activity.cs
+++ b/src/Worker.Extensions.DurableTask/Execution/DurableFunctionExecutor.Activity.cs
@@ -1,0 +1,73 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.Azure.Functions.Worker.Extensions.DurableTask.Exceptions;
+using Microsoft.DurableTask;
+
+namespace Microsoft.Azure.Functions.Worker.Extensions.DurableTask.Execution;
+
+internal partial class DurableFunctionExecutor
+{
+    // Must point to a PUBLIC method.
+    // Functions runtime will validate this, even though it is never called.
+    public static readonly string ActivityEntryPoint =
+        $"{typeof(DurableFunctionExecutor).FullName}.{nameof(Activity)}";
+
+    public void Activity()
+    {
+        throw new NotImplementedException(
+            "Do not call this method. It is a placeholder for activity function metadata.");
+    }
+
+    private async ValueTask RunActivityAsync(FunctionContext context, BindingMetadata triggerBinding)
+    {
+        if (context.FunctionDefinition.EntryPoint == ActivityEntryPoint)
+        {
+            await this.RunDirectActivityAsync(context, triggerBinding);
+            return;
+        }
+
+        try
+        {
+            await inner.ExecuteAsync(context);
+            return;
+        }
+        catch (Exception ex)
+        {
+            throw new DurableSerializationException(ex);
+        }
+    }
+
+    private async Task RunDirectActivityAsync(FunctionContext context, BindingMetadata triggerBinding)
+    {
+        if (!factory.TryCreateActivity(
+            context.FunctionDefinition.Name, context.InstanceServices, out ITaskActivity? activity))
+        {
+            throw new InvalidOperationException(
+                $"No activity with name '{context.FunctionDefinition.Name}' is registered.");
+        }
+
+        InputBindingData<object> triggerInputData = await context.BindInputAsync<object>(triggerBinding);
+        if (triggerInputData?.Value is not string { } data)
+        {
+            throw new InvalidOperationException(
+                "Activity input data was either missing from the input or not a JSON string.");
+        }
+
+        object? input = this.Converter.Deserialize(data, activity.InputType);
+        object? activityResult = await activity.RunAsync(new FunctionsTaskActivityContext(context), input);
+        context.GetInvocationResult().Value = activityResult;
+    }
+
+    private sealed class FunctionsTaskActivityContext(FunctionContext context)
+        : TaskActivityContext
+    {
+        public FunctionContext Context { get; } = context;
+
+        public override TaskName Name { get; } = context.FunctionDefinition.Name;
+
+        public override string InstanceId { get; } = context.GetInstanceId();
+    }
+}

--- a/src/Worker.Extensions.DurableTask/Execution/DurableFunctionExecutor.Activity.cs
+++ b/src/Worker.Extensions.DurableTask/Execution/DurableFunctionExecutor.Activity.cs
@@ -5,6 +5,7 @@ using System;
 using System.Threading.Tasks;
 using Microsoft.Azure.Functions.Worker.Extensions.DurableTask.Exceptions;
 using Microsoft.DurableTask;
+using Microsoft.DurableTask.Worker;
 
 namespace Microsoft.Azure.Functions.Worker.Extensions.DurableTask.Execution;
 
@@ -36,7 +37,8 @@ internal partial class DurableFunctionExecutor
         }
         catch (Exception ex)
         {
-            throw new DurableSerializationException(ex);
+            IExceptionPropertiesProvider? exceptionPropertiesProvider = context.InstanceServices.GetService(typeof(IExceptionPropertiesProvider)) as IExceptionPropertiesProvider;
+            throw new DurableSerializationException(ex, exceptionPropertiesProvider);
         }
     }
 

--- a/src/Worker.Extensions.DurableTask/Execution/DurableFunctionExecutor.Entity.cs
+++ b/src/Worker.Extensions.DurableTask/Execution/DurableFunctionExecutor.Entity.cs
@@ -1,0 +1,66 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.DurableTask.Entities;
+using Microsoft.DurableTask.Worker;
+using Microsoft.DurableTask.Worker.Grpc;
+
+namespace Microsoft.Azure.Functions.Worker.Extensions.DurableTask.Execution;
+
+internal partial class DurableFunctionExecutor
+{
+    // Must point to a PUBLIC method.
+    // Functions runtime will validate this, even though it is never called.
+    public static readonly string EntityEntryPoint =
+        $"{typeof(DurableFunctionExecutor).FullName}.{nameof(Entity)}";
+
+    public void Entity()
+    {
+        throw new NotImplementedException(
+            "Do not call this method. It is a placeholder for entity function metadata.");
+    }
+
+    private async ValueTask RunEntityAsync(FunctionContext context, BindingMetadata triggerBinding)
+    {
+        InputBindingData<object> triggerInputData = await context.BindInputAsync<object>(triggerBinding);
+        if (triggerInputData?.Value is not string encodedEntityBatch)
+        {
+            throw new InvalidOperationException(
+                "Entity batch was either missing from the input or not a string value.");
+        }
+
+        if (context.FunctionDefinition.EntryPoint == EntityEntryPoint)
+        {
+            await this.RunDirectEntityAsync(context, encodedEntityBatch);
+            return;
+        }
+
+        TaskEntityDispatcher dispatcher = new(encodedEntityBatch, context.InstanceServices);
+        triggerInputData.Value = dispatcher;
+        await inner.ExecuteAsync(context);
+        context.GetInvocationResult().Value = dispatcher.Result;
+    }
+
+    private async Task RunDirectEntityAsync(
+        FunctionContext context, string encodedEntityBatch)
+    {
+        if (factory is not IDurableTaskFactory2 factory2)
+        {
+            throw new InvalidOperationException(
+                "The registered durable task factory does not support entity invocations.");
+        }
+
+        if (!factory2.TryCreateEntity(
+            context.FunctionDefinition.Name, context.InstanceServices, out ITaskEntity? entity))
+        {
+            throw new InvalidOperationException(
+                $"No entity with name '{context.FunctionDefinition.Name}' is registered.");
+        }
+
+        string result = await GrpcEntityRunner.LoadAndRunAsync(
+            encodedEntityBatch, entity, context.InstanceServices);
+        context.GetInvocationResult().Value = result;
+    }
+}

--- a/src/Worker.Extensions.DurableTask/Execution/DurableFunctionExecutor.Orchestration.cs
+++ b/src/Worker.Extensions.DurableTask/Execution/DurableFunctionExecutor.Orchestration.cs
@@ -1,0 +1,63 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.DurableTask;
+using Microsoft.DurableTask.Worker.Grpc;
+
+namespace Microsoft.Azure.Functions.Worker.Extensions.DurableTask.Execution;
+
+internal partial class DurableFunctionExecutor
+{
+    // Must point to a PUBLIC method.
+    // Functions runtime will validate this, even though it is never called.
+    public static readonly string OrchestrationEntryPoint =
+        $"{typeof(DurableFunctionExecutor).FullName}.{nameof(Orchestration)}";
+
+    public void Orchestration()
+    {
+        throw new NotImplementedException(
+            "Do not call this method. It is a placeholder for orchestration function metadata.");
+    }
+
+    private async ValueTask RunOrchestrationAsync(FunctionContext context, BindingMetadata triggerBinding)
+    {
+        InputBindingData<object> triggerInputData = await context.BindInputAsync<object>(triggerBinding);
+        if (triggerInputData?.Value is not string encodedOrchestratorState)
+        {
+            throw new InvalidOperationException(
+                "Orchestration history state was either missing from the input or not a string value.");
+        }
+
+        await using IDisposableOrchestrator orchestrator = this.CreateOrchestrator(context, triggerInputData);
+        string orchestratorOutput = GrpcOrchestrationRunner.LoadAndRun(
+            encodedOrchestratorState, orchestrator, extendedSessionsCache, context.InstanceServices);
+
+        // Send the encoded orchestrator output as the return value seen by the functions host extension
+        context.GetInvocationResult().Value = orchestratorOutput;
+    }
+
+    private IDisposableOrchestrator CreateOrchestrator(
+        FunctionContext context, InputBindingData<object> triggerInputData)
+    {
+        if (context.FunctionDefinition.EntryPoint == OrchestrationEntryPoint)
+        {
+            return this.CreateWrapper(context);
+        }
+
+        return new FunctionsOrchestrator(context, inner, triggerInputData);
+    }
+
+    private WrapperOrchestrator CreateWrapper(FunctionContext context)
+    {
+        if (!factory.TryCreateOrchestrator(
+            context.FunctionDefinition.Name, context.InstanceServices, out ITaskOrchestrator? orchestrator))
+        {
+            throw new InvalidOperationException(
+                $"No orchestrator with name '{context.FunctionDefinition.Name}' is registered.");
+        }
+
+        return new(orchestrator, context);
+    }
+}

--- a/src/Worker.Extensions.DurableTask/Execution/DurableFunctionExecutor.cs
+++ b/src/Worker.Extensions.DurableTask/Execution/DurableFunctionExecutor.cs
@@ -15,7 +15,7 @@ internal partial class DurableFunctionExecutor(
     ExtendedSessionsCache extendedSessionsCache,
     IDurableTaskFactory factory,
     IOptions<DurableTaskWorkerOptions> options,
-    IExceptionPropertiesProvider? exceptionPropertiesProvider)
+    IExceptionPropertiesProvider? exceptionPropertiesProvider = null)
     : IFunctionExecutor
 {
     private DataConverter Converter => options.Value.DataConverter;

--- a/src/Worker.Extensions.DurableTask/Execution/DurableFunctionExecutor.cs
+++ b/src/Worker.Extensions.DurableTask/Execution/DurableFunctionExecutor.cs
@@ -14,7 +14,8 @@ internal partial class DurableFunctionExecutor(
     IFunctionExecutor inner,
     ExtendedSessionsCache extendedSessionsCache,
     IDurableTaskFactory factory,
-    IOptions<DurableTaskWorkerOptions> options)
+    IOptions<DurableTaskWorkerOptions> options,
+    IExceptionPropertiesProvider? exceptionPropertiesProvider)
     : IFunctionExecutor
 {
     private DataConverter Converter => options.Value.DataConverter;

--- a/src/Worker.Extensions.DurableTask/Execution/DurableFunctionExecutor.cs
+++ b/src/Worker.Extensions.DurableTask/Execution/DurableFunctionExecutor.cs
@@ -1,0 +1,49 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.Azure.Functions.Worker.Invocation;
+using Microsoft.DurableTask;
+using Microsoft.DurableTask.Worker;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.Azure.Functions.Worker.Extensions.DurableTask.Execution;
+
+internal partial class DurableFunctionExecutor(
+    IFunctionExecutor inner,
+    ExtendedSessionsCache extendedSessionsCache,
+    IDurableTaskFactory factory,
+    IOptions<DurableTaskWorkerOptions> options)
+    : IFunctionExecutor
+{
+    private DataConverter Converter => options.Value.DataConverter;
+
+    public virtual ValueTask ExecuteAsync(FunctionContext context)
+    {
+        if (context is null)
+        {
+            throw new ArgumentNullException(nameof(context));
+        }
+
+        if (context.TryGetOrchestrationBinding(out BindingMetadata? triggerBinding))
+        {
+            return this.RunOrchestrationAsync(context, triggerBinding);
+        }
+
+        if (context.TryGetEntityBinding(out triggerBinding))
+        {
+            // Entity functions are handled in middleware.
+            return this.RunEntityAsync(context, triggerBinding);
+        }
+
+        if (context.TryGetActivityBinding(out triggerBinding))
+        {
+            // Activity functions are handled in middleware.
+            return this.RunActivityAsync(context, triggerBinding);
+        }
+
+        throw new NotSupportedException(
+            $"Function '{context.FunctionDefinition.Name}' is not supported by {nameof(DurableFunctionExecutor)}.");
+    }
+}

--- a/src/Worker.Extensions.DurableTask/Execution/DurableFunctionMetadata.cs
+++ b/src/Worker.Extensions.DurableTask/Execution/DurableFunctionMetadata.cs
@@ -1,0 +1,116 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using Microsoft.Azure.Functions.Worker.Core.FunctionMetadata;
+
+namespace Microsoft.Azure.Functions.Worker.Extensions.DurableTask.Execution;
+
+/// <summary>
+/// Function metadata for Durable Functions.
+/// </summary>
+public sealed class DurableFunctionMetadata : IFunctionMetadata
+{
+    private static readonly string ScriptFileName = typeof(DurableFunctionMetadata).Assembly.Location;
+
+    private DurableFunctionMetadata(string name, string triggerName, string entryPoint)
+    {
+        this.Name = name;
+        this.EntryPoint = entryPoint;
+        this.RawBindings = [
+            $$"""
+            {
+                "type": "{{triggerName}}",
+                "name": "context",
+                "direction": "In",
+                "properties": {}
+            }
+            """];
+        this.FunctionId = this.HashFunctionId();
+    }
+
+    /// <inheritdoc/>
+    public string? FunctionId { get; }
+
+    /// <inheritdoc/>
+    public bool IsProxy => false;
+
+    /// <inheritdoc/>
+    public string? Language => "dotnet-isolated";
+
+    /// <inheritdoc/>
+    public bool ManagedDependencyEnabled => false;
+
+    /// <inheritdoc/>
+    public string? Name { get; }
+
+    /// <inheritdoc/>
+    public string? EntryPoint { get; }
+
+    /// <inheritdoc/>
+    public IList<string>? RawBindings { get; } = [];
+
+    /// <inheritdoc/>
+    public string? ScriptFile => ScriptFileName;
+
+    /// <inheritdoc/>
+    public IRetryOptions? Retry => null;
+
+    /// <summary>
+    /// Creates metadata for a durable orchestrator function.
+    /// </summary>
+    /// <param name="name">The name of the orchestrator function.</param>
+    /// <returns>A <see cref="DurableFunctionMetadata"/> instance representing the orchestrator.</returns>
+    public static DurableFunctionMetadata CreateOrchestrator(string name)
+    {
+        return new(name, TriggerNames.Orchestration, DurableFunctionExecutor.OrchestrationEntryPoint);
+    }
+
+    /// <summary>
+    /// Creates metadata for a durable entity function.
+    /// </summary>
+    /// <param name="name">The name of the entity function.</param>
+    /// <returns>A <see cref="DurableFunctionMetadata"/> instance representing the entity.</returns>
+    public static DurableFunctionMetadata CreateEntity(string name)
+    {
+        return new(name, TriggerNames.Entity, DurableFunctionExecutor.EntityEntryPoint);
+    }
+
+    /// <summary>
+    /// Creates metadata for a durable activity function.
+    /// </summary>
+    /// <param name="name">The name of the activity function.</param>
+    /// <returns>A <see cref="DurableFunctionMetadata"/> instance representing the activity.</returns>
+    public static DurableFunctionMetadata CreateActivity(string name)
+    {
+        return new(name, TriggerNames.Activity, DurableFunctionExecutor.ActivityEntryPoint);
+    }
+
+    private string? HashFunctionId()
+    {
+        // We use uint to avoid the '-' sign when we .ToString() the result.
+        // This function is adapted from https://github.com/Azure/azure-functions-host/blob/71ecbb2c303214f96d7e17310681fd717180bdbb/src/WebJobs.Script/Utility.cs#L847-L863
+        static uint GetStableHash(string value)
+        {
+            unchecked
+            {
+                uint hash = 23;
+                foreach (char c in value)
+                {
+                    hash = (hash * 31) + c;
+                }
+
+                return hash;
+            }
+        }
+
+        unchecked
+        {
+            uint hash = 17;
+            hash = hash * 31 + GetStableHash(this.Name!);
+            hash = hash * 31 + GetStableHash(this.ScriptFile!);
+            hash = hash * 31 + GetStableHash(this.EntryPoint!);
+            return hash.ToString();
+        }
+    }
+}

--- a/src/Worker.Extensions.DurableTask/Execution/DurableMetadataTransformer.cs
+++ b/src/Worker.Extensions.DurableTask/Execution/DurableMetadataTransformer.cs
@@ -1,0 +1,66 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.Azure.Functions.Worker.Core.FunctionMetadata;
+using Microsoft.DurableTask;
+using Microsoft.DurableTask.Entities;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.Azure.Functions.Worker.Extensions.DurableTask.Execution;
+
+internal class DurableMetadataTransformer(IOptions<DurableTaskRegistry> registry) : IFunctionMetadataTransformer
+{
+    private readonly DurableTaskRegistry registry = registry?.Value
+        ?? throw new ArgumentNullException(nameof(registry));
+
+    public string Name => "DurableMetadataTransformer";
+
+    public void Transform(IList<IFunctionMetadata> original)
+    {
+        if (original is null)
+        {
+            throw new ArgumentNullException(nameof(original));
+        }
+
+        foreach (DurableFunctionMetadata orchestrator in this.GetOrchestrators())
+        {
+            original.Add(orchestrator);
+        }
+
+        foreach (DurableFunctionMetadata entity in this.GetEntities())
+        {
+            original.Add(entity);
+        }
+
+        foreach (DurableFunctionMetadata activity in this.GetActivities())
+        {
+            original.Add(activity);
+        }
+    }
+
+    private IEnumerable<DurableFunctionMetadata> GetOrchestrators()
+    {
+        foreach (KeyValuePair<TaskName, Func<IServiceProvider, ITaskOrchestrator>> kvp in this.registry.GetOrchestrators())
+        {
+            yield return DurableFunctionMetadata.CreateOrchestrator(kvp.Key.ToString());
+        }
+    }
+
+    private IEnumerable<DurableFunctionMetadata> GetEntities()
+    {
+        foreach (KeyValuePair<TaskName, Func<IServiceProvider, ITaskEntity>> kvp in this.registry.GetEntities())
+        {
+            yield return DurableFunctionMetadata.CreateEntity(kvp.Key.ToString());
+        }
+    }
+
+    private IEnumerable<DurableFunctionMetadata> GetActivities()
+    {
+        foreach (KeyValuePair<TaskName, Func<IServiceProvider, ITaskActivity>> kvp in this.registry.GetActivities())
+        {
+            yield return DurableFunctionMetadata.CreateActivity(kvp.Key.ToString());
+        }
+    }
+}

--- a/src/Worker.Extensions.DurableTask/Execution/DurableTaskRegistryExtensions.cs
+++ b/src/Worker.Extensions.DurableTask/Execution/DurableTaskRegistryExtensions.cs
@@ -1,0 +1,72 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using Microsoft.DurableTask;
+using Microsoft.DurableTask.Entities;
+
+namespace Microsoft.Azure.Functions.Worker.Extensions.DurableTask.Execution;
+
+/// <summary>
+/// Extension methods for <see cref="DurableTaskRegistry"/>.
+/// </summary>
+internal static class DurableTaskRegistryExtensions
+{
+    private static readonly BindingFlags Flags = BindingFlags.Instance | BindingFlags.NonPublic;
+
+    /// <summary>
+    /// Gets the registered orchestrators from the registry.
+    /// </summary>
+    /// <param name="registry">The registry to get orchestrators from.</param>
+    /// <returns>The current registered orchestrators.</returns>
+    public static IEnumerable<KeyValuePair<TaskName, Func<IServiceProvider, ITaskOrchestrator>>> GetOrchestrators(
+            this DurableTaskRegistry registry)
+    {
+        if (registry is null)
+        {
+            throw new ArgumentNullException(nameof(registry));
+        }
+
+        // TODO: expose this in durabletask-dotnet
+        object orchestrators = registry.GetType().GetProperty("Orchestrators", Flags)!.GetValue(registry, null)!;
+        return (IEnumerable<KeyValuePair<TaskName, Func<IServiceProvider, ITaskOrchestrator>>>)orchestrators;
+    }
+
+    /// <summary>
+    /// Gets the registered activities from the registry.
+    /// </summary>
+    /// <param name="registry">The registry to get activities from.</param>
+    /// <returns>The current registered activities.</returns>
+    public static IEnumerable<KeyValuePair<TaskName, Func<IServiceProvider, ITaskActivity>>> GetActivities(
+            this DurableTaskRegistry registry)
+    {
+        if (registry is null)
+        {
+            throw new ArgumentNullException(nameof(registry));
+        }
+
+        // TODO: expose this in durabletask-dotnet
+        object activities = registry.GetType().GetProperty("Activities", Flags)!.GetValue(registry, null)!;
+        return (IEnumerable<KeyValuePair<TaskName, Func<IServiceProvider, ITaskActivity>>>)activities;
+    }
+
+    /// <summary>
+    /// Gets the registered entities from the registry.
+    /// </summary>
+    /// <param name="registry">The registry to get entities from.</param>
+    /// <returns>The current registered entities.</returns>
+    public static IEnumerable<KeyValuePair<TaskName, Func<IServiceProvider, ITaskEntity>>> GetEntities(
+            this DurableTaskRegistry registry)
+    {
+        if (registry is null)
+        {
+            throw new ArgumentNullException(nameof(registry));
+        }
+
+        // TODO: expose this in durabletask-dotnet
+        object entities = registry.GetType().GetProperty("Entities", Flags)!.GetValue(registry, null)!;
+        return (IEnumerable<KeyValuePair<TaskName, Func<IServiceProvider, ITaskEntity>>>)entities;
+    }
+}

--- a/src/Worker.Extensions.DurableTask/Execution/DurableWorkerBuilderExtensions.cs
+++ b/src/Worker.Extensions.DurableTask/Execution/DurableWorkerBuilderExtensions.cs
@@ -1,0 +1,58 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.DurableTask.Worker;
+using Microsoft.DurableTask.Worker.Hosting;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Microsoft.Azure.Functions.Worker.Extensions.DurableTask.Execution;
+
+internal static class DurableWorkerBuilderExtensions
+{
+    /// <summary>
+    /// Adds the <see cref="DurableMetadataTransformer"/> to the worker builder.
+    /// </summary>
+    /// <param name="builder">The worker builder.</param>
+    /// <returns>The updated worker builder.</returns>
+    public static IDurableTaskWorkerBuilder UseFunctions(this IDurableTaskWorkerBuilder builder)
+    {
+        if (builder is null)
+        {
+            throw new ArgumentNullException(nameof(builder));
+        }
+
+        builder.UseBuildTarget<Worker>();
+
+        // A very workaround way to get IDurableTaskFactory directly into the DI container.
+        builder.Services.TryAddSingleton(sp =>
+        {
+            var worker = (Worker)builder.Build(sp);
+            return worker.Factory;
+        });
+
+        return builder;
+    }
+
+    /// <summary>
+    /// Checks if the build target is set to what functions expects.
+    /// </summary>
+    /// <param name="builder">The builder to validate.</param>
+    /// <returns><c>true</c> if valid, <c>false</c> otherwise.</returns>
+    public static bool ValidateBuildTarget(this IDurableTaskWorkerBuilder builder)
+    {
+        return builder.BuildTarget == typeof(Worker);
+    }
+
+    private class Worker(string name, IDurableTaskFactory factory) : DurableTaskWorker(name, factory)
+    {
+        public new IDurableTaskFactory Factory => base.Factory;
+
+        protected override Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Worker.Extensions.DurableTask/Execution/DurableWorkerBuilderExtensions.cs
+++ b/src/Worker.Extensions.DurableTask/Execution/DurableWorkerBuilderExtensions.cs
@@ -46,7 +46,7 @@ internal static class DurableWorkerBuilderExtensions
         return builder.BuildTarget == typeof(Worker);
     }
 
-    private class Worker(string name, IDurableTaskFactory factory) : DurableTaskWorker(name, factory)
+    private class Worker(string name, IDurableTaskFactory factory, IExceptionPropertiesProvider? provider = null) : DurableTaskWorker(name, factory)
     {
         public new IDurableTaskFactory Factory => base.Factory;
 

--- a/src/Worker.Extensions.DurableTask/Execution/DurableWorkerBuilderExtensions.cs
+++ b/src/Worker.Extensions.DurableTask/Execution/DurableWorkerBuilderExtensions.cs
@@ -46,6 +46,7 @@ internal static class DurableWorkerBuilderExtensions
         return builder.BuildTarget == typeof(Worker);
     }
 
+#pragma warning disable CS9113 // Parameter is unread. Suppressed to let a breaking change get fixed before we remove this parameter.
     private class Worker(string name, IDurableTaskFactory factory, IExceptionPropertiesProvider? provider = null) : DurableTaskWorker(name, factory)
     {
         public new IDurableTaskFactory Factory => base.Factory;
@@ -55,4 +56,5 @@ internal static class DurableWorkerBuilderExtensions
             return Task.CompletedTask;
         }
     }
+#pragma warning restore CS9113 // Parameter is unread.
 }

--- a/src/Worker.Extensions.DurableTask/Execution/IDisposableOrchestrator.cs
+++ b/src/Worker.Extensions.DurableTask/Execution/IDisposableOrchestrator.cs
@@ -1,0 +1,6 @@
+using System;
+using Microsoft.DurableTask;
+
+internal interface IDisposableOrchestrator : ITaskOrchestrator, IAsyncDisposable
+{
+}

--- a/src/Worker.Extensions.DurableTask/Execution/TriggerNames.cs
+++ b/src/Worker.Extensions.DurableTask/Execution/TriggerNames.cs
@@ -1,0 +1,11 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+namespace Microsoft.Azure.Functions.Worker.Extensions.DurableTask.Execution;
+
+internal static class TriggerNames
+{
+    internal const string Orchestration = "orchestrationTrigger";
+    internal const string Activity = "activityTrigger";
+    internal const string Entity = "entityTrigger";
+}

--- a/src/Worker.Extensions.DurableTask/Execution/WrapperOrchestrator.cs
+++ b/src/Worker.Extensions.DurableTask/Execution/WrapperOrchestrator.cs
@@ -1,0 +1,69 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.DurableTask;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Azure.Functions.Worker.Extensions.DurableTask.Execution;
+
+internal class WrapperOrchestrator(ITaskOrchestrator inner, FunctionContext functionContext)
+    : IDisposableOrchestrator
+{
+    public Type InputType => inner.InputType;
+
+    public Type OutputType => inner.OutputType;
+
+    public async Task<object?> RunAsync(TaskOrchestrationContext context, object? input)
+    {
+        FunctionsOrchestrationContext wrapperContext = new(context, functionContext);
+
+        try
+        {
+            // This method will advance to the next middleware and throw if it detects an asynchronous execution.
+            return await this.EnsureSynchronousExecutionAsync(wrapperContext, input);
+        }
+        catch (Exception ex)
+        {
+            functionContext.GetLogger<FunctionsOrchestrator>().LogError(
+                ex,
+                "An error occurred while executing the orchestrator function '{FunctionName}'.",
+                functionContext.FunctionDefinition.Name);
+            throw;
+        }
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        if (inner is IAsyncDisposable asyncDisposable)
+        {
+            return asyncDisposable.DisposeAsync();
+        }
+        else if (inner is IDisposable disposable)
+        {
+            disposable.Dispose();
+        }
+
+        return default;
+    }
+
+    private async Task<object?> EnsureSynchronousExecutionAsync(
+        FunctionsOrchestrationContext orchestrationContext, object? input)
+    {
+        Task<object?> orchestratorTask = inner.RunAsync(orchestrationContext, input);
+        if (!orchestratorTask.IsCompleted && !orchestrationContext.IsAccessed)
+        {
+            // If the middleware returns before the orchestrator function's context object was accessed and before
+            // it completes its execution, then we know that the orchestrator function did some illegal await as
+            // its very first action.
+            throw new InvalidOperationException(Constants.IllegalAwaitErrorMessage);
+        }
+
+        object? result = await orchestratorTask;
+
+        // This will throw if either the orchestrator performed an illegal await.
+        orchestrationContext.ThrowIfIllegalAccess();
+        return result;
+    }
+}

--- a/src/Worker.Extensions.DurableTask/FunctionContextExtensions.cs
+++ b/src/Worker.Extensions.DurableTask/FunctionContextExtensions.cs
@@ -1,0 +1,82 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.Azure.Functions.Worker.Extensions.DurableTask.Execution;
+
+namespace Microsoft.Azure.Functions.Worker.Extensions.DurableTask;
+
+internal static class FunctionContextExtensions
+{
+    /// <summary>
+    /// Tries to get the orchestration trigger binding from the function context.
+    /// </summary>
+    /// <param name="context">The function context.</param>
+    /// <param name="binding">The binding metadata if found; otherwise, null.</param>
+    /// <returns>True if the orchestration trigger binding is found; otherwise, false.</returns>
+    public static bool TryGetOrchestrationBinding(this FunctionContext context, [NotNullWhen(true)] out BindingMetadata? binding)
+        => context.TryGetBinding(TriggerNames.Orchestration, out binding);
+
+    /// <summary>
+    /// Tries to get the orchestration trigger binding from the function context.
+    /// </summary>
+    /// <param name="context">The function context.</param>
+    /// <param name="binding">The binding metadata if found; otherwise, null.</param>
+    /// <returns>True if the orchestration trigger binding is found; otherwise, false.</returns>
+    public static bool TryGetActivityBinding(this FunctionContext context, [NotNullWhen(true)] out BindingMetadata? binding)
+        => context.TryGetBinding(TriggerNames.Activity, out binding);
+
+    /// <summary>
+    /// Tries to get the orchestration trigger binding from the function context.
+    /// </summary>
+    /// <param name="context">The function context.</param>
+    /// <param name="binding">The binding metadata if found; otherwise, null.</param>
+    /// <returns>True if the orchestration trigger binding is found; otherwise, false.</returns>
+    public static bool TryGetEntityBinding(this FunctionContext context, [NotNullWhen(true)] out BindingMetadata? binding)
+        => context.TryGetBinding(TriggerNames.Entity, out binding);
+
+    /// <summary>
+    /// Tries to get the specified trigger binding from the function context.
+    /// </summary>
+    /// <param name="context">The function context.</param>
+    /// <param name="triggerName">The name of the trigger.</param>
+    /// <param name="binding">The binding metadata if found; otherwise, null.</param>
+    /// <returns>True if the specified trigger binding is found; otherwise, false.</returns>
+    public static bool TryGetBinding(this FunctionContext context, string triggerName, [NotNullWhen(true)] out BindingMetadata? binding)
+    {
+        if (context is null)
+        {
+            throw new ArgumentNullException(nameof(context));
+        }
+
+        foreach (BindingMetadata current in context.FunctionDefinition.InputBindings.Values)
+        {
+            if (string.Equals(current.Type, triggerName, StringComparison.OrdinalIgnoreCase))
+            {
+                binding = current;
+                return true;
+            }
+        }
+
+        binding = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Gets the orchestration instance ID from the function context.
+    /// </summary>
+    /// <param name="context">The function context.</param>
+    /// <returns>The orchestration instance ID.</returns>
+    public static string GetInstanceId(this FunctionContext context)
+    {
+        if (context is null)
+        {
+            throw new ArgumentNullException(nameof(context));
+        }
+
+        return (string)context.BindingContext.BindingData["instanceId"]!;
+    }
+}

--- a/test/Directory.Packages.props
+++ b/test/Directory.Packages.props
@@ -9,9 +9,6 @@
   <ItemGroup>
     <PackageVersion Include="coverlet.collector" Version="6.0.0" />
     <PackageVersion Include="FluentAssertions" Version="4.19.4" />
-    <PackageVersion Include="Microsoft.Azure.DurableTask.Emulator" Version="2.5.4" />
-    <PackageVersion Include="Microsoft.Azure.DurableTask.Netherite.AzureFunctions" Version="3.1.0" />
-    <PackageVersion Include="Microsoft.Azure.DurableTask.Redis" Version="0.1.9-alpha" />
     <PackageVersion Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" Version="3.0.33" />
     <PackageVersion Include="Microsoft.Build" Version="17.3.2" />
     <PackageVersion Include="Microsoft.Build.Framework" Version="17.3.2" />
@@ -20,7 +17,6 @@
     <PackageVersion Include="Microsoft.CodeAnalysis" Version="3.9.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="3.9.0" />
     <PackageVersion Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.65" />
-    <PackageVersion Include="Microsoft.DurableTask.Abstractions" Version="1.16.0" />
     <PackageVersion Include="Microsoft.DurableTask.Generators" Version="1.0.0-preview.1" />
     <PackageVersion Include="Microsoft.DurableTask.SqlServer.AzureFunctions" Version="1.5.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="9.0.0" />

--- a/test/SmokeTests/OOProcSmokeTests/DotNetIsolated/Counter.cs
+++ b/test/SmokeTests/OOProcSmokeTests/DotNetIsolated/Counter.cs
@@ -2,11 +2,8 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System.Text;
-using Azure.Core;
 using Microsoft.Azure.Functions.Worker;
-using Microsoft.Azure.Functions.Worker.Extensions.DurableTask;
 using Microsoft.Azure.Functions.Worker.Http;
-using Microsoft.DurableTask;
 using Microsoft.DurableTask.Client;
 using Microsoft.DurableTask.Entities;
 using Microsoft.Extensions.Logging;

--- a/test/SmokeTests/OOProcSmokeTests/DotNetIsolated/DotNetIsolated.csproj
+++ b/test/SmokeTests/OOProcSmokeTests/DotNetIsolated/DotNetIsolated.csproj
@@ -11,13 +11,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Functions.Worker" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" />
-
-    <!--
-      This preview package is to enable better NuGet restore behavior with custom feeds.
-      TODO: upgrade to 1.16.0 when it's released.
-    -->
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" OutputItemType="Analyzer" />
-    <PackageReference Include="Microsoft.DurableTask.Generators" OutputItemType="Analyzer" />
+    <!-- <PackageReference Include="Microsoft.DurableTask.Generators" OutputItemType="Analyzer" /> -->
   </ItemGroup>
 
   <ItemGroup>

--- a/test/SmokeTests/OOProcSmokeTests/DotNetIsolated/EntityOrchestration.cs
+++ b/test/SmokeTests/OOProcSmokeTests/DotNetIsolated/EntityOrchestration.cs
@@ -1,0 +1,95 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
+using Microsoft.DurableTask;
+using Microsoft.DurableTask.Client;
+using Microsoft.DurableTask.Entities;
+using Microsoft.Extensions.Logging;
+
+namespace DotNetIsolated.Typed;
+
+/// <summary>
+/// A simple entity for counting with class-based syntax, inheriting from TaskEntity.
+/// </summary>
+[DurableTask(nameof(CountingEntity))]
+public class CountingEntity : TaskEntity<int>
+{
+    public void Increment(int amount)
+    {
+        this.State += amount;
+    }
+
+    public int Get()
+    {
+        return this.State;
+    }
+}
+
+public static class EntityOrchestrationStarter
+{
+    /// <summary>
+    /// HTTP-triggered function that starts the <see cref="EntityOrchestration"/> orchestration.
+    /// </summary>
+    [Function(nameof(StartEntityOrchestration))]
+    public static async Task<HttpResponseData> StartEntityOrchestration(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", "post")] HttpRequestData req,
+        [DurableClient] DurableTaskClient client,
+        FunctionContext executionContext)
+    {
+        ILogger logger = executionContext.GetLogger(nameof(StartEntityOrchestration));
+
+        string instanceId = await client.ScheduleNewOrchestrationInstanceAsync(nameof(EntityOrchestration));
+        logger.LogInformation("Created new orchestration with instance ID = {instanceId}", instanceId);
+
+        return client.CreateCheckStatusResponse(req, instanceId);
+    }
+}
+
+/// <summary>
+/// Class-based orchestrator that interacts with entities and validates their state.
+/// </summary>
+[DurableTask(nameof(EntityOrchestration))]
+public class EntityOrchestration : TaskOrchestrator<string?, string>
+{
+    public async override Task<string> RunAsync(TaskOrchestrationContext context, string? input)
+    {
+        var entityId = new EntityInstanceId(nameof(CountingEntity), "testEntity");
+
+        // Fetch initial state (should be 0 or not exist)
+        int initialState = await context.Entities.CallEntityAsync<int>(entityId, "Get");
+
+        // Assert initial value is 0
+        if (initialState != 0)
+        {
+            throw new InvalidOperationException($"Expected initial value to be 0, but got {initialState}");
+        }
+
+        // Increment the entity by 5
+        await context.Entities.CallEntityAsync(entityId, "Increment", 5);
+
+        // Fetch the state again
+        int updatedState = await context.Entities.CallEntityAsync<int>(entityId, "Get");
+
+        // Assert the value is now 5
+        if (updatedState != 5)
+        {
+            throw new InvalidOperationException($"Expected value to be 5 after increment, but got {updatedState}");
+        }
+
+        // Increment again by 3
+        await context.Entities.CallEntityAsync(entityId, "Increment", 3);
+
+        // Fetch the final state
+        int finalState = await context.Entities.CallEntityAsync<int>(entityId, "Get");
+
+        // Assert the value is now 8
+        if (finalState != 8)
+        {
+            throw new InvalidOperationException($"Expected final value to be 8, but got {finalState}");
+        }
+
+        return $"Entity test completed successfully! Final value: {finalState}";
+    }
+}

--- a/test/SmokeTests/OOProcSmokeTests/DotNetIsolated/HelloCitiesTyped.cs
+++ b/test/SmokeTests/OOProcSmokeTests/DotNetIsolated/HelloCitiesTyped.cs
@@ -1,11 +1,11 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using Microsoft.DurableTask;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
-using Microsoft.Extensions.Logging;
+using Microsoft.DurableTask;
 using Microsoft.DurableTask.Client;
+using Microsoft.Extensions.Logging;
 
 namespace DotNetIsolated.Typed;
 
@@ -52,9 +52,9 @@ public class HelloCitiesTyped : TaskOrchestrator<string?, string>
         // methods are derived from the names of the activity classes. Note that both
         // activity classes and activity functions are supported by the source generator.
         string result = "";
-        result += await context.CallActivityAsync<string>("SayHelloTyped", "Tokyo") + " ";
-        result += await context.CallActivityAsync<string>("SayHelloTyped", "London") + " ";
-        result += await context.CallActivityAsync<string>("SayHelloTyped", "Seattle");
+        result += await context.CallActivityAsync<string>("SayHello", "Tokyo") + " ";
+        result += await context.CallActivityAsync<string>("SayHello", "London") + " ";
+        result += await context.CallActivityAsync<string>("SayHello", "Seattle");
         return result;
     }
 }
@@ -63,7 +63,7 @@ public class HelloCitiesTyped : TaskOrchestrator<string?, string>
 /// Class-based activity function implementation. Source generators are used to a generate an activity function
 /// definition that creates an instance of this class and invokes its <see cref="OnRun"/> method.
 /// </summary>
-[DurableTask(nameof(SayHelloTyped))]
+[DurableTask("SayHello")]
 public class SayHelloTyped : TaskActivity<string, string>
 {
     private readonly ILogger? logger;
@@ -84,7 +84,7 @@ public class SayHelloTyped : TaskActivity<string, string>
 
     public override Task<string> RunAsync(TaskActivityContext context, string cityName)
     {
-        this.logger?.LogInformation("Saying hello to {name}", cityName);
+        this.logger?.LogInformation("Saying hello to {name}!", cityName);
         return Task.FromResult($"Hello, {cityName}!");
     }
 }

--- a/test/SmokeTests/OOProcSmokeTests/DotNetIsolated/HelloCitiesTyped.cs
+++ b/test/SmokeTests/OOProcSmokeTests/DotNetIsolated/HelloCitiesTyped.cs
@@ -30,7 +30,7 @@ public static class HelloCitiesTypedStarter
         // orchestrators that are defined in the current project. The name of the generated extension methods
         // are based on the names of the orchestrator classes. Note that the source generator will *not*
         // generate type-safe extension methods for non-class-based orchestrator functions.
-        string instanceId = await client.ScheduleNewHelloCitiesTypedInstanceAsync();
+        string instanceId = await client.ScheduleNewOrchestrationInstanceAsync(nameof(HelloCitiesTyped));
         logger.LogInformation("Created new orchestration with instance ID = {instanceId}", instanceId);
 
         return client.CreateCheckStatusResponse(req, instanceId);
@@ -52,9 +52,9 @@ public class HelloCitiesTyped : TaskOrchestrator<string?, string>
         // methods are derived from the names of the activity classes. Note that both
         // activity classes and activity functions are supported by the source generator.
         string result = "";
-        result += await context.CallSayHelloTypedAsync("Tokyo") + " ";
-        result += await context.CallSayHelloTypedAsync("London") + " ";
-        result += await context.CallSayHelloTypedAsync("Seattle");
+        result += await context.CallActivityAsync<string>("SayHelloTyped", "Tokyo") + " ";
+        result += await context.CallActivityAsync<string>("SayHelloTyped", "London") + " ";
+        result += await context.CallActivityAsync<string>("SayHelloTyped", "Seattle");
         return result;
     }
 }

--- a/test/SmokeTests/OOProcSmokeTests/DotNetIsolated/Program.cs
+++ b/test/SmokeTests/OOProcSmokeTests/DotNetIsolated/Program.cs
@@ -1,17 +1,19 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using DotNetIsolated.Typed;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Builder;
+using Microsoft.DurableTask.Worker;
 using Microsoft.Extensions.Hosting;
 
-namespace DotNetIsolated;
+FunctionsApplicationBuilder builder = FunctionsApplication.CreateBuilder(args);
 
-public class Program
-{
-    public static void Main()
-    {
-        IHost host = new HostBuilder()
-            .ConfigureFunctionsWorkerDefaults()
-            .Build();
-        host.Run();
-    }
-}
+builder.ConfigureDurableWorker()
+    .AddTasks(r => r
+        .AddOrchestrator<HelloCitiesTyped>()
+        .AddActivity<SayHelloTyped>());
+
+IHost app = builder.Build();
+
+app.Run();

--- a/test/SmokeTests/OOProcSmokeTests/DotNetIsolated/Program.cs
+++ b/test/SmokeTests/OOProcSmokeTests/DotNetIsolated/Program.cs
@@ -12,7 +12,9 @@ FunctionsApplicationBuilder builder = FunctionsApplication.CreateBuilder(args);
 builder.ConfigureDurableWorker()
     .AddTasks(r => r
         .AddOrchestrator<HelloCitiesTyped>()
-        .AddActivity<SayHelloTyped>());
+        .AddOrchestrator<EntityOrchestration>()
+        .AddActivity<SayHelloTyped>()
+        .AddEntity<CountingEntity>());
 
 IHost app = builder.Build();
 

--- a/test/SmokeTests/OOProcSmokeTests/DotNetIsolated/host.json
+++ b/test/SmokeTests/OOProcSmokeTests/DotNetIsolated/host.json
@@ -15,5 +15,6 @@
         "controlQueueVisibilityTimeout": "00:01:00"
       }
     }
-  }
+  },
+  "functionTimeout": "00:00:30"
 }

--- a/test/SmokeTests/OOProcSmokeTests/DotNetIsolated/host.json
+++ b/test/SmokeTests/OOProcSmokeTests/DotNetIsolated/host.json
@@ -15,6 +15,5 @@
         "controlQueueVisibilityTimeout": "00:01:00"
       }
     }
-  },
-  "functionTimeout": "00:00:30"
+  }
 }

--- a/test/Worker.Extensions.DurableTask.Tests/DurableFunctionMetadataTests.cs
+++ b/test/Worker.Extensions.DurableTask.Tests/DurableFunctionMetadataTests.cs
@@ -1,0 +1,131 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Microsoft.Azure.Functions.Worker.Extensions.DurableTask.Execution;
+
+namespace Microsoft.Azure.Functions.Worker.Tests;
+
+public class DurableFunctionMetadataTests
+{
+    [Fact]
+    public void CreateOrchestrator_ShouldSetCorrectProperties()
+    {
+        // Arrange
+        string functionName = "MyOrchestrator";
+
+        // Act
+        DurableFunctionMetadata metadata = DurableFunctionMetadata.CreateOrchestrator(functionName);
+
+        // Assert
+        Assert.Equal(functionName, metadata.Name);
+        Assert.Equal(DurableFunctionExecutor.OrchestrationEntryPoint, metadata.EntryPoint);
+        Assert.Equal("dotnet-isolated", metadata.Language);
+        Assert.False(metadata.IsProxy);
+        Assert.False(metadata.ManagedDependencyEnabled);
+        Assert.Null(metadata.Retry);
+        Assert.NotNull(metadata.FunctionId);
+        Assert.NotNull(metadata.ScriptFile);
+        Assert.NotNull(metadata.RawBindings);
+        Assert.Single(metadata.RawBindings);
+        Assert.Contains("orchestrationTrigger", metadata.RawBindings[0]);
+    }
+
+    [Fact]
+    public void CreateEntity_ShouldSetCorrectProperties()
+    {
+        // Arrange
+        string functionName = "MyEntity";
+
+        // Act
+        DurableFunctionMetadata metadata = DurableFunctionMetadata.CreateEntity(functionName);
+
+        // Assert
+        Assert.Equal(functionName, metadata.Name);
+        Assert.Equal(DurableFunctionExecutor.EntityEntryPoint, metadata.EntryPoint);
+        Assert.Equal("dotnet-isolated", metadata.Language);
+        Assert.False(metadata.IsProxy);
+        Assert.False(metadata.ManagedDependencyEnabled);
+        Assert.Null(metadata.Retry);
+        Assert.NotNull(metadata.FunctionId);
+        Assert.NotNull(metadata.ScriptFile);
+        Assert.NotNull(metadata.RawBindings);
+        Assert.Single(metadata.RawBindings);
+        Assert.Contains("entityTrigger", metadata.RawBindings[0]);
+    }
+
+    [Fact]
+    public void CreateActivity_ShouldSetCorrectProperties()
+    {
+        // Arrange
+        string functionName = "MyActivity";
+
+        // Act
+        DurableFunctionMetadata metadata = DurableFunctionMetadata.CreateActivity(functionName);
+
+        // Assert
+        Assert.Equal(functionName, metadata.Name);
+        Assert.Equal(DurableFunctionExecutor.ActivityEntryPoint, metadata.EntryPoint);
+        Assert.Equal("dotnet-isolated", metadata.Language);
+        Assert.False(metadata.IsProxy);
+        Assert.False(metadata.ManagedDependencyEnabled);
+        Assert.Null(metadata.Retry);
+        Assert.NotNull(metadata.FunctionId);
+        Assert.NotNull(metadata.ScriptFile);
+        Assert.NotNull(metadata.RawBindings);
+        Assert.Single(metadata.RawBindings);
+        Assert.Contains("activityTrigger", metadata.RawBindings[0]);
+    }
+
+    [Fact]
+    public void FunctionId_ShouldBeConsistentForSameName()
+    {
+        // Arrange
+        string functionName = "TestFunction";
+
+        // Act
+        DurableFunctionMetadata metadata1 = DurableFunctionMetadata.CreateOrchestrator(functionName);
+        DurableFunctionMetadata metadata2 = DurableFunctionMetadata.CreateOrchestrator(functionName);
+
+        // Assert
+        Assert.Equal(metadata1.FunctionId, metadata2.FunctionId);
+    }
+
+    [Fact]
+    public void FunctionId_ShouldBeDifferentForDifferentNames()
+    {
+        // Arrange & Act
+        DurableFunctionMetadata metadata1 = DurableFunctionMetadata.CreateOrchestrator("Function1");
+        DurableFunctionMetadata metadata2 = DurableFunctionMetadata.CreateOrchestrator("Function2");
+
+        // Assert
+        Assert.NotEqual(metadata1.FunctionId, metadata2.FunctionId);
+    }
+
+    [Fact]
+    public void FunctionId_ShouldBeDifferentForDifferentTypes()
+    {
+        // Arrange
+        string functionName = "TestFunction";
+
+        // Act
+        DurableFunctionMetadata orchestrator = DurableFunctionMetadata.CreateOrchestrator(functionName);
+        DurableFunctionMetadata activity = DurableFunctionMetadata.CreateActivity(functionName);
+        DurableFunctionMetadata entity = DurableFunctionMetadata.CreateEntity(functionName);
+
+        // Assert - Different entry points should result in different function IDs
+        Assert.NotEqual(orchestrator.FunctionId, activity.FunctionId);
+        Assert.NotEqual(orchestrator.FunctionId, entity.FunctionId);
+        Assert.NotEqual(activity.FunctionId, entity.FunctionId);
+    }
+
+    [Fact]
+    public void RawBindings_ShouldContainContextParameter()
+    {
+        // Arrange & Act
+        DurableFunctionMetadata metadata = DurableFunctionMetadata.CreateOrchestrator("TestFunction");
+
+        // Assert
+        Assert.Contains("\"name\": \"context\"", metadata.RawBindings[0]);
+        Assert.Contains("\"direction\": \"In\"", metadata.RawBindings[0]);
+    }
+}

--- a/test/Worker.Extensions.DurableTask.Tests/DurableFunctionMetadataTests.cs
+++ b/test/Worker.Extensions.DurableTask.Tests/DurableFunctionMetadataTests.cs
@@ -125,7 +125,7 @@ public class DurableFunctionMetadataTests
         DurableFunctionMetadata metadata = DurableFunctionMetadata.CreateOrchestrator("TestFunction");
 
         // Assert
-        Assert.Contains("\"name\": \"context\"", metadata.RawBindings[0]);
-        Assert.Contains("\"direction\": \"In\"", metadata.RawBindings[0]);
+        Assert.Contains("\"name\": \"context\"", metadata.RawBindings?[0]);
+        Assert.Contains("\"direction\": \"In\"", metadata.RawBindings?[0]);
     }
 }

--- a/test/Worker.Extensions.DurableTask.Tests/DurableMetadataTransformerTests.cs
+++ b/test/Worker.Extensions.DurableTask.Tests/DurableMetadataTransformerTests.cs
@@ -1,0 +1,167 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Microsoft.Azure.Functions.Worker.Core.FunctionMetadata;
+using Microsoft.Azure.Functions.Worker.Extensions.DurableTask.Execution;
+using Microsoft.DurableTask;
+using Microsoft.DurableTask.Entities;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.Azure.Functions.Worker.Tests;
+
+public class DurableMetadataTransformerTests
+{
+    [Fact]
+    public void Constructor_WithNullRegistry_ShouldThrowArgumentNullException()
+    {
+        // Arrange, Act & Assert
+        Assert.Throws<ArgumentNullException>(() => new DurableMetadataTransformer(null!));
+    }
+
+    [Fact]
+    public void Transform_WithNullOriginal_ShouldThrowArgumentNullException()
+    {
+        // Arrange
+        DurableTaskRegistry registry = new DurableTaskRegistry();
+        IOptions<DurableTaskRegistry> options = Options.Create(registry);
+        DurableMetadataTransformer transformer = new DurableMetadataTransformer(options);
+
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() => transformer.Transform(null!));
+    }
+
+    [Fact]
+    public void Transform_WithEmptyRegistry_ShouldNotAddAnyMetadata()
+    {
+        // Arrange
+        DurableTaskRegistry registry = new DurableTaskRegistry();
+        IOptions<DurableTaskRegistry> options = Options.Create(registry);
+        DurableMetadataTransformer transformer = new DurableMetadataTransformer(options);
+        List<IFunctionMetadata> original = new List<IFunctionMetadata>();
+
+        // Act
+        transformer.Transform(original);
+
+        // Assert
+        Assert.Empty(original);
+    }
+
+    [Fact]
+    public void Transform_WithOrchestrators_ShouldAddOrchestratorMetadata()
+    {
+        // Arrange
+        DurableTaskRegistry registry = new DurableTaskRegistry();
+        registry.AddOrchestrator<TestOrchestrator>("TestOrchestrator");
+        IOptions<DurableTaskRegistry> options = Options.Create(registry);
+        DurableMetadataTransformer transformer = new DurableMetadataTransformer(options);
+        List<IFunctionMetadata> original = new List<IFunctionMetadata>();
+
+        // Act
+        transformer.Transform(original);
+
+        // Assert
+        Assert.Single(original);
+        DurableFunctionMetadata metadata = Assert.IsType<DurableFunctionMetadata>(original[0]);
+        Assert.Equal("TestOrchestrator", metadata.Name);
+        Assert.Contains("orchestrationTrigger", metadata.RawBindings![0]);
+    }
+
+    [Fact]
+    public void Transform_WithActivities_ShouldAddActivityMetadata()
+    {
+        // Arrange
+        DurableTaskRegistry registry = new DurableTaskRegistry();
+        registry.AddActivity<TestActivity>("TestActivity");
+        IOptions<DurableTaskRegistry> options = Options.Create(registry);
+        DurableMetadataTransformer transformer = new DurableMetadataTransformer(options);
+        List<IFunctionMetadata> original = new List<IFunctionMetadata>();
+
+        // Act
+        transformer.Transform(original);
+
+        // Assert
+        Assert.Single(original);
+        DurableFunctionMetadata metadata = Assert.IsType<DurableFunctionMetadata>(original[0]);
+        Assert.Equal("TestActivity", metadata.Name);
+        Assert.Contains("activityTrigger", metadata.RawBindings![0]);
+    }
+
+    [Fact]
+    public void Transform_WithEntities_ShouldAddEntityMetadata()
+    {
+        // Arrange
+        DurableTaskRegistry registry = new DurableTaskRegistry();
+        registry.AddEntity<TestEntity>("TestEntity");
+        IOptions<DurableTaskRegistry> options = Options.Create(registry);
+        DurableMetadataTransformer transformer = new DurableMetadataTransformer(options);
+        List<IFunctionMetadata> original = new List<IFunctionMetadata>();
+
+        // Act
+        transformer.Transform(original);
+
+        // Assert
+        Assert.Single(original);
+        DurableFunctionMetadata metadata = Assert.IsType<DurableFunctionMetadata>(original[0]);
+        Assert.Equal("TestEntity", metadata.Name);
+        Assert.Contains("entityTrigger", metadata.RawBindings![0]);
+    }
+
+    [Fact]
+    public void Transform_WithMultipleTypes_ShouldAddAllMetadata()
+    {
+        // Arrange
+        DurableTaskRegistry registry = new DurableTaskRegistry();
+        registry.AddOrchestrator<TestOrchestrator>("Orchestrator1");
+        registry.AddOrchestrator<TestOrchestrator>("Orchestrator2");
+        registry.AddActivity<TestActivity>("Activity1");
+        registry.AddEntity<TestEntity>("Entity1");
+        IOptions<DurableTaskRegistry> options = Options.Create(registry);
+        DurableMetadataTransformer transformer = new DurableMetadataTransformer(options);
+        List<IFunctionMetadata> original = new List<IFunctionMetadata>();
+
+        // Act
+        transformer.Transform(original);
+
+        // Assert
+        Assert.Equal(4, original.Count);
+        Assert.Contains(original, m => m.Name == "Orchestrator1");
+        Assert.Contains(original, m => m.Name == "Orchestrator2");
+        Assert.Contains(original, m => m.Name == "Activity1");
+        Assert.Contains(original, m => m.Name == "Entity1");
+    }
+
+    [Fact]
+    public void Name_ShouldReturnExpectedValue()
+    {
+        // Arrange
+        DurableTaskRegistry registry = new DurableTaskRegistry();
+        IOptions<DurableTaskRegistry> options = Options.Create(registry);
+        DurableMetadataTransformer transformer = new DurableMetadataTransformer(options);
+
+        // Act
+        string name = transformer.Name;
+
+        // Assert
+        Assert.Equal("DurableMetadataTransformer", name);
+    }
+
+    private class TestOrchestrator : TaskOrchestrator<object?, object?>
+    {
+        public override Task<object?> RunAsync(TaskOrchestrationContext context, object? input)
+        {
+            return Task.FromResult<object?>(new object());
+        }
+    }
+
+    private class TestActivity : TaskActivity<object?, object?>
+    {
+        public override Task<object?> RunAsync(TaskActivityContext context, object? input)
+        {
+            return Task.FromResult<object?>(new object());
+        }
+    }
+
+    private class TestEntity : TaskEntity<object>
+    {
+    }
+}

--- a/test/Worker.Extensions.DurableTask.Tests/DurableTaskRegistryExtensionsTests.cs
+++ b/test/Worker.Extensions.DurableTask.Tests/DurableTaskRegistryExtensionsTests.cs
@@ -1,0 +1,200 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Microsoft.Azure.Functions.Worker.Extensions.DurableTask.Execution;
+using Microsoft.DurableTask;
+using Microsoft.DurableTask.Entities;
+
+namespace Microsoft.Azure.Functions.Worker.Tests;
+
+public class DurableTaskRegistryExtensionsTests
+{
+    [Fact]
+    public void GetOrchestrators_WithNullRegistry_ShouldThrowArgumentNullException()
+    {
+        // Arrange, Act & Assert
+        Assert.Throws<ArgumentNullException>(() =>
+            DurableTaskRegistryExtensions.GetOrchestrators(null!));
+    }
+
+    [Fact]
+    public void GetOrchestrators_WithEmptyRegistry_ShouldReturnEmpty()
+    {
+        // Arrange
+        DurableTaskRegistry registry = new DurableTaskRegistry();
+
+        // Act
+        IEnumerable<KeyValuePair<TaskName, Func<IServiceProvider, ITaskOrchestrator>>> orchestrators = registry.GetOrchestrators();
+
+        // Assert
+        Assert.Empty(orchestrators);
+    }
+
+    [Fact]
+    public void GetOrchestrators_WithRegisteredOrchestrators_ShouldReturnThem()
+    {
+        // Arrange
+        DurableTaskRegistry registry = new DurableTaskRegistry();
+        registry.AddOrchestrator<TestOrchestrator>("Orchestrator1");
+        registry.AddOrchestrator<TestOrchestrator>("Orchestrator2");
+
+        // Act
+        List<KeyValuePair<TaskName, Func<IServiceProvider, ITaskOrchestrator>>> orchestrators = registry.GetOrchestrators().ToList();
+
+        // Assert
+        Assert.Equal(2, orchestrators.Count);
+        Assert.Contains(orchestrators, kvp => kvp.Key.ToString() == "Orchestrator1");
+        Assert.Contains(orchestrators, kvp => kvp.Key.ToString() == "Orchestrator2");
+    }
+
+    [Fact]
+    public void GetActivities_WithNullRegistry_ShouldThrowArgumentNullException()
+    {
+        // Arrange, Act & Assert
+        Assert.Throws<ArgumentNullException>(() =>
+            DurableTaskRegistryExtensions.GetActivities(null!));
+    }
+
+    [Fact]
+    public void GetActivities_WithEmptyRegistry_ShouldReturnEmpty()
+    {
+        // Arrange
+        DurableTaskRegistry registry = new DurableTaskRegistry();
+
+        // Act
+        IEnumerable<KeyValuePair<TaskName, Func<IServiceProvider, ITaskActivity>>> activities = registry.GetActivities();
+
+        // Assert
+        Assert.Empty(activities);
+    }
+
+    [Fact]
+    public void GetActivities_WithRegisteredActivities_ShouldReturnThem()
+    {
+        // Arrange
+        DurableTaskRegistry registry = new DurableTaskRegistry();
+        registry.AddActivity<TestActivity>("Activity1");
+        registry.AddActivity<TestActivity>("Activity2");
+
+        // Act
+        List<KeyValuePair<TaskName, Func<IServiceProvider, ITaskActivity>>> activities = registry.GetActivities().ToList();
+
+        // Assert
+        Assert.Equal(2, activities.Count);
+        Assert.Contains(activities, kvp => kvp.Key.ToString() == "Activity1");
+        Assert.Contains(activities, kvp => kvp.Key.ToString() == "Activity2");
+    }
+
+    [Fact]
+    public void GetEntities_WithNullRegistry_ShouldThrowArgumentNullException()
+    {
+        // Arrange, Act & Assert
+        Assert.Throws<ArgumentNullException>(() =>
+            DurableTaskRegistryExtensions.GetEntities(null!));
+    }
+
+    [Fact]
+    public void GetEntities_WithEmptyRegistry_ShouldReturnEmpty()
+    {
+        // Arrange
+        DurableTaskRegistry registry = new DurableTaskRegistry();
+
+        // Act
+        IEnumerable<KeyValuePair<TaskName, Func<IServiceProvider, ITaskEntity>>> entities = registry.GetEntities();
+
+        // Assert
+        Assert.Empty(entities);
+    }
+
+    [Fact]
+    public void GetEntities_WithRegisteredEntities_ShouldReturnThem()
+    {
+        // Arrange
+        DurableTaskRegistry registry = new DurableTaskRegistry();
+        registry.AddEntity<TestEntity>("Entity1");
+        registry.AddEntity<TestEntity>("Entity2");
+
+        // Act
+        List<KeyValuePair<TaskName, Func<IServiceProvider, ITaskEntity>>> entities = registry.GetEntities().ToList();
+
+        // Assert
+        Assert.Equal(2, entities.Count);
+        Assert.Contains(entities, kvp => kvp.Key.ToString() == "Entity1");
+        Assert.Contains(entities, kvp => kvp.Key.ToString() == "Entity2");
+    }
+
+    [Fact]
+    public void GetOrchestrators_ShouldNotReturnActivitiesOrEntities()
+    {
+        // Arrange
+        DurableTaskRegistry registry = new DurableTaskRegistry();
+        registry.AddOrchestrator<TestOrchestrator>("Orchestrator1");
+        registry.AddActivity<TestActivity>("Activity1");
+        registry.AddEntity<TestEntity>("Entity1");
+
+        // Act
+        List<KeyValuePair<TaskName, Func<IServiceProvider, ITaskOrchestrator>>> orchestrators = registry.GetOrchestrators().ToList();
+
+        // Assert
+        Assert.Single(orchestrators);
+        Assert.Equal("Orchestrator1", orchestrators[0].Key.ToString());
+    }
+
+    [Fact]
+    public void GetActivities_ShouldNotReturnOrchestratorsOrEntities()
+    {
+        // Arrange
+        DurableTaskRegistry registry = new DurableTaskRegistry();
+        registry.AddOrchestrator<TestOrchestrator>("Orchestrator1");
+        registry.AddActivity<TestActivity>("Activity1");
+        registry.AddEntity<TestEntity>("Entity1");
+
+        // Act
+        List<KeyValuePair<TaskName, Func<IServiceProvider, ITaskActivity>>> activities = registry.GetActivities().ToList();
+
+        // Assert
+        Assert.Single(activities);
+        Assert.Equal("Activity1", activities[0].Key.ToString());
+    }
+
+    [Fact]
+    public void GetEntities_ShouldNotReturnOrchestratorsOrActivities()
+    {
+        // Arrange
+        DurableTaskRegistry registry = new DurableTaskRegistry();
+        registry.AddOrchestrator<TestOrchestrator>("Orchestrator1");
+        registry.AddActivity<TestActivity>("Activity1");
+        registry.AddEntity<TestEntity>("Entity1");
+
+        // Act
+        List<KeyValuePair<TaskName, Func<IServiceProvider, ITaskEntity>>> entities = registry.GetEntities().ToList();
+
+        // Assert
+        Assert.Single(entities);
+        Assert.Equal("Entity1", entities[0].Key.ToString());
+    }
+
+    private class TestOrchestrator : TaskOrchestrator<object, object>
+    {
+        public override Task<object> RunAsync(TaskOrchestrationContext context, object input)
+        {
+            return Task.FromResult<object>(string.Empty);
+        }
+    }
+
+    private class TestActivity : TaskActivity<object, object>
+    {
+        public override Task<object> RunAsync(TaskActivityContext context, object input)
+        {
+            return Task.FromResult<object>(string.Empty);
+        }
+    }
+
+    private class TestEntity : TaskEntity<string>
+    {
+        public Task RunAsync(TaskEntityContext context)
+        {
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/test/Worker.Extensions.DurableTask.Tests/FunctionContextExtensionsTests.cs
+++ b/test/Worker.Extensions.DurableTask.Tests/FunctionContextExtensionsTests.cs
@@ -1,0 +1,292 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Collections.Immutable;
+using Microsoft.Azure.Functions.Worker.Extensions.DurableTask;
+using Microsoft.Azure.Functions.Worker.Extensions.DurableTask.Execution;
+
+namespace Microsoft.Azure.Functions.Worker.Tests;
+
+public class FunctionContextExtensionsTests
+{
+    [Fact]
+    public void TryGetOrchestrationBinding_WithNullContext_ShouldThrowArgumentNullException()
+    {
+        // Arrange, Act & Assert
+        Assert.Throws<ArgumentNullException>(() =>
+            FunctionContextExtensions.TryGetOrchestrationBinding(null!, out _));
+    }
+
+    [Fact]
+    public void TryGetOrchestrationBinding_WithOrchestrationTrigger_ShouldReturnTrue()
+    {
+        // Arrange
+        FunctionContext context = CreateContextWithBinding(TriggerNames.Orchestration);
+
+        // Act
+        bool result = context.TryGetOrchestrationBinding(out BindingMetadata? binding);
+
+        // Assert
+        Assert.True(result);
+        Assert.NotNull(binding);
+        Assert.Equal(TriggerNames.Orchestration, binding.Type);
+    }
+
+    [Fact]
+    public void TryGetOrchestrationBinding_WithoutOrchestrationTrigger_ShouldReturnFalse()
+    {
+        // Arrange
+        FunctionContext context = CreateContextWithBinding(TriggerNames.Activity);
+
+        // Act
+        bool result = context.TryGetOrchestrationBinding(out BindingMetadata? binding);
+
+        // Assert
+        Assert.False(result);
+        Assert.Null(binding);
+    }
+
+    [Fact]
+    public void TryGetActivityBinding_WithNullContext_ShouldThrowArgumentNullException()
+    {
+        // Arrange, Act & Assert
+        Assert.Throws<ArgumentNullException>(() =>
+            FunctionContextExtensions.TryGetActivityBinding(null!, out _));
+    }
+
+    [Fact]
+    public void TryGetActivityBinding_WithActivityTrigger_ShouldReturnTrue()
+    {
+        // Arrange
+        FunctionContext context = CreateContextWithBinding(TriggerNames.Activity);
+
+        // Act
+        bool result = context.TryGetActivityBinding(out BindingMetadata? binding);
+
+        // Assert
+        Assert.True(result);
+        Assert.NotNull(binding);
+        Assert.Equal(TriggerNames.Activity, binding.Type);
+    }
+
+    [Fact]
+    public void TryGetActivityBinding_WithoutActivityTrigger_ShouldReturnFalse()
+    {
+        // Arrange
+        FunctionContext context = CreateContextWithBinding(TriggerNames.Entity);
+
+        // Act
+        bool result = context.TryGetActivityBinding(out BindingMetadata? binding);
+
+        // Assert
+        Assert.False(result);
+        Assert.Null(binding);
+    }
+
+    [Fact]
+    public void TryGetEntityBinding_WithNullContext_ShouldThrowArgumentNullException()
+    {
+        // Arrange, Act & Assert
+        Assert.Throws<ArgumentNullException>(() =>
+            FunctionContextExtensions.TryGetEntityBinding(null!, out _));
+    }
+
+    [Fact]
+    public void TryGetEntityBinding_WithEntityTrigger_ShouldReturnTrue()
+    {
+        // Arrange
+        FunctionContext context = CreateContextWithBinding(TriggerNames.Entity);
+
+        // Act
+        bool result = context.TryGetEntityBinding(out BindingMetadata? binding);
+
+        // Assert
+        Assert.True(result);
+        Assert.NotNull(binding);
+        Assert.Equal(TriggerNames.Entity, binding.Type);
+    }
+
+    [Fact]
+    public void TryGetEntityBinding_WithoutEntityTrigger_ShouldReturnFalse()
+    {
+        // Arrange
+        FunctionContext context = CreateContextWithBinding(TriggerNames.Orchestration);
+
+        // Act
+        bool result = context.TryGetEntityBinding(out BindingMetadata? binding);
+
+        // Assert
+        Assert.False(result);
+        Assert.Null(binding);
+    }
+
+    [Fact]
+    public void TryGetBinding_WithNullContext_ShouldThrowArgumentNullException()
+    {
+        // Arrange, Act & Assert
+        Assert.Throws<ArgumentNullException>(() =>
+            FunctionContextExtensions.TryGetBinding(null!, "anyTrigger", out _));
+    }
+
+    [Fact]
+    public void TryGetBinding_WithMatchingTrigger_ShouldReturnTrue()
+    {
+        // Arrange
+        string triggerName = "customTrigger";
+        FunctionContext context = CreateContextWithBinding(triggerName);
+
+        // Act
+        bool result = context.TryGetBinding(triggerName, out BindingMetadata? binding);
+
+        // Assert
+        Assert.True(result);
+        Assert.NotNull(binding);
+        Assert.Equal(triggerName, binding.Type);
+    }
+
+    [Fact]
+    public void TryGetBinding_IsCaseInsensitive()
+    {
+        // Arrange
+        FunctionContext context = CreateContextWithBinding("orchestrationTrigger");
+
+        // Act
+        bool result = context.TryGetBinding("ORCHESTRATIONTRIGGER", out BindingMetadata? binding);
+
+        // Assert
+        Assert.True(result);
+        Assert.NotNull(binding);
+    }
+
+    [Fact]
+    public void GetInstanceId_WithNullContext_ShouldThrowArgumentNullException()
+    {
+        // Arrange, Act & Assert
+        Assert.Throws<ArgumentNullException>(() =>
+            FunctionContextExtensions.GetInstanceId(null!));
+    }
+
+    [Fact]
+    public void GetInstanceId_ShouldReturnInstanceIdFromBindingData()
+    {
+        // Arrange
+        string expectedInstanceId = "test-instance-123";
+        FunctionContext context = CreateContextWithInstanceId(expectedInstanceId);
+
+        // Act
+        string actualInstanceId = context.GetInstanceId();
+
+        // Assert
+        Assert.Equal(expectedInstanceId, actualInstanceId);
+    }
+
+    private static FunctionContext CreateContextWithBinding(string triggerType)
+    {
+        TestBindingMetadata binding = new TestBindingMetadata(triggerType);
+        Dictionary<string, BindingMetadata> bindingDict = new Dictionary<string, BindingMetadata>
+        {
+            ["trigger"] = binding
+        };
+
+        return new TestFunctionContext(bindingDict, new Dictionary<string, object?>());
+    }
+
+    private static FunctionContext CreateContextWithInstanceId(string instanceId)
+    {
+        Dictionary<string, object?> bindingDataDict = new Dictionary<string, object?>
+        {
+            ["instanceId"] = instanceId
+        };
+        return new TestFunctionContext(new Dictionary<string, BindingMetadata>(), bindingDataDict);
+    }
+
+    class TestFunctionContext : FunctionContext
+    {
+        public TestFunctionContext(IDictionary<string, BindingMetadata> inputBindings, IDictionary<string, object?> bindingContext)
+        {
+            this.FunctionDefinition = new TestFunctionDefinition(inputBindings);
+            this.BindingContext = new TestBindingContext(bindingContext);
+        }
+
+        public override string InvocationId => throw new NotImplementedException();
+
+        public override string FunctionId => throw new NotImplementedException();
+
+        public override TraceContext TraceContext => throw new NotImplementedException();
+
+        public override BindingContext BindingContext { get; }
+
+        public override RetryContext RetryContext => throw new NotImplementedException();
+
+        public override IServiceProvider InstanceServices
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+
+            set
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public override FunctionDefinition FunctionDefinition { get; }
+
+        public override IDictionary<object, object> Items
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+
+            set
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public override IInvocationFeatures Features => throw new NotImplementedException();
+    }
+
+    class TestFunctionDefinition : FunctionDefinition
+    {
+        public TestFunctionDefinition(IDictionary<string, BindingMetadata> inputBindings)
+        {
+            this.InputBindings = inputBindings.ToImmutableDictionary();
+        }
+
+        public override string Name => throw new NotImplementedException();
+        public override IImmutableDictionary<string, BindingMetadata> InputBindings { get; }
+        public override IImmutableDictionary<string, BindingMetadata> OutputBindings => throw new NotImplementedException();
+
+        public override ImmutableArray<FunctionParameter> Parameters => throw new NotImplementedException();
+
+        public override string PathToAssembly => throw new NotImplementedException();
+
+        public override string EntryPoint => throw new NotImplementedException();
+
+        public override string Id => throw new NotImplementedException();
+    }
+
+    class TestBindingMetadata : BindingMetadata
+    {
+        public TestBindingMetadata(string type)
+        {
+            this.Type = type;
+        }
+
+        public override string Name { get; } = string.Empty;
+        public override string Type { get; } = string.Empty;
+        public override BindingDirection Direction { get; } = BindingDirection.In;
+    }
+
+    class TestBindingContext : BindingContext
+    {
+        public TestBindingContext(IDictionary<string, object?> bindingData)
+        {
+            this.BindingData = bindingData.AsReadOnly();
+        }
+        public override IReadOnlyDictionary<string, object?> BindingData { get; }
+    }
+}

--- a/test/e2e/Apps/BasicDotNetIsolated/TestAsyncMiddleware.cs
+++ b/test/e2e/Apps/BasicDotNetIsolated/TestAsyncMiddleware.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Middleware;
+
+namespace Microsoft.Azure.Durable.Tests.E2E;
+
+/// <summary>
+/// Test middleware that performs async operations to validate the fix for
+/// https://github.com/microsoft/durabletask-dotnet/issues/158
+/// This middleware simulates async behaviors like App Configuration or logging services.
+/// </summary>
+public class TestAsyncMiddleware : IFunctionsWorkerMiddleware
+{
+    public async Task Invoke(FunctionContext context, FunctionExecutionDelegate next)
+    {
+        // Simulate an async operation like fetching configuration or logging
+        await Task.Delay(1);
+
+        // Store metadata to verify the middleware ran
+        context.Items["AsyncMiddlewareExecuted"] = true;
+        context.Items["AsyncMiddlewareTimestamp"] = DateTime.UtcNow;
+
+        // Continue to the next middleware/function
+        await next(context);
+
+        // Simulate async post-processing
+        await Task.Delay(1);
+    }
+}


### PR DESCRIPTION
This change set adds support for:
1. Invoking class-based orchestration, entity, and activities directly. No source generator needed.
2. Moves handling invoking or func-based tasks out of the middleware and into a dedicated executor.

<!-- Start the PR description with some context for the change. -->

This PR really is two in one, may consider breaking into separate PRs.

## Issue 1 - Solving Asynchronous Middleware Breaking Orchestrations

This PR solves orchestrations not support asynchronous middleware by moving the orchestration invocation handling to a custom `IFunctionExector`, which will always be ran at the very end of the middleware pipeline. So any async middleware will not be captured as part of the orchestration invocation.

**NOTE**: this PR moves activities and entities to be invoked the same way as well. This does have implications where some bindings are no longer prepared in the middleware. It might be a 'breaking' change for some customers if they tried to access that directly, but we could argue that behavior was never officially supported.

## Issue 2 - Fully Support Class Based Tasks

Today class-based tasks are only supported via the source generator and require _disabling_ the functions worker source generator. This is a poor experience for customers. Instead, this PR leverages a new extensibility point from functions allowing durable to supply function definitions directly. Now we can take existing durabletask-dotnet configuration and apply it to functions. No source generation needed - customers directly declare their class-based tasks during startup.

To further improve this experience, durable can adjust how to register implementations to the `DurableTaskRegistry`. This could be a great use of source-gen. Durable generator (still in preview) can generate a method which registers all discovered types to `DurableTaskRegistry`. In function projects a startup hook could also be emitted to automatically register those to `DurableTaskRegistry`.

TODO
- tests
- **DO NOT MERGE** until the next version of Microsoft.Azure.Functions.Worker.Core is released and this project is updated (this code is not functional until then)

<!-- Make sure to delete the markdown comments and the below sections when squash merging -->
### Issue describing the changes in this PR

resolves #2720
resolve #2876
resolves https://github.com/microsoft/durabletask-dotnet/issues/158

### Pull request checklist

* [ ] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)
* [ ] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk
* [ ] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
    * [ ] Otherwise: major or minor version updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
* [ ] My changes **do not** add EventIds to our EventSource logs
    * [ ] Otherwise: Ensure the EventIds are within the supported range in our existing Windows infrastructure. You may validate this with a deployed app's telemetry. You may also extend the range by completing a PR such as [this one](https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files).
* [ ] My changes **should** be added to **v2.x** branch.
    * [ ] Otherwise: This change applies exclusively to WebJobs.Extensions.DurableTask v3.x. It will be retained only in the `dev` and `main` branches and will not be merged into the `v2.x` branch.
