### PR TITLE
 Update .NET SDK versions and target frameworks across workflows and projects

### DIFF
--- a/.github/workflows/E2ETest.yml
+++ b/.github/workflows/E2ETest.yml
@@ -313,15 +313,20 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup .NET Core
+      - name: Setup .NET 6
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 6.0.x
 
-      - name: Setup .NET Core
+      - name: Setup .NET 8
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 8.0.x
+
+      - name: Setup .NET 10
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: 10.0.x
 
       - name: Set up Node.js (needed for Azurite)
         uses: actions/setup-node@v3

--- a/.github/workflows/E2ETest.yml
+++ b/.github/workflows/E2ETest.yml
@@ -123,15 +123,20 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup .NET Core
+      - name: Setup .NET 6
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 6.0.x
 
-      - name: Setup .NET Core
+      - name: Setup .NET 8
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 8.0.x
+
+      - name: Setup .NET 10
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: 10.0.x
 
       - name: Set up Node.js (needed for Azurite)
         uses: actions/setup-node@v3
@@ -216,15 +221,20 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup .NET Core
+      - name: Setup .NET 6
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 6.0.x
 
-      - name: Setup .NET Core
+      - name: Setup .NET 8
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 8.0.x
+
+      - name: Setup .NET 10
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: 10.0.x
 
       - name: Set up Node.js (needed for Azurite)
         uses: actions/setup-node@v3

--- a/.github/workflows/E2ETest.yml
+++ b/.github/workflows/E2ETest.yml
@@ -25,15 +25,20 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup .NET Core
+      - name: Setup .NET 6.0
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: 6.0.x
+          dotnet-version: '6.0.x'
 
-      - name: Setup .NET Core
+      - name: Setup .NET 8.0
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: '8.0.x'
+
+      - name: Setup .NET 10.0
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: '10.0.x'
 
       - name: Set up Node.js (needed for Azurite)
         uses: actions/setup-node@v3

--- a/.github/workflows/smoketest-dotnet-isolated-v4.yml
+++ b/.github/workflows/smoketest-dotnet-isolated-v4.yml
@@ -40,6 +40,11 @@ jobs:
       with:
         dotnet-version: '8.x'
 
+    - name: Set up .NET Core 10.x
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: '10.x'
+
     # Install Azurite
     - name: Set up Node.js (needed for Azurite)
       uses: actions/setup-node@v3

--- a/.github/workflows/smoketest-dotnet-isolated-v4.yml
+++ b/.github/workflows/smoketest-dotnet-isolated-v4.yml
@@ -16,6 +16,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        dotnet-version: ['6.0', '8.0', '10.0']
     steps:
     - uses: actions/checkout@v2
 
@@ -65,10 +68,10 @@ jobs:
         dotnet nuget push ./out/Microsoft.Azure.WebJobs.Extensions.DurableTask.*.nupkg --source ~/packages &&
         dotnet nuget add source ~/packages
 
-    - name: Build .NET Isolated Smoke Test
+    - name: Build .NET Isolated Smoke Test (.NET ${{ matrix.dotnet-version }})
       run: cd ./test/SmokeTests/OOProcSmokeTests/DotNetIsolated &&
         dotnet restore --verbosity normal &&
-        dotnet build -c Release
+        dotnet build -c Release -f net${{ matrix.dotnet-version }}
 
     - name: Install core tools
       run: npm i -g azure-functions-core-tools@4 --unsafe-perm true
@@ -78,42 +81,42 @@ jobs:
     # when building the smoke test app in docker, causing the build to fail. This is a temporary workaround until the
     # root cause is identified and fixed.
 
-    - name: Run smoke tests (Hello Cities (Typed))
+    - name: Run smoke tests (Hello Cities (Typed)) - .NET ${{ matrix.dotnet-version }}
       shell: pwsh
       run: azurite --silent --blobPort 10000 --queuePort 10001 --tablePort 10002 &
         cd ./test/SmokeTests/OOProcSmokeTests/DotNetIsolated && func host start --port 7071 &
         ./test/SmokeTests/OOProcSmokeTests/DotNetIsolated/run-smoke-tests.ps1 -HttpStartPath api/StartHelloCitiesTyped
         
-    - name: Run smoke tests (Hello Cities (Untyped))
+    - name: Run smoke tests (Hello Cities (Untyped)) - .NET ${{ matrix.dotnet-version }}
       shell: pwsh
       run: azurite --silent --blobPort 10000 --queuePort 10001 --tablePort 10002 &
         cd ./test/SmokeTests/OOProcSmokeTests/DotNetIsolated && func host start --port 7071 &
         ./test/SmokeTests/OOProcSmokeTests/DotNetIsolated/run-smoke-tests.ps1 -HttpStartPath api/StartHelloCitiesUntyped
 
-    - name: Run smoke tests (Hello Cities) with provided Instance Id
+    - name: Run smoke tests (Hello Cities) with provided Instance Id - .NET ${{ matrix.dotnet-version }}
       shell: pwsh
       run: azurite --silent --blobPort 10000 --queuePort 10001 --tablePort 10002 &
         cd ./test/SmokeTests/OOProcSmokeTests/DotNetIsolated && func host start --port 7071 &
         ./test/SmokeTests/OOProcSmokeTests/DotNetIsolated/run-smoke-tests.ps1 -HttpStartPath api/StartHelloCitiesUntyped -TestWithCustomInstanceId
 
-    - name: Run smoke tests (Process Exit)
+    - name: Run smoke tests (Process Exit) - .NET ${{ matrix.dotnet-version }}
       shell: pwsh
       run: azurite --silent --blobPort 10000 --queuePort 10001 --tablePort 10002 &
         ./test/SmokeTests/OOProcSmokeTests/DotNetIsolated/run-smoke-tests.ps1 -HttpStartPath api/durable_HttpStartProcessExitOrchestrator
 
-    - name: Run smoke tests (Timeout)
+    - name: Run smoke tests (Timeout) - .NET ${{ matrix.dotnet-version }}
       shell: pwsh
       run: azurite --silent --blobPort 10000 --queuePort 10001 --tablePort 10002 &
         cd ./test/SmokeTests/OOProcSmokeTests/DotNetIsolated && func host start --port 7071 &
         ./test/SmokeTests/OOProcSmokeTests/DotNetIsolated/run-smoke-tests.ps1 -HttpStartPath api/durable_HttpStartTimeoutOrchestrator
 
-    - name: Run smoke tests (OOM)
+    - name: Run smoke tests (OOM) - .NET ${{ matrix.dotnet-version }}
       shell: pwsh
       run: azurite --silent --blobPort 10000 --queuePort 10001 --tablePort 10002 &
         cd ./test/SmokeTests/OOProcSmokeTests/DotNetIsolated && func host start --port 7071 &
         ./test/SmokeTests/OOProcSmokeTests/DotNetIsolated/run-smoke-tests.ps1 -HttpStartPath api/durable_HttpStartOOMOrchestrator
 
-    - name: Run smoke tests (Entity Counting (Typed))
+    - name: Run smoke tests (Entity Counting (Typed)) - .NET ${{ matrix.dotnet-version }}
       shell: pwsh
       run: azurite --silent --blobPort 10000 --queuePort 10001 --tablePort 10002 &
         cd ./test/SmokeTests/OOProcSmokeTests/DotNetIsolated && func host start --port 7071 &

--- a/.github/workflows/smoketest-dotnet-isolated-v4.yml
+++ b/.github/workflows/smoketest-dotnet-isolated-v4.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        dotnet-version: ['6.0', '8.0', '10.0']
+        dotnet-version: ['6.0', '8.0']
     steps:
     - uses: actions/checkout@v2
 
@@ -42,11 +42,6 @@ jobs:
       uses: actions/setup-dotnet@v3
       with:
         dotnet-version: '8.x'
-
-    - name: Set up .NET Core 10.x
-      uses: actions/setup-dotnet@v3
-      with:
-        dotnet-version: '10.x'
 
     # Install Azurite
     - name: Set up Node.js (needed for Azurite)

--- a/.github/workflows/smoketest-dotnet-isolated-v4.yml
+++ b/.github/workflows/smoketest-dotnet-isolated-v4.yml
@@ -43,6 +43,11 @@ jobs:
       with:
         dotnet-version: '8.x'
 
