### PR TITLE
Support async middleware in Durable Functions

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -16,7 +16,7 @@
     <PackageVersion Include="Microsoft.Azure.DurableTask.ApplicationInsights" Version="0.7.1" />
     <PackageVersion Include="Microsoft.Azure.DurableTask.AzureStorage" Version="2.6.1" />
     <PackageVersion Include="Microsoft.Azure.DurableTask.Core" Version="3.5.1" />
-    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Core" Version="2.0.0" />
+    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Core" Version="2.2.0" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Abstractions" Version="1.3.0" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Storage.Blobs" Version="6.7.0" />
     <PackageVersion Include="Microsoft.Azure.WebJobs" Version="3.0.39" />
@@ -51,9 +51,9 @@
   <!-- Dependencies used by both tests and samples -->
   <ItemGroup>
     <PackageVersion Include="Microsoft.ApplicationInsights.WorkerService" Version="2.22.0" />
-    <PackageVersion Include="Microsoft.Azure.Functions.Worker" Version="2.0.0" />
+    <PackageVersion Include="Microsoft.Azure.Functions.Worker" Version="2.2.0" />
     <!-- TODO: Update this to Worker SDK 2.x -->
-    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.18.1" />
+    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.5" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="2.0.0" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask.AzureManaged" Version="0.4.2-alpha" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask.SqlServer" Version="1.5.0" />

--- a/src/Worker.Extensions.DurableTask/DurableTaskFunctionsMiddleware.cs
+++ b/src/Worker.Extensions.DurableTask/DurableTaskFunctionsMiddleware.cs
@@ -1,137 +1,28 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System;
-using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
-using Microsoft.Azure.Functions.Worker.Extensions.DurableTask.Exceptions;
+using Microsoft.Azure.Functions.Worker.Extensions.DurableTask.Execution;
+using Microsoft.Azure.Functions.Worker.Invocation;
 using Microsoft.Azure.Functions.Worker.Middleware;
-using Microsoft.DurableTask.Worker;
-using Microsoft.DurableTask.Worker.Grpc;
 
 namespace Microsoft.Azure.Functions.Worker.Extensions.DurableTask;
 
 /// <summary>
 /// A middleware to handle orchestration triggers.
 /// </summary>
