### PR TITLE
Andystaples/update more deps

### DIFF
--- a/.github/workflows/smoketest-mssql-inproc-v4.yml
+++ b/.github/workflows/smoketest-mssql-inproc-v4.yml
@@ -21,6 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       SA_PASSWORD: ${{ secrets.SA_PASSWORD }}
+      FUNCTIONS_INPROC_NET8_ENABLED: "1"
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/smoketest-netherite-inproc-v4.yml
+++ b/.github/workflows/smoketest-netherite-inproc-v4.yml
@@ -16,6 +16,10 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+
+    env:
+      FUNCTIONS_INPROC_NET8_ENABLED: "1"
+
     steps:
     - uses: actions/checkout@v2
     - name: Run V4 .NET in-proc w/ Netherite Smoke Test

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -47,46 +47,23 @@
     <!-- Used by TypedInterfaces -->
     <PackageVersion Include="Microsoft.AspNetCore.Server.Kestrel.Core" Version="2.3.6" />
   </ItemGroup>
-  <!-- Test dependencies -->
+  <!-- Dependencies used by both tests and samples -->
   <ItemGroup>
-    <PackageVersion Include="coverlet.collector" Version="6.0.0" />
-    <PackageVersion Include="FluentAssertions" Version="4.19.4" />
+    <PackageVersion Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="2.13.7" />
+    <PackageVersion Include="Microsoft.Azure.WebJobs.Extensions.Http" Version="3.2.0" />
+    <PackageVersion Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="5.1.3" />
+    <PackageVersion Include="Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator" Version="4.0.1" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageVersion Include="Moq" Version="4.16.1" />
+    <PackageVersion Include="xunit" Version="2.9.2" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
     <PackageVersion Include="Microsoft.ApplicationInsights.WorkerService" Version="2.22.0" />
-    <PackageVersion Include="Microsoft.Azure.DurableTask.Emulator" Version="2.5.4" />
-    <PackageVersion Include="Microsoft.Azure.DurableTask.Netherite.AzureFunctions" Version="3.1.0" />
-    <PackageVersion Include="Microsoft.Azure.DurableTask.Redis" Version="0.1.9-alpha" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker" Version="2.0.0" />
+    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.18.1" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="2.0.0" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask.AzureManaged" Version="0.4.2-alpha" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask.SqlServer" Version="1.5.0" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.3.0" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="2.0.2" />
-    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.18.1" />
-    <PackageVersion Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="2.13.7" />
-    <PackageVersion Include="Microsoft.Azure.WebJobs.Extensions.Http" Version="3.2.0" />
-    <PackageVersion Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="5.1.3" />
-    <PackageVersion Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" Version="3.0.33" />
-    <PackageVersion Include="Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator" Version="4.0.1" />
-    <PackageVersion Include="Microsoft.Build" Version="17.3.2" />
-    <PackageVersion Include="Microsoft.Build.Framework" Version="17.3.2" />
-    <PackageVersion Include="Microsoft.Build.Locator" Version="1.4.1" />
-    <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="17.3.2" />
-    <PackageVersion Include="Microsoft.CodeAnalysis" Version="3.9.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="3.9.0" />
-    <PackageVersion Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.65" />
-    <PackageVersion Include="Microsoft.DurableTask.Abstractions" Version="1.15.0" />
-    <PackageVersion Include="Microsoft.DurableTask.Generators" Version="1.0.0-preview.1" />
-    <PackageVersion Include="Microsoft.DurableTask.SqlServer.AzureFunctions" Version="1.5.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="6.0.0" Condition="'$(TargetFramework)' == 'net6.0'" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="9.0.0" Condition="'$(TargetFramework)' == 'net8.0'" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageVersion Include="Moq" Version="4.16.1" />
-    <PackageVersion Include="MSTest.TestAdapter" Version="1.3.2" />
-    <PackageVersion Include="MSTest.TestFramework" Version="1.3.2" />
-    <PackageVersion Include="xunit" Version="2.9.2" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
   </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -42,13 +42,24 @@
     <PackageVersion Include="System.Text.Json" Version="8.0.5" />
     <PackageVersion Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
+
   <!-- Non-Production product dependencies -->
   <ItemGroup>
     <!-- Used by TypedInterfaces -->
     <PackageVersion Include="Microsoft.AspNetCore.Server.Kestrel.Core" Version="2.3.6" />
   </ItemGroup>
+
   <!-- Dependencies used by both tests and samples -->
   <ItemGroup>
+    <PackageVersion Include="Microsoft.ApplicationInsights.WorkerService" Version="2.22.0" />
+    <PackageVersion Include="Microsoft.Azure.Functions.Worker" Version="2.0.0" />
+    <!-- TODO: Update this to Worker SDK 2.x -->
+    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.18.1" />
+    <PackageVersion Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="2.0.0" />
+    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask.AzureManaged" Version="0.4.2-alpha" />
+    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask.SqlServer" Version="1.5.0" />
+    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.3.0" />
+    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="2.0.2" />
     <PackageVersion Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="2.13.7" />
     <PackageVersion Include="Microsoft.Azure.WebJobs.Extensions.Http" Version="3.2.0" />
     <PackageVersion Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="5.1.3" />
@@ -57,13 +68,5 @@
     <PackageVersion Include="Moq" Version="4.16.1" />
     <PackageVersion Include="xunit" Version="2.9.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
-    <PackageVersion Include="Microsoft.ApplicationInsights.WorkerService" Version="2.22.0" />
-    <PackageVersion Include="Microsoft.Azure.Functions.Worker" Version="2.0.0" />
-    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.18.1" />
-    <PackageVersion Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="2.0.0" />
-    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask.AzureManaged" Version="0.4.2-alpha" />
-    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask.SqlServer" Version="1.5.0" />
-    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.3.0" />
-    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="2.0.2" />
   </ItemGroup>
 </Project>

