### PR TITLE
Update .NET SDK versions to 6.0, 8.0, and 10.0 across workflows and projects

### DIFF
--- a/.github/workflows/E2ETest.yml
+++ b/.github/workflows/E2ETest.yml
@@ -25,15 +25,20 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup .NET Core
+      - name: Setup .NET 6.0
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 6.0.x
 
-      - name: Setup .NET Core
+      - name: Setup .NET 8.0
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 8.0.x
+
+      - name: Setup .NET 10.0
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: 10.0.x
 
       - name: Set up Node.js (needed for Azurite)
         uses: actions/setup-node@v3
@@ -118,15 +123,20 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup .NET Core
+      - name: Setup .NET 6.0
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 6.0.x
 
-      - name: Setup .NET Core
+      - name: Setup .NET 8.0
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 8.0.x
+
+      - name: Setup .NET 10.0
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: 10.0.x
 
       - name: Set up Node.js (needed for Azurite)
         uses: actions/setup-node@v3
@@ -211,15 +221,20 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup .NET Core
+      - name: Setup .NET 6.0
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 6.0.x
 
-      - name: Setup .NET Core
+      - name: Setup .NET 8.0
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 8.0.x
+
+      - name: Setup .NET 10.0
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: 10.0.x
 
       - name: Set up Node.js (needed for Azurite)
         uses: actions/setup-node@v3
@@ -308,15 +323,20 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup .NET Core
+      - name: Setup .NET 6.0
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 6.0.x
 
-      - name: Setup .NET Core
+      - name: Setup .NET 8.0
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 8.0.x
+
+      - name: Setup .NET 10.0
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: 10.0.x
 
       - name: Set up Node.js (needed for Azurite)
         uses: actions/setup-node@v3

--- a/.github/workflows/smoketest-dotnet-isolated-v4.yml
+++ b/.github/workflows/smoketest-dotnet-isolated-v4.yml
@@ -40,6 +40,11 @@ jobs:
       with:
         dotnet-version: '8.x'
 
+    - name: Set up .NET 10.x
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: '10.x'
+
     # Install Azurite
     - name: Set up Node.js (needed for Azurite)
       uses: actions/setup-node@v3

--- a/.github/workflows/smoketest-dotnet-isolated-v4.yml
+++ b/.github/workflows/smoketest-dotnet-isolated-v4.yml
@@ -76,79 +76,118 @@ jobs:
     # Run smoke tests on .NET 6.0
     - name: Run smoke tests on .NET 6.0 (Hello Cities (Typed))
       shell: pwsh
-      run: azurite --silent --blobPort 10000 --queuePort 10001 --tablePort 10002 &
+      run: |
+        Get-Process azurite,func,dotnet -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
+        azurite --silent --blobPort 10000 --queuePort 10001 --tablePort 10002 &
         cd ./test/SmokeTests/OOProcSmokeTests/DotNetIsolated && func host start --port 7071 --dotnet-isolated-debug --target-framework net6.0 &
         ./test/SmokeTests/OOProcSmokeTests/DotNetIsolated/run-smoke-tests.ps1 -HttpStartPath api/StartHelloCitiesTyped
+        Get-Process azurite,func,dotnet -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
         
     - name: Run smoke tests on .NET 6.0 (Hello Cities (Untyped))
       shell: pwsh
-      run: azurite --silent --blobPort 10000 --queuePort 10001 --tablePort 10002 &
+      run: |
+        Get-Process azurite,func,dotnet -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
+        azurite --silent --blobPort 10000 --queuePort 10001 --tablePort 10002 &
         cd ./test/SmokeTests/OOProcSmokeTests/DotNetIsolated && func host start --port 7071 --dotnet-isolated-debug --target-framework net6.0 &
         ./test/SmokeTests/OOProcSmokeTests/DotNetIsolated/run-smoke-tests.ps1 -HttpStartPath api/StartHelloCitiesUntyped
+        Get-Process azurite,func,dotnet -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
 
     - name: Run smoke tests on .NET 6.0 (Entity Counting (Typed))
       shell: pwsh
-      run: azurite --silent --blobPort 10000 --queuePort 10001 --tablePort 10002 &
+      run: |
+        Get-Process azurite,func,dotnet -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
+        azurite --silent --blobPort 10000 --queuePort 10001 --tablePort 10002 &
         cd ./test/SmokeTests/OOProcSmokeTests/DotNetIsolated && func host start --port 7071 --dotnet-isolated-debug --target-framework net6.0 &
         ./test/SmokeTests/OOProcSmokeTests/DotNetIsolated/run-smoke-tests.ps1 -HttpStartPath api/StartEntityOrchestration
+        Get-Process azurite,func,dotnet -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
 
     # Run smoke tests on .NET 8.0
     - name: Run smoke tests on .NET 8.0 (Hello Cities (Typed))
       shell: pwsh
-      run: azurite --silent --blobPort 10000 --queuePort 10001 --tablePort 10002 &
+      run: |
+        Get-Process azurite,func,dotnet -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
+        azurite --silent --blobPort 10000 --queuePort 10001 --tablePort 10002 &
         cd ./test/SmokeTests/OOProcSmokeTests/DotNetIsolated && func host start --port 7071 --dotnet-isolated-debug --target-framework net8.0 &
         ./test/SmokeTests/OOProcSmokeTests/DotNetIsolated/run-smoke-tests.ps1 -HttpStartPath api/StartHelloCitiesTyped