-internal class DurableTaskFunctionsMiddleware(ExtendedSessionsCache extendedSessionsCache) : IFunctionsWorkerMiddleware
+internal class DurableTaskFunctionsMiddleware(DurableFunctionExecutor invoker) : IFunctionsWorkerMiddleware
 {
-    private readonly ExtendedSessionsCache extendedSessionsCache = extendedSessionsCache;
-
     /// <inheritdoc />
     public Task Invoke(FunctionContext functionContext, FunctionExecutionDelegate next)
     {
-        if (IsOrchestrationTrigger(functionContext, out BindingMetadata? triggerBinding))
+        if (functionContext.TryGetOrchestrationBinding(out _)
+            || functionContext.TryGetEntityBinding(out _)
+            || functionContext.TryGetActivityBinding(out _))
         {
-            return this.RunOrchestrationAsync(functionContext, triggerBinding, next);
-        }
-
-        if (IsEntityTrigger(functionContext, out triggerBinding))
-        {
-            return RunEntityAsync(functionContext, triggerBinding, next);
-        }
-
-        if (IsActivityTrigger(functionContext, out triggerBinding))
-        {
-            return RunActivityAsync(functionContext, triggerBinding, next);
+            functionContext.Features.Set<IFunctionExecutor>(invoker);
         }
 
         return next(functionContext);
-    }
-
-    private static bool IsOrchestrationTrigger(
-        FunctionContext context, [NotNullWhen(true)] out BindingMetadata? orchestrationTriggerBinding)
-    {
-        foreach (BindingMetadata binding in context.FunctionDefinition.InputBindings.Values)
-        {
-            if (string.Equals(binding.Type, "orchestrationTrigger", StringComparison.OrdinalIgnoreCase))
-            {
-                orchestrationTriggerBinding = binding;
-                return true;
-            }
-        }
-
-        orchestrationTriggerBinding = null;
-        return false;
-    }
-
-    async Task RunOrchestrationAsync(
-        FunctionContext context, BindingMetadata triggerBinding, FunctionExecutionDelegate next)
-    {
-        InputBindingData<object> triggerInputData = await context.BindInputAsync<object>(triggerBinding);
-        if (triggerInputData?.Value is not string encodedOrchestratorState)
-        {
-            throw new InvalidOperationException("Orchestration history state was either missing from the input or not a string value.");
-        }
-
-        FunctionsOrchestrator orchestrator = new(context, next, triggerInputData);
-        string orchestratorOutput = GrpcOrchestrationRunner.LoadAndRun(
-            encodedOrchestratorState, orchestrator, this.extendedSessionsCache, context.InstanceServices);
-
-        // Send the encoded orchestrator output as the return value seen by the functions host extension
-        context.GetInvocationResult().Value = orchestratorOutput;
-    }
-
-    private static bool IsEntityTrigger(
-        FunctionContext context, [NotNullWhen(true)] out BindingMetadata? entityTriggerBinding)
-    {
-        foreach (BindingMetadata binding in context.FunctionDefinition.InputBindings.Values)
-        {
-            if (string.Equals(binding.Type, "entityTrigger", StringComparison.OrdinalIgnoreCase))
-            {
-                entityTriggerBinding = binding;
-                return true;
-            }
-        }
-
-        entityTriggerBinding = null;
-        return false;
-    }
-
-    static async Task RunEntityAsync(
-        FunctionContext context, BindingMetadata triggerBinding, FunctionExecutionDelegate next)
-    {
-        InputBindingData<object> triggerInputData = await context.BindInputAsync<object>(triggerBinding);
-        if (triggerInputData?.Value is not string encodedEntityBatch)
-        {
-            throw new InvalidOperationException("Entity batch was either missing from the input or not a string value.");
-        }
-
-        TaskEntityDispatcher dispatcher = new(encodedEntityBatch, context.InstanceServices);
-        triggerInputData.Value = dispatcher;
-
-        await next(context);
-        context.GetInvocationResult().Value = dispatcher.Result;
-    }
-
-    private static bool IsActivityTrigger(
-        FunctionContext context, [NotNullWhen(true)] out BindingMetadata? activityTriggerBinding)
-    {
-        foreach (BindingMetadata binding in context.FunctionDefinition.InputBindings.Values)
-        {
-            if (string.Equals(binding.Type, "activityTrigger", StringComparison.OrdinalIgnoreCase))
-            {
-                activityTriggerBinding = binding;
-                return true;
-            }
-        }
-
-        activityTriggerBinding = null;
-        return false;
-    }
-
-    private static async Task RunActivityAsync(FunctionContext functionContext, BindingMetadata triggerBinding, FunctionExecutionDelegate next)
-    {
-        try
-        {
-            await next(functionContext);
-            return;
-        }
-        catch (Exception ex)
-        {
-            // Get the exception properties provider from the service provider if available
-            IExceptionPropertiesProvider? exceptionPropertiesProvider = functionContext.InstanceServices.GetService(typeof(IExceptionPropertiesProvider)) as IExceptionPropertiesProvider;
-            throw new DurableSerializationException(ex, exceptionPropertiesProvider);
-        }
     }
 }

--- a/src/Worker.Extensions.DurableTask/Execution/DurableFunctionExecutor.Activity.cs
+++ b/src/Worker.Extensions.DurableTask/Execution/DurableFunctionExecutor.Activity.cs
@@ -1,0 +1,26 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.Azure.Functions.Worker.Extensions.DurableTask.Exceptions;
+using Microsoft.DurableTask.Worker;
+
+namespace Microsoft.Azure.Functions.Worker.Extensions.DurableTask.Execution;
+
+internal partial class DurableFunctionExecutor
+{
+    private async ValueTask RunActivityAsync(FunctionContext context, BindingMetadata triggerBinding)
+    {
+        try
+        {
+            await inner.ExecuteAsync(context);
+            return;
+        }
+        catch (Exception ex)
+        {
+            IExceptionPropertiesProvider? exceptionPropertiesProvider = context.InstanceServices.GetService(typeof(IExceptionPropertiesProvider)) as IExceptionPropertiesProvider;
+            throw new DurableSerializationException(ex, exceptionPropertiesProvider);
+        }
+    }
+}