+    - name: Set up .NET Core 10.x
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: '10.x'
+
     # Install Azurite
     - name: Set up Node.js (needed for Azurite)
       uses: actions/setup-node@v3

--- a/.github/workflows/smoketest-java8-v4.yml
+++ b/.github/workflows/smoketest-java8-v4.yml
@@ -33,5 +33,5 @@ jobs:
         run: |
           wget -P test/SmokeTests/OOProcSmokeTests/durableJava/build/azure-functions/durableJava/lib/ "https://repo.maven.apache.org/maven2/com/microsoft/azure/functions/azure-functions-java-library/2.0.1/azure-functions-java-library-2.0.1.jar" --show-progress
       - name: Run V4 Java 8 Smoke Test
-        run: test/SmokeTests/e2e-test.ps1 -DockerfilePath test/SmokeTests/OOProcSmokeTests/durableJava/Dockerfile -HttpStartPath api/StartOrchestration -TestWithCustomInstanceId -DotNetVersion 8.0
+        run: test/SmokeTests/e2e-test.ps1 -DockerfilePath test/SmokeTests/OOProcSmokeTests/durableJava/Dockerfile -HttpStartPath api/StartOrchestration -TestWithCustomInstanceId -DotNetVersion 8
         shell: pwsh

--- a/.github/workflows/smoketest-java8-v4.yml
+++ b/.github/workflows/smoketest-java8-v4.yml
@@ -33,5 +33,5 @@ jobs:
         run: |
           wget -P test/SmokeTests/OOProcSmokeTests/durableJava/build/azure-functions/durableJava/lib/ "https://repo.maven.apache.org/maven2/com/microsoft/azure/functions/azure-functions-java-library/2.0.1/azure-functions-java-library-2.0.1.jar" --show-progress
       - name: Run V4 Java 8 Smoke Test
-        run: test/SmokeTests/e2e-test.ps1 -DockerfilePath test/SmokeTests/OOProcSmokeTests/durableJava/Dockerfile -HttpStartPath api/StartOrchestration -TestWithCustomInstanceId
+        run: test/SmokeTests/e2e-test.ps1 -DockerfilePath test/SmokeTests/OOProcSmokeTests/durableJava/Dockerfile -HttpStartPath api/StartOrchestration -TestWithCustomInstanceId -DotNetVersion 8.0
         shell: pwsh

--- a/.github/workflows/smoketest-mssql-inproc-v4.yml
+++ b/.github/workflows/smoketest-mssql-inproc-v4.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        dotnet-version: ['6.0', '8.0', '10.0']
+        dotnet-version: ['6', '8']
     env:
       SA_PASSWORD: ${{ secrets.SA_PASSWORD }}
       FUNCTIONS_INPROC_NET8_ENABLED: "1"

--- a/.github/workflows/smoketest-mssql-inproc-v4.yml
+++ b/.github/workflows/smoketest-mssql-inproc-v4.yml
@@ -19,6 +19,9 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        dotnet-version: ['6.0', '8.0', '10.0']
     env:
       SA_PASSWORD: ${{ secrets.SA_PASSWORD }}
       FUNCTIONS_INPROC_NET8_ENABLED: "1"
@@ -26,6 +29,6 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Run V4 .NET in-proc w/ MSSQL Smoke Test
-      run: test/SmokeTests/e2e-test.ps1 -DockerfilePath test/SmokeTests/BackendSmokeTests/MSSQL/Dockerfile -HttpStartPath api/DurableFunctionsHttpStart -ContainerName MSSQLApp -SetupSQLServer
+    - name: Run V4 .NET in-proc w/ MSSQL Smoke Test (.NET ${{ matrix.dotnet-version }})
+      run: test/SmokeTests/e2e-test.ps1 -DockerfilePath test/SmokeTests/BackendSmokeTests/MSSQL/Dockerfile -HttpStartPath api/DurableFunctionsHttpStart -ContainerName MSSQLApp -SetupSQLServer -DotNetVersion ${{ matrix.dotnet-version }}
       shell: pwsh

--- a/.github/workflows/smoketest-netherite-inproc-v4.yml
+++ b/.github/workflows/smoketest-netherite-inproc-v4.yml
@@ -16,12 +16,15 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        dotnet-version: ['6.0', '8.0', '10.0']
 
     env:
       FUNCTIONS_INPROC_NET8_ENABLED: "1"
 
     steps:
     - uses: actions/checkout@v2
-    - name: Run V4 .NET in-proc w/ Netherite Smoke Test
-      run: test/SmokeTests/e2e-test.ps1 -DockerfilePath test/SmokeTests/BackendSmokeTests/Netherite/Dockerfile -HttpStartPath api/DurableFunctionsHttpStart -ContainerName NetheriteApp
+    - name: Run V4 .NET in-proc w/ Netherite Smoke Test (.NET ${{ matrix.dotnet-version }})
+      run: test/SmokeTests/e2e-test.ps1 -DockerfilePath test/SmokeTests/BackendSmokeTests/Netherite/Dockerfile -HttpStartPath api/DurableFunctionsHttpStart -ContainerName NetheriteApp -DotNetVersion ${{ matrix.dotnet-version }}
       shell: pwsh

--- a/.github/workflows/smoketest-netherite-inproc-v4.yml
+++ b/.github/workflows/smoketest-netherite-inproc-v4.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        dotnet-version: ['6.0', '8.0', '10.0']
+        dotnet-version: ['6', '8']
 
     env:
       FUNCTIONS_INPROC_NET8_ENABLED: "1"

--- a/.github/workflows/smoketest-node20-v4.yml
+++ b/.github/workflows/smoketest-node20-v4.yml
@@ -19,5 +19,5 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Run V4 Node 20 Smoke Test
-      run: test/SmokeTests/e2e-test.ps1 -DockerfilePath test/SmokeTests/OOProcSmokeTests/durableJS/Dockerfile -HttpStartPath api/DurableFunctionsHttpStart -TestWithCustomInstanceId -DotNetVersion 8.0
+      run: test/SmokeTests/e2e-test.ps1 -DockerfilePath test/SmokeTests/OOProcSmokeTests/durableJS/Dockerfile -HttpStartPath api/DurableFunctionsHttpStart -TestWithCustomInstanceId -DotNetVersion 8
       shell: pwsh

--- a/.github/workflows/smoketest-node20-v4.yml
+++ b/.github/workflows/smoketest-node20-v4.yml
@@ -19,5 +19,5 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Run V4 Node 20 Smoke Test
-      run: test/SmokeTests/e2e-test.ps1 -DockerfilePath test/SmokeTests/OOProcSmokeTests/durableJS/Dockerfile -HttpStartPath api/DurableFunctionsHttpStart -TestWithCustomInstanceId
+      run: test/SmokeTests/e2e-test.ps1 -DockerfilePath test/SmokeTests/OOProcSmokeTests/durableJS/Dockerfile -HttpStartPath api/DurableFunctionsHttpStart -TestWithCustomInstanceId -DotNetVersion 8.0
       shell: pwsh

--- a/.github/workflows/smoketest-python37-v4.yml
+++ b/.github/workflows/smoketest-python37-v4.yml
@@ -19,5 +19,5 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Run V4 Python 3.7 Smoke Test
-      run: test/SmokeTests/e2e-test.ps1 -DockerfilePath test/SmokeTests/OOProcSmokeTests/durablePy/Dockerfile -HttpStartPath api/DurableFunctionsHttpStart -ContainerName pyApp -TestWithCustomInstanceId -DotNetVersion 8.0
+      run: test/SmokeTests/e2e-test.ps1 -DockerfilePath test/SmokeTests/OOProcSmokeTests/durablePy/Dockerfile -HttpStartPath api/DurableFunctionsHttpStart -ContainerName pyApp -TestWithCustomInstanceId -DotNetVersion 8
       shell: pwsh

--- a/.github/workflows/smoketest-python37-v4.yml
+++ b/.github/workflows/smoketest-python37-v4.yml
@@ -19,5 +19,5 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Run V4 Python 3.7 Smoke Test
-      run: test/SmokeTests/e2e-test.ps1 -DockerfilePath test/SmokeTests/OOProcSmokeTests/durablePy/Dockerfile -HttpStartPath api/DurableFunctionsHttpStart -ContainerName pyApp -TestWithCustomInstanceId
+      run: test/SmokeTests/e2e-test.ps1 -DockerfilePath test/SmokeTests/OOProcSmokeTests/durablePy/Dockerfile -HttpStartPath api/DurableFunctionsHttpStart -ContainerName pyApp -TestWithCustomInstanceId -DotNetVersion 8.0
       shell: pwsh