+        Get-Process azurite,func,dotnet -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
         
     - name: Run smoke tests on .NET 8.0 (Hello Cities (Untyped))
       shell: pwsh
-      run: azurite --silent --blobPort 10000 --queuePort 10001 --tablePort 10002 &
+      run: |
+        Get-Process azurite,func,dotnet -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
+        azurite --silent --blobPort 10000 --queuePort 10001 --tablePort 10002 &
         cd ./test/SmokeTests/OOProcSmokeTests/DotNetIsolated && func host start --port 7071 --dotnet-isolated-debug --target-framework net8.0 &
         ./test/SmokeTests/OOProcSmokeTests/DotNetIsolated/run-smoke-tests.ps1 -HttpStartPath api/StartHelloCitiesUntyped
+        Get-Process azurite,func,dotnet -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
 
     - name: Run smoke tests on .NET 8.0 (Hello Cities) with provided Instance Id
       shell: pwsh
-      run: azurite --silent --blobPort 10000 --queuePort 10001 --tablePort 10002 &
+      run: |
+        Get-Process azurite,func,dotnet -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
+        azurite --silent --blobPort 10000 --queuePort 10001 --tablePort 10002 &
         cd ./test/SmokeTests/OOProcSmokeTests/DotNetIsolated && func host start --port 7071 --dotnet-isolated-debug --target-framework net8.0 &
         ./test/SmokeTests/OOProcSmokeTests/DotNetIsolated/run-smoke-tests.ps1 -HttpStartPath api/StartHelloCitiesUntyped -TestWithCustomInstanceId
+        Get-Process azurite,func,dotnet -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
 
     - name: Run smoke tests on .NET 8.0 (Process Exit)
       shell: pwsh
-      run: azurite --silent --blobPort 10000 --queuePort 10001 --tablePort 10002 &
+      run: |
+        Get-Process azurite,func,dotnet -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
+        azurite --silent --blobPort 10000 --queuePort 10001 --tablePort 10002 &
         ./test/SmokeTests/OOProcSmokeTests/DotNetIsolated/run-smoke-tests.ps1 -HttpStartPath api/durable_HttpStartProcessExitOrchestrator
+        Get-Process azurite,func,dotnet -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
 
     - name: Run smoke tests on .NET 8.0 (Timeout)
       shell: pwsh
-      run: azurite --silent --blobPort 10000 --queuePort 10001 --tablePort 10002 &
+      run: |
+        Get-Process azurite,func,dotnet -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
+        azurite --silent --blobPort 10000 --queuePort 10001 --tablePort 10002 &
         cd ./test/SmokeTests/OOProcSmokeTests/DotNetIsolated && func host start --port 7071 --dotnet-isolated-debug --target-framework net8.0 &
         ./test/SmokeTests/OOProcSmokeTests/DotNetIsolated/run-smoke-tests.ps1 -HttpStartPath api/durable_HttpStartTimeoutOrchestrator
+        Get-Process azurite,func,dotnet -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
 
     - name: Run smoke tests on .NET 8.0 (OOM)
       shell: pwsh
-      run: azurite --silent --blobPort 10000 --queuePort 10001 --tablePort 10002 &
+      run: |
+        Get-Process azurite,func,dotnet -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
+        azurite --silent --blobPort 10000 --queuePort 10001 --tablePort 10002 &
         cd ./test/SmokeTests/OOProcSmokeTests/DotNetIsolated && func host start --port 7071 --dotnet-isolated-debug --target-framework net8.0 &
         ./test/SmokeTests/OOProcSmokeTests/DotNetIsolated/run-smoke-tests.ps1 -HttpStartPath api/durable_HttpStartOOMOrchestrator
+        Get-Process azurite,func,dotnet -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
 
     - name: Run smoke tests on .NET 8.0 (Entity Counting (Typed))
       shell: pwsh
-      run: azurite --silent --blobPort 10000 --queuePort 10001 --tablePort 10002 &
+      run: |
+        Get-Process azurite,func,dotnet -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
+        azurite --silent --blobPort 10000 --queuePort 10001 --tablePort 10002 &
         cd ./test/SmokeTests/OOProcSmokeTests/DotNetIsolated && func host start --port 7071 --dotnet-isolated-debug --target-framework net8.0 &
         ./test/SmokeTests/OOProcSmokeTests/DotNetIsolated/run-smoke-tests.ps1 -HttpStartPath api/StartEntityOrchestration
+        Get-Process azurite,func,dotnet -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
 
     # Run smoke tests on .NET 10.0
     - name: Run smoke tests on .NET 10.0 (Hello Cities (Typed))
       shell: pwsh
-      run: azurite --silent --blobPort 10000 --queuePort 10001 --tablePort 10002 &
+      run: |
+        Get-Process azurite,func,dotnet -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
+        azurite --silent --blobPort 10000 --queuePort 10001 --tablePort 10002 &
         cd ./test/SmokeTests/OOProcSmokeTests/DotNetIsolated && func host start --port 7071 --dotnet-isolated-debug --target-framework net10.0 &
         ./test/SmokeTests/OOProcSmokeTests/DotNetIsolated/run-smoke-tests.ps1 -HttpStartPath api/StartHelloCitiesTyped
+        Get-Process azurite,func,dotnet -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
         
     - name: Run smoke tests on .NET 10.0 (Hello Cities (Untyped))
       shell: pwsh