--- a/src/Worker.Extensions.DurableTask/Execution/DurableFunctionExecutor.Entity.cs
+++ b/src/Worker.Extensions.DurableTask/Execution/DurableFunctionExecutor.Entity.cs
@@ -1,0 +1,26 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.DurableTask.Worker;
+
+namespace Microsoft.Azure.Functions.Worker.Extensions.DurableTask.Execution;
+
+internal partial class DurableFunctionExecutor
+{
+    private async ValueTask RunEntityAsync(FunctionContext context, BindingMetadata triggerBinding)
+    {
+        InputBindingData<object> triggerInputData = await context.BindInputAsync<object>(triggerBinding);
+        if (triggerInputData?.Value is not string encodedEntityBatch)
+        {
+            throw new InvalidOperationException(
+                "Entity batch was either missing from the input or not a string value.");
+        }
+
+        TaskEntityDispatcher dispatcher = new(encodedEntityBatch, context.InstanceServices);
+        triggerInputData.Value = dispatcher;
+        await inner.ExecuteAsync(context);
+        context.GetInvocationResult().Value = dispatcher.Result;
+    }
+}

--- a/src/Worker.Extensions.DurableTask/Execution/DurableFunctionExecutor.Orchestration.cs
+++ b/src/Worker.Extensions.DurableTask/Execution/DurableFunctionExecutor.Orchestration.cs
@@ -1,0 +1,28 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.DurableTask.Worker.Grpc;
+
+namespace Microsoft.Azure.Functions.Worker.Extensions.DurableTask.Execution;
+
+internal partial class DurableFunctionExecutor
+{
+    private async ValueTask RunOrchestrationAsync(FunctionContext context, BindingMetadata triggerBinding)
+    {
+        InputBindingData<object> triggerInputData = await context.BindInputAsync<object>(triggerBinding);
+        if (triggerInputData?.Value is not string encodedOrchestratorState)
+        {
+            throw new InvalidOperationException(
+                "Orchestration history state was either missing from the input or not a string value.");
+        }
+
+        FunctionsOrchestrator orchestrator = new(context, inner, triggerInputData);
+        string orchestratorOutput = GrpcOrchestrationRunner.LoadAndRun(
+            encodedOrchestratorState, orchestrator, extendedSessionsCache, context.InstanceServices);
+
+        // Send the encoded orchestrator output as the return value seen by the functions host extension
+        context.GetInvocationResult().Value = orchestratorOutput;
+    }
+}

--- a/src/Worker.Extensions.DurableTask/Execution/DurableFunctionExecutor.cs
+++ b/src/Worker.Extensions.DurableTask/Execution/DurableFunctionExecutor.cs
@@ -1,0 +1,42 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.Azure.Functions.Worker.Invocation;
+using Microsoft.DurableTask.Worker;
+
+namespace Microsoft.Azure.Functions.Worker.Extensions.DurableTask.Execution;
+
+internal partial class DurableFunctionExecutor(
+    IFunctionExecutor inner,
+    ExtendedSessionsCache extendedSessionsCache)
+    : IFunctionExecutor
+{
+
+    public virtual ValueTask ExecuteAsync(FunctionContext context)
+    {
+        if (context is null)
+        {
+            throw new ArgumentNullException(nameof(context));
+        }
+
+        if (context.TryGetOrchestrationBinding(out BindingMetadata? triggerBinding))
+        {
+            return this.RunOrchestrationAsync(context, triggerBinding);
+        }
+
+        if (context.TryGetEntityBinding(out triggerBinding))
+        {
+            return this.RunEntityAsync(context, triggerBinding);
+        }
+
+        if (context.TryGetActivityBinding(out triggerBinding))
+        {
+            return this.RunActivityAsync(context, triggerBinding);
+        }
+
+        throw new NotSupportedException(
+            $"Function '{context.FunctionDefinition.Name}' is not supported by {nameof(DurableFunctionExecutor)}.");
+    }
+}

--- a/src/Worker.Extensions.DurableTask/Execution/FunctionsOrchestrator.cs
+++ b/src/Worker.Extensions.DurableTask/Execution/FunctionsOrchestrator.cs
@@ -3,29 +3,29 @@
 
 using System;
 using System.Threading.Tasks;
-using Microsoft.Azure.Functions.Worker.Middleware;
+using Microsoft.Azure.Functions.Worker.Invocation;
 using Microsoft.DurableTask;
 using Microsoft.Extensions.Logging;
 