--- a/.github/workflows/validate-build-analyzer.yml
+++ b/.github/workflows/validate-build-analyzer.yml
@@ -43,6 +43,16 @@ jobs:
       with:
         dotnet-version: '6.0.x'
 
+    - name: Set up .NET 8.0
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: '8.0.x'
+
+    - name: Set up .NET 10.0
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: '10.0.x'
+
     - name: Restore dependencies
       run: dotnet restore $solution
 

--- a/.github/workflows/validate-build-e2e.yml
+++ b/.github/workflows/validate-build-e2e.yml
@@ -42,7 +42,17 @@ jobs:
       uses: actions/setup-dotnet@v3
       with:
         dotnet-version: '6.0.x'
+        
+    - name: Set up .NET 8.0
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: '8.0.x'   
 
+    - name: Set up .NET 10.0
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: '10.0.x'
+        
     - name: Restore dependencies
       run: dotnet restore $solution
 

--- a/.github/workflows/validate-build.yml
+++ b/.github/workflows/validate-build.yml
@@ -42,6 +42,15 @@ jobs:
       uses: actions/setup-dotnet@v3
       with:
         dotnet-version: '6.0.x'
+    - name: Set up .NET 8.0
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: '8.0.x'
+
+    - name: Set up .NET 10.0
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: '10.0.x'
 
     - name: Restore dependencies
       run: dotnet restore $solution

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -39,7 +39,7 @@
     <PackageVersion Include="StyleCop.Analyzers" Version="1.1.118" />
     <PackageVersion Include="System.Drawing.Common" Version="4.7.3" />
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
-    <PackageVersion Include="System.Text.Json" Version="8.0.5" />
+    <PackageVersion Include="System.Text.Json" Version="10.0.0" />
     <PackageVersion Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
   <!-- Non-Production product dependencies -->
@@ -50,6 +50,7 @@
 
   <!-- Dependencies used by both tests and samples -->
   <ItemGroup>
+    <PackageVersion Include="FluentAssertions" Version="6.12.0" />
     <PackageVersion Include="Microsoft.ApplicationInsights.WorkerService" Version="2.22.0" />
     <PackageVersion Include="Microsoft.Azure.DurableTask.Emulator" Version="2.5.4" />
     <PackageVersion Include="Microsoft.Azure.DurableTask.Netherite.AzureFunctions" Version="3.1.0" />
@@ -64,7 +65,13 @@
     <PackageVersion Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="2.13.7" />
     <PackageVersion Include="Microsoft.Azure.WebJobs.Extensions.Http" Version="3.2.0" />
     <PackageVersion Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="5.1.3" />
+    <PackageVersion Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" Version="3.0.41" />
     <PackageVersion Include="Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator" Version="4.0.1" />
+    <PackageVersion Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.1.8" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageVersion Include="Moq" Version="4.16.1" />
     <PackageVersion Include="xunit" Version="2.9.2" />

--- a/azure-pipelines-analyzer-release.yml
+++ b/azure-pipelines-analyzer-release.yml
@@ -27,6 +27,19 @@ steps:
     packageType: 'sdk'
     version: '6.0.x'
 
+- task: UseDotNet@2
+  displayName: 'Use the .NET 8 SDK'
+  inputs:
+    packageType: 'sdk'
+    version: '8.0.x'
+
+- task: UseDotNet@2
+  displayName: 'Use the .NET 10 SDK'
+  inputs:
+    packageType: 'sdk'
+    version: '10.0.x'
+
+  
 # Use NuGet
 - task: NuGetToolInstaller@1
   displayName: 'Use NuGet '

--- a/azure-pipelines-release-dotnet-isolated.yml
+++ b/azure-pipelines-release-dotnet-isolated.yml
@@ -13,6 +13,18 @@ steps:
   inputs:
     packageType: 'sdk'
     version: '6.0.x'
+    
+- task: UseDotNet@2
+  displayName: 'Use the .NET 8 SDK'
+  inputs:
+    packageType: 'sdk'
+    version: '8.0.x'
+
+- task: UseDotNet@2
+  displayName: 'Use the .NET 10 SDK'
+  inputs:
+    packageType: 'sdk'
+    version: '10.0.x'
 
 # Start by restoring all the .NET Isolated worker extension dependencies. This needs to be its own task.
 - task: DotNetCoreCLI@2

--- a/azure-pipelines-release-nightly.yml
+++ b/azure-pipelines-release-nightly.yml
@@ -41,6 +41,18 @@ steps:
     packageType: 'sdk'
     version: '6.0.x'
 
+- task: UseDotNet@2
+  displayName: 'Use the .NET 8 SDK'
+  inputs:
+    packageType: 'sdk'
+    version: '8.0.x'
+
+- task: UseDotNet@2
+  displayName: 'Use the .NET 10 SDK'
+  inputs:
+    packageType: 'sdk'
+    version: '10.0.x'
+    
 # Use NuGet
 - task: NuGetToolInstaller@1
   displayName: 'Use NuGet '

--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -38,6 +38,18 @@ steps:
     packageType: 'sdk'
     version: '6.0.x'
 
+- task: UseDotNet@2
+  displayName: 'Use the .NET 8 SDK'
+  inputs:
+    packageType: 'sdk'
+    version: '8.0.x'
+
+- task: UseDotNet@2
+  displayName: 'Use the .NET 10 SDK'
+  inputs:
+    packageType: 'sdk'
+    version: '10.0.x'
+    
 # Use NuGet
 - task: NuGetToolInstaller@1
   displayName: 'Use NuGet '

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,6 +23,18 @@ jobs:
         packageType: 'sdk'
         version: '6.0.x'
 