--- a/global.json
+++ b/global.json
@@ -1,0 +1,10 @@
+{
+  "sdk": {
+    "version": "8.0.121",
+    "rollForward": "latestFeature"
+  },
+  "msbuild-sdks": {
+    "Microsoft.Build.NoTargets": "3.7.56",
+    "Microsoft.Build.Traversal": "4.1.0"
+  }
+}

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "9.0.111",
+    "version": "8.0.121",
     "rollForward": "latestFeature"
   },
   "msbuild-sdks": {

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.121",
+    "version": "9.0.111",
     "rollForward": "latestFeature"
   },
   "msbuild-sdks": {

--- a/samples/Directory.Packages.props
+++ b/samples/Directory.Packages.props
@@ -1,30 +1,48 @@
 <Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
   
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Packages.props, $(MSBuildThisFileDirectory)..))" />
 
+  <!-- Dependencies only required for samples -->
   <ItemGroup>
     <PackageVersion Include="EntityFramework" Version="6.5.1" />
     <PackageVersion Include="Microsoft.AspNet.WebApi.Client" Version="5.2.7" />
     <PackageVersion Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
-    <PackageVersion Include="Microsoft.Azure.WebJobs.Extensions.Http" Version="3.2.0" />
-    <PackageVersion Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="2.13.4" />
-    <PackageVersion Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="3.0.10" />
     <PackageVersion Include="Microsoft.Azure.WebJobs.Extensions.Twilio" Version="3.0.2" />
-    <PackageVersion Include="Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator" Version="1.1.0" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.3" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="3.1.3" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="3.1.3" />
-    <PackageVersion Include="Microsoft.NET.Sdk.Functions" Version="4.2.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageVersion Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.1.2" />
-    <PackageVersion Include="StyleCop.Analyzers" Version="1.1.118" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="5.4.0" />
     <PackageVersion Include="TaskBuilder.fs" Version="1.0.0" />
-    <PackageVersion Include="Moq" Version="4.16.1" />
-    <PackageVersion Include="xunit" Version="2.9.2" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
   </ItemGroup>
+
+  <!-- Dependencies pinned for samples -->
+   <ItemGroup>
+    <PackageVersion Update="Microsoft.Azure.WebJobs.Extensions.Http" Version="3.2.0" />
+    <PackageVersion Update="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="2.13.4" />
+    <PackageVersion Update="Microsoft.Azure.WebJobs.Extensions.Storage" Version="3.0.10" />
+    <PackageVersion Update="Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator" Version="1.1.0" />
+    <PackageVersion Update="Microsoft.NET.Sdk.Functions" Version="4.2.0" />
+    <PackageVersion Update="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageVersion Update="Moq" Version="4.16.1" />
+    <PackageVersion Update="StyleCop.Analyzers" Version="1.1.118" />
+    <PackageVersion Update="xunit" Version="2.9.2" />
+    <PackageVersion Update="xunit.runner.visualstudio" Version="2.8.2" />
+   </ItemGroup>
+
+  <!-- Transitive dependencies with specific versions -->
+   <ItemGroup>
+    <PackageVersion Update="Microsoft.AspNet.WebApi.Client" Version="5.2.8" />
+    <PackageVersion Update="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.0" />
+    <PackageVersion Update="Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator" Version="4.0.1" />
+    <PackageVersion Update="Microsoft.Bcl.AsyncInterfaces" Version="9.0.0"/>
+    <PackageVersion Update="Microsoft.Extensions.Logging.Debug" Version="8.0.1"/>
+    <PackageVersion Update="System.Drawing.Common" Version="6.0.0" />
+    <PackageVersion Update="System.Text.Json" Version="9.0.0" />
+   </ItemGroup>
+
 </Project>

