### PR TITLE
Re-enable the E2E test for terminating a pending orchestration

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,9 +13,9 @@
     <PackageVersion Include="Grpc.Net.Client" Version="2.70.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.WebApiCompatShim" Version="2.2.0" />
-    <PackageVersion Include="Microsoft.Azure.DurableTask.ApplicationInsights" Version="0.7.1" />
-    <PackageVersion Include="Microsoft.Azure.DurableTask.AzureStorage" Version="2.6.1" />
-    <PackageVersion Include="Microsoft.Azure.DurableTask.Core" Version="3.5.1" />
+    <PackageVersion Include="Microsoft.Azure.DurableTask.ApplicationInsights" Version="0.8.0" />
+    <PackageVersion Include="Microsoft.Azure.DurableTask.AzureStorage" Version="2.7.0" />
+    <PackageVersion Include="Microsoft.Azure.DurableTask.Core" Version="3.6.0" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Core" Version="2.0.0" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Abstractions" Version="1.3.0" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Storage.Blobs" Version="6.7.0" />
@@ -56,7 +56,7 @@
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.18.1" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="2.0.0" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask.AzureManaged" Version="0.4.2-alpha" />
-    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask.SqlServer" Version="1.5.0" />
+    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask.SqlServer" Version="1.5.2" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.3.0" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="2.0.2" />
     <PackageVersion Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="2.13.7" />

--- a/test/e2e/Tests/Tests/TerminateOrchestratorTests.cs
+++ b/test/e2e/Tests/Tests/TerminateOrchestratorTests.cs
@@ -47,7 +47,7 @@ public class TerminateOrchestratorTests
     public async Task TerminateScheduledOrchestration_ShouldSucceed()
     {
         DateTime scheduledStartTime = DateTime.UtcNow + TimeSpan.FromMinutes(1);
-        using HttpResponseMessage response = await HttpHelpers.InvokeHttpTrigger("HelloCities_HttpStart_Scheduled", $"?scheduledStartTime={scheduledStartTime.ToString("o")}");
+        using HttpResponseMessage response = await HttpHelpers.InvokeHttpTrigger("HelloCities_HttpStart_Scheduled", $"?ScheduledStartTime={scheduledStartTime.ToString("o")}");
 
         Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
         string instanceId = await DurableHelpers.ParseInstanceIdAsync(response);

--- a/test/e2e/Tests/Tests/TerminateOrchestratorTests.cs
+++ b/test/e2e/Tests/Tests/TerminateOrchestratorTests.cs
@@ -40,7 +40,7 @@ public class TerminateOrchestratorTests
     }
 
 
-    [Fact(Skip = "Will enable when https://github.com/Azure/azure-functions-durable-extension/issues/3025 is fixed")]
+    [Fact]
     [Trait("PowerShell", "Skip")] // Scheduled orchestrations not implemented in PowerShell
     public async Task TerminateScheduledOrchestration_ShouldSucceed()
     {

--- a/test/e2e/Tests/Tests/TerminateOrchestratorTests.cs
+++ b/test/e2e/Tests/Tests/TerminateOrchestratorTests.cs
@@ -42,6 +42,8 @@ public class TerminateOrchestratorTests
 
     [Fact]
     [Trait("PowerShell", "Skip")] // Scheduled orchestrations not implemented in PowerShell
+    [Trait("Python", "Skip")] // Scheduled orchestrations not implemented in Node
+    [Trait("Node", "Skip")] // Scheduled orchestrations not implemented in Python
     public async Task TerminateScheduledOrchestration_ShouldSucceed()
     {
         DateTime scheduledStartTime = DateTime.UtcNow + TimeSpan.FromMinutes(1);


### PR DESCRIPTION
<!-- Start the PR description with some context for the change. -->
The bug fixes in the MSSQL and Azure Storage backend have since been released for terminating pending orchestrations, so we can re-enable the E2E test now.

<!-- Make sure to delete the markdown comments and the below sections when squash merging -->
### Issue describing the changes in this PR

resolves #issue_for_this_pr

### Pull request checklist

* [ ] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)
* [ ] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk
* [ ] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
    * [ ] Otherwise: major or minor version updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
* [ ] My changes **do not** add EventIds to our EventSource logs
    * [ ] Otherwise: Ensure the EventIds are within the supported range in our existing Windows infrastructure. You may validate this with a deployed app's telemetry. You may also extend the range by completing a PR such as [this one](https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files).
* [ ] My changes **should** be added to **v2.x** branch.
    * [ ] Otherwise: This change applies exclusively to WebJobs.Extensions.DurableTask v3.x. It will be retained only in the `dev` and `main` branches and will not be merged into the `v2.x` branch.