+    - task: UseDotNet@2
+      displayName: 'Use the .NET 8 SDK'
+      inputs:
+        packageType: 'sdk'
+        version: '8.0.x'
+
+    - task: UseDotNet@2
+      displayName: 'Use the .NET 10 SDK'
+      inputs:
+        packageType: 'sdk'
+        version: '10.0.x'
+        
     - task: DotNetCoreCLI@2
       inputs:
         command: 'restore'

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.416",
+    "version": "10.0.100",
     "rollForward": "latestFeature"
   },
   "msbuild-sdks": {

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.100",
+    "version": "8.0.416",
     "rollForward": "latestFeature"
   },
   "msbuild-sdks": {

--- a/samples/VSSample.Tests/VSSample.Tests.csproj
+++ b/samples/VSSample.Tests/VSSample.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net6.0;net8.0;net10.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/samples/VSSample.Tests/VSSample.Tests.csproj
+++ b/samples/VSSample.Tests/VSSample.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net8.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/samples/distributed-tracing/v1/FunctionAppCorrelation/FunctionAppCorrelation.csproj
+++ b/samples/distributed-tracing/v1/FunctionAppCorrelation/FunctionAppCorrelation.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net6.0;net8.0;net10.0</TargetFrameworks>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
     <RunAnalyzersDuringLiveAnalysis>true</RunAnalyzersDuringLiveAnalysis>
     <RunAnalyzersDuringBuild>true</RunAnalyzersDuringBuild>

--- a/samples/distributed-tracing/v1/FunctionAppCorrelation/FunctionAppCorrelation.csproj
+++ b/samples/distributed-tracing/v1/FunctionAppCorrelation/FunctionAppCorrelation.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net8.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
     <RunAnalyzersDuringLiveAnalysis>true</RunAnalyzersDuringLiveAnalysis>
     <RunAnalyzersDuringBuild>true</RunAnalyzersDuringBuild>

--- a/samples/distributed-tracing/v2/DistributedTracingSample/DistributedTracingSample/DistributedTracingSample.csproj
+++ b/samples/distributed-tracing/v2/DistributedTracingSample/DistributedTracingSample/DistributedTracingSample.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net8.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
   </PropertyGroup>
 

--- a/samples/distributed-tracing/v2/DistributedTracingSample/DistributedTracingSample/DistributedTracingSample.csproj
+++ b/samples/distributed-tracing/v2/DistributedTracingSample/DistributedTracingSample/DistributedTracingSample.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net6.0;net8.0;net10.0</TargetFrameworks>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
   </PropertyGroup>
 

--- a/samples/durable-client-managed-identity/aspnetcore-app/ToDoList.csproj
+++ b/samples/durable-client-managed-identity/aspnetcore-app/ToDoList.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net6.0;net8.0;net10.0</TargetFrameworks>
   </PropertyGroup>
 
   <!-- We use central package management. For version details, refer to `samples/Directory.packages.props`. -->

--- a/samples/durable-client-managed-identity/aspnetcore-app/ToDoList.csproj
+++ b/samples/durable-client-managed-identity/aspnetcore-app/ToDoList.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net8.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <!-- We use central package management. For version details, refer to `samples/Directory.packages.props`. -->

--- a/samples/durable-client-managed-identity/functions-app/DurableClientSampleFunctionApp.csproj
+++ b/samples/durable-client-managed-identity/functions-app/DurableClientSampleFunctionApp.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net6.0;net8.0;net10.0</TargetFrameworks>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
   </PropertyGroup>
 

--- a/samples/durable-client-managed-identity/functions-app/DurableClientSampleFunctionApp.csproj
+++ b/samples/durable-client-managed-identity/functions-app/DurableClientSampleFunctionApp.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net8.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
   </PropertyGroup>
 

--- a/samples/entitites-csharp/Chirper/Chirper.Service/Chirper.Service.csproj
+++ b/samples/entitites-csharp/Chirper/Chirper.Service/Chirper.Service.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net8.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
   </PropertyGroup>
 

--- a/samples/entitites-csharp/Chirper/Chirper.Service/Chirper.Service.csproj
+++ b/samples/entitites-csharp/Chirper/Chirper.Service/Chirper.Service.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net6.0;net8.0;net10.0</TargetFrameworks>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
   </PropertyGroup>
 

--- a/samples/entitites-csharp/RideSharing/RideSharing/RideSharing.csproj
+++ b/samples/entitites-csharp/RideSharing/RideSharing/RideSharing.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net8.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
   </PropertyGroup>
 

--- a/samples/entitites-csharp/RideSharing/RideSharing/RideSharing.csproj
+++ b/samples/entitites-csharp/RideSharing/RideSharing/RideSharing.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net6.0;net8.0;net10.0</TargetFrameworks>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
   </PropertyGroup>
 

--- a/samples/functionapp-csharp/DurableClientSampleFunctionApp.csproj
+++ b/samples/functionapp-csharp/DurableClientSampleFunctionApp.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net6.0;net8.0;net10.0</TargetFrameworks>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
   </PropertyGroup>
 

--- a/samples/functionapp-csharp/DurableClientSampleFunctionApp.csproj
+++ b/samples/functionapp-csharp/DurableClientSampleFunctionApp.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net8.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
   </PropertyGroup>
 

--- a/samples/isolated-unit-tests/IsolatedUnitTest.csproj
+++ b/samples/isolated-unit-tests/IsolatedUnitTest.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net8.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
     <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/samples/isolated-unit-tests/IsolatedUnitTest.csproj
+++ b/samples/isolated-unit-tests/IsolatedUnitTest.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net6.0;net8.0;net10.0</TargetFrameworks>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
     <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/samples/precompiled/VSSample.csproj
+++ b/samples/precompiled/VSSample.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net8.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
   </PropertyGroup>
 

--- a/samples/precompiled/VSSample.csproj
+++ b/samples/precompiled/VSSample.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net6.0;net8.0;net10.0</TargetFrameworks>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
   </PropertyGroup>
 

--- a/samples/todolist-aspnetcore/ToDoList.csproj
+++ b/samples/todolist-aspnetcore/ToDoList.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net6.0;net8.0;net10.0</TargetFrameworks>
   </PropertyGroup>
 
   <!-- We use central package management. For version details, refer to `samples/Directory.packages.props`. -->

--- a/samples/todolist-aspnetcore/ToDoList.csproj
+++ b/samples/todolist-aspnetcore/ToDoList.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net8.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <!-- We use central package management. For version details, refer to `samples/Directory.packages.props`. -->

--- a/src/DurableFunctions.TypedInterfaces/Example/DurableFunctions.TypedInterfaces.Example.csproj
+++ b/src/DurableFunctions.TypedInterfaces/Example/DurableFunctions.TypedInterfaces.Example.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net8.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
     <CompilerGeneratedFilesOutputPath>$(BaseIntermediateOutputPath)Generated</CompilerGeneratedFilesOutputPath>

--- a/src/DurableFunctions.TypedInterfaces/Example/DurableFunctions.TypedInterfaces.Example.csproj
+++ b/src/DurableFunctions.TypedInterfaces/Example/DurableFunctions.TypedInterfaces.Example.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net6.0;net8.0;net10.0</TargetFrameworks>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
     <CompilerGeneratedFilesOutputPath>$(BaseIntermediateOutputPath)Generated</CompilerGeneratedFilesOutputPath>

--- a/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
+++ b/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net6.0;net8.0;net10.0</TargetFrameworks>
     <AssemblyName>Microsoft.Azure.WebJobs.Extensions.DurableTask</AssemblyName>
     <RootNamespace>Microsoft.Azure.WebJobs.Extensions.DurableTask</RootNamespace>
     <MajorVersion>3</MajorVersion>
@@ -60,14 +60,12 @@
     <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers" />
     <PackageReference Include="Microsoft.Extensions.Azure" />
-    <PackageReference Include="Microsoft.Extensions.Http" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.WebApiCompatShim" />
     <PackageReference Include="Microsoft.Azure.DurableTask.ApplicationInsights" />
     <!-- Build-time dependencies -->
     <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
     <PackageReference Include="StyleCop.Analyzers" PrivateAssets="All" />
     <PackageReference Include="Grpc.Tools" PrivateAssets="All" />
-    <PackageReference Include="System.Text.RegularExpressions" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
+++ b/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net8.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <AssemblyName>Microsoft.Azure.WebJobs.Extensions.DurableTask</AssemblyName>
     <RootNamespace>Microsoft.Azure.WebJobs.Extensions.DurableTask</RootNamespace>
     <MajorVersion>3</MajorVersion>

--- a/src/Worker.Extensions.DurableTask/Worker.Extensions.DurableTask.csproj
+++ b/src/Worker.Extensions.DurableTask/Worker.Extensions.DurableTask.csproj
@@ -2,7 +2,7 @@
 
   <!-- Core compiler settings -->
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0;net8.0;net10.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <DebugType>embedded</DebugType>

--- a/src/Worker.Extensions.DurableTask/Worker.Extensions.DurableTask.csproj
+++ b/src/Worker.Extensions.DurableTask/Worker.Extensions.DurableTask.csproj
@@ -2,7 +2,7 @@
 
   <!-- Core compiler settings -->
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0;net8.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <DebugType>embedded</DebugType>

--- a/test/CodeGen.Example.Test/DurableFunctions.TypedInterfaces.Examples.Test.csproj
+++ b/test/CodeGen.Example.Test/DurableFunctions.TypedInterfaces.Examples.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net6.0;net8.0;net10.0</TargetFrameworks>
     <Company>Microsoft Corporation</Company>
     <NoWarn>SA0001;SA1600;SA1615</NoWarn>
     <SignAssembly>true</SignAssembly>

--- a/test/CodeGen.Example.Test/DurableFunctions.TypedInterfaces.Examples.Test.csproj
+++ b/test/CodeGen.Example.Test/DurableFunctions.TypedInterfaces.Examples.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net8.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <Company>Microsoft Corporation</Company>
     <NoWarn>SA0001;SA1600;SA1615</NoWarn>
     <SignAssembly>true</SignAssembly>

--- a/test/DFPerfScenarios/DFPerfScenariosV4.csproj
+++ b/test/DFPerfScenarios/DFPerfScenariosV4.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net8.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
   </PropertyGroup>
 

--- a/test/DFPerfScenarios/DFPerfScenariosV4.csproj
+++ b/test/DFPerfScenarios/DFPerfScenariosV4.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net6.0;net8.0;net10.0</TargetFrameworks>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
   </PropertyGroup>
 

--- a/test/Directory.Packages.props
+++ b/test/Directory.Packages.props
@@ -19,10 +19,10 @@
     <PackageVersion Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.65" />
     <PackageVersion Include="Microsoft.DurableTask.Generators" Version="1.0.0-preview.1" />
     <PackageVersion Include="Microsoft.DurableTask.SqlServer.AzureFunctions" Version="1.5.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="9.0.0" Condition="'$(TargetFramework)' == 'net8.0'" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.0" Condition="'$(TargetFramework)' == 'net8.0'" />
     <PackageVersion Include="MSTest.TestAdapter" Version="1.3.2" />
     <PackageVersion Include="MSTest.TestFramework" Version="1.3.2" />
   </ItemGroup>
@@ -30,10 +30,10 @@
   <!-- Transitive dependencies with higher versions -->
   <ItemGroup>
     <PackageVersion Update="Azure.Identity" Version="1.17.0" />
-    <PackageVersion Update="Microsoft.Bcl.AsyncInterfaces" Version="9.0.0"/>
+    <PackageVersion Update="Microsoft.Bcl.AsyncInterfaces" Version="10.0.0"/>
     <PackageVersion Update="Microsoft.Extensions.Azure" Version="1.10.0" />
     <PackageVersion Update="System.Drawing.Common" Version="6.0.0" />
-    <PackageVersion Update="System.Text.Json" Version="9.0.0" />
+    <PackageVersion Update="System.Text.Json" Version="10.0.0" />
   </ItemGroup>
 
 </Project>

--- a/test/FunctionsV2/WebJobs.Extensions.DurableTask.Tests.V2.csproj
+++ b/test/FunctionsV2/WebJobs.Extensions.DurableTask.Tests.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <Company>Microsoft Corporation</Company>
     <NoWarn>SA0001;SA1600;SA1615</NoWarn>
     <SignAssembly>true</SignAssembly>

--- a/test/PerfTests/DFPerfTests/perf.csproj
+++ b/test/PerfTests/DFPerfTests/perf.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net8.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/test/PerfTests/DFPerfTests/perf.csproj
+++ b/test/PerfTests/DFPerfTests/perf.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net6.0;net8.0;net10.0</TargetFrameworks>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/test/PerfTests/JavaScript/extensions.csproj
+++ b/test/PerfTests/JavaScript/extensions.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net8.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <WarningsAsErrors></WarningsAsErrors>
     <DefaultItemExcludes>**</DefaultItemExcludes>
   </PropertyGroup>

--- a/test/PerfTests/JavaScript/extensions.csproj
+++ b/test/PerfTests/JavaScript/extensions.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net6.0;net8.0;net10.0</TargetFrameworks>
     <WarningsAsErrors></WarningsAsErrors>
     <DefaultItemExcludes>**</DefaultItemExcludes>
   </PropertyGroup>

--- a/test/PerfTests/Python/extensions.csproj
+++ b/test/PerfTests/Python/extensions.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net8.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <WarningsAsErrors></WarningsAsErrors>
     <DefaultItemExcludes>**</DefaultItemExcludes>
   </PropertyGroup>

--- a/test/PerfTests/Python/extensions.csproj
+++ b/test/PerfTests/Python/extensions.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net6.0;net8.0;net10.0</TargetFrameworks>
     <WarningsAsErrors></WarningsAsErrors>
     <DefaultItemExcludes>**</DefaultItemExcludes>
   </PropertyGroup>

--- a/test/SmokeTests/BackendSmokeTests/MSSQL/Dockerfile
+++ b/test/SmokeTests/BackendSmokeTests/MSSQL/Dockerfile
@@ -6,7 +6,8 @@ FROM mcr.microsoft.com/dotnet/sdk:${DOTNET_VERSION}.0 AS build-env
 
 # Build the DF MSSQL app
 COPY . /root
-RUN cd /root/test/SmokeTests/BackendSmokeTests/MSSQL && \
+RUN rm -f /root/global.json && \
+    cd /root/test/SmokeTests/BackendSmokeTests/MSSQL && \
     mkdir -p /home/site/wwwroot && \
     dotnet publish -c Release --output /home/site/wwwroot
 

--- a/test/SmokeTests/BackendSmokeTests/MSSQL/Dockerfile
+++ b/test/SmokeTests/BackendSmokeTests/MSSQL/Dockerfile
@@ -1,8 +1,8 @@
 ﻿# Copyright (c) .NET Foundation. All rights reserved.
 # Licensed under the MIT License. See LICENSE in the project root for license information.
 
-ARG DOTNET_VERSION=8.0
-FROM mcr.microsoft.com/dotnet/sdk:${DOTNET_VERSION} AS build-env
+ARG DOTNET_VERSION=8
+FROM mcr.microsoft.com/dotnet/sdk:${DOTNET_VERSION}.0 AS build-env
 
 # Build the DF MSSQL app
 COPY . /root
@@ -11,7 +11,7 @@ RUN cd /root/test/SmokeTests/BackendSmokeTests/MSSQL && \
     dotnet publish -c Release --output /home/site/wwwroot
 
 # Deploy the app
-ARG DOTNET_VERSION=8.0
+ARG DOTNET_VERSION=8
 FROM mcr.microsoft.com/azure-functions/dotnet:4-dotnet${DOTNET_VERSION}
 ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     AzureFunctionsJobHost__Logging__Console__IsEnabled=true

--- a/test/SmokeTests/BackendSmokeTests/MSSQL/Dockerfile
+++ b/test/SmokeTests/BackendSmokeTests/MSSQL/Dockerfile
@@ -1,7 +1,8 @@
 ﻿# Copyright (c) .NET Foundation. All rights reserved.
 # Licensed under the MIT License. See LICENSE in the project root for license information.
 
-FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build-env
+ARG DOTNET_VERSION=8.0
+FROM mcr.microsoft.com/dotnet/sdk:${DOTNET_VERSION} AS build-env
 
 # Build the DF MSSQL app
 COPY . /root
@@ -10,7 +11,8 @@ RUN cd /root/test/SmokeTests/BackendSmokeTests/MSSQL && \
     dotnet publish -c Release --output /home/site/wwwroot
 
 # Deploy the app
-FROM mcr.microsoft.com/azure-functions/dotnet:4-dotnet8
+ARG DOTNET_VERSION=8.0
+FROM mcr.microsoft.com/azure-functions/dotnet:4-dotnet${DOTNET_VERSION}
 ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     AzureFunctionsJobHost__Logging__Console__IsEnabled=true
 COPY --from=build-env ["/home/site/wwwroot", "/home/site/wwwroot"]

--- a/test/SmokeTests/BackendSmokeTests/MSSQL/MSSQL.csproj
+++ b/test/SmokeTests/BackendSmokeTests/MSSQL/MSSQL.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net8.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
     <!-- CPM seems to be broken for .net8 inproc apps when WebJobs.Extensions.DurableTask.csproj is targeting net6.0 -->
     <!-- If enabled, func complains about "Could not load file or assembly 'Microsoft.Extensions.Logging.Abstractions, Version=9.0.0.0" -->

--- a/test/SmokeTests/BackendSmokeTests/MSSQL/MSSQL.csproj
+++ b/test/SmokeTests/BackendSmokeTests/MSSQL/MSSQL.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net6.0;net8.0;net10.0</TargetFrameworks>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
     <!-- CPM seems to be broken for .net8 inproc apps when WebJobs.Extensions.DurableTask.csproj is targeting net6.0 -->
     <!-- If enabled, func complains about "Could not load file or assembly 'Microsoft.Extensions.Logging.Abstractions, Version=9.0.0.0" -->

--- a/test/SmokeTests/BackendSmokeTests/Netherite/Dockerfile
+++ b/test/SmokeTests/BackendSmokeTests/Netherite/Dockerfile
@@ -6,7 +6,8 @@ FROM mcr.microsoft.com/dotnet/sdk:${DOTNET_VERSION}.0 AS build-env
 
 # Build the app
 COPY . /root
-RUN cd /root/test/SmokeTests/BackendSmokeTests/Netherite && \
+RUN rm -f /root/global.json && \
+    cd /root/test/SmokeTests/BackendSmokeTests/Netherite && \
     mkdir -p /home/site/wwwroot && \
     dotnet publish -c Release --output /home/site/wwwroot
 

--- a/test/SmokeTests/BackendSmokeTests/Netherite/Dockerfile
+++ b/test/SmokeTests/BackendSmokeTests/Netherite/Dockerfile
@@ -1,7 +1,8 @@
 ﻿# Copyright (c) .NET Foundation. All rights reserved.
 # Licensed under the MIT License. See LICENSE in the project root for license information.
 
-FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build-env
+ARG DOTNET_VERSION=8.0
+FROM mcr.microsoft.com/dotnet/sdk:${DOTNET_VERSION} AS build-env
 
 # Build the app
 COPY . /root
@@ -10,7 +11,8 @@ RUN cd /root/test/SmokeTests/BackendSmokeTests/Netherite && \
     dotnet publish -c Release --output /home/site/wwwroot
 
 # Deploy the app
-FROM mcr.microsoft.com/azure-functions/dotnet:4-dotnet8.0
+ARG DOTNET_VERSION=8.0
+FROM mcr.microsoft.com/azure-functions/dotnet:4-dotnet${DOTNET_VERSION}
 ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     AzureFunctionsJobHost__Logging__Console__IsEnabled=true
 COPY --from=build-env ["/home/site/wwwroot", "/home/site/wwwroot"]

--- a/test/SmokeTests/BackendSmokeTests/Netherite/Dockerfile
+++ b/test/SmokeTests/BackendSmokeTests/Netherite/Dockerfile
@@ -1,8 +1,8 @@
 ﻿# Copyright (c) .NET Foundation. All rights reserved.
 # Licensed under the MIT License. See LICENSE in the project root for license information.
 
-ARG DOTNET_VERSION=8.0
-FROM mcr.microsoft.com/dotnet/sdk:${DOTNET_VERSION} AS build-env
+ARG DOTNET_VERSION=8
+FROM mcr.microsoft.com/dotnet/sdk:${DOTNET_VERSION}.0 AS build-env
 
 # Build the app
 COPY . /root
@@ -11,7 +11,7 @@ RUN cd /root/test/SmokeTests/BackendSmokeTests/Netherite && \
     dotnet publish -c Release --output /home/site/wwwroot
 
 # Deploy the app
-ARG DOTNET_VERSION=8.0
+ARG DOTNET_VERSION=8
 FROM mcr.microsoft.com/azure-functions/dotnet:4-dotnet${DOTNET_VERSION}
 ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     AzureFunctionsJobHost__Logging__Console__IsEnabled=true

--- a/test/SmokeTests/BackendSmokeTests/Netherite/Netherite.csproj
+++ b/test/SmokeTests/BackendSmokeTests/Netherite/Netherite.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net8.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
     <!-- CPM seems to be broken for .net8 inproc apps when WebJobs.Extensions.DurableTask.csproj is targeting net6.0 -->
     <!-- If enabled, func complains about "Could not load file or assembly 'Microsoft.Extensions.Logging.Abstractions, Version=9.0.0.0" -->

--- a/test/SmokeTests/BackendSmokeTests/Netherite/Netherite.csproj
+++ b/test/SmokeTests/BackendSmokeTests/Netherite/Netherite.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net6.0;net8.0;net10.0</TargetFrameworks>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
     <!-- CPM seems to be broken for .net8 inproc apps when WebJobs.Extensions.DurableTask.csproj is targeting net6.0 -->
     <!-- If enabled, func complains about "Could not load file or assembly 'Microsoft.Extensions.Logging.Abstractions, Version=9.0.0.0" -->

--- a/test/SmokeTests/OOProcSmokeTests/DotNetIsolated/Dockerfile
+++ b/test/SmokeTests/OOProcSmokeTests/DotNetIsolated/Dockerfile
@@ -1,7 +1,8 @@
 ﻿# Copyright (c) .NET Foundation. All rights reserved.
 # Licensed under the MIT License. See LICENSE in the project root for license information.
 
-FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build-env
+ARG DOTNET_VERSION=8.0
+FROM mcr.microsoft.com/dotnet/sdk:${DOTNET_VERSION} AS build-env
 
 # Step 1: Build the WebJobs extension and publish it as a local NuGet package
 COPY . /root
@@ -26,7 +27,8 @@ RUN cd /root/test/SmokeTests/OOProcSmokeTests/DotNetIsolated && \
     cat /home/site/wwwroot/extensions.json # debugging
 
 # Step 3: Generate the final app image to run
-FROM mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0
+ARG DOTNET_VERSION=8.0
+FROM mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated${DOTNET_VERSION}
 
 # This is the standard setup for Azure Functions running in Docker containers
 ENV AzureWebJobsScriptRoot=/home/site/wwwroot \

--- a/test/SmokeTests/OOProcSmokeTests/DotNetIsolated/Dockerfile
+++ b/test/SmokeTests/OOProcSmokeTests/DotNetIsolated/Dockerfile
@@ -1,8 +1,8 @@
 ﻿# Copyright (c) .NET Foundation. All rights reserved.
 # Licensed under the MIT License. See LICENSE in the project root for license information.
 
-ARG DOTNET_VERSION=8.0
-FROM mcr.microsoft.com/dotnet/sdk:${DOTNET_VERSION} AS build-env
+ARG DOTNET_VERSION=8
+FROM mcr.microsoft.com/dotnet/sdk:${DOTNET_VERSION}.0 AS build-env
 
 # Step 1: Build the WebJobs extension and publish it as a local NuGet package
 COPY . /root
@@ -27,8 +27,8 @@ RUN cd /root/test/SmokeTests/OOProcSmokeTests/DotNetIsolated && \
     cat /home/site/wwwroot/extensions.json # debugging
 
 # Step 3: Generate the final app image to run
-ARG DOTNET_VERSION=8.0
-FROM mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated${DOTNET_VERSION}
+ARG DOTNET_VERSION=8
+FROM mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated${DOTNET_VERSION}.0
 
 # This is the standard setup for Azure Functions running in Docker containers
 ENV AzureWebJobsScriptRoot=/home/site/wwwroot \

--- a/test/SmokeTests/OOProcSmokeTests/DotNetIsolated/Dockerfile
+++ b/test/SmokeTests/OOProcSmokeTests/DotNetIsolated/Dockerfile
@@ -6,7 +6,8 @@ FROM mcr.microsoft.com/dotnet/sdk:${DOTNET_VERSION}.0 AS build-env
 
 # Step 1: Build the WebJobs extension and publish it as a local NuGet package
 COPY . /root
-RUN cd /root/src/WebJobs.Extensions.DurableTask && \
+RUN rm -f /root/global.json && \
+    cd /root/src/WebJobs.Extensions.DurableTask && \
     mkdir /out && \
     dotnet build -c Release WebJobs.Extensions.DurableTask.csproj --output /out && \
     mkdir /packages && \

--- a/test/SmokeTests/OOProcSmokeTests/DotNetIsolated/DotNetIsolated.csproj
+++ b/test/SmokeTests/OOProcSmokeTests/DotNetIsolated/DotNetIsolated.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net8.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
     <OutputType>exe</OutputType>
     <IsPackable>false</IsPackable>

--- a/test/SmokeTests/OOProcSmokeTests/DotNetIsolated/DotNetIsolated.csproj
+++ b/test/SmokeTests/OOProcSmokeTests/DotNetIsolated/DotNetIsolated.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net6.0;net8.0;net10.0</TargetFrameworks>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
     <OutputType>exe</OutputType>
     <IsPackable>false</IsPackable>

--- a/test/SmokeTests/OOProcSmokeTests/durableJS/Dockerfile
+++ b/test/SmokeTests/OOProcSmokeTests/durableJS/Dockerfile
@@ -6,7 +6,8 @@
 ARG DOTNET_VERSION=8
 FROM mcr.microsoft.com/dotnet/sdk:${DOTNET_VERSION}.0 AS build-env
 COPY . /root
-RUN cd /root/test/SmokeTests/OOProcSmokeTests/durableJS && \
+RUN rm -f /root/global.json && \
+    cd /root/test/SmokeTests/OOProcSmokeTests/durableJS && \
     dotnet build -o bin
 
 # Step 2: Deploy and run npm install to get the Durable Functions SDK

--- a/test/SmokeTests/OOProcSmokeTests/durableJS/Dockerfile
+++ b/test/SmokeTests/OOProcSmokeTests/durableJS/Dockerfile
@@ -3,8 +3,8 @@
 
 # Step 1: Add the durable extension by building it locally.
 #         This is an alternative to "func extensions install"
-ARG DOTNET_VERSION=8.0
-FROM mcr.microsoft.com/dotnet/sdk:${DOTNET_VERSION} AS build-env
+ARG DOTNET_VERSION=8
+FROM mcr.microsoft.com/dotnet/sdk:${DOTNET_VERSION}.0 AS build-env
 COPY . /root
 RUN cd /root/test/SmokeTests/OOProcSmokeTests/durableJS && \
     dotnet build -o bin

--- a/test/SmokeTests/OOProcSmokeTests/durableJS/Dockerfile
+++ b/test/SmokeTests/OOProcSmokeTests/durableJS/Dockerfile
@@ -3,7 +3,8 @@
 
 # Step 1: Add the durable extension by building it locally.
 #         This is an alternative to "func extensions install"
-FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build-env
+ARG DOTNET_VERSION=8.0
+FROM mcr.microsoft.com/dotnet/sdk:${DOTNET_VERSION} AS build-env
 COPY . /root
 RUN cd /root/test/SmokeTests/OOProcSmokeTests/durableJS && \
     dotnet build -o bin

--- a/test/SmokeTests/OOProcSmokeTests/durableJS/extensions.csproj
+++ b/test/SmokeTests/OOProcSmokeTests/durableJS/extensions.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net8.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <WarningsAsErrors></WarningsAsErrors>
     <DefaultItemExcludes>**</DefaultItemExcludes>
   </PropertyGroup>

--- a/test/SmokeTests/OOProcSmokeTests/durableJS/extensions.csproj
+++ b/test/SmokeTests/OOProcSmokeTests/durableJS/extensions.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net6.0;net8.0;net10.0</TargetFrameworks>
     <WarningsAsErrors></WarningsAsErrors>
     <DefaultItemExcludes>**</DefaultItemExcludes>
   </PropertyGroup>

--- a/test/SmokeTests/OOProcSmokeTests/durableJava/Dockerfile
+++ b/test/SmokeTests/OOProcSmokeTests/durableJava/Dockerfile
@@ -1,4 +1,5 @@
-FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build-env
+ARG DOTNET_VERSION=8.0
+FROM mcr.microsoft.com/dotnet/sdk:${DOTNET_VERSION} AS build-env
 COPY . /root
 RUN cd /root/test/SmokeTests/OOProcSmokeTests/durableJava && \
     dotnet build -o bin

--- a/test/SmokeTests/OOProcSmokeTests/durableJava/Dockerfile
+++ b/test/SmokeTests/OOProcSmokeTests/durableJava/Dockerfile
@@ -1,7 +1,8 @@
 ARG DOTNET_VERSION=8
 FROM mcr.microsoft.com/dotnet/sdk:${DOTNET_VERSION}.0 AS build-env
 COPY . /root
-RUN cd /root/test/SmokeTests/OOProcSmokeTests/durableJava && \
+RUN rm -f /root/global.json && \
+    cd /root/test/SmokeTests/OOProcSmokeTests/durableJava && \
     dotnet build -o bin
 
 FROM mcr.microsoft.com/azure-functions/java:4-java8

--- a/test/SmokeTests/OOProcSmokeTests/durableJava/Dockerfile
+++ b/test/SmokeTests/OOProcSmokeTests/durableJava/Dockerfile
@@ -1,5 +1,5 @@
-ARG DOTNET_VERSION=8.0
-FROM mcr.microsoft.com/dotnet/sdk:${DOTNET_VERSION} AS build-env
+ARG DOTNET_VERSION=8
+FROM mcr.microsoft.com/dotnet/sdk:${DOTNET_VERSION}.0 AS build-env
 COPY . /root
 RUN cd /root/test/SmokeTests/OOProcSmokeTests/durableJava && \
     dotnet build -o bin

--- a/test/SmokeTests/OOProcSmokeTests/durableJava/extensions.csproj
+++ b/test/SmokeTests/OOProcSmokeTests/durableJava/extensions.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net8.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <WarningsAsErrors></WarningsAsErrors>
     <DefaultItemExcludes>**</DefaultItemExcludes>
   </PropertyGroup>

--- a/test/SmokeTests/OOProcSmokeTests/durableJava/extensions.csproj
+++ b/test/SmokeTests/OOProcSmokeTests/durableJava/extensions.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net6.0;net8.0;net10.0</TargetFrameworks>
     <WarningsAsErrors></WarningsAsErrors>
     <DefaultItemExcludes>**</DefaultItemExcludes>
   </PropertyGroup>

--- a/test/SmokeTests/OOProcSmokeTests/durablePy/Dockerfile
+++ b/test/SmokeTests/OOProcSmokeTests/durablePy/Dockerfile
@@ -6,7 +6,8 @@
 ARG DOTNET_VERSION=8
 FROM mcr.microsoft.com/dotnet/sdk:${DOTNET_VERSION}.0 AS build-env
 COPY . /root
-RUN cd /root/test/SmokeTests/OOProcSmokeTests/durablePy && \
+RUN rm -f /root/global.json && \
+    cd /root/test/SmokeTests/OOProcSmokeTests/durablePy && \
     dotnet build -o bin
 
 # Step 2: Deploy and run pip install to get the Durable Functions SDK

--- a/test/SmokeTests/OOProcSmokeTests/durablePy/Dockerfile
+++ b/test/SmokeTests/OOProcSmokeTests/durablePy/Dockerfile
@@ -3,8 +3,8 @@
 
 # Step 1: Add the durable extension by building it locally.
 #         This is an alternative to "func extensions install"
-ARG DOTNET_VERSION=8.0
-FROM mcr.microsoft.com/dotnet/sdk:${DOTNET_VERSION} AS build-env
+ARG DOTNET_VERSION=8
+FROM mcr.microsoft.com/dotnet/sdk:${DOTNET_VERSION}.0 AS build-env
 COPY . /root
 RUN cd /root/test/SmokeTests/OOProcSmokeTests/durablePy && \
     dotnet build -o bin

--- a/test/SmokeTests/OOProcSmokeTests/durablePy/Dockerfile
+++ b/test/SmokeTests/OOProcSmokeTests/durablePy/Dockerfile
@@ -3,7 +3,8 @@
 
 # Step 1: Add the durable extension by building it locally.
 #         This is an alternative to "func extensions install"
-FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build-env
+ARG DOTNET_VERSION=8.0
+FROM mcr.microsoft.com/dotnet/sdk:${DOTNET_VERSION} AS build-env
 COPY . /root
 RUN cd /root/test/SmokeTests/OOProcSmokeTests/durablePy && \
     dotnet build -o bin

--- a/test/SmokeTests/OOProcSmokeTests/durablePy/extensions.csproj
+++ b/test/SmokeTests/OOProcSmokeTests/durablePy/extensions.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net8.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <WarningsAsErrors></WarningsAsErrors>
     <DefaultItemExcludes>**</DefaultItemExcludes>
   </PropertyGroup>

--- a/test/SmokeTests/OOProcSmokeTests/durablePy/extensions.csproj
+++ b/test/SmokeTests/OOProcSmokeTests/durablePy/extensions.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net6.0;net8.0;net10.0</TargetFrameworks>
     <WarningsAsErrors></WarningsAsErrors>
     <DefaultItemExcludes>**</DefaultItemExcludes>
   </PropertyGroup>

--- a/test/SmokeTests/e2e-test.ps1
+++ b/test/SmokeTests/e2e-test.ps1
@@ -16,7 +16,8 @@ param(
      	[string]$tag="2019-latest",
     	[int]$port=1433,
      	[string]$dbname="DurableDB",
-    	[string]$collation="Latin1_General_100_BIN2_UTF8"
+    	[string]$collation="Latin1_General_100_BIN2_UTF8",
+	[string]$DotNetVersion="8.0"
 )
 
 function Exit-OnError() {
@@ -74,8 +75,8 @@ $AzuriteVersion = "3.34.0"
 
 if ($NoSetup -eq $false) {
 	# Build the docker image first, since that's the most critical step
-	Write-Host "Building sample app Docker container from '$DockerfilePath'..." -ForegroundColor Yellow
-	docker build --pull -f $DockerfilePath -t $ImageName --progress plain $PSScriptRoot/../../
+	Write-Host "Building sample app Docker container from '$DockerfilePath' with .NET version $DotNetVersion..." -ForegroundColor Yellow
+	docker build --pull -f $DockerfilePath -t $ImageName --build-arg DOTNET_VERSION=$DotNetVersion --progress plain $PSScriptRoot/../../
 	Exit-OnError
 
 	# Next, download and start the Azurite emulator Docker image

--- a/test/SmokeTests/e2e-test.ps1
+++ b/test/SmokeTests/e2e-test.ps1
@@ -17,7 +17,7 @@ param(
     	[int]$port=1433,
      	[string]$dbname="DurableDB",
     	[string]$collation="Latin1_General_100_BIN2_UTF8",
-	[string]$DotNetVersion="8.0"
+	[string]$DotNetVersion="8"
 )
 
 function Exit-OnError() {

--- a/test/TimeoutTests/CSharp/TimeoutTests.csproj
+++ b/test/TimeoutTests/CSharp/TimeoutTests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net6.0;net8.0;net10.0</TargetFrameworks>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
   </PropertyGroup>
   <!-- Common packages for all targets -->

--- a/test/TimeoutTests/CSharp/TimeoutTests.csproj
+++ b/test/TimeoutTests/CSharp/TimeoutTests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net8.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
   </PropertyGroup>
   <!-- Common packages for all targets -->

--- a/test/TimeoutTests/Python/extensions.csproj
+++ b/test/TimeoutTests/Python/extensions.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net8.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
   <WarningsAsErrors></WarningsAsErrors>
   <DefaultItemExcludes>**</DefaultItemExcludes>

--- a/test/TimeoutTests/Python/extensions.csproj
+++ b/test/TimeoutTests/Python/extensions.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net6.0;net8.0;net10.0</TargetFrameworks>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
   <WarningsAsErrors></WarningsAsErrors>
   <DefaultItemExcludes>**</DefaultItemExcludes>

--- a/test/WebJobs.Extensions.DurableTask.Analyzers.Test/WebJobs.Extensions.DurableTask.Analyzers.Test.csproj
+++ b/test/WebJobs.Extensions.DurableTask.Analyzers.Test/WebJobs.Extensions.DurableTask.Analyzers.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net6.0;net8.0;net10.0</TargetFrameworks>
     <AssemblyName>Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers.Test</AssemblyName>
     <RootNamespace>Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers.Test</RootNamespace>
   </PropertyGroup>

--- a/test/WebJobs.Extensions.DurableTask.Analyzers.Test/WebJobs.Extensions.DurableTask.Analyzers.Test.csproj
+++ b/test/WebJobs.Extensions.DurableTask.Analyzers.Test/WebJobs.Extensions.DurableTask.Analyzers.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net8.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <AssemblyName>Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers.Test</AssemblyName>
     <RootNamespace>Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers.Test</RootNamespace>
   </PropertyGroup>

--- a/test/Worker.Extensions.DurableTask.Tests/FunctionContextExtensionsTests.cs
+++ b/test/Worker.Extensions.DurableTask.Tests/FunctionContextExtensionsTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System.Collections.Immutable;
+using System.Collections.ObjectModel;
 using Microsoft.Azure.Functions.Worker.Extensions.DurableTask;
 using Microsoft.Azure.Functions.Worker.Extensions.DurableTask.Execution;
 
@@ -285,7 +286,7 @@ public class FunctionContextExtensionsTests
     {
         public TestBindingContext(IDictionary<string, object?> bindingData)
         {
-            this.BindingData = bindingData.AsReadOnly();
+            this.BindingData = new ReadOnlyDictionary<string, object?>(bindingData);
         }
         public override IReadOnlyDictionary<string, object?> BindingData { get; }
     }

--- a/test/Worker.Extensions.DurableTask.Tests/Worker.Extensions.DurableTask.Tests.csproj
+++ b/test/Worker.Extensions.DurableTask.Tests/Worker.Extensions.DurableTask.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net6.0;net8.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/test/Worker.Extensions.DurableTask.Tests/Worker.Extensions.DurableTask.Tests.csproj
+++ b/test/Worker.Extensions.DurableTask.Tests/Worker.Extensions.DurableTask.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net8.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/test/e2e/Apps/BasicDotNetIsolated/app.csproj
+++ b/test/e2e/Apps/BasicDotNetIsolated/app.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net8.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
     <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/test/e2e/Apps/BasicDotNetIsolated/app.csproj
+++ b/test/e2e/Apps/BasicDotNetIsolated/app.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net6.0;net8.0;net10.0</TargetFrameworks>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
     <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/test/e2e/Apps/BasicJava/extensions.csproj
+++ b/test/e2e/Apps/BasicJava/extensions.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net8.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
 	<WarningsAsErrors></WarningsAsErrors>
 	<DefaultItemExcludes>**</DefaultItemExcludes>

--- a/test/e2e/Apps/BasicJava/extensions.csproj
+++ b/test/e2e/Apps/BasicJava/extensions.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net6.0;net8.0;net10.0</TargetFrameworks>
     <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
 	<WarningsAsErrors></WarningsAsErrors>
 	<DefaultItemExcludes>**</DefaultItemExcludes>

--- a/test/e2e/Apps/BasicNode/extensions.csproj
+++ b/test/e2e/Apps/BasicNode/extensions.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net8.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
 	<WarningsAsErrors></WarningsAsErrors>
 	<DefaultItemExcludes>**</DefaultItemExcludes>

--- a/test/e2e/Apps/BasicNode/extensions.csproj
+++ b/test/e2e/Apps/BasicNode/extensions.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net6.0;net8.0;net10.0</TargetFrameworks>
     <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
 	<WarningsAsErrors></WarningsAsErrors>
 	<DefaultItemExcludes>**</DefaultItemExcludes>

--- a/test/e2e/Apps/BasicPowerShell/extensions.csproj
+++ b/test/e2e/Apps/BasicPowerShell/extensions.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net8.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
 	<WarningsAsErrors></WarningsAsErrors>
 	<DefaultItemExcludes>**</DefaultItemExcludes>

--- a/test/e2e/Apps/BasicPowerShell/extensions.csproj
+++ b/test/e2e/Apps/BasicPowerShell/extensions.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net6.0;net8.0;net10.0</TargetFrameworks>
     <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
 	<WarningsAsErrors></WarningsAsErrors>
 	<DefaultItemExcludes>**</DefaultItemExcludes>

--- a/test/e2e/Apps/BasicPython/extensions.csproj
+++ b/test/e2e/Apps/BasicPython/extensions.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net8.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
 	<WarningsAsErrors></WarningsAsErrors>
 	<DefaultItemExcludes>**</DefaultItemExcludes>

--- a/test/e2e/Apps/BasicPython/extensions.csproj
+++ b/test/e2e/Apps/BasicPython/extensions.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net6.0;net8.0;net10.0</TargetFrameworks>
     <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
 	<WarningsAsErrors></WarningsAsErrors>
 	<DefaultItemExcludes>**</DefaultItemExcludes>

--- a/test/e2e/Tests/E2ETests.csproj
+++ b/test/e2e/Tests/E2ETests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net6.0;net8.0;net10.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/test/e2e/Tests/E2ETests.csproj
+++ b/test/e2e/Tests/E2ETests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net8.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/test/e2e/Tests/Fixtures/FunctionAppProcess.cs
+++ b/test/e2e/Tests/Fixtures/FunctionAppProcess.cs
@@ -63,7 +63,7 @@ internal class FunctionAppProcess
                     else
                         e2eAppBuiltLocationPath = Path.Combine(rootDir, @$"test/e2e/Apps/{this.appName}/bin");
 
-                    if (!Path.Exists(e2eAppBuiltLocationPath))
+                    if (!Directory.Exists(e2eAppBuiltLocationPath))
                     {
                         throw new InvalidOperationException($"The app bin path {e2eAppBuiltLocationPath} does not exist!");
                     }


### PR DESCRIPTION
Add backword compatability to .NET 6

<!-- Make sure to delete the markdown comments and the below sections when squash merging -->
### Issue describing the changes in this PR

resolves #issue_for_this_pr

### Pull request checklist

* [ ] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)
* [ ] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk
* [ ] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
    * [ ] Otherwise: major or minor version updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
* [ ] My changes **do not** add EventIds to our EventSource logs
    * [ ] Otherwise: Ensure the EventIds are within the supported range in our existing Windows infrastructure. You may validate this with a deployed app's telemetry. You may also extend the range by completing a PR such as [this one](https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files).
* [ ] My changes **should** be added to **v2.x** branch.
    * [ ] Otherwise: This change applies exclusively to WebJobs.Extensions.DurableTask v3.x. It will be retained only in the `dev` and `main` branches and will not be merged into the `v2.x` branch.
