### PR TITLE
Check for existing executor

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -6,6 +6,8 @@
 
 ### Bug Fixes
 
+- Check if function invocation already has an executor before registering durable executor. (#3265)
+
 ### Breaking Changes
 
 ### Dependency Updates

--- a/src/Worker.Extensions.DurableTask/DurableTaskFunctionsMiddleware.cs
+++ b/src/Worker.Extensions.DurableTask/DurableTaskFunctionsMiddleware.cs
@@ -16,9 +16,9 @@ internal class DurableTaskFunctionsMiddleware(DurableFunctionExecutor invoker) :
     /// <inheritdoc />
     public Task Invoke(FunctionContext functionContext, FunctionExecutionDelegate next)
     {
-        if (functionContext.TryGetOrchestrationBinding(out _)
-            || functionContext.TryGetEntityBinding(out _)
-            || functionContext.TryGetActivityBinding(out _))
+        // If the function is a Durable Task function and there is no executor registered yet,
+        // register the Durable Function executor.
+        if (functionContext.Features.Get<IFunctionExecutor>() is null && functionContext.IsDurableTaskFunction())
         {
             functionContext.Features.Set<IFunctionExecutor>(invoker);
         }

--- a/src/Worker.Extensions.DurableTask/FunctionContextExtensions.cs
+++ b/src/Worker.Extensions.DurableTask/FunctionContextExtensions.cs
@@ -12,6 +12,16 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.DurableTask;
 internal static class FunctionContextExtensions
 {
     /// <summary>
+    /// Determines whether the function context represents a Durable Task function.
+    /// </summary>
+    /// <param name="context">The function context.</param>
+    /// <returns>True if function is a durable task trigger, false otherwise.</returns>
+    public static bool IsDurableTaskFunction(this FunctionContext context)
+        => context.TryGetOrchestrationBinding(out _)
+        || context.TryGetActivityBinding(out _)
+        || context.TryGetEntityBinding(out _);
+
+    /// <summary>
     /// Tries to get the orchestration trigger binding from the function context.
     /// </summary>
     /// <param name="context">The function context.</param>


### PR DESCRIPTION
<!-- Start the PR description with some context for the change. -->

Check if an `IFunctionExecutor` has already been registered for the function invocation. If one already is registered, durable extension will skip registering its own executor.

<!-- Make sure to delete the markdown comments and the below sections when squash merging -->
### Issue describing the changes in this PR

resolves https://github.com/microsoft/agent-framework/issues/2327

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)
* [x] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk
* [x] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
    * [ ] Otherwise: major or minor version updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
* [x] My changes **do not** add EventIds to our EventSource logs
    * [ ] Otherwise: Ensure the EventIds are within the supported range in our existing Windows infrastructure. You may validate this with a deployed app's telemetry. You may also extend the range by completing a PR such as [this one](https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files).
* [ ] My changes **should** be added to **v2.x** branch.
    * [x] Otherwise: This change applies exclusively to WebJobs.Extensions.DurableTask v3.x. It will be retained only in the `dev` and `main` branches and will not be merged into the `v2.x` branch.