--- a/samples/Samples.sln
+++ b/samples/Samples.sln
@@ -1,0 +1,141 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FunctionAppCorrelation", "distributed-tracing\v1\FunctionAppCorrelation\FunctionAppCorrelation.csproj", "{A386213C-00DD-AA04-C1FD-2D476A66C5EA}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "distributed-tracing", "distributed-tracing", "{02EA681E-C7D8-13C7-8484-4AC65E1B71E8}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "V1", "V1", "{3BF2A5E4-5913-4337-BFB0-B24EBC57AA2F}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "V2", "V2", "{E7F2305F-AE0C-49A6-9EAD-C4B1B9852862}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "durable-client-managed-identity", "durable-client-managed-identity", "{0E02EE74-373B-416B-8D51-7D10CE5C7D24}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "aspnetcore-app", "aspnetcore-app", "{73C7FA96-A8A6-4629-BAF1-149135017BEC}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "functions-app", "functions-app", "{D5FD36EA-02FB-4358-84E8-C3DA3EE4D82C}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "entitites-csharp", "entitites-csharp", "{C4365D82-24BC-4ABB-ACD7-4D50BA5072BA}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "functionapp-csharp", "functionapp-csharp", "{09098F79-705F-46CE-8B08-B03BD8C232BB}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "isolated-unit-tests", "isolated-unit-tests", "{D1D1BBAA-1419-4AC0-A106-1BA4EA1AA638}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "precompiled", "precompiled", "{B3D6D847-4660-4F92-9335-2827A63391D8}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "todolist-aspnetcore", "todolist-aspnetcore", "{3F05061C-EA5B-4393-BF2C-C37C26B7BA31}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "VSSample.Tests", "VSSample.Tests", "{AB39036E-9676-4C1E-9121-AFCE0463F773}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DistributedTracingSample", "distributed-tracing\v2\DistributedTracingSample\DistributedTracingSample\DistributedTracingSample.csproj", "{51EA10BE-70DF-D4A7-19E3-334C63D237D9}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ToDoList", "durable-client-managed-identity\aspnetcore-app\ToDoList.csproj", "{FD13E64E-6934-83D6-6D61-B7FBB0B32BF5}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DurableClientSampleFunctionApp", "durable-client-managed-identity\functions-app\DurableClientSampleFunctionApp.csproj", "{3F6B29AC-3D06-A092-B13C-00166D9BAEC4}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Chirper.Service", "entitites-csharp\Chirper\Chirper.Service\Chirper.Service.csproj", "{18FADC7B-E045-2793-CA2E-9EEA9D90D622}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RideSharing", "entitites-csharp\RideSharing\RideSharing\RideSharing.csproj", "{9E2C2405-9CA2-B319-8D66-97C0C6FD9345}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DurableClientSampleFunctionApp", "functionapp-csharp\DurableClientSampleFunctionApp.csproj", "{FE0E52C1-0B5D-5BEB-16AE-A78989D0A4D2}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "IsolatedUnitTest", "isolated-unit-tests\IsolatedUnitTest.csproj", "{116C3DC0-731D-E03C-B9D1-49319056CCC0}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "VSSample", "precompiled\VSSample.csproj", "{DE1BEAF3-4B9D-4EDE-4E80-E0B53E501158}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ToDoList", "todolist-aspnetcore\ToDoList.csproj", "{2C2F8888-D5E7-2D90-BC8B-6067624343BE}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "VSSample.Tests", "VSSample.Tests\VSSample.Tests.csproj", "{983B12AA-866D-CA82-76EF-80F7B5359A56}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Worker.Extensions.DurableTask", "..\src\Worker.Extensions.DurableTask\Worker.Extensions.DurableTask.csproj", "{AB46487C-B01C-70BB-7F2C-20FF2630F471}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "csx", "csx", "{BC98A14A-711B-4872-85A8-A805EE650D72}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "extensions", "csx\extensions.csproj", "{C0D4D58E-91F0-EEE3-C30B-96D514E1D7B1}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{A386213C-00DD-AA04-C1FD-2D476A66C5EA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A386213C-00DD-AA04-C1FD-2D476A66C5EA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A386213C-00DD-AA04-C1FD-2D476A66C5EA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A386213C-00DD-AA04-C1FD-2D476A66C5EA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{51EA10BE-70DF-D4A7-19E3-334C63D237D9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{51EA10BE-70DF-D4A7-19E3-334C63D237D9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{51EA10BE-70DF-D4A7-19E3-334C63D237D9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{51EA10BE-70DF-D4A7-19E3-334C63D237D9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FD13E64E-6934-83D6-6D61-B7FBB0B32BF5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FD13E64E-6934-83D6-6D61-B7FBB0B32BF5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FD13E64E-6934-83D6-6D61-B7FBB0B32BF5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FD13E64E-6934-83D6-6D61-B7FBB0B32BF5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3F6B29AC-3D06-A092-B13C-00166D9BAEC4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3F6B29AC-3D06-A092-B13C-00166D9BAEC4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3F6B29AC-3D06-A092-B13C-00166D9BAEC4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3F6B29AC-3D06-A092-B13C-00166D9BAEC4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{18FADC7B-E045-2793-CA2E-9EEA9D90D622}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{18FADC7B-E045-2793-CA2E-9EEA9D90D622}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{18FADC7B-E045-2793-CA2E-9EEA9D90D622}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{18FADC7B-E045-2793-CA2E-9EEA9D90D622}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9E2C2405-9CA2-B319-8D66-97C0C6FD9345}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9E2C2405-9CA2-B319-8D66-97C0C6FD9345}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9E2C2405-9CA2-B319-8D66-97C0C6FD9345}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9E2C2405-9CA2-B319-8D66-97C0C6FD9345}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FE0E52C1-0B5D-5BEB-16AE-A78989D0A4D2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FE0E52C1-0B5D-5BEB-16AE-A78989D0A4D2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FE0E52C1-0B5D-5BEB-16AE-A78989D0A4D2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FE0E52C1-0B5D-5BEB-16AE-A78989D0A4D2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{116C3DC0-731D-E03C-B9D1-49319056CCC0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{116C3DC0-731D-E03C-B9D1-49319056CCC0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{116C3DC0-731D-E03C-B9D1-49319056CCC0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{116C3DC0-731D-E03C-B9D1-49319056CCC0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DE1BEAF3-4B9D-4EDE-4E80-E0B53E501158}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DE1BEAF3-4B9D-4EDE-4E80-E0B53E501158}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DE1BEAF3-4B9D-4EDE-4E80-E0B53E501158}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DE1BEAF3-4B9D-4EDE-4E80-E0B53E501158}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2C2F8888-D5E7-2D90-BC8B-6067624343BE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2C2F8888-D5E7-2D90-BC8B-6067624343BE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2C2F8888-D5E7-2D90-BC8B-6067624343BE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2C2F8888-D5E7-2D90-BC8B-6067624343BE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{983B12AA-866D-CA82-76EF-80F7B5359A56}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{983B12AA-866D-CA82-76EF-80F7B5359A56}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{983B12AA-866D-CA82-76EF-80F7B5359A56}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{983B12AA-866D-CA82-76EF-80F7B5359A56}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AB46487C-B01C-70BB-7F2C-20FF2630F471}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AB46487C-B01C-70BB-7F2C-20FF2630F471}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AB46487C-B01C-70BB-7F2C-20FF2630F471}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AB46487C-B01C-70BB-7F2C-20FF2630F471}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C0D4D58E-91F0-EEE3-C30B-96D514E1D7B1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C0D4D58E-91F0-EEE3-C30B-96D514E1D7B1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C0D4D58E-91F0-EEE3-C30B-96D514E1D7B1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C0D4D58E-91F0-EEE3-C30B-96D514E1D7B1}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{A386213C-00DD-AA04-C1FD-2D476A66C5EA} = {3BF2A5E4-5913-4337-BFB0-B24EBC57AA2F}
+		{3BF2A5E4-5913-4337-BFB0-B24EBC57AA2F} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+		{E7F2305F-AE0C-49A6-9EAD-C4B1B9852862} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+		{73C7FA96-A8A6-4629-BAF1-149135017BEC} = {0E02EE74-373B-416B-8D51-7D10CE5C7D24}
+		{D5FD36EA-02FB-4358-84E8-C3DA3EE4D82C} = {0E02EE74-373B-416B-8D51-7D10CE5C7D24}
+		{51EA10BE-70DF-D4A7-19E3-334C63D237D9} = {E7F2305F-AE0C-49A6-9EAD-C4B1B9852862}
+		{FD13E64E-6934-83D6-6D61-B7FBB0B32BF5} = {73C7FA96-A8A6-4629-BAF1-149135017BEC}
+		{3F6B29AC-3D06-A092-B13C-00166D9BAEC4} = {D5FD36EA-02FB-4358-84E8-C3DA3EE4D82C}
+		{18FADC7B-E045-2793-CA2E-9EEA9D90D622} = {C4365D82-24BC-4ABB-ACD7-4D50BA5072BA}
+		{9E2C2405-9CA2-B319-8D66-97C0C6FD9345} = {C4365D82-24BC-4ABB-ACD7-4D50BA5072BA}
+		{FE0E52C1-0B5D-5BEB-16AE-A78989D0A4D2} = {09098F79-705F-46CE-8B08-B03BD8C232BB}
+		{116C3DC0-731D-E03C-B9D1-49319056CCC0} = {D1D1BBAA-1419-4AC0-A106-1BA4EA1AA638}
+		{DE1BEAF3-4B9D-4EDE-4E80-E0B53E501158} = {B3D6D847-4660-4F92-9335-2827A63391D8}
+		{2C2F8888-D5E7-2D90-BC8B-6067624343BE} = {3F05061C-EA5B-4393-BF2C-C37C26B7BA31}
+		{983B12AA-866D-CA82-76EF-80F7B5359A56} = {AB39036E-9676-4C1E-9121-AFCE0463F773}
+		{C0D4D58E-91F0-EEE3-C30B-96D514E1D7B1} = {BC98A14A-711B-4872-85A8-A805EE650D72}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {AE502478-3E68-4705-94BF-1B3B47CFEDE4}
+	EndGlobalSection
+EndGlobal