-      run: azurite --silent --blobPort 10000 --queuePort 10001 --tablePort 10002 &
+      run: |
+        Get-Process azurite,func,dotnet -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
+        azurite --silent --blobPort 10000 --queuePort 10001 --tablePort 10002 &
         cd ./test/SmokeTests/OOProcSmokeTests/DotNetIsolated && func host start --port 7071 --dotnet-isolated-debug --target-framework net10.0 &
         ./test/SmokeTests/OOProcSmokeTests/DotNetIsolated/run-smoke-tests.ps1 -HttpStartPath api/StartHelloCitiesUntyped
+        Get-Process azurite,func,dotnet -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
 
     - name: Run smoke tests on .NET 10.0 (Entity Counting (Typed))
       shell: pwsh
-      run: azurite --silent --blobPort 10000 --queuePort 10001 --tablePort 10002 &
+      run: |
+        Get-Process azurite,func,dotnet -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
+        azurite --silent --blobPort 10000 --queuePort 10001 --tablePort 10002 &
         cd ./test/SmokeTests/OOProcSmokeTests/DotNetIsolated && func host start --port 7071 --dotnet-isolated-debug --target-framework net10.0 &
         ./test/SmokeTests/OOProcSmokeTests/DotNetIsolated/run-smoke-tests.ps1 -HttpStartPath api/StartEntityOrchestration
+        Get-Process azurite,func,dotnet -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue

--- a/.github/workflows/smoketest-dotnet-isolated-v4.yml
+++ b/.github/workflows/smoketest-dotnet-isolated-v4.yml
@@ -73,48 +73,82 @@ jobs:
     - name: Install core tools
       run: npm i -g azure-functions-core-tools@4 --unsafe-perm true
   
-    # Run smoke tests
-    # Unlike other smoke tests, the .NET isolated smoke tests run outside of a docker container, but to race conditions
-    # when building the smoke test app in docker, causing the build to fail. This is a temporary workaround until the
-    # root cause is identified and fixed.
-
-    - name: Run smoke tests (Hello Cities (Typed))
+    # Run smoke tests on .NET 6.0
+    - name: Run smoke tests on .NET 6.0 (Hello Cities (Typed))
       shell: pwsh
       run: azurite --silent --blobPort 10000 --queuePort 10001 --tablePort 10002 &
-        cd ./test/SmokeTests/OOProcSmokeTests/DotNetIsolated && func host start --port 7071 &
+        cd ./test/SmokeTests/OOProcSmokeTests/DotNetIsolated && func host start --port 7071 --dotnet-isolated-debug --target-framework net6.0 &
         ./test/SmokeTests/OOProcSmokeTests/DotNetIsolated/run-smoke-tests.ps1 -HttpStartPath api/StartHelloCitiesTyped
         
-    - name: Run smoke tests (Hello Cities (Untyped))
+    - name: Run smoke tests on .NET 6.0 (Hello Cities (Untyped))
       shell: pwsh
       run: azurite --silent --blobPort 10000 --queuePort 10001 --tablePort 10002 &
-        cd ./test/SmokeTests/OOProcSmokeTests/DotNetIsolated && func host start --port 7071 &
+        cd ./test/SmokeTests/OOProcSmokeTests/DotNetIsolated && func host start --port 7071 --dotnet-isolated-debug --target-framework net6.0 &
         ./test/SmokeTests/OOProcSmokeTests/DotNetIsolated/run-smoke-tests.ps1 -HttpStartPath api/StartHelloCitiesUntyped
 
-    - name: Run smoke tests (Hello Cities) with provided Instance Id
+    - name: Run smoke tests on .NET 6.0 (Entity Counting (Typed))
       shell: pwsh
       run: azurite --silent --blobPort 10000 --queuePort 10001 --tablePort 10002 &
-        cd ./test/SmokeTests/OOProcSmokeTests/DotNetIsolated && func host start --port 7071 &
+        cd ./test/SmokeTests/OOProcSmokeTests/DotNetIsolated && func host start --port 7071 --dotnet-isolated-debug --target-framework net6.0 &
+        ./test/SmokeTests/OOProcSmokeTests/DotNetIsolated/run-smoke-tests.ps1 -HttpStartPath api/StartEntityOrchestration
+
+    # Run smoke tests on .NET 8.0
+    - name: Run smoke tests on .NET 8.0 (Hello Cities (Typed))
+      shell: pwsh
+      run: azurite --silent --blobPort 10000 --queuePort 10001 --tablePort 10002 &
+        cd ./test/SmokeTests/OOProcSmokeTests/DotNetIsolated && func host start --port 7071 --dotnet-isolated-debug --target-framework net8.0 &
+        ./test/SmokeTests/OOProcSmokeTests/DotNetIsolated/run-smoke-tests.ps1 -HttpStartPath api/StartHelloCitiesTyped
+        
+    - name: Run smoke tests on .NET 8.0 (Hello Cities (Untyped))
+      shell: pwsh
+      run: azurite --silent --blobPort 10000 --queuePort 10001 --tablePort 10002 &
+        cd ./test/SmokeTests/OOProcSmokeTests/DotNetIsolated && func host start --port 7071 --dotnet-isolated-debug --target-framework net8.0 &
+        ./test/SmokeTests/OOProcSmokeTests/DotNetIsolated/run-smoke-tests.ps1 -HttpStartPath api/StartHelloCitiesUntyped
+
+    - name: Run smoke tests on .NET 8.0 (Hello Cities) with provided Instance Id
+      shell: pwsh
+      run: azurite --silent --blobPort 10000 --queuePort 10001 --tablePort 10002 &
+        cd ./test/SmokeTests/OOProcSmokeTests/DotNetIsolated && func host start --port 7071 --dotnet-isolated-debug --target-framework net8.0 &
         ./test/SmokeTests/OOProcSmokeTests/DotNetIsolated/run-smoke-tests.ps1 -HttpStartPath api/StartHelloCitiesUntyped -TestWithCustomInstanceId
 