-namespace Microsoft.Azure.Functions.Worker.Extensions.DurableTask;
+namespace Microsoft.Azure.Functions.Worker.Extensions.DurableTask.Execution;
 
 /// <summary>
 /// A custom orchestrator for running functions-triggered orchestrations.
 /// </summary>
-internal class FunctionsOrchestrator : ITaskOrchestrator
+internal class FunctionsOrchestrator : IDisposableOrchestrator
 {
     private readonly FunctionContext functionContext;
-    private readonly FunctionExecutionDelegate next;
+    private readonly IFunctionExecutor executor;
     private readonly InputBindingData<object> contextBinding;
     private readonly OrchestrationInputConverter.InputContext inputContext;
 
     public FunctionsOrchestrator(
         FunctionContext functionContext,
-        FunctionExecutionDelegate next,
+        IFunctionExecutor executor,
         InputBindingData<object> contextBinding)
     {
         this.functionContext = functionContext;
-        this.next = next;
+        this.executor = executor;
         this.contextBinding = contextBinding;
         this.inputContext = OrchestrationInputConverter.GetInputContext(functionContext);
     }
@@ -48,7 +48,7 @@ internal class FunctionsOrchestrator : ITaskOrchestrator
         try
         {
             // This method will advance to the next middleware and throw if it detects an asynchronous execution.
-            await EnsureSynchronousExecution(this.functionContext, this.next, wrapperContext);
+            await this.EnsureSynchronousExecution(wrapperContext);
         }
         catch (Exception ex)
         {
@@ -64,12 +64,15 @@ internal class FunctionsOrchestrator : ITaskOrchestrator
         return functionOutput;
     }
 
-    private static async Task EnsureSynchronousExecution(
-        FunctionContext functionContext,
-        FunctionExecutionDelegate next,
-        FunctionsOrchestrationContext orchestrationContext)
+    public ValueTask DisposeAsync()
     {
-        Task orchestratorTask = next(functionContext);
+        // no op
+        return default;
+    }
+
+    private async Task EnsureSynchronousExecution(FunctionsOrchestrationContext orchestrationContext)
+    {
+        ValueTask orchestratorTask = this.executor.ExecuteAsync(this.functionContext);
         if (!orchestratorTask.IsCompleted && !orchestrationContext.IsAccessed)
         {
             // If the middleware returns before the orchestrator function's context object was accessed and before

--- a/src/Worker.Extensions.DurableTask/Execution/IDisposableOrchestrator.cs
+++ b/src/Worker.Extensions.DurableTask/Execution/IDisposableOrchestrator.cs
@@ -1,0 +1,11 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.DurableTask;
+
+namespace Microsoft.Azure.Functions.Worker.Extensions.DurableTask.Execution;
+
+internal interface IDisposableOrchestrator : ITaskOrchestrator, IAsyncDisposable
+{
+}

--- a/src/Worker.Extensions.DurableTask/Execution/TriggerNames.cs
+++ b/src/Worker.Extensions.DurableTask/Execution/TriggerNames.cs
@@ -1,0 +1,11 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+namespace Microsoft.Azure.Functions.Worker.Extensions.DurableTask.Execution;
+
+internal static class TriggerNames
+{
+    internal const string Orchestration = "orchestrationTrigger";
+    internal const string Activity = "activityTrigger";
+    internal const string Entity = "entityTrigger";
+}

--- a/src/Worker.Extensions.DurableTask/FunctionContextExtensions.cs
+++ b/src/Worker.Extensions.DurableTask/FunctionContextExtensions.cs
@@ -1,0 +1,82 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.Azure.Functions.Worker.Extensions.DurableTask.Execution;
+
+namespace Microsoft.Azure.Functions.Worker.Extensions.DurableTask;
+
+internal static class FunctionContextExtensions
+{
+    /// <summary>
+    /// Tries to get the orchestration trigger binding from the function context.
+    /// </summary>
+    /// <param name="context">The function context.</param>
+    /// <param name="binding">The binding metadata if found; otherwise, null.</param>
+    /// <returns>True if the orchestration trigger binding is found; otherwise, false.</returns>
+    public static bool TryGetOrchestrationBinding(this FunctionContext context, [NotNullWhen(true)] out BindingMetadata? binding)
+        => context.TryGetBinding(TriggerNames.Orchestration, out binding);
+
+    /// <summary>
+    /// Tries to get the orchestration trigger binding from the function context.
+    /// </summary>
+    /// <param name="context">The function context.</param>
+    /// <param name="binding">The binding metadata if found; otherwise, null.</param>
+    /// <returns>True if the orchestration trigger binding is found; otherwise, false.</returns>
+    public static bool TryGetActivityBinding(this FunctionContext context, [NotNullWhen(true)] out BindingMetadata? binding)
+        => context.TryGetBinding(TriggerNames.Activity, out binding);
+
+    /// <summary>
+    /// Tries to get the orchestration trigger binding from the function context.
+    /// </summary>
+    /// <param name="context">The function context.</param>
+    /// <param name="binding">The binding metadata if found; otherwise, null.</param>
+    /// <returns>True if the orchestration trigger binding is found; otherwise, false.</returns>
+    public static bool TryGetEntityBinding(this FunctionContext context, [NotNullWhen(true)] out BindingMetadata? binding)
+        => context.TryGetBinding(TriggerNames.Entity, out binding);
+
+    /// <summary>
+    /// Tries to get the specified trigger binding from the function context.
+    /// </summary>
+    /// <param name="context">The function context.</param>
+    /// <param name="triggerName">The name of the trigger.</param>
+    /// <param name="binding">The binding metadata if found; otherwise, null.</param>
+    /// <returns>True if the specified trigger binding is found; otherwise, false.</returns>
+    public static bool TryGetBinding(this FunctionContext context, string triggerName, [NotNullWhen(true)] out BindingMetadata? binding)
+    {
+        if (context is null)
+        {
+            throw new ArgumentNullException(nameof(context));
+        }
+
+        foreach (BindingMetadata current in context.FunctionDefinition.InputBindings.Values)
+        {
+            if (string.Equals(current.Type, triggerName, StringComparison.OrdinalIgnoreCase))
+            {
+                binding = current;
+                return true;
+            }
+        }
+
+        binding = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Gets the orchestration instance ID from the function context.
+    /// </summary>
+    /// <param name="context">The function context.</param>
+    /// <returns>The orchestration instance ID.</returns>
+    public static string GetInstanceId(this FunctionContext context)
+    {
+        if (context is null)
+        {
+            throw new ArgumentNullException(nameof(context));
+        }
+
+        return (string)context.BindingContext.BindingData["instanceId"]!;
+    }
+}

--- a/src/Worker.Extensions.DurableTask/FunctionsWorkerApplicationBuilderExtensions.cs
+++ b/src/Worker.Extensions.DurableTask/FunctionsWorkerApplicationBuilderExtensions.cs
@@ -3,14 +3,10 @@
 
 using System;
 using System.Linq;
-using Azure.Core.Serialization;
-using Microsoft.Azure.Functions.Worker.Core;
 using Microsoft.Azure.Functions.Worker.Extensions.DurableTask;
-using Microsoft.DurableTask;
+using Microsoft.Azure.Functions.Worker.Extensions.DurableTask.Execution;
 using Microsoft.DurableTask.Client;
-using Microsoft.DurableTask.Converters;
 using Microsoft.DurableTask.Worker;
-using Microsoft.DurableTask.Worker.Grpc;
 using Microsoft.DurableTask.Worker.Shims;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -30,7 +26,8 @@ public static class FunctionsWorkerApplicationBuilderExtensions
     /// </summary>
     /// <param name="builder">The builder to configure.</param>
     /// <returns>The <paramref name="builder"/> for call chaining.</returns>
-    public static IFunctionsWorkerApplicationBuilder ConfigureDurableExtension(this IFunctionsWorkerApplicationBuilder builder)
+    public static IFunctionsWorkerApplicationBuilder ConfigureDurableExtension(
+        this IFunctionsWorkerApplicationBuilder builder)
     {
         if (builder is null)
         {
@@ -60,7 +57,9 @@ public static class FunctionsWorkerApplicationBuilderExtensions
         {
             builder.UseMiddleware<DurableTaskFunctionsMiddleware>();
         }
-        builder.Services.TryAddSingleton(new ExtendedSessionsCache());
+
+        builder.Services.TryAddSingleton<DurableFunctionExecutor>();
+        builder.Services.TryAddSingleton<ExtendedSessionsCache>();
 
         return builder;
     }
@@ -81,18 +80,12 @@ public static class FunctionsWorkerApplicationBuilderExtensions
         }
     }
 
-    private class PostConfigureClientOptions : IPostConfigureOptions<DurableTaskClientOptions>
+    private class PostConfigureClientOptions(IOptionsMonitor<WorkerOptions> workerOptions)
+        : IPostConfigureOptions<DurableTaskClientOptions>
     {
-        readonly IOptionsMonitor<WorkerOptions> workerOptions;
-
-        public PostConfigureClientOptions(IOptionsMonitor<WorkerOptions> workerOptions)
-        {
-            this.workerOptions = workerOptions;
-        }
-
         public void PostConfigure(string? name, DurableTaskClientOptions options)
         {
-            if (this.workerOptions.Get(name).Serializer is { } serializer)
+            if (workerOptions.Get(name).Serializer is { } serializer)
             {
                 options.DataConverter = new ObjectConverterShim(serializer);
             }
@@ -107,18 +100,12 @@ public static class FunctionsWorkerApplicationBuilderExtensions
         }
     }
 
-    private class PostConfigureWorkerOptions : IPostConfigureOptions<DurableTaskWorkerOptions>
+    private class PostConfigureWorkerOptions(IOptionsMonitor<WorkerOptions> workerOptions)
+        : IPostConfigureOptions<DurableTaskWorkerOptions>
     {
-        readonly IOptionsMonitor<WorkerOptions> workerOptions;
-
-        public PostConfigureWorkerOptions(IOptionsMonitor<WorkerOptions> workerOptions)
-        {
-            this.workerOptions = workerOptions;
-        }
-
         public void PostConfigure(string? name, DurableTaskWorkerOptions options)
         {
-            if (this.workerOptions.Get(name).Serializer is { } serializer)
+            if (workerOptions.Get(name).Serializer is { } serializer)
             {
                 options.DataConverter = new ObjectConverterShim(serializer);
             }

--- a/test/Directory.Packages.props
+++ b/test/Directory.Packages.props
@@ -20,7 +20,6 @@
     <PackageVersion Include="Microsoft.CodeAnalysis" Version="3.9.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="3.9.0" />
     <PackageVersion Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.65" />
-    <PackageVersion Include="Microsoft.DurableTask.Abstractions" Version="1.16.0" />
     <PackageVersion Include="Microsoft.DurableTask.Generators" Version="1.0.0-preview.1" />
     <PackageVersion Include="Microsoft.DurableTask.SqlServer.AzureFunctions" Version="1.5.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="9.0.0" />

--- a/test/SmokeTests/OOProcSmokeTests/DotNetIsolated/Counter.cs
+++ b/test/SmokeTests/OOProcSmokeTests/DotNetIsolated/Counter.cs
@@ -2,11 +2,8 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System.Text;
-using Azure.Core;
 using Microsoft.Azure.Functions.Worker;
-using Microsoft.Azure.Functions.Worker.Extensions.DurableTask;
 using Microsoft.Azure.Functions.Worker.Http;
-using Microsoft.DurableTask;
 using Microsoft.DurableTask.Client;
 using Microsoft.DurableTask.Entities;
 using Microsoft.Extensions.Logging;

--- a/test/SmokeTests/OOProcSmokeTests/DotNetIsolated/DotNetIsolated.csproj
+++ b/test/SmokeTests/OOProcSmokeTests/DotNetIsolated/DotNetIsolated.csproj
@@ -11,13 +11,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Functions.Worker" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" />
-
-    <!--
-      This preview package is to enable better NuGet restore behavior with custom feeds.
-      TODO: upgrade to 1.16.0 when it's released.
-    -->
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" OutputItemType="Analyzer" />
-    <PackageReference Include="Microsoft.DurableTask.Generators" OutputItemType="Analyzer" />
+    <PackageReference Include="Microsoft.DurableTask.Generators" OutputItemType="Analyzer" /> 
   </ItemGroup>
 
   <ItemGroup>

--- a/test/SmokeTests/OOProcSmokeTests/DotNetIsolated/HelloCitiesTyped.cs
+++ b/test/SmokeTests/OOProcSmokeTests/DotNetIsolated/HelloCitiesTyped.cs
@@ -1,11 +1,11 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using Microsoft.DurableTask;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
-using Microsoft.Extensions.Logging;
+using Microsoft.DurableTask;
 using Microsoft.DurableTask.Client;
+using Microsoft.Extensions.Logging;
 
 namespace DotNetIsolated.Typed;
 
@@ -30,7 +30,7 @@ public static class HelloCitiesTypedStarter
         // orchestrators that are defined in the current project. The name of the generated extension methods
         // are based on the names of the orchestrator classes. Note that the source generator will *not*
         // generate type-safe extension methods for non-class-based orchestrator functions.
-        string instanceId = await client.ScheduleNewHelloCitiesTypedInstanceAsync();
+        string instanceId = await client.ScheduleNewOrchestrationInstanceAsync(nameof(HelloCitiesTyped));
         logger.LogInformation("Created new orchestration with instance ID = {instanceId}", instanceId);
 
         return client.CreateCheckStatusResponse(req, instanceId);
@@ -52,9 +52,9 @@ public class HelloCitiesTyped : TaskOrchestrator<string?, string>
         // methods are derived from the names of the activity classes. Note that both
         // activity classes and activity functions are supported by the source generator.
         string result = "";
-        result += await context.CallSayHelloTypedAsync("Tokyo") + " ";
-        result += await context.CallSayHelloTypedAsync("London") + " ";
-        result += await context.CallSayHelloTypedAsync("Seattle");
+        result += await context.CallActivityAsync<string>("SayHelloTyped", "Tokyo") + " ";
+        result += await context.CallActivityAsync<string>("SayHelloTyped", "London") + " ";
+        result += await context.CallActivityAsync<string>("SayHelloTyped", "Seattle");
         return result;
     }
 }

--- a/test/SmokeTests/OOProcSmokeTests/DotNetIsolated/host.json
+++ b/test/SmokeTests/OOProcSmokeTests/DotNetIsolated/host.json
@@ -15,6 +15,5 @@
         "controlQueueVisibilityTimeout": "00:01:00"
       }
     }
-  },
-  "functionTimeout": "00:00:30"
+  }
 }