--- a/samples/VSSample.Tests/VSSample.Tests.csproj
+++ b/samples/VSSample.Tests/VSSample.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/samples/distributed-tracing/v1/FunctionAppCorrelation/FunctionAppCorrelation.csproj
+++ b/samples/distributed-tracing/v1/FunctionAppCorrelation/FunctionAppCorrelation.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <AzureFunctionsVersion>v3</AzureFunctionsVersion>
+    <AzureFunctionsVersion>v4</AzureFunctionsVersion>
     <RunAnalyzersDuringLiveAnalysis>true</RunAnalyzersDuringLiveAnalysis>
     <RunAnalyzersDuringBuild>true</RunAnalyzersDuringBuild>
   </PropertyGroup>

--- a/samples/distributed-tracing/v1/FunctionAppCorrelation/FunctionAppCorrelation.csproj
+++ b/samples/distributed-tracing/v1/FunctionAppCorrelation/FunctionAppCorrelation.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AzureFunctionsVersion>v3</AzureFunctionsVersion>
     <RunAnalyzersDuringLiveAnalysis>true</RunAnalyzersDuringLiveAnalysis>
     <RunAnalyzersDuringBuild>true</RunAnalyzersDuringBuild>
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" />
-    <PackageReference Include="StyleCop.Analyzers" PrivateAssets="All"/>
+    <PackageReference Include="StyleCop.Analyzers" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup>
     <AdditionalFiles Include="..\..\..\..\.stylecop\stylecop.json" />

--- a/samples/distributed-tracing/v2/DistributedTracingSample/DistributedTracingSample.sln
+++ b/samples/distributed-tracing/v2/DistributedTracingSample/DistributedTracingSample.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 17.2.32210.308
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DistributedTracingSample", "DistributedTracingSample\DistributedTracingSample.csproj", "{363FCA38-CE94-4EBF-8627-B4519E8D7926}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebJobs.Extensions.DurableTask", "..\..\..\..\src\WebJobs.Extensions.DurableTask\WebJobs.Extensions.DurableTask.csproj", "{82E8B252-8293-4DDC-A797-C3384A93E2D5}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,6 +17,10 @@ Global
 		{363FCA38-CE94-4EBF-8627-B4519E8D7926}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{363FCA38-CE94-4EBF-8627-B4519E8D7926}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{363FCA38-CE94-4EBF-8627-B4519E8D7926}.Release|Any CPU.Build.0 = Release|Any CPU