-    - name: Run smoke tests (Process Exit)
+    - name: Run smoke tests on .NET 8.0 (Process Exit)
       shell: pwsh
       run: azurite --silent --blobPort 10000 --queuePort 10001 --tablePort 10002 &
         ./test/SmokeTests/OOProcSmokeTests/DotNetIsolated/run-smoke-tests.ps1 -HttpStartPath api/durable_HttpStartProcessExitOrchestrator
 
-    - name: Run smoke tests (Timeout)
+    - name: Run smoke tests on .NET 8.0 (Timeout)
       shell: pwsh
       run: azurite --silent --blobPort 10000 --queuePort 10001 --tablePort 10002 &
-        cd ./test/SmokeTests/OOProcSmokeTests/DotNetIsolated && func host start --port 7071 &
+        cd ./test/SmokeTests/OOProcSmokeTests/DotNetIsolated && func host start --port 7071 --dotnet-isolated-debug --target-framework net8.0 &
         ./test/SmokeTests/OOProcSmokeTests/DotNetIsolated/run-smoke-tests.ps1 -HttpStartPath api/durable_HttpStartTimeoutOrchestrator
 
-    - name: Run smoke tests (OOM)
+    - name: Run smoke tests on .NET 8.0 (OOM)
       shell: pwsh
       run: azurite --silent --blobPort 10000 --queuePort 10001 --tablePort 10002 &
-        cd ./test/SmokeTests/OOProcSmokeTests/DotNetIsolated && func host start --port 7071 &
+        cd ./test/SmokeTests/OOProcSmokeTests/DotNetIsolated && func host start --port 7071 --dotnet-isolated-debug --target-framework net8.0 &
         ./test/SmokeTests/OOProcSmokeTests/DotNetIsolated/run-smoke-tests.ps1 -HttpStartPath api/durable_HttpStartOOMOrchestrator
 
-    - name: Run smoke tests (Entity Counting (Typed))
+    - name: Run smoke tests on .NET 8.0 (Entity Counting (Typed))
       shell: pwsh
       run: azurite --silent --blobPort 10000 --queuePort 10001 --tablePort 10002 &
-        cd ./test/SmokeTests/OOProcSmokeTests/DotNetIsolated && func host start --port 7071 &
+        cd ./test/SmokeTests/OOProcSmokeTests/DotNetIsolated && func host start --port 7071 --dotnet-isolated-debug --target-framework net8.0 &
+        ./test/SmokeTests/OOProcSmokeTests/DotNetIsolated/run-smoke-tests.ps1 -HttpStartPath api/StartEntityOrchestration
+
+    # Run smoke tests on .NET 10.0
+    - name: Run smoke tests on .NET 10.0 (Hello Cities (Typed))
+      shell: pwsh
+      run: azurite --silent --blobPort 10000 --queuePort 10001 --tablePort 10002 &
+        cd ./test/SmokeTests/OOProcSmokeTests/DotNetIsolated && func host start --port 7071 --dotnet-isolated-debug --target-framework net10.0 &
+        ./test/SmokeTests/OOProcSmokeTests/DotNetIsolated/run-smoke-tests.ps1 -HttpStartPath api/StartHelloCitiesTyped
+        
+    - name: Run smoke tests on .NET 10.0 (Hello Cities (Untyped))
+      shell: pwsh
+      run: azurite --silent --blobPort 10000 --queuePort 10001 --tablePort 10002 &
+        cd ./test/SmokeTests/OOProcSmokeTests/DotNetIsolated && func host start --port 7071 --dotnet-isolated-debug --target-framework net10.0 &
+        ./test/SmokeTests/OOProcSmokeTests/DotNetIsolated/run-smoke-tests.ps1 -HttpStartPath api/StartHelloCitiesUntyped
+
+    - name: Run smoke tests on .NET 10.0 (Entity Counting (Typed))
+      shell: pwsh
+      run: azurite --silent --blobPort 10000 --queuePort 10001 --tablePort 10002 &
+        cd ./test/SmokeTests/OOProcSmokeTests/DotNetIsolated && func host start --port 7071 --dotnet-isolated-debug --target-framework net10.0 &
         ./test/SmokeTests/OOProcSmokeTests/DotNetIsolated/run-smoke-tests.ps1 -HttpStartPath api/StartEntityOrchestration

--- a/.github/workflows/validate-build-analyzer.yml
+++ b/.github/workflows/validate-build-analyzer.yml
@@ -43,6 +43,16 @@ jobs:
       with:
         dotnet-version: '6.0.x'
 
+    - name: Set up .NET 8.0
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: '8.0.x'
+
+    - name: Set up .NET 10.0
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: '10.0.x'
+
     - name: Restore dependencies
       run: dotnet restore $solution
 