--- a/test/e2e/Apps/BasicDotNetIsolated/Program.cs
+++ b/test/e2e/Apps/BasicDotNetIsolated/Program.cs
@@ -8,7 +8,12 @@ using Microsoft.DurableTask.Worker;
 using System.Diagnostics;
 
 var host = new HostBuilder()
-    .ConfigureFunctionsWebApplication()
+    .ConfigureFunctionsWebApplication(workerApplication =>
+    {
+        // Register async middleware to test the fix for https://github.com/microsoft/durabletask-dotnet/issues/158
+        // This middleware performs async operations that previously caused non-determinism exceptions
+        workerApplication.UseMiddleware<Microsoft.Azure.Durable.Tests.E2E.TestAsyncMiddleware>();
+    })
     .ConfigureServices(services => {
         services.AddApplicationInsightsTelemetryWorkerService();
         services.ConfigureFunctionsApplicationInsights();

--- a/test/e2e/Apps/BasicDotNetIsolated/TestAsyncMiddleware.cs
+++ b/test/e2e/Apps/BasicDotNetIsolated/TestAsyncMiddleware.cs
@@ -1,0 +1,33 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Middleware;
+
+namespace Microsoft.Azure.Durable.Tests.E2E;
+
+/// <summary>
+/// Test middleware that performs async operations to validate the fix for
+/// https://github.com/microsoft/durabletask-dotnet/issues/158
+/// This middleware simulates async behaviors like App Configuration or logging services.
+/// </summary>
+public class TestAsyncMiddleware : IFunctionsWorkerMiddleware
+{
+    public async Task Invoke(FunctionContext context, FunctionExecutionDelegate next)
+    {
+        // Simulate an async operation like fetching configuration or logging
+        await Task.Delay(1);
+        
+        // Store metadata to verify the middleware ran
+        context.Items["AsyncMiddlewareExecuted"] = true;
+        context.Items["AsyncMiddlewareTimestamp"] = DateTime.UtcNow;
+        
+        // Continue to the next middleware/function
+        await next(context);
+        
+        // Simulate async post-processing
+        await Task.Delay(1);
+    }
+}


### PR DESCRIPTION
Support async middleware in Durable Functions

This commit moves the Durable Function execution outside of the
middleware chain. This allows middleware to make async calls
without interfering with the orchestration itself.

Resolves: #2876 

Co-authored-by: Jacob Viau
Co-authored-by: Hal Spang <halspang@microsoft.com>

Signed-off-by: Hal Spang <halspang@microsoft.com>