+		{82E8B252-8293-4DDC-A797-C3384A93E2D5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{82E8B252-8293-4DDC-A797-C3384A93E2D5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{82E8B252-8293-4DDC-A797-C3384A93E2D5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{82E8B252-8293-4DDC-A797-C3384A93E2D5}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/samples/distributed-tracing/v2/DistributedTracingSample/DistributedTracingSample.sln
+++ b/samples/distributed-tracing/v2/DistributedTracingSample/DistributedTracingSample.sln
@@ -5,8 +5,6 @@ VisualStudioVersion = 17.2.32210.308
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DistributedTracingSample", "DistributedTracingSample\DistributedTracingSample.csproj", "{363FCA38-CE94-4EBF-8627-B4519E8D7926}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebJobs.Extensions.DurableTask", "..\..\..\..\src\WebJobs.Extensions.DurableTask\WebJobs.Extensions.DurableTask.csproj", "{82E8B252-8293-4DDC-A797-C3384A93E2D5}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -17,10 +15,6 @@ Global
 		{363FCA38-CE94-4EBF-8627-B4519E8D7926}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{363FCA38-CE94-4EBF-8627-B4519E8D7926}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{363FCA38-CE94-4EBF-8627-B4519E8D7926}.Release|Any CPU.Build.0 = Release|Any CPU
-		{82E8B252-8293-4DDC-A797-C3384A93E2D5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{82E8B252-8293-4DDC-A797-C3384A93E2D5}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{82E8B252-8293-4DDC-A797-C3384A93E2D5}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{82E8B252-8293-4DDC-A797-C3384A93E2D5}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/samples/distributed-tracing/v2/DistributedTracingSample/DistributedTracingSample/DistributedTracingSample.csproj
+++ b/samples/distributed-tracing/v2/DistributedTracingSample/DistributedTracingSample/DistributedTracingSample.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
   </PropertyGroup>
 

--- a/samples/durable-client-managed-identity/aspnetcore-app/Controllers/TodoController.cs
+++ b/samples/durable-client-managed-identity/aspnetcore-app/Controllers/TodoController.cs
@@ -1,15 +1,11 @@
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.Azure.WebJobs.Extensions.DurableTask;
 using Microsoft.Azure.WebJobs.Extensions.DurableTask.ContextImplementations;
 using Microsoft.Azure.WebJobs.Extensions.DurableTask.Options;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
-using Newtonsoft.Json;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net.Http;
-using System.Net.Http.Headers;
 using System.Threading.Tasks;
 using TodoApi.Models;
 
@@ -43,7 +39,7 @@ namespace TodoApi.Controllers
         [HttpGet]
         public async Task<ActionResult<IEnumerable<TodoItem>>> GetTodoItem()
         {
-            return await _context.TodoItems.ToListAsync();
+            return await EntityFrameworkQueryableExtensions.ToListAsync(_context.TodoItems);
         }
 
         // GET: api/Todo/5

--- a/samples/durable-client-managed-identity/aspnetcore-app/ToDoList.csproj
+++ b/samples/durable-client-managed-identity/aspnetcore-app/ToDoList.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <!-- We use central package management. For version details, refer to `samples/Directory.packages.props`. -->

--- a/samples/durable-client-managed-identity/functions-app/DurableClientSampleFunctionApp.csproj
+++ b/samples/durable-client-managed-identity/functions-app/DurableClientSampleFunctionApp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <AzureFunctionsVersion>v3</AzureFunctionsVersion>
+    <AzureFunctionsVersion>v4</AzureFunctionsVersion>
   </PropertyGroup>
 
   <!-- We use central package management. For version details, refer to `samples/Directory.packages.props`. -->

--- a/samples/durable-client-managed-identity/functions-app/DurableClientSampleFunctionApp.csproj
+++ b/samples/durable-client-managed-identity/functions-app/DurableClientSampleFunctionApp.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AzureFunctionsVersion>v3</AzureFunctionsVersion>
   </PropertyGroup>
 

--- a/samples/entitites-csharp/Chirper/Chirper.Service/Chirper.Service.csproj
+++ b/samples/entitites-csharp/Chirper/Chirper.Service/Chirper.Service.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AzureFunctionsVersion>v3</AzureFunctionsVersion>
   </PropertyGroup>
 
@@ -10,7 +10,7 @@
     <None Include="..\README.md" Link="README.md" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask"/>
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Http" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" />
   </ItemGroup>

--- a/samples/entitites-csharp/Chirper/Chirper.Service/Chirper.Service.csproj
+++ b/samples/entitites-csharp/Chirper/Chirper.Service/Chirper.Service.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <AzureFunctionsVersion>v3</AzureFunctionsVersion>
+    <AzureFunctionsVersion>v4</AzureFunctionsVersion>
   </PropertyGroup>
 
   <!-- We use central package management. For version details, refer to `samples/Directory.packages.props`. -->

--- a/samples/functionapp-csharp/DurableClientSampleFunctionApp.csproj
+++ b/samples/functionapp-csharp/DurableClientSampleFunctionApp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <AzureFunctionsVersion>v3</AzureFunctionsVersion>
+    <AzureFunctionsVersion>v4</AzureFunctionsVersion>
   </PropertyGroup>
 
   <!-- We use central package management. For version details, refer to `samples/Directory.packages.props`. -->

--- a/samples/functionapp-csharp/DurableClientSampleFunctionApp.csproj
+++ b/samples/functionapp-csharp/DurableClientSampleFunctionApp.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AzureFunctionsVersion>v3</AzureFunctionsVersion>
   </PropertyGroup>
 

--- a/samples/precompiled/VSSample.csproj
+++ b/samples/precompiled/VSSample.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <AzureFunctionsVersion>v3</AzureFunctionsVersion>
+    <AzureFunctionsVersion>v4</AzureFunctionsVersion>
   </PropertyGroup>
 
   <!-- We use central package management. For version details, refer to `samples/Directory.packages.props`. -->

--- a/samples/precompiled/VSSample.csproj
+++ b/samples/precompiled/VSSample.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AzureFunctionsVersion>v3</AzureFunctionsVersion>
   </PropertyGroup>
 

--- a/samples/todolist-aspnetcore/Controllers/TodoController.cs
+++ b/samples/todolist-aspnetcore/Controllers/TodoController.cs
@@ -43,7 +43,7 @@ namespace TodoApi.Controllers
         [HttpGet]
         public async Task<ActionResult<IEnumerable<TodoItem>>> GetTodoItem()
         {
-            return await _context.TodoItems.ToListAsync();
+            return await EntityFrameworkQueryableExtensions.ToListAsync(_context.TodoItems);
         }
 
         // GET: api/Todo/5

--- a/samples/todolist-aspnetcore/ToDoList.csproj
+++ b/samples/todolist-aspnetcore/ToDoList.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <!-- We use central package management. For version details, refer to `samples/Directory.packages.props`. -->

--- a/src/DurableFunctions.TypedInterfaces/Example/DurableFunctions.TypedInterfaces.Example.csproj
+++ b/src/DurableFunctions.TypedInterfaces/Example/DurableFunctions.TypedInterfaces.Example.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
     <CompilerGeneratedFilesOutputPath>$(BaseIntermediateOutputPath)Generated</CompilerGeneratedFilesOutputPath>

--- a/test/CodeGen.Example.Test/DurableFunctions.TypedInterfaces.Examples.Test.csproj
+++ b/test/CodeGen.Example.Test/DurableFunctions.TypedInterfaces.Examples.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Company>Microsoft Corporation</Company>
     <NoWarn>SA0001;SA1600;SA1615</NoWarn>
     <SignAssembly>true</SignAssembly>

--- a/test/CodeGen.SourceGenerator.Test/DurableFunctions.TypedInterfaces.SourceGenerator.Test.csproj
+++ b/test/CodeGen.SourceGenerator.Test/DurableFunctions.TypedInterfaces.SourceGenerator.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <Company>Microsoft Corporation</Company>
     <NoWarn>SA0001;SA1600;SA1615</NoWarn>
     <SignAssembly>true</SignAssembly>

--- a/test/DFPerfScenarios/DFPerfScenariosV4.csproj
+++ b/test/DFPerfScenarios/DFPerfScenariosV4.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
   </PropertyGroup>
 

--- a/test/DFPerfScenarios/DFPerfScenariosV4.csproj
+++ b/test/DFPerfScenarios/DFPerfScenariosV4.csproj
@@ -6,7 +6,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Sdk.Functions" />
-    <PackageReference Include="System.Text.RegularExpressions" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Directory.Packages.props
+++ b/test/Directory.Packages.props
@@ -1,0 +1,44 @@
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
+  </PropertyGroup>
+  
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Packages.props, $(MSBuildThisFileDirectory)..))" />
+
+  <ItemGroup>
+    <PackageVersion Include="coverlet.collector" Version="6.0.0" />
+    <PackageVersion Include="FluentAssertions" Version="4.19.4" />
+    <PackageVersion Include="Microsoft.Azure.DurableTask.Emulator" Version="2.5.4" />
+    <PackageVersion Include="Microsoft.Azure.DurableTask.Netherite.AzureFunctions" Version="3.1.0" />
+    <PackageVersion Include="Microsoft.Azure.DurableTask.Redis" Version="0.1.9-alpha" />
+    <PackageVersion Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" Version="3.0.33" />
+    <PackageVersion Include="Microsoft.Build" Version="17.3.2" />
+    <PackageVersion Include="Microsoft.Build.Framework" Version="17.3.2" />
+    <PackageVersion Include="Microsoft.Build.Locator" Version="1.4.1" />
+    <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="17.3.2" />
+    <PackageVersion Include="Microsoft.CodeAnalysis" Version="3.9.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="3.9.0" />
+    <PackageVersion Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.65" />
+    <PackageVersion Include="Microsoft.DurableTask.Abstractions" Version="1.15.0" />
+    <PackageVersion Include="Microsoft.DurableTask.Generators" Version="1.0.0-preview.1" />
+    <PackageVersion Include="Microsoft.DurableTask.SqlServer.AzureFunctions" Version="1.5.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="6.0.0" Condition="'$(TargetFramework)' == 'net6.0'" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="9.0.0" Condition="'$(TargetFramework)' == 'net8.0'" />
+    <PackageVersion Include="MSTest.TestAdapter" Version="1.3.2" />
+    <PackageVersion Include="MSTest.TestFramework" Version="1.3.2" />
+  </ItemGroup>
+
+  <!-- Transitive dependencies with higher versions -->
+  <ItemGroup>
+    <PackageVersion Update="Azure.Identity" Version="1.13.1" />
+    <PackageVersion Update="Microsoft.Bcl.AsyncInterfaces" Version="9.0.0"/>
+    <PackageVersion Update="Microsoft.Extensions.Azure" Version="1.10.0" />
+    <PackageVersion Update="System.Drawing.Common" Version="6.0.0" />
+    <PackageVersion Update="System.Text.Json" Version="9.0.0" />
+  </ItemGroup>
+
+</Project>

--- a/test/FunctionsV2/WebJobs.Extensions.DurableTask.Tests.V2.csproj
+++ b/test/FunctionsV2/WebJobs.Extensions.DurableTask.Tests.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Company>Microsoft Corporation</Company>
     <NoWarn>SA0001;SA1600;SA1615</NoWarn>
     <SignAssembly>true</SignAssembly>

--- a/test/FunctionsV2/WebJobs.Extensions.DurableTask.Tests.V2.csproj
+++ b/test/FunctionsV2/WebJobs.Extensions.DurableTask.Tests.V2.csproj
@@ -23,9 +23,6 @@
     <PackageReference Include="Microsoft.Extensions.Logging" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Moq" />
-    <PackageReference Include="System.Drawing.Common" />
-    <PackageReference Include="System.Net.Http" />
-    <PackageReference Include="System.Text.RegularExpressions" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="StyleCop.Analyzers" PrivateAssets="All" />

--- a/test/PerfTests/DFPerfTests/perf.csproj
+++ b/test/PerfTests/DFPerfTests/perf.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/test/PerfTests/JavaScript/extensions.csproj
+++ b/test/PerfTests/JavaScript/extensions.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <WarningsAsErrors></WarningsAsErrors>
     <DefaultItemExcludes>**</DefaultItemExcludes>
   </PropertyGroup>

--- a/test/PerfTests/Python/extensions.csproj
+++ b/test/PerfTests/Python/extensions.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <WarningsAsErrors></WarningsAsErrors>
     <DefaultItemExcludes>**</DefaultItemExcludes>
   </PropertyGroup>

--- a/test/SmokeTests/BackendSmokeTests/MSSQL/MSSQL.csproj
+++ b/test/SmokeTests/BackendSmokeTests/MSSQL/MSSQL.csproj
@@ -2,13 +2,17 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
+    <!-- CPM seems to be broken for .net8 inproc apps when WebJobs.Extensions.DurableTask.csproj is targeting net6.0 -->
+    <!-- If enabled, func complains about "Could not load file or assembly 'Microsoft.Extensions.Logging.Abstractions, Version=9.0.0.0" -->
+    <!-- This is probably due to the per-TFM versioning we do for Microsoft.Extensions.Logging -->
+    <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\src\WebJobs.Extensions.DurableTask\WebJobs.Extensions.DurableTask.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" />
-    <PackageReference Include="Microsoft.DurableTask.SqlServer.AzureFunctions" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.6.0" />
+    <PackageReference Include="Microsoft.DurableTask.SqlServer.AzureFunctions" Version="1.5.1" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">

--- a/test/SmokeTests/BackendSmokeTests/Netherite/Dockerfile
+++ b/test/SmokeTests/BackendSmokeTests/Netherite/Dockerfile
@@ -1,7 +1,7 @@
 ﻿# Copyright (c) .NET Foundation. All rights reserved.
 # Licensed under the MIT License. See LICENSE in the project root for license information.
 
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build-env
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build-env
 
 # Build the app
 COPY . /root

--- a/test/SmokeTests/BackendSmokeTests/Netherite/Netherite.csproj
+++ b/test/SmokeTests/BackendSmokeTests/Netherite/Netherite.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/test/SmokeTests/BackendSmokeTests/Netherite/Netherite.csproj
+++ b/test/SmokeTests/BackendSmokeTests/Netherite/Netherite.csproj
@@ -2,11 +2,15 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
+    <!-- CPM seems to be broken for .net8 inproc apps when WebJobs.Extensions.DurableTask.csproj is targeting net6.0 -->
+    <!-- If enabled, func complains about "Could not load file or assembly 'Microsoft.Extensions.Logging.Abstractions, Version=9.0.0.0" -->
+    <!-- This is probably due to the per-TFM versioning we do for Microsoft.Extensions.Logging -->
+    <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\src\WebJobs.Extensions.DurableTask\WebJobs.Extensions.DurableTask.csproj" />
-    <PackageReference Include="Microsoft.Azure.DurableTask.Netherite.AzureFunctions" />
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" />
+    <PackageReference Include="Microsoft.Azure.DurableTask.Netherite.AzureFunctions" Version="3.1.0" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.6.0" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">

--- a/test/SmokeTests/OOProcSmokeTests/DotNetIsolated/Dockerfile
+++ b/test/SmokeTests/OOProcSmokeTests/DotNetIsolated/Dockerfile
@@ -26,7 +26,7 @@ RUN cd /root/test/SmokeTests/OOProcSmokeTests/DotNetIsolated && \
     cat /home/site/wwwroot/extensions.json # debugging
 
 # Step 3: Generate the final app image to run
-FROM mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated6.0
+FROM mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0
 
 # This is the standard setup for Azure Functions running in Docker containers
 ENV AzureWebJobsScriptRoot=/home/site/wwwroot \

--- a/test/SmokeTests/OOProcSmokeTests/DotNetIsolated/Dockerfile
+++ b/test/SmokeTests/OOProcSmokeTests/DotNetIsolated/Dockerfile
@@ -1,7 +1,7 @@
 ﻿# Copyright (c) .NET Foundation. All rights reserved.
 # Licensed under the MIT License. See LICENSE in the project root for license information.
 
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build-env
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build-env
 
 # Step 1: Build the WebJobs extension and publish it as a local NuGet package
 COPY . /root

--- a/test/SmokeTests/OOProcSmokeTests/DotNetIsolated/DotNetIsolated.csproj
+++ b/test/SmokeTests/OOProcSmokeTests/DotNetIsolated/DotNetIsolated.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
     <OutputType>exe</OutputType>
     <IsPackable>false</IsPackable>

--- a/test/SmokeTests/OOProcSmokeTests/durableJS/Dockerfile
+++ b/test/SmokeTests/OOProcSmokeTests/durableJS/Dockerfile
@@ -3,7 +3,7 @@
 
 # Step 1: Add the durable extension by building it locally.
 #         This is an alternative to "func extensions install"
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build-env
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build-env
 COPY . /root
 RUN cd /root/test/SmokeTests/OOProcSmokeTests/durableJS && \
     dotnet build -o bin

--- a/test/SmokeTests/OOProcSmokeTests/durableJS/extensions.csproj
+++ b/test/SmokeTests/OOProcSmokeTests/durableJS/extensions.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <WarningsAsErrors></WarningsAsErrors>
     <DefaultItemExcludes>**</DefaultItemExcludes>
   </PropertyGroup>

--- a/test/SmokeTests/OOProcSmokeTests/durableJS/extensions.csproj
+++ b/test/SmokeTests/OOProcSmokeTests/durableJS/extensions.csproj
@@ -14,6 +14,5 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator" />
-    <PackageReference Include="System.Text.RegularExpressions" />
   </ItemGroup>
 </Project>

--- a/test/SmokeTests/OOProcSmokeTests/durableJava/Dockerfile
+++ b/test/SmokeTests/OOProcSmokeTests/durableJava/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build-env
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build-env
 COPY . /root
 RUN cd /root/test/SmokeTests/OOProcSmokeTests/durableJava && \
     dotnet build -o bin

--- a/test/SmokeTests/OOProcSmokeTests/durableJava/extensions.csproj
+++ b/test/SmokeTests/OOProcSmokeTests/durableJava/extensions.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <WarningsAsErrors></WarningsAsErrors>
     <DefaultItemExcludes>**</DefaultItemExcludes>
   </PropertyGroup>

--- a/test/SmokeTests/OOProcSmokeTests/durablePy/Dockerfile
+++ b/test/SmokeTests/OOProcSmokeTests/durablePy/Dockerfile
@@ -3,7 +3,7 @@
 
 # Step 1: Add the durable extension by building it locally.
 #         This is an alternative to "func extensions install"
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build-env
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build-env
 COPY . /root
 RUN cd /root/test/SmokeTests/OOProcSmokeTests/durablePy && \
     dotnet build -o bin

--- a/test/SmokeTests/OOProcSmokeTests/durablePy/extensions.csproj
+++ b/test/SmokeTests/OOProcSmokeTests/durablePy/extensions.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <WarningsAsErrors></WarningsAsErrors>
     <DefaultItemExcludes>**</DefaultItemExcludes>
   </PropertyGroup>

--- a/test/SmokeTests/OOProcSmokeTests/durablePy/extensions.csproj
+++ b/test/SmokeTests/OOProcSmokeTests/durablePy/extensions.csproj
@@ -14,7 +14,5 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator" />
-    <PackageReference Include="System.Net.Http" />
-    <PackageReference Include="System.Text.RegularExpressions" />
   </ItemGroup>
 </Project>

--- a/test/TimeoutTests/CSharp/TimeoutTests.csproj
+++ b/test/TimeoutTests/CSharp/TimeoutTests.csproj
@@ -7,8 +7,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Http" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" />
-    <PackageReference Include="System.Net.Http" />
-    <PackageReference Include="System.Text.RegularExpressions" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\WebJobs.Extensions.DurableTask\WebJobs.Extensions.DurableTask.csproj" />

--- a/test/TimeoutTests/CSharp/TimeoutTests.csproj
+++ b/test/TimeoutTests/CSharp/TimeoutTests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
   </PropertyGroup>
   <!-- Common packages for all targets -->

--- a/test/TimeoutTests/Python/extensions.csproj
+++ b/test/TimeoutTests/Python/extensions.csproj
@@ -12,8 +12,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator" />
-    <PackageReference Include="System.Net.Http" />
-    <PackageReference Include="System.Text.RegularExpressions" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\WebJobs.Extensions.DurableTask\WebJobs.Extensions.DurableTask.csproj" />

--- a/test/TimeoutTests/Python/extensions.csproj
+++ b/test/TimeoutTests/Python/extensions.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
   <WarningsAsErrors></WarningsAsErrors>
   <DefaultItemExcludes>**</DefaultItemExcludes>

--- a/test/WebJobs.Extensions.DurableTask.Analyzers.Test/WebJobs.Extensions.DurableTask.Analyzers.Test.csproj
+++ b/test/WebJobs.Extensions.DurableTask.Analyzers.Test/WebJobs.Extensions.DurableTask.Analyzers.Test.csproj
@@ -12,8 +12,6 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="MSTest.TestAdapter" />
     <PackageReference Include="MSTest.TestFramework" />
-    <PackageReference Include="System.Net.Http" />
-    <PackageReference Include="System.Text.RegularExpressions" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/WebJobs.Extensions.DurableTask.Analyzers.Test/WebJobs.Extensions.DurableTask.Analyzers.Test.csproj
+++ b/test/WebJobs.Extensions.DurableTask.Analyzers.Test/WebJobs.Extensions.DurableTask.Analyzers.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers.Test</AssemblyName>
     <RootNamespace>Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers.Test</RootNamespace>
   </PropertyGroup>

--- a/test/Worker.Extensions.DurableTask.Tests/Worker.Extensions.DurableTask.Tests.csproj
+++ b/test/Worker.Extensions.DurableTask.Tests/Worker.Extensions.DurableTask.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>


### PR DESCRIPTION
- Update projects in /samples and /tests to net8.0
- Add a Directory.Packages.props to /test
- Use Transitive pinning to allow mass updating transitives in .props
- Add a Samples.sln file for easy compiling .NET samples in VS
- Add global.json pinning .NET SDK version used for build

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)
* [x] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk
* [x] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
    * [ ] Otherwise: major or minor version updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
* [x] My changes **do not** add EventIds to our EventSource logs
    * [ ] Otherwise: Ensure the EventIds are within the supported range in our existing Windows infrastructure. You may validate this with a deployed app's telemetry. You may also extend the range by completing a PR such as [this one](https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files).
* [ ] My changes **should** be added to **v2.x** branch.
    * [x] Otherwise: This change applies exclusively to WebJobs.Extensions.DurableTask v3.x. It will be retained only in the `dev` and `main` branches and will not be merged into the `v2.x` branch.