--- a/.github/workflows/validate-build-e2e.yml
+++ b/.github/workflows/validate-build-e2e.yml
@@ -43,6 +43,16 @@ jobs:
       with:
         dotnet-version: '6.0.x'
 
+    - name: Set up .NET 8.0
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: '8.0.x'
+
+    - name: Set up .NET 10.0
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: '10.0.x'
+
     - name: Restore dependencies
       run: dotnet restore $solution
 

--- a/.github/workflows/validate-build.yml
+++ b/.github/workflows/validate-build.yml
@@ -43,6 +43,16 @@ jobs:
       with:
         dotnet-version: '6.0.x'
 
+    - name: Set up .NET 8.0
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: '8.0.x'
+
+    - name: Set up .NET 10.0
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: '10.0.x'
+
     - name: Restore dependencies
       run: dotnet restore $solution
 

--- a/azure-pipelines-release-dotnet-isolated.yml
+++ b/azure-pipelines-release-dotnet-isolated.yml
@@ -14,6 +14,18 @@ steps:
     packageType: 'sdk'
     version: '6.0.x'
 
+- task: UseDotNet@2
+  displayName: 'Use the .NET 8 SDK'
+  inputs:
+    packageType: 'sdk'
+    version: '8.0.x'
+
+- task: UseDotNet@2
+  displayName: 'Use the .NET 10 SDK'
+  inputs:
+    packageType: 'sdk'
+    version: '10.0.x'
+
 # Start by restoring all the .NET Isolated worker extension dependencies. This needs to be its own task.
 - task: DotNetCoreCLI@2
   displayName: 'Restore nuget dependencies'

--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -38,6 +38,18 @@ steps:
     packageType: 'sdk'
     version: '6.0.x'
 
+- task: UseDotNet@2
+  displayName: 'Use the .NET 8 SDK'
+  inputs:
+    packageType: 'sdk'
+    version: '8.0.x'
+
+- task: UseDotNet@2
+  displayName: 'Use the .NET 10 SDK'
+  inputs:
+    packageType: 'sdk'
+    version: '10.0.x'
+
 # Use NuGet
 - task: NuGetToolInstaller@1
   displayName: 'Use NuGet '

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,6 +23,18 @@ jobs:
         packageType: 'sdk'
         version: '6.0.x'
 
+    - task: UseDotNet@2
+      displayName: 'Use the .NET 8 SDK'
+      inputs:
+        packageType: 'sdk'
+        version: '8.0.x'
+
+    - task: UseDotNet@2
+      displayName: 'Use the .NET 10 SDK'
+      inputs:
+        packageType: 'sdk'
+        version: '10.0.x'
+
     - task: DotNetCoreCLI@2
       inputs:
         command: 'restore'
@@ -72,6 +84,18 @@ jobs:
         packageType: 'sdk'
         version: '6.0.x'
 
+    - task: UseDotNet@2
+      displayName: 'Use the .NET 8 SDK'
+      inputs:
+        packageType: 'sdk'
+        version: '8.0.x'
+
+    - task: UseDotNet@2
+      displayName: 'Use the .NET 10 SDK'
+      inputs:
+        packageType: 'sdk'
+        version: '10.0.x'
+
     - task: DotNetCoreCLI@2
       inputs:
         command: 'restore'
@@ -118,6 +142,18 @@ jobs:
       inputs:
         packageType: 'sdk'
         version: '6.0.x'
+
+    - task: UseDotNet@2
+      displayName: 'Use the .NET 8 SDK'
+      inputs:
+        packageType: 'sdk'
+        version: '8.0.x'
+
+    - task: UseDotNet@2
+      displayName: 'Use the .NET 10 SDK'
+      inputs:
+        packageType: 'sdk'
+        version: '10.0.x'
 
     - task: DotNetCoreCLI@2
       inputs:

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.416",
+    "version": "10.0.100",
     "rollForward": "latestFeature"
   },
   "msbuild-sdks": {

--- a/samples/precompiled/VSSample.csproj
+++ b/samples/precompiled/VSSample.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net6.0;net8.0;net10.0</TargetFrameworks>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
   </PropertyGroup>
 

--- a/src/WebJobs.Extensions.DurableTask/LocalHttpListener.cs
+++ b/src/WebJobs.Extensions.DurableTask/LocalHttpListener.cs
@@ -78,8 +78,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     this.InternalRpcUri = new Uri($"http://127.0.0.1:{listeningPort}/durabletask/");
                     var listenUri = new Uri(this.InternalRpcUri.GetLeftPart(UriPartial.Authority));
 
-                    var builder = Microsoft.Extensions.Hosting.Host.CreateDefaultBuilder()
-                        .ConfigureWebHostDefaults(webBuilder =>
+                    this.localWebHost = new Microsoft.Extensions.Hosting.HostBuilder()
+                        .ConfigureWebHost(webBuilder =>
                         {
                             webBuilder
                                 .UseKestrel(o =>
@@ -89,9 +89,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                                 })
                                 .UseUrls(listenUri.OriginalString)
                                 .Configure(a => a.Run(this.HandleRequestAsync));
-                        });
-
-                    this.localWebHost = builder.Build();
+                        })
+                        .Build();
                     await this.localWebHost.StartAsync();
                     this.IsListening = true;
                     break;

--- a/src/WebJobs.Extensions.DurableTask/LocalHttpListener.cs
+++ b/src/WebJobs.Extensions.DurableTask/LocalHttpListener.cs
@@ -15,6 +15,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Mvc.WebApiCompatShim;
+using Microsoft.Extensions.Hosting;
 
 namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 {
@@ -34,7 +35,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         private readonly Random portGenerator;
         private readonly HashSet<int> attemptedPorts;
 
-        private IWebHost localWebHost;
+        private IHost localWebHost;
 
         public LocalHttpListener(
             EndToEndTraceHelper traceHelper,
@@ -76,17 +77,21 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 {
                     this.InternalRpcUri = new Uri($"http://127.0.0.1:{listeningPort}/durabletask/");
                     var listenUri = new Uri(this.InternalRpcUri.GetLeftPart(UriPartial.Authority));
-                    this.localWebHost = new WebHostBuilder()
-                        .UseKestrel()
-                        .ConfigureKestrel(o =>
-                        {
-                            // remove request's Content size limits
-                            o.Limits.MaxRequestBodySize = null;
-                        })
-                        .UseUrls(listenUri.OriginalString)
-                        .Configure(a => a.Run(this.HandleRequestAsync))
-                        .Build();
 
+                    var builder = Microsoft.Extensions.Hosting.Host.CreateDefaultBuilder()
+                        .ConfigureWebHostDefaults(webBuilder =>
+                        {
+                            webBuilder
+                                .UseKestrel(o =>
+                                {
+                                    // remove request's Content size limits
+                                    o.Limits.MaxRequestBodySize = null;
+                                })
+                                .UseUrls(listenUri.OriginalString)
+                                .Configure(a => a.Run(this.HandleRequestAsync));
+                        });
+
+                    this.localWebHost = builder.Build();
                     await this.localWebHost.StartAsync();
                     this.IsListening = true;
                     break;
@@ -180,15 +185,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             }
         }
 
-        private class NoOpWebHost : IWebHost
+        private class NoOpWebHost : IHost
         {
-            public IFeatureCollection ServerFeatures => throw new NotImplementedException();
-
             public IServiceProvider Services => throw new NotImplementedException();
 
             public void Dispose() { }
-
-            public void Start() { }
 
             public Task StartAsync(CancellationToken cancellationToken = default(CancellationToken)) => Task.CompletedTask;
 

--- a/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
+++ b/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
@@ -18,7 +18,7 @@
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <DebugType>embedded</DebugType>
     <!-- See https://github.com/Azure/azure-functions-durable-extension/issues/1433 -->
-    <NoWarn>NU5125;SA0001</NoWarn>
+    <NoWarn>NU5125;SA0001;NU1510</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup Condition="$(VersionSuffix) == ''">

--- a/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
+++ b/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net6.0;net8.0;net10.0</TargetFrameworks>
     <AssemblyName>Microsoft.Azure.WebJobs.Extensions.DurableTask</AssemblyName>
     <RootNamespace>Microsoft.Azure.WebJobs.Extensions.DurableTask</RootNamespace>
     <MajorVersion>3</MajorVersion>

--- a/src/Worker.Extensions.DurableTask/Worker.Extensions.DurableTask.csproj
+++ b/src/Worker.Extensions.DurableTask/Worker.Extensions.DurableTask.csproj
@@ -2,7 +2,7 @@
 
   <!-- Core compiler settings -->
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0;net8.0;net10.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <DebugType>embedded</DebugType>

--- a/test/CodeGen.Example.Test/DurableFunctions.TypedInterfaces.Examples.Test.csproj
+++ b/test/CodeGen.Example.Test/DurableFunctions.TypedInterfaces.Examples.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net6.0;net8.0;net10.0</TargetFrameworks>
     <Company>Microsoft Corporation</Company>
     <NoWarn>SA0001;SA1600;SA1615</NoWarn>
     <SignAssembly>true</SignAssembly>

--- a/test/Directory.Packages.props
+++ b/test/Directory.Packages.props
@@ -19,10 +19,10 @@
     <PackageVersion Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.65" />
     <PackageVersion Include="Microsoft.DurableTask.Generators" Version="1.0.0-preview.1" />
     <PackageVersion Include="Microsoft.DurableTask.SqlServer.AzureFunctions" Version="1.5.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="8.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="8.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.1" />
     <PackageVersion Include="MSTest.TestAdapter" Version="1.3.2" />
     <PackageVersion Include="MSTest.TestFramework" Version="1.3.2" />
   </ItemGroup>
@@ -30,10 +30,10 @@
   <!-- Transitive dependencies with higher versions -->
   <ItemGroup>
     <PackageVersion Update="Azure.Identity" Version="1.17.0" />
-    <PackageVersion Update="Microsoft.Bcl.AsyncInterfaces" Version="10.0.0"/>
+    <PackageVersion Update="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0"/>
     <PackageVersion Update="Microsoft.Extensions.Azure" Version="1.10.0" />
     <PackageVersion Update="System.Drawing.Common" Version="6.0.0" />
-    <PackageVersion Update="System.Text.Json" Version="10.0.0" />
+    <PackageVersion Update="System.Text.Json" Version="8.0.5" />
   </ItemGroup>
 
 </Project>

--- a/test/Directory.Packages.props
+++ b/test/Directory.Packages.props
@@ -19,10 +19,10 @@
     <PackageVersion Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.65" />
     <PackageVersion Include="Microsoft.DurableTask.Generators" Version="1.0.0-preview.1" />
     <PackageVersion Include="Microsoft.DurableTask.SqlServer.AzureFunctions" Version="1.5.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="9.0.0" Condition="'$(TargetFramework)' == 'net8.0'" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.0" />
     <PackageVersion Include="MSTest.TestAdapter" Version="1.3.2" />
     <PackageVersion Include="MSTest.TestFramework" Version="1.3.2" />
   </ItemGroup>
@@ -30,10 +30,10 @@
   <!-- Transitive dependencies with higher versions -->
   <ItemGroup>
     <PackageVersion Update="Azure.Identity" Version="1.17.0" />
-    <PackageVersion Update="Microsoft.Bcl.AsyncInterfaces" Version="9.0.0"/>
+    <PackageVersion Update="Microsoft.Bcl.AsyncInterfaces" Version="10.0.0"/>
     <PackageVersion Update="Microsoft.Extensions.Azure" Version="1.10.0" />
     <PackageVersion Update="System.Drawing.Common" Version="6.0.0" />
-    <PackageVersion Update="System.Text.Json" Version="9.0.0" />
+    <PackageVersion Update="System.Text.Json" Version="10.0.0" />
   </ItemGroup>
 
 </Project>

--- a/test/Directory.Packages.props
+++ b/test/Directory.Packages.props
@@ -19,10 +19,10 @@
     <PackageVersion Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.65" />
     <PackageVersion Include="Microsoft.DurableTask.Generators" Version="1.0.0-preview.1" />
     <PackageVersion Include="Microsoft.DurableTask.SqlServer.AzureFunctions" Version="1.5.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="8.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="8.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="9.0.0" />
     <PackageVersion Include="MSTest.TestAdapter" Version="1.3.2" />
     <PackageVersion Include="MSTest.TestFramework" Version="1.3.2" />
   </ItemGroup>
@@ -30,10 +30,10 @@
   <!-- Transitive dependencies with higher versions -->
   <ItemGroup>
     <PackageVersion Update="Azure.Identity" Version="1.17.0" />
-    <PackageVersion Update="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0"/>
+    <PackageVersion Update="Microsoft.Bcl.AsyncInterfaces" Version="9.0.0"/>
     <PackageVersion Update="Microsoft.Extensions.Azure" Version="1.10.0" />
     <PackageVersion Update="System.Drawing.Common" Version="6.0.0" />
-    <PackageVersion Update="System.Text.Json" Version="8.0.5" />
+    <PackageVersion Update="System.Text.Json" Version="9.0.0" />
   </ItemGroup>
 
 </Project>

--- a/test/SmokeTests/BackendSmokeTests/MSSQL/Dockerfile
+++ b/test/SmokeTests/BackendSmokeTests/MSSQL/Dockerfile
@@ -1,7 +1,7 @@
 ﻿# Copyright (c) .NET Foundation. All rights reserved.
 # Licensed under the MIT License. See LICENSE in the project root for license information.
 
-FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build-env
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build-env
 
 # Build the DF MSSQL app
 COPY . /root

--- a/test/SmokeTests/BackendSmokeTests/MSSQL/MSSQL.csproj
+++ b/test/SmokeTests/BackendSmokeTests/MSSQL/MSSQL.csproj
@@ -6,13 +6,15 @@
     <!-- If enabled, func complains about "Could not load file or assembly 'Microsoft.Extensions.Logging.Abstractions, Version=9.0.0.0" -->
     <!-- This is probably due to the per-TFM versioning we do for Microsoft.Extensions.Logging -->
     <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+    <!-- Suppress NuGet warnings -->
+    <NoWarn>NU1510</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\src\WebJobs.Extensions.DurableTask\WebJobs.Extensions.DurableTask.csproj" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.6.0" />
-    <PackageReference Include="Microsoft.DurableTask.SqlServer.AzureFunctions" Version="1.5.1" />
+    <PackageReference Include="Microsoft.DurableTask.SqlServer.AzureFunctions" Version="1.5.2" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">

--- a/test/SmokeTests/BackendSmokeTests/Netherite/Dockerfile
+++ b/test/SmokeTests/BackendSmokeTests/Netherite/Dockerfile
@@ -1,7 +1,7 @@
 ﻿# Copyright (c) .NET Foundation. All rights reserved.
 # Licensed under the MIT License. See LICENSE in the project root for license information.
 
-FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build-env
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build-env
 
 # Build the app
 COPY . /root

--- a/test/SmokeTests/BackendSmokeTests/Netherite/Netherite.csproj
+++ b/test/SmokeTests/BackendSmokeTests/Netherite/Netherite.csproj
@@ -6,6 +6,8 @@
     <!-- If enabled, func complains about "Could not load file or assembly 'Microsoft.Extensions.Logging.Abstractions, Version=9.0.0.0" -->
     <!-- This is probably due to the per-TFM versioning we do for Microsoft.Extensions.Logging -->
     <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+    <!-- Suppress NuGet warnings -->
+    <NoWarn>NU1510</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\src\WebJobs.Extensions.DurableTask\WebJobs.Extensions.DurableTask.csproj" />

--- a/test/SmokeTests/OOProcSmokeTests/DotNetIsolated/Dockerfile
+++ b/test/SmokeTests/OOProcSmokeTests/DotNetIsolated/Dockerfile
@@ -1,7 +1,7 @@
 ﻿# Copyright (c) .NET Foundation. All rights reserved.
 # Licensed under the MIT License. See LICENSE in the project root for license information.
 
-FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build-env
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build-env
 
 # Step 1: Build the WebJobs extension and publish it as a local NuGet package
 COPY . /root

--- a/test/SmokeTests/OOProcSmokeTests/DotNetIsolated/DotNetIsolated.csproj
+++ b/test/SmokeTests/OOProcSmokeTests/DotNetIsolated/DotNetIsolated.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net6.0;net8.0;net10.0</TargetFrameworks>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
     <OutputType>exe</OutputType>
     <IsPackable>false</IsPackable>

--- a/test/SmokeTests/OOProcSmokeTests/durableJS/Dockerfile
+++ b/test/SmokeTests/OOProcSmokeTests/durableJS/Dockerfile
@@ -3,7 +3,7 @@
 
 # Step 1: Add the durable extension by building it locally.
 #         This is an alternative to "func extensions install"
-FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build-env
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build-env
 COPY . /root
 RUN cd /root/test/SmokeTests/OOProcSmokeTests/durableJS && \
     dotnet build -o bin

--- a/test/SmokeTests/OOProcSmokeTests/durableJava/Dockerfile
+++ b/test/SmokeTests/OOProcSmokeTests/durableJava/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build-env
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build-env
 COPY . /root
 RUN cd /root/test/SmokeTests/OOProcSmokeTests/durableJava && \
     dotnet build -o bin

--- a/test/SmokeTests/OOProcSmokeTests/durablePy/Dockerfile
+++ b/test/SmokeTests/OOProcSmokeTests/durablePy/Dockerfile
@@ -3,7 +3,7 @@
 
 # Step 1: Add the durable extension by building it locally.
 #         This is an alternative to "func extensions install"
-FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build-env
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build-env
 COPY . /root
 RUN cd /root/test/SmokeTests/OOProcSmokeTests/durablePy && \
     dotnet build -o bin

--- a/test/WebJobs.Extensions.DurableTask.Analyzers.Test/WebJobs.Extensions.DurableTask.Analyzers.Test.csproj
+++ b/test/WebJobs.Extensions.DurableTask.Analyzers.Test/WebJobs.Extensions.DurableTask.Analyzers.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net6.0;net8.0;net10.0</TargetFrameworks>
     <AssemblyName>Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers.Test</AssemblyName>
     <RootNamespace>Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers.Test</RootNamespace>
   </PropertyGroup>

--- a/test/Worker.Extensions.DurableTask.Tests/FunctionContextExtensionsTests.cs
+++ b/test/Worker.Extensions.DurableTask.Tests/FunctionContextExtensionsTests.cs
@@ -285,7 +285,11 @@ public class FunctionContextExtensionsTests
     {
         public TestBindingContext(IDictionary<string, object?> bindingData)
         {
+#if NET8_0_OR_GREATER
             this.BindingData = bindingData.AsReadOnly();
+#else
+            this.BindingData = new System.Collections.ObjectModel.ReadOnlyDictionary<string, object?>(bindingData);
+#endif
         }
         public override IReadOnlyDictionary<string, object?> BindingData { get; }
     }

--- a/test/Worker.Extensions.DurableTask.Tests/Worker.Extensions.DurableTask.Tests.csproj
+++ b/test/Worker.Extensions.DurableTask.Tests/Worker.Extensions.DurableTask.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net6.0;net8.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/test/e2e/Apps/BasicDotNetIsolated/app.csproj
+++ b/test/e2e/Apps/BasicDotNetIsolated/app.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net6.0;net8.0;net10.0</TargetFrameworks>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
     <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/test/e2e/Apps/BasicDotNetIsolated/app.csproj
+++ b/test/e2e/Apps/BasicDotNetIsolated/app.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net8.0;net10.0</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
     <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/test/e2e/Tests/E2ETests.csproj
+++ b/test/e2e/Tests/E2ETests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net6.0;net8.0;net10.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/test/e2e/Tests/Fixtures/FunctionAppProcess.cs
+++ b/test/e2e/Tests/Fixtures/FunctionAppProcess.cs
@@ -63,7 +63,7 @@ internal class FunctionAppProcess
                     else
                         e2eAppBuiltLocationPath = Path.Combine(rootDir, @$"test/e2e/Apps/{this.appName}/bin");
 
-                    if (!Path.Exists(e2eAppBuiltLocationPath))
+                    if (!Directory.Exists(e2eAppBuiltLocationPath))
                     {
                         throw new InvalidOperationException($"The app bin path {e2eAppBuiltLocationPath} does not exist!");
                     }


### PR DESCRIPTION
<!-- Start the PR description with some context for the change. -->


<!-- Make sure to delete the markdown comments and the below sections when squash merging -->
### Issue describing the changes in this PR

resolves #issue_for_this_pr

### Pull request checklist

* [ ] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)
* [x] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk
* [ ] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
    * [ ] Otherwise: major or minor version updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
* [x] My changes **do not** add EventIds to our EventSource logs
    * [ ] Otherwise: Ensure the EventIds are within the supported range in our existing Windows infrastructure. You may validate this with a deployed app's telemetry. You may also extend the range by completing a PR such as [this one](https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files).
* [ ] My changes **should** be added to **v2.x** branch.
    * [x] Otherwise: This change applies exclusively to WebJobs.Extensions.DurableTask v3.x. It will be retained only in the `dev` and `main` branches and will not be merged into the `v2.x` branch.
