### PR TITLE
Add API to get orchestration history in .NET Isolated 

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -27,9 +27,9 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="3.9.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.9.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="3.9.0" />
-    <PackageVersion Include="Microsoft.DurableTask.Client.Grpc" Version="1.17.1" />
-    <PackageVersion Include="Microsoft.DurableTask.Worker.Grpc" Version="1.17.1" />
-    <PackageVersion Include="Microsoft.DurableTask.Abstractions" Version="1.17.1" />
+    <PackageVersion Include="Microsoft.DurableTask.Client.Grpc" Version="1.18.0" />
+    <PackageVersion Include="Microsoft.DurableTask.Worker.Grpc" Version="1.18.0" />
+    <PackageVersion Include="Microsoft.DurableTask.Abstractions" Version="1.18.0" />
     <PackageVersion Include="Microsoft.DurableTask.Analyzers" Version="0.1.0" />
     <PackageVersion Include="Microsoft.Extensions.Azure" Version="1.7.0" />
     <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="6.0.3" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -30,7 +30,7 @@
     <PackageVersion Include="Microsoft.DurableTask.Client.Grpc" Version="1.18.0" />
     <PackageVersion Include="Microsoft.DurableTask.Worker.Grpc" Version="1.18.0" />
     <PackageVersion Include="Microsoft.DurableTask.Abstractions" Version="1.18.0" />
-    <PackageVersion Include="Microsoft.DurableTask.Analyzers" Version="0.1.0" />
+    <PackageVersion Include="Microsoft.DurableTask.Analyzers" Version="0.2.0" />
     <PackageVersion Include="Microsoft.Extensions.Azure" Version="1.7.0" />
     <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Http" Version="6.0.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -32,7 +32,7 @@
     <PackageVersion Include="Microsoft.DurableTask.Abstractions" Version="1.18.0" />
     <PackageVersion Include="Microsoft.DurableTask.Analyzers" Version="0.1.0" />
     <PackageVersion Include="Microsoft.Extensions.Azure" Version="1.7.0" />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="6.0.3" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Http" Version="6.0.0" />
     <PackageVersion Include="Microsoft.NET.Sdk.Functions" Version="4.2.0" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.0.0" />
@@ -40,7 +40,7 @@
     <PackageVersion Include="System.Drawing.Common" Version="4.7.3" />
     <PackageVersion Include="System.Formats.Asn1" Version="6.0.1" />
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
-    <PackageVersion Include="System.Text.Json" Version="8.0.5" />
+    <PackageVersion Include="System.Text.Json" Version="10.0.0" />
     <PackageVersion Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
   <!-- Non-Production product dependencies -->

--- a/samples/Directory.Packages.props
+++ b/samples/Directory.Packages.props
@@ -39,10 +39,10 @@
     <PackageVersion Update="Microsoft.AspNet.WebApi.Client" Version="5.2.8" />
     <PackageVersion Update="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.0" />
     <PackageVersion Update="Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator" Version="4.0.1" />
-    <PackageVersion Update="Microsoft.Bcl.AsyncInterfaces" Version="9.0.0"/>
+    <PackageVersion Update="Microsoft.Bcl.AsyncInterfaces" Version="10.0.0"/>
     <PackageVersion Update="Microsoft.Extensions.Logging.Debug" Version="8.0.1"/>
     <PackageVersion Update="System.Drawing.Common" Version="6.0.0" />
-    <PackageVersion Update="System.Text.Json" Version="9.0.0" />
+    <PackageVersion Update="System.Text.Json" Version="10.0.0" />
    </ItemGroup>
 
 </Project>

--- a/src/WebJobs.Extensions.DurableTask/DurabilityProvider.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurabilityProvider.cs
@@ -605,7 +605,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// Streams the history of the specified orchestration instance as an enumerable of serialized history chunks.
         /// </summary>
         /// <param name="instanceId">The instance ID of the orchestration.</param>
-        /// <param name="historyChunkSize">The maximum size (in bytes) of each history chunk.</param>
         /// <param name="jsonFormatter">The JSON formatter used to serialize the history chunks.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The enumerable of history chunks representing the orchestration's history.</returns>

--- a/src/WebJobs.Extensions.DurableTask/DurabilityProvider.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurabilityProvider.cs
@@ -602,13 +602,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         }
 
         /// <summary>
-        /// Streams the history of the specified orchestration instance as an enumerable of serialized history chunks.
+        /// Streams the history of the specified orchestration instance as an enumerable of history events.
         /// </summary>
         /// <param name="instanceId">The instance ID of the orchestration.</param>
-        /// <param name="jsonFormatter">The JSON formatter used to serialize the history chunks.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
-        /// <returns>The enumerable of history chunks representing the orchestration's history.</returns>
-        public virtual Task<IEnumerable<string>> StreamOrchestrationHistoryAsync(string instanceId, JsonFormatter jsonFormatter, CancellationToken cancellationToken)
+        /// <returns>The enumerable of history events representing the orchestration's history.</returns>
+        public virtual Task<IAsyncEnumerable<HistoryEvent>> StreamOrchestrationHistoryAsync(string instanceId, CancellationToken cancellationToken)
         {
             throw this.GetNotImplementedException(nameof(this.StreamOrchestrationHistoryAsync));
         }

--- a/src/WebJobs.Extensions.DurableTask/DurabilityProvider.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurabilityProvider.cs
@@ -9,6 +9,7 @@ using DurableTask.Core;
 using DurableTask.Core.Entities;
 using DurableTask.Core.History;
 using DurableTask.Core.Query;
+using Google.Protobuf;
 using Microsoft.Azure.WebJobs.Host.Scale;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -598,6 +599,19 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         {
             targetScaler = null;
             return false;
+        }
+
+        /// <summary>
+        /// Streams the history of the specified orchestration instance as an enumerable of serialized history chunks.
+        /// </summary>
+        /// <param name="instanceId">The instance ID of the orchestration.</param>
+        /// <param name="historyChunkSize">The maximum size (in bytes) of each history chunk.</param>
+        /// <param name="jsonFormatter">The JSON formatter used to serialize the history chunks.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>The enumerable of history chunks representing the orchestration's history.</returns>
+        public virtual Task<IEnumerable<string>> StreamOrchestrationHistoryAsync(string instanceId, JsonFormatter jsonFormatter, CancellationToken cancellationToken)
+        {
+            throw this.GetNotImplementedException(nameof(this.StreamOrchestrationHistoryAsync));
         }
     }
 }

--- a/src/WebJobs.Extensions.DurableTask/DurabilityProvider.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurabilityProvider.cs
@@ -9,7 +9,6 @@ using DurableTask.Core;
 using DurableTask.Core.Entities;
 using DurableTask.Core.History;
 using DurableTask.Core.Query;
-using Google.Protobuf;
 using Microsoft.Azure.WebJobs.Host.Scale;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;

--- a/src/WebJobs.Extensions.DurableTask/HistoryEventJsonConverter.cs
+++ b/src/WebJobs.Extensions.DurableTask/HistoryEventJsonConverter.cs
@@ -3,9 +3,12 @@
 
 #nullable enable
 using System;
+using System.Runtime.CompilerServices;
 using DurableTask.Core.History;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+
+[assembly: InternalsVisibleTo("E2ETests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100cd1dabd5a893b40e75dc901fe7293db4a3caf9cd4d3e3ed6178d49cd476969abe74a9e0b7f4a0bb15edca48758155d35a4f05e6e852fff1b319d103b39ba04acbadd278c2753627c95e1f6f6582425374b92f51cca3deb0d2aab9de3ecda7753900a31f70a236f163006beefffe282888f85e3c76d1205ec7dfef7fa472a17b1")]
 
 namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 {

--- a/src/WebJobs.Extensions.DurableTask/HistoryEventJsonConverter.cs
+++ b/src/WebJobs.Extensions.DurableTask/HistoryEventJsonConverter.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
     /// otherwise, a <see cref="JsonSerializationException"/> (for a missing EventType property) or <see cref="NotSupportedException"/>
     /// (for an unknown EventType) will be thrown.
     /// </remarks>
-    public class HistoryEventJsonConverter : JsonConverter
+    internal class HistoryEventJsonConverter : JsonConverter
     {
         /// <inheritdoc/>
         public override bool CanWrite => false;

--- a/src/WebJobs.Extensions.DurableTask/HistoryEventJsonConverter.cs
+++ b/src/WebJobs.Extensions.DurableTask/HistoryEventJsonConverter.cs
@@ -9,15 +9,31 @@ using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 {
+    /// <summary>
+    /// Provides custom JSON deserialization for <see cref="HistoryEvent"> objects, mapping each event type to its corresponding
+    /// concrete class. This converter enables polymorphic deserialization of history events based on the EventType
+    /// property in the JSON payload.
+    /// </summary>
+    /// <remarks>
+    /// This converter only supports reading (deserialization) and does not support writing (serialization) of <see cref="HistoryEvent"> objects.
+    /// When deserializing, the EventType property in the JSON must be present and correspond to a known <see cref="EventType">;
+    /// otherwise, a <see cref="JsonSerializationException"/> (for a missing EventType property) or <see cref="NotSupportedException"/>
+    /// (for an unknown EventType) will be thrown.
+    /// </remarks>
     public class HistoryEventJsonConverter : JsonConverter
     {
+        /// <inheritdoc/>
         public override bool CanWrite => false;
 
+        /// <inheritdoc/>
         public override bool CanConvert(Type objectType)
         {
             return objectType == typeof(HistoryEvent);
         }
 
+        /// <inheritdoc/>
+        /// <throws><see cref="JsonSerializationException"/> If the EventType property is missing in the JSON object attempted to be deserialized.</throws>
+        /// <throws><see cref="InvalidOperationException"/>If the EventType property does not correspond to a known <see cref="EventType"/>.</throws>
         public override object? ReadJson(JsonReader reader, Type objectType, object? existingValue, JsonSerializer serializer)
         {
             var jo = JObject.Load(reader);
@@ -53,6 +69,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             return jo.ToObject(concreteType, serializer);
         }
 
+        /// <inheritdoc/>
         public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer)
         {
             throw new NotImplementedException();

--- a/src/WebJobs.Extensions.DurableTask/HistoryEventJsonConverter.cs
+++ b/src/WebJobs.Extensions.DurableTask/HistoryEventJsonConverter.cs
@@ -1,0 +1,61 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#nullable enable
+using System;
+using DurableTask.Core.History;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
+{
+    public class HistoryEventJsonConverter : JsonConverter
+    {
+        public override bool CanWrite => false;
+
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType == typeof(HistoryEvent);
+        }
+
+        public override object? ReadJson(JsonReader reader, Type objectType, object? existingValue, JsonSerializer serializer)
+        {
+            var jo = JObject.Load(reader);
+            int eventType = jo["EventType"]?.Value<int>()
+                ?? throw new JsonSerializationException("EventType missing");
+
+            Type concreteType = (EventType)eventType switch
+            {
+                EventType.ExecutionStarted => typeof(ExecutionStartedEvent),
+                EventType.ExecutionCompleted => typeof(ExecutionCompletedEvent),
+                EventType.TaskScheduled => typeof(TaskScheduledEvent),
+                EventType.TaskCompleted => typeof(TaskCompletedEvent),
+                EventType.TaskFailed => typeof(TaskFailedEvent),
+                EventType.SubOrchestrationInstanceCreated => typeof(SubOrchestrationInstanceCreatedEvent),
+                EventType.SubOrchestrationInstanceCompleted => typeof(SubOrchestrationInstanceCompletedEvent),
+                EventType.SubOrchestrationInstanceFailed => typeof(SubOrchestrationInstanceFailedEvent),
+                EventType.TimerCreated => typeof(TimerCreatedEvent),
+                EventType.TimerFired => typeof(TimerFiredEvent),
+                EventType.OrchestratorStarted => typeof(OrchestratorStartedEvent),
+                EventType.OrchestratorCompleted => typeof(OrchestratorCompletedEvent),
+                EventType.EventSent => typeof(EventSentEvent),
+                EventType.EventRaised => typeof(EventRaisedEvent),
+                EventType.GenericEvent => typeof(GenericEvent),
+                EventType.ContinueAsNew => typeof(ContinueAsNewEvent),
+                EventType.ExecutionTerminated => typeof(ExecutionTerminatedEvent),
+                EventType.ExecutionSuspended => typeof(ExecutionSuspendedEvent),
+                EventType.ExecutionResumed => typeof(ExecutionResumedEvent),
+                EventType.ExecutionRewound => typeof(ExecutionRewoundEvent),
+                EventType.HistoryState => typeof(HistoryStateEvent),
+                _ => throw new NotSupportedException($"Unknown HistoryEvent type {eventType}")
+            };
+
+            return jo.ToObject(concreteType, serializer);
+        }
+
+        public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/WebJobs.Extensions.DurableTask/HistoryEventJsonConverter.cs
+++ b/src/WebJobs.Extensions.DurableTask/HistoryEventJsonConverter.cs
@@ -13,13 +13,13 @@ using Newtonsoft.Json.Linq;
 namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 {
     /// <summary>
-    /// Provides custom JSON deserialization for <see cref="HistoryEvent"> objects, mapping each event type to its corresponding
+    /// Provides custom JSON deserialization for <see cref="HistoryEvent"/> objects, mapping each event type to its corresponding
     /// concrete class. This converter enables polymorphic deserialization of history events based on the EventType
     /// property in the JSON payload.
     /// </summary>
     /// <remarks>
-    /// This converter only supports reading (deserialization) and does not support writing (serialization) of <see cref="HistoryEvent"> objects.
-    /// When deserializing, the EventType property in the JSON must be present and correspond to a known <see cref="EventType">;
+    /// This converter only supports reading (deserialization) and does not support writing (serialization) of <see cref="HistoryEvent"/> objects.
+    /// When deserializing, the EventType property in the JSON must be present and correspond to a known <see cref="EventType"/>;
     /// otherwise, a <see cref="JsonSerializationException"/> (for a missing EventType property) or <see cref="NotSupportedException"/>
     /// (for an unknown EventType) will be thrown.
     /// </remarks>
@@ -35,8 +35,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         }
 
         /// <inheritdoc/>
-        /// <throws><see cref="JsonSerializationException"/> If the EventType property is missing in the JSON object attempted to be deserialized.</throws>
-        /// <throws><see cref="InvalidOperationException"/>If the EventType property does not correspond to a known <see cref="EventType"/>.</throws>
+        /// <exception cref="JsonSerializationException"> If the EventType property is missing in the JSON object attempted to be deserialized.</exception>
+        /// <exception cref="InvalidOperationException">If the EventType property does not correspond to a known <see cref="EventType"/>.</exception>
         public override object? ReadJson(JsonReader reader, Type objectType, object? existingValue, JsonSerializer serializer)
         {
             var jo = JObject.Load(reader);

--- a/src/WebJobs.Extensions.DurableTask/ProtobufUtils.cs
+++ b/src/WebJobs.Extensions.DurableTask/ProtobufUtils.cs
@@ -66,16 +66,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     var completedEvent = (ExecutionCompletedEvent)e;
                     payload.ExecutionCompleted = new P.ExecutionCompletedEvent
                     {
-                        OrchestrationStatus = P.OrchestrationStatus.Completed,
+                        OrchestrationStatus = (P.OrchestrationStatus)completedEvent.OrchestrationStatus,
                         Result = completedEvent.Result,
-                    };
-                    break;
-                case EventType.ExecutionFailed:
-                    var failedEvent = (ExecutionCompletedEvent)e;
-                    payload.ExecutionCompleted = new P.ExecutionCompletedEvent
-                    {
-                        OrchestrationStatus = P.OrchestrationStatus.Failed,
-                        Result = failedEvent.Result,
+                        FailureDetails = GetFailureDetails(completedEvent.FailureDetails),
                     };
                     break;
                 case EventType.ExecutionStarted:
@@ -109,6 +102,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                             TraceState = startedEvent.ParentTraceContext.TraceState,
                         },
                     };
+
+                    if (startedEvent.Tags != null)
+                    {
+                        foreach (KeyValuePair<string, string> tag in startedEvent.Tags)
+                        {
+                            payload.ExecutionStarted.Tags[tag.Key] = tag.Value;
+                        }
+                    }
+
                     break;
                 case EventType.ExecutionTerminated:
                     var terminatedEvent = (ExecutionTerminatedEvent)e;
@@ -125,6 +127,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                         Version = taskScheduledEvent.Version,
                         Input = taskScheduledEvent.Input,
                     };
+
+                    if (taskScheduledEvent.Tags != null)
+                    {
+                        foreach (KeyValuePair<string, string> tag in taskScheduledEvent.Tags)
+                        {
+                            payload.TaskScheduled.Tags[tag.Key] = tag.Value;
+                        }
+                    }
+
                     break;
                 case EventType.TaskCompleted:
                     var taskCompletedEvent = (TaskCompletedEvent)e;
@@ -252,6 +263,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                         Input = a.ScheduleTask.Input,
                         Name = a.ScheduleTask.Name,
                         Version = a.ScheduleTask.Version,
+                        Tags = a.ScheduleTask.Tags.ToDictionary(),
                     };
                 case P.OrchestratorAction.OrchestratorActionTypeOneofCase.CreateSubOrchestration:
                     return new CreateSubOrchestrationAction

--- a/src/WebJobs.Extensions.DurableTask/TaskHubGrpcServer.cs
+++ b/src/WebJobs.Extensions.DurableTask/TaskHubGrpcServer.cs
@@ -491,21 +491,39 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 throw new RpcException(new Status(StatusCode.NotFound, $"Orchestration instance with ID {request.InstanceId} was not found."));
             }
 
+            async Task<(P.HistoryChunk, int)> AddToHistoryChunkAndStream(HistoryEvent historyEvent, P.HistoryChunk historyChunk, int currentChunkSizeInBytes)
+            {
+                P.HistoryEvent result = ProtobufUtils.ToHistoryEventProto(historyEvent);
+
+                int currentEventSize = result.CalculateSize();
+                if (currentChunkSizeInBytes + currentEventSize > MaxHistoryChunkSizeInBytes)
+                {
+                    // If we exceeded the chunk size threshold, send what we have so far.
+                    await responseStream.WriteAsync(historyChunk);
+                    historyChunk = new ();
+                    currentChunkSizeInBytes = 0;
+                }
+
+                historyChunk.Events.Add(result);
+                currentChunkSizeInBytes += currentEventSize;
+                return (historyChunk, currentChunkSizeInBytes);
+            }
+
             try
             {
+                int currentChunkSizeInBytes = 0;
+                P.HistoryChunk historyChunk = new ();
+
                 // First, try to use the streaming API if it's implemented.
                 try
                 {
-                    IEnumerable<string> historyChunks = await this.GetDurabilityProvider(context).StreamOrchestrationHistoryAsync(
+                    IAsyncEnumerable<HistoryEvent> historyEvents = await this.GetDurabilityProvider(context).StreamOrchestrationHistoryAsync(
                         request.InstanceId,
-                        new JsonFormatter(new JsonFormatter.Settings(formatDefaultValues: true)),
                         context.CancellationToken);
 
-                    JsonParser jsonParser = new (JsonParser.Settings.Default.WithIgnoreUnknownFields(true));
-                    foreach (string chunk in historyChunks)
+                    await foreach (HistoryEvent historyEvent in historyEvents)
                     {
-                        context.CancellationToken.ThrowIfCancellationRequested();
-                        await responseStream.WriteAsync(jsonParser.Parse<P.HistoryChunk>(chunk));
+                        (historyChunk, currentChunkSizeInBytes) = await AddToHistoryChunkAndStream(historyEvent, historyChunk, currentChunkSizeInBytes);
                     }
                 }
 
@@ -524,33 +542,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                         })
                         ?? throw new Exception($"Failed to deserialize orchestration history.");
 
-                    int currentChunkSizeInBytes = 0;
-
-                    P.HistoryChunk chunk = new ();
-
                     foreach (HistoryEvent historyEvent in historyEvents)
                     {
-                        context.CancellationToken.ThrowIfCancellationRequested();
-                        P.HistoryEvent result = ProtobufUtils.ToHistoryEventProto(historyEvent);
-
-                        int currentEventSize = result.CalculateSize();
-                        if (currentChunkSizeInBytes + currentEventSize > MaxHistoryChunkSizeInBytes)
-                        {
-                            // If we exceeded the chunk size threshold, send what we have so far.
-                            await responseStream.WriteAsync(chunk);
-                            chunk = new ();
-                            currentChunkSizeInBytes = 0;
-                        }
-
-                        chunk.Events.Add(result);
-                        currentChunkSizeInBytes += currentEventSize;
+                        (historyChunk, currentChunkSizeInBytes) = await AddToHistoryChunkAndStream(historyEvent, historyChunk, currentChunkSizeInBytes);
                     }
+                }
 
-                    // Send the last chunk, which may be smaller than the maximum chunk size.
-                    if (chunk.Events.Count > 0)
-                    {
-                        await responseStream.WriteAsync(chunk);
-                    }
+                // Send the last chunk, which may be smaller than the maximum chunk size.
+                if (historyChunk.Events.Count > 0)
+                {
+                    await responseStream.WriteAsync(historyChunk);
                 }
             }
             catch (OperationCanceledException)

--- a/src/WebJobs.Extensions.DurableTask/TaskHubGrpcServer.cs
+++ b/src/WebJobs.Extensions.DurableTask/TaskHubGrpcServer.cs
@@ -516,14 +516,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                         request.InstanceId,
                         executionId: null);
 
-                    // Throw exception or return an empty list?
                     List<HistoryEvent>? historyEvents = JsonConvert.DeserializeObject<List<HistoryEvent>>(
                         jsonHistory,
                         new JsonSerializerSettings()
                         {
                             Converters = { new HistoryEventJsonConverter() },
                         })
-                        ?? throw new RpcException(new Status(StatusCode.Internal, "Failed to deserialize orchestration history."));
+                        ?? throw new Exception($"Failed to deserialize orchestration history.");
 
                     int currentChunkSizeInBytes = 0;
 

--- a/src/WebJobs.Extensions.DurableTask/TaskHubGrpcServer.cs
+++ b/src/WebJobs.Extensions.DurableTask/TaskHubGrpcServer.cs
@@ -3,7 +3,9 @@
 
 #nullable enable
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using DurableTask.Core;
@@ -12,9 +14,11 @@ using DurableTask.Core.Exceptions;
 using DurableTask.Core.History;
 using DurableTask.Core.Query;
 using DurableTask.Core.Serializing.Internal;
+using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
 using Grpc.Core;
 using Microsoft.Azure.WebJobs.Extensions.DurableTask.Correlation;
+using Newtonsoft.Json;
 using DTCore = DurableTask.Core;
 using P = Microsoft.DurableTask.Protobuf;
 
@@ -22,6 +26,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 {
     internal class TaskHubGrpcServer : P.TaskHubSidecarService.TaskHubSidecarServiceBase
     {
+        private const int MaxHistoryChunkSizeInBytes = 2 * 1024 * 1024; // 2 MB
         private readonly DurableTaskExtension extension;
 
         public TaskHubGrpcServer(DurableTaskExtension extension)
@@ -64,6 +69,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     Version = request.Version != null ? request.Version : this.extension.Options.DefaultVersion,
                     OrchestrationInstance = instance,
                     ScheduledStartTime = request.ScheduledStartTimestamp?.ToDateTime(),
+                    Tags = request.Tags.ToDictionary(),
                 };
 
                 // Get the parent trace context from CreateInstanceRequest
@@ -473,6 +479,89 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     FailureDetails = request.GetInputsAndOutputs ? GetFailureDetails(state.FailureDetails) : null,
                 },
             };
+        }
+
+        public async override Task StreamInstanceHistory(
+            P.StreamInstanceHistoryRequest request,
+            IServerStreamWriter<P.HistoryChunk> responseStream,
+            ServerCallContext context)
+        {
+            if (await this.GetClient(context).GetStatusAsync(request.InstanceId, showInput: false) is null)
+            {
+                throw new RpcException(new Status(StatusCode.NotFound, $"Orchestration instance with ID {request.InstanceId} was not found."));
+            }
+
+            try
+            {
+                // First, try to use the streaming API if it's implemented.
+                try
+                {
+                    IEnumerable<string> historyChunks = await this.GetDurabilityProvider(context).StreamOrchestrationHistoryAsync(
+                        request.InstanceId,
+                        new JsonFormatter(new JsonFormatter.Settings(formatDefaultValues: true)),
+                        context.CancellationToken);
+
+                    JsonParser jsonParser = new (JsonParser.Settings.Default.WithIgnoreUnknownFields(true));
+                    foreach (string chunk in historyChunks)
+                    {
+                        context.CancellationToken.ThrowIfCancellationRequested();
+                        await responseStream.WriteAsync(jsonParser.Parse<P.HistoryChunk>(chunk));
+                    }
+                }
+
+                // Otherwise default to the older non-streaming implementation.
+                catch (NotImplementedException)
+                {
+                    string jsonHistory = await this.GetDurabilityProvider(context).GetOrchestrationHistoryAsync(
+                        request.InstanceId,
+                        executionId: null);
+
+                    // Throw exception or return an empty list?
+                    List<HistoryEvent>? historyEvents = JsonConvert.DeserializeObject<List<HistoryEvent>>(
+                        jsonHistory,
+                        new JsonSerializerSettings()
+                        {
+                            Converters = { new HistoryEventJsonConverter() },
+                        })
+                        ?? throw new RpcException(new Status(StatusCode.Internal, "Failed to deserialize orchestration history."));
+
+                    int currentChunkSizeInBytes = 0;
+
+                    P.HistoryChunk chunk = new ();
+
+                    foreach (HistoryEvent historyEvent in historyEvents)
+                    {
+                        context.CancellationToken.ThrowIfCancellationRequested();
+                        P.HistoryEvent result = ProtobufUtils.ToHistoryEventProto(historyEvent);
+
+                        int currentEventSize = result.CalculateSize();
+                        if (currentChunkSizeInBytes + currentEventSize > MaxHistoryChunkSizeInBytes)
+                        {
+                            // If we exceeded the chunk size threshold, send what we have so far.
+                            await responseStream.WriteAsync(chunk);
+                            chunk = new ();
+                            currentChunkSizeInBytes = 0;
+                        }
+
+                        chunk.Events.Add(result);
+                        currentChunkSizeInBytes += currentEventSize;
+                    }
+
+                    // Send the last chunk, which may be smaller than the maximum chunk size.
+                    if (chunk.Events.Count > 0)
+                    {
+                        await responseStream.WriteAsync(chunk);
+                    }
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                throw new RpcException(new Status(StatusCode.Cancelled, $"Orchestration history streaming cancelled for instance {request.InstanceId}"));
+            }
+            catch (Exception ex)
+            {
+                throw new RpcException(new Status(StatusCode.Internal, $"Failed to stream orchestration history for instance {request.InstanceId}: {ex.Message}"));
+            }
         }
 
         private static P.TaskFailureDetails? GetFailureDetails(FailureDetails? failureDetails)

--- a/src/Worker.Extensions.DurableTask/FunctionsDurableTaskClient.cs
+++ b/src/Worker.Extensions.DurableTask/FunctionsDurableTaskClient.cs
@@ -1,9 +1,10 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using DurableTask.Core.History;
 using Microsoft.DurableTask;
 using Microsoft.DurableTask.Client;
 using Microsoft.DurableTask.Client.Entities;
@@ -114,5 +115,12 @@ internal sealed class FunctionsDurableTaskClient : DurableTaskClient
         string instanceId, string reason, CancellationToken cancellation = default)
     {
         return this.inner.RewindInstanceAsync(instanceId, reason, cancellation);
+    }
+
+    public override Task<IList<HistoryEvent>> GetOrchestrationHistoryAsync(
+        string instanceId,
+        CancellationToken cancellation = default)
+    {
+        return this.inner.GetOrchestrationHistoryAsync(instanceId, cancellation);
     }
 }

--- a/test/Directory.Packages.props
+++ b/test/Directory.Packages.props
@@ -30,10 +30,10 @@
   <!-- Transitive dependencies with higher versions -->
   <ItemGroup>
     <PackageVersion Update="Azure.Identity" Version="1.17.1" />
-    <PackageVersion Update="Microsoft.Bcl.AsyncInterfaces" Version="9.0.0"/>
+    <PackageVersion Update="Microsoft.Bcl.AsyncInterfaces" Version="10.0.0"/>
     <PackageVersion Update="Microsoft.Extensions.Azure" Version="1.10.0" />
     <PackageVersion Update="System.Drawing.Common" Version="6.0.0" />
-    <PackageVersion Update="System.Text.Json" Version="9.0.0" />
+    <PackageVersion Update="System.Text.Json" Version="10.0.0" />
   </ItemGroup>
 
 </Project>

--- a/test/SmokeTests/OOProcSmokeTests/durablePy/Nuget.config
+++ b/test/SmokeTests/OOProcSmokeTests/durablePy/Nuget.config
@@ -4,6 +4,5 @@
         <clear/>
         <add key="nuget.org" value="https://api.nuget.org/v3/index.json"/>
         <add key="local" value="." />
-        <add key="durabletask" value="https://azfunc.pkgs.visualstudio.com/public/_packaging/durabletask/nuget/v3/index.json" />
     </packageSources>
 </configuration>

--- a/test/TimeoutTests/Python/Nuget.config
+++ b/test/TimeoutTests/Python/Nuget.config
@@ -4,6 +4,5 @@
         <clear/>
         <add key="nuget.org" value="https://api.nuget.org/v3/index.json"/>
         <add key="local" value="." />
-        <add key="durabletask" value="https://azfunc.pkgs.visualstudio.com/public/_packaging/durabletask/nuget/v3/index.json" />
     </packageSources>
 </configuration>

--- a/test/e2e/Apps/BasicDotNetIsolated/GetOrchestrationHistory.cs
+++ b/test/e2e/Apps/BasicDotNetIsolated/GetOrchestrationHistory.cs
@@ -197,13 +197,13 @@ public static class GetOrchestrationHistory
             }
             return other.CallEntities == this.CallEntities
                 && ((other.OrchestrationType is null && this.OrchestrationType is null)
-                    || (other.OrchestrationType is not null && this.OrchestrationType is not null
-                    && other.OrchestrationType.Equals(this.OrchestrationType)))
+                || (other.OrchestrationType is not null && this.OrchestrationType is not null
+                && other.OrchestrationType.Equals(this.OrchestrationType)))
                 && other.SubOrchestrationInstanceId.Equals(this.SubOrchestrationInstanceId)
                 && other.OutputSize == this.OutputSize
                 && ((other.Tags is null && this.Tags is null)
-                    || (other.Tags is not null && this.Tags is not null
-                    && other.Tags.OrderBy(x => x.Key).SequenceEqual(this.Tags.OrderBy(x => x.Key))));
+                || (other.Tags is not null && this.Tags is not null
+                && other.Tags.OrderBy(x => x.Key).SequenceEqual(this.Tags.OrderBy(x => x.Key))));
         }
 
         public override int GetHashCode()

--- a/test/e2e/Apps/BasicDotNetIsolated/GetOrchestrationHistory.cs
+++ b/test/e2e/Apps/BasicDotNetIsolated/GetOrchestrationHistory.cs
@@ -1,0 +1,214 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Net;
+using DurableTask.Core.History;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
+using Microsoft.DurableTask;
+using Microsoft.DurableTask.Client;
+using Microsoft.DurableTask.Entities;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+
+namespace Microsoft.Azure.Durable.Tests.E2E;
+
+public static class GetOrchestrationHistory
+{
+    public static readonly EntityInstanceId entityId = new(nameof(SimpleEntity), "singleton");
+
+    [Function(nameof(ParentOrchestration))]
+    public static async Task<ComplexInput> ParentOrchestration(
+        [OrchestrationTrigger] TaskOrchestrationContext context)
+    {
+        ComplexInput? input = context.GetInput<ComplexInput>();
+
+        if (input == null)
+        {
+            throw new ArgumentNullException(nameof(input));
+        }
+
+        if (input.OrchestrationType == "succeed")
+        {
+            // Try setting various fields to null to ensure serialization of the history works as expected.
+            input.Tags = null;
+            await context.CallSubOrchestratorAsync(
+                nameof(CallLargeOutputTasksSubOrchestration),
+                input,
+                new SubOrchestrationOptions { InstanceId = input.SubOrchestrationInstanceId }
+           );
+        }
+        else
+        {
+            // Try setting various fields to null to ensure serialization of the history works as expected.
+            input.OrchestrationType = null;
+            await context.CallSubOrchestratorAsync(
+                nameof(FailSubOrchestration),
+                input,
+                new SubOrchestrationOptions { InstanceId = input.SubOrchestrationInstanceId, Tags = input.Tags }
+           );
+        }
+
+        return input;
+    }
+
+    [Function(nameof(FailSubOrchestration))]
+    public static async Task FailSubOrchestration(
+        [OrchestrationTrigger] TaskOrchestrationContext context)
+    {
+        await context.CallActivityAsync<string>(nameof(ThrowExceptionActivity), new TaskOptions {  Tags = context.GetInput<ComplexInput>()?.Tags });
+    }
+
+    [Function(nameof(CallLargeOutputTasksSubOrchestration))]
+    public static async Task<ComplexInput> CallLargeOutputTasksSubOrchestration(
+        [OrchestrationTrigger] TaskOrchestrationContext context)
+    {
+        ComplexInput? input = context.GetInput<ComplexInput>();
+        if (input == null)
+        {
+            throw new ArgumentNullException(nameof(input));
+        }
+
+        await context.CallActivityAsync<string>(nameof(LargeOutputActivity), input.OutputSize);
+
+        if (input.CallEntities)
+        {
+            await context.Entities.SignalEntityAsync(entityId, "set", input.OutputSize);
+            // Add a timer to give the signal some more time to be processed before we read the entity state.
+            // We could make this a "call" rather than a "signal", but this ensures we get more history event types in the orchestration history.
+            await context.CreateTimer(context.CurrentUtcDateTime.AddSeconds(5), CancellationToken.None);
+            await context.Entities.CallEntityAsync<string>(entityId, "get");
+        }
+        else
+        {
+            await context.CallActivityAsync<string>(nameof(LargeOutputActivity), input.OutputSize);
+        }
+        return input;
+    }
+
+    [Function(nameof(LargeOutputActivity))]
+    public static string LargeOutputActivity([ActivityTrigger] int outputSize, FunctionContext executionContext)
+    {
+        return new string('a', outputSize);
+    }
+
+    [Function(nameof(ThrowExceptionActivity))]
+    public static string ThrowExceptionActivity([ActivityTrigger] FunctionContext executionContext)
+    {
+        throw new Exception("Failure!");
+    }
+
+    [Function(nameof(GetInstanceHistory))]
+    public static async Task<HttpResponseData> GetInstanceHistory(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", "post")] HttpRequestData req,
+        [DurableClient] DurableTaskClient client,
+        string instanceId)
+    {
+        try
+        {
+            IList<HistoryEvent> history = await client.GetOrchestrationHistoryAsync(instanceId);
+            HttpResponseData response = req.CreateResponse(HttpStatusCode.OK);
+
+            // The WriteAsJsonAsync method does not serialize the HistoryEvent polymorphic types correctly, so we use WriteStringAsync instead
+            // and use JsonConvert to serialize the history ourselves.
+            await response.WriteStringAsync(JsonConvert.SerializeObject(history));
+            return response;
+        }
+        catch (ArgumentException)
+        {
+            return req.CreateResponse(HttpStatusCode.NotFound);
+        }
+    }
+
+    [Function(nameof(GetOrchestrationHistory_HttpStart))]
+    public static async Task<HttpResponseData> GetOrchestrationHistory_HttpStart(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", "post")] HttpRequestData req,
+        [DurableClient] DurableTaskClient client,
+        FunctionContext executionContext,
+        string orchestrationType,
+        string subOrchestrationInstanceId,
+        int outputSize,
+        bool callEntities,
+        string tagsKey,
+        string tagsValue)
+    {
+        ILogger logger = executionContext.GetLogger(nameof(GetOrchestrationHistory_HttpStart));
+        Dictionary<string, string> tags = new() { { tagsKey, tagsValue } };
+
+        string instanceId = await client.ScheduleNewOrchestrationInstanceAsync(
+            nameof(ParentOrchestration),
+            new ComplexInput(
+                orchestrationType,
+                subOrchestrationInstanceId,
+                outputSize,
+                callEntities,
+                tags),
+            new StartOrchestrationOptions { Tags = tags });
+
+        logger.LogInformation("Started orchestration with ID = '{instanceId}'.", instanceId);
+
+        // Returns an HTTP 202 response with an instance management payload.
+        // See https://learn.microsoft.com/azure/azure-functions/durable/durable-functions-http-api#start-orchestration
+        return await client.CreateCheckStatusResponseAsync(req, instanceId);
+    }
+
+    [Function(nameof(SimpleEntity))]
+    public static Task SimpleEntity([EntityTrigger] TaskEntityDispatcher dispatcher)
+    {
+        return dispatcher.DispatchAsync(operation =>
+        {
+            switch (operation.Name)
+            {
+                case "get":
+                    return new(operation.State.GetState<string>());
+                case "set":
+                    int size = operation.GetInput<int>();
+                    operation.State.SetState(new string('a', size));
+                    break;
+                default:
+                    throw new InvalidOperationException($"Unknown operation '{operation.Name}'");
+            }
+            return default;
+        });
+    }
+
+    public class ComplexInput(
+        string? orchestrationType,
+        string subOrchestrationInstanceId,
+        int outputSize,
+        bool callEntities,
+        Dictionary<string, string>? tags)
+    {
+        public bool CallEntities { get; set; } = callEntities;
+
+        public string? OrchestrationType { get; set; } = orchestrationType;
+
+        public string SubOrchestrationInstanceId { get; set; } = subOrchestrationInstanceId;
+
+        public int OutputSize { get; set; } = outputSize;
+
+        public Dictionary<string, string>? Tags { get; set; } = tags;
+
+        public override bool Equals(object? obj)
+        {
+            if (obj is not ComplexInput other)
+            {
+                return false;
+            }
+            return other.CallEntities == this.CallEntities
+                && ((other.OrchestrationType is null && this.OrchestrationType is null)
+                    || (other.OrchestrationType is not null && this.OrchestrationType is not null
+                    && other.OrchestrationType.Equals(this.OrchestrationType)))
+                && other.SubOrchestrationInstanceId.Equals(this.SubOrchestrationInstanceId)
+                && other.OutputSize == this.OutputSize
+                && ((other.Tags is null && this.Tags is null)
+                    || (other.Tags is not null && this.Tags is not null
+                    && other.Tags.OrderBy(x => x.Key).SequenceEqual(this.Tags.OrderBy(x => x.Key))));
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(this.CallEntities, this.OrchestrationType, this.SubOrchestrationInstanceId, this.OutputSize, this.Tags);
+        }
+    }
+}

--- a/test/e2e/Tests/E2ETests.csproj
+++ b/test/e2e/Tests/E2ETests.csproj
@@ -5,9 +5,9 @@
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-	<SignAssembly>true</SignAssembly>
+    <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\..\sign.snk</AssemblyOriginatorKeyFile>
-	<RootNamespace>Microsoft.Azure.Durable.Tests.DotnetIsolatedE2E</RootNamespace>
+    <RootNamespace>Microsoft.Azure.Durable.Tests.DotnetIsolatedE2E</RootNamespace>
     <!-- Only add the following line when you want to locally debug
     <RunSettingsFilePath>$(MSBuildProjectDirectory)\test.runsettings</RunSettingsFilePath> -->
   </PropertyGroup>

--- a/test/e2e/Tests/E2ETests.csproj
+++ b/test/e2e/Tests/E2ETests.csproj
@@ -5,7 +5,9 @@
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <RootNamespace>Microsoft.Azure.Durable.Tests.DotnetIsolatedE2E</RootNamespace>
+	<SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>..\..\..\sign.snk</AssemblyOriginatorKeyFile>
+	<RootNamespace>Microsoft.Azure.Durable.Tests.DotnetIsolatedE2E</RootNamespace>
     <!-- Only add the following line when you want to locally debug
     <RunSettingsFilePath>$(MSBuildProjectDirectory)\test.runsettings</RunSettingsFilePath> -->
   </PropertyGroup>
@@ -22,6 +24,11 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\WebJobs.Extensions.DurableTask\WebJobs.Extensions.DurableTask.csproj" />
+    <ProjectReference Include="..\Apps\BasicDotNetIsolated\app.csproj" />
   </ItemGroup>
 
 </Project>

--- a/test/e2e/Tests/E2ETests.csproj
+++ b/test/e2e/Tests/E2ETests.csproj
@@ -28,7 +28,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\WebJobs.Extensions.DurableTask\WebJobs.Extensions.DurableTask.csproj" />
-    <ProjectReference Include="..\Apps\BasicDotNetIsolated\app.csproj" />
   </ItemGroup>
 
 </Project>

--- a/test/e2e/Tests/Tests/DistributedTracingEntitiesTests.cs
+++ b/test/e2e/Tests/Tests/DistributedTracingEntitiesTests.cs
@@ -73,8 +73,9 @@ public class DistributedTracingEntitiesTests
 
         HttpResponseMessage result = await HttpHelpers.InvokeHttpTrigger("GetActivityInfoOrchestration_Output", $"?id={orchestrationId}");
         Assert.Equal(HttpStatusCode.OK, result.StatusCode);
-        var remainingIds = (await result.Content.ReadAsStringAsync()).Replace("\r", "").Replace("\n", "").Replace("\"", "").Replace("[", "").Replace("]", "").Replace(" ", "");
-        ids.AddRange(remainingIds.Split(","));
+        List<string>? remainingIds = JsonSerializer.Deserialize<List<string>>((await result.Content.ReadAsStringAsync()));
+        Assert.NotNull(remainingIds);
+        ids.AddRange(remainingIds);
         Assert.Equal(8, ids.Count);
         Assert.True(ids.All(traceId => traceId.Equals(activity.TraceId.ToString())));
     }

--- a/test/e2e/Tests/Tests/GetOrchestrationHistoryTests.cs
+++ b/test/e2e/Tests/Tests/GetOrchestrationHistoryTests.cs
@@ -5,10 +5,10 @@ using System.Net;
 using DurableTask.Core;
 using DurableTask.Core.History;
 using Microsoft.Azure.WebJobs.Extensions.DurableTask;
+using Microsoft.DurableTask.Entities;
 using Newtonsoft.Json;
 using Xunit;
 using Xunit.Abstractions;
-using static Microsoft.Azure.Durable.Tests.E2E.GetOrchestrationHistory;
 
 namespace Microsoft.Azure.Durable.Tests.DotnetIsolatedE2E;
 
@@ -24,6 +24,9 @@ public class GetOrchestrationHistoryTests
     private const string TagsValue = "value";
 
     private readonly Dictionary<string, string> tags = new() { { TagsKey, TagsValue } };
+
+    // Duplicated from GetOrchestrationHistory since the import is failing - see comment above the ComplexInput class.
+    private static readonly EntityInstanceId entityId = new("SimpleEntity", "singleton");
 
     public GetOrchestrationHistoryTests(FunctionAppFixture fixture, ITestOutputHelper testOutputHelper)
     {
@@ -369,5 +372,48 @@ public class GetOrchestrationHistoryTests
         getOrchestrationHistoryResponse = await HttpHelpers.InvokeHttpTrigger("GetInstanceHistory", $"?instanceId={entityId}");
         Assert.Equal(HttpStatusCode.NotFound, getOrchestrationHistoryResponse.StatusCode);
         getOrchestrationHistoryResponse.Dispose();
+    }
+
+    // Unfortunately something about building from the command line fails if we try to import this from the GetOrchestrationHistory class
+    // (even though it builds just fine in Visual Studio). As such the GitHub pipelines fail.
+    // For now we will just duplicate this class here.
+    public class ComplexInput(
+        string? orchestrationType,
+        string subOrchestrationInstanceId,
+        int outputSize,
+        bool callEntities,
+        Dictionary<string, string>? tags)
+    {
+        public bool CallEntities { get; set; } = callEntities;
+
+        public string? OrchestrationType { get; set; } = orchestrationType;
+
+        public string SubOrchestrationInstanceId { get; set; } = subOrchestrationInstanceId;
+
+        public int OutputSize { get; set; } = outputSize;
+
+        public Dictionary<string, string>? Tags { get; set; } = tags;
+
+        public override bool Equals(object? obj)
+        {
+            if (obj is not ComplexInput other)
+            {
+                return false;
+            }
+            return other.CallEntities == this.CallEntities
+                && ((other.OrchestrationType is null && this.OrchestrationType is null)
+                || (other.OrchestrationType is not null && this.OrchestrationType is not null
+                && other.OrchestrationType.Equals(this.OrchestrationType)))
+                && other.SubOrchestrationInstanceId.Equals(this.SubOrchestrationInstanceId)
+                && other.OutputSize == this.OutputSize
+                && ((other.Tags is null && this.Tags is null)
+                || (other.Tags is not null && this.Tags is not null
+                && other.Tags.OrderBy(x => x.Key).SequenceEqual(this.Tags.OrderBy(x => x.Key))));
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(this.CallEntities, this.OrchestrationType, this.SubOrchestrationInstanceId, this.OutputSize, this.Tags);
+        }
     }
 }

--- a/test/e2e/Tests/Tests/GetOrchestrationHistoryTests.cs
+++ b/test/e2e/Tests/Tests/GetOrchestrationHistoryTests.cs
@@ -67,9 +67,10 @@ public class GetOrchestrationHistoryTests
 
         // Confirm the correct count and sequence of events
         Assert.Equal(8, historyEvents.Count);
+
+        // OrchestratorStarted, ExecutionStarted, SubOrchestrationInstanceCreated, OrchestratorCompleted
         Assert.Equal(EventType.OrchestratorStarted, historyEvents[0].EventType);
         Assert.Equal(EventType.ExecutionStarted, historyEvents[1].EventType);
-
         // Confirm the fields of the ExecutionStartedEvent (name, orchestration input, and orchestration tags)
         var parentExecutionStartedEvent = (ExecutionStartedEvent)historyEvents[1];
         Assert.Equal("ParentOrchestration", parentExecutionStartedEvent.Name);
@@ -81,7 +82,6 @@ public class GetOrchestrationHistoryTests
             Assert.Contains(TagsKey, parentExecutionStartedEvent.Tags.Keys);
             Assert.Contains(TagsValue, parentExecutionStartedEvent.Tags.Values);
         }
-
         Assert.Equal(EventType.SubOrchestrationInstanceCreated, historyEvents[2].EventType);
         var subOrchestrationInstanceCreatedEvent = (SubOrchestrationInstanceCreatedEvent)historyEvents[2];
         Assert.Equal("FailSubOrchestration", subOrchestrationInstanceCreatedEvent.Name);
@@ -92,6 +92,7 @@ public class GetOrchestrationHistoryTests
         }
         Assert.Equal(EventType.OrchestratorCompleted, historyEvents[3].EventType);
 
+        // OrchestratorStarted, SubOrchestrationInstanceFailed, ExecutionCompleted, OrchestratorCompleted
         Assert.Equal(EventType.OrchestratorStarted, historyEvents[4].EventType);
         Assert.Equal(EventType.SubOrchestrationInstanceFailed, historyEvents[5].EventType);
         Assert.Equal(subOrchestrationInstanceCreatedEvent.EventId, ((SubOrchestrationInstanceFailedEvent)historyEvents[5]).TaskScheduledId);
@@ -136,9 +137,10 @@ public class GetOrchestrationHistoryTests
 
         // Confirm the correct count and sequence of events for the suborchestration
         Assert.Equal(8, subOrchestrationHistoryEvents.Count);
+
+        // OrchestratorStarted, ExecutionStarted, TaskScheduled, OrchestratorCompleted
         Assert.Equal(EventType.OrchestratorStarted, subOrchestrationHistoryEvents[0].EventType);
         Assert.Equal(EventType.ExecutionStarted, subOrchestrationHistoryEvents[1].EventType);
-
         // Confirm the fields of the ExecutionStartedEvent for the suborchestration (name, orchestration input, parent information, task ID)
         var subOrchestrationExecutionStartedEvent = (ExecutionStartedEvent)subOrchestrationHistoryEvents[1];
         Assert.Equal("FailSubOrchestration", subOrchestrationExecutionStartedEvent.Name);
@@ -152,7 +154,6 @@ public class GetOrchestrationHistoryTests
             Assert.Equal("ParentOrchestration", subOrchestrationExecutionStartedEvent.ParentInstance.Name);
             Assert.Equal(parentExecutionStartedEvent.OrchestrationInstance.ExecutionId, subOrchestrationExecutionStartedEvent.ParentInstance.OrchestrationInstance.ExecutionId);
         }
-
         Assert.Equal(EventType.TaskScheduled, subOrchestrationHistoryEvents[2].EventType);
         var taskScheduledEvent = (TaskScheduledEvent)subOrchestrationHistoryEvents[2];
         Assert.Equal("ThrowExceptionActivity", taskScheduledEvent.Name);
@@ -164,6 +165,7 @@ public class GetOrchestrationHistoryTests
         }
         Assert.Equal(EventType.OrchestratorCompleted, subOrchestrationHistoryEvents[3].EventType);
 
+        // OrchestratorStarted, TaskFailed, ExecutionCompleted, OrchestratorCompleted
         Assert.Equal(EventType.OrchestratorStarted, subOrchestrationHistoryEvents[4].EventType);
         Assert.Equal(EventType.TaskFailed, subOrchestrationHistoryEvents[5].EventType);
         // Confirm the event ID of the TaskScheduledEvent matches the TaskScheduledId field of the TaskFailedEvent
@@ -225,9 +227,10 @@ public class GetOrchestrationHistoryTests
 
         // Confirm the correct count and sequence of events
         Assert.Equal(8, historyEvents.Count);
+
+        // OrchestratorStarted, ExecutionStarted, SubOrchestrationInstanceCreated, OrchestratorCompleted
         Assert.Equal(EventType.OrchestratorStarted, historyEvents[0].EventType);
         Assert.Equal(EventType.ExecutionStarted, historyEvents[1].EventType);
-
         // Confirm the fields of the ExecutionStartedEvent (name, orchestration input, and orchestration tags)
         var parentExecutionStartedEvent = (ExecutionStartedEvent)historyEvents[1];
         Assert.Equal("ParentOrchestration", parentExecutionStartedEvent.Name);
@@ -239,7 +242,6 @@ public class GetOrchestrationHistoryTests
             Assert.Contains(TagsKey, parentExecutionStartedEvent.Tags.Keys);
             Assert.Contains(TagsValue, parentExecutionStartedEvent.Tags.Values);
         }
-
         Assert.Equal(EventType.SubOrchestrationInstanceCreated, historyEvents[2].EventType);
         var subOrchestrationInstanceCreatedEvent = (SubOrchestrationInstanceCreatedEvent)historyEvents[2];
         Assert.Equal("CallLargeOutputTasksSubOrchestration", subOrchestrationInstanceCreatedEvent.Name);
@@ -250,6 +252,7 @@ public class GetOrchestrationHistoryTests
         }
         Assert.Equal(EventType.OrchestratorCompleted, historyEvents[3].EventType);
 
+        // OrchestratorStarted, SubOrchestrationInstanceCompleted, ExecutionCompleted, OrchestratorCompleted
         Assert.Equal(EventType.OrchestratorStarted, historyEvents[4].EventType);
         Assert.Equal(EventType.SubOrchestrationInstanceCompleted, historyEvents[5].EventType);
         Assert.Equal(EventType.ExecutionCompleted, historyEvents[6].EventType);
@@ -280,9 +283,10 @@ public class GetOrchestrationHistoryTests
 
         // Confirm the correct count and sequence of events for the suborchestration
         Assert.Equal(isNotMSSQL ? 17 : 12, subOrchestrationHistoryEvents.Count);
+
+        // OrchestratorStarted, ExecutionStarted, TaskScheduled, OrchestratorCompleted
         Assert.Equal(EventType.OrchestratorStarted, subOrchestrationHistoryEvents[0].EventType);
         Assert.Equal(EventType.ExecutionStarted, subOrchestrationHistoryEvents[1].EventType);
-
         // Confirm the fields of the ExecutionStartedEvent for the suborchestration (name, orchestration input, parent information, task ID)
         var subOrchestrationExecutionStartedEvent = (ExecutionStartedEvent)subOrchestrationHistoryEvents[1];
         Assert.Equal("CallLargeOutputTasksSubOrchestration", subOrchestrationExecutionStartedEvent.Name);
@@ -295,11 +299,11 @@ public class GetOrchestrationHistoryTests
             Assert.Equal("ParentOrchestration", subOrchestrationExecutionStartedEvent.ParentInstance.Name);
             Assert.Equal(parentExecutionStartedEvent.OrchestrationInstance.ExecutionId, subOrchestrationExecutionStartedEvent.ParentInstance.OrchestrationInstance.ExecutionId);
         }
-
         Assert.Equal(EventType.TaskScheduled, subOrchestrationHistoryEvents[2].EventType);
         Assert.Equal("LargeOutputActivity", ((TaskScheduledEvent)subOrchestrationHistoryEvents[2]).Name);
         Assert.Equal(EventType.OrchestratorCompleted, subOrchestrationHistoryEvents[3].EventType);
 
+        // OrchestratorStarted, TaskCompleted
         Assert.Equal(EventType.OrchestratorStarted, subOrchestrationHistoryEvents[4].EventType);
         Assert.Equal(EventType.TaskCompleted, subOrchestrationHistoryEvents[5].EventType);
         var taskCompletedEvent = (TaskCompletedEvent)subOrchestrationHistoryEvents[5];
@@ -310,11 +314,13 @@ public class GetOrchestrationHistoryTests
         ExecutionCompletedEvent subOrchestrationExecutionCompletedEvent;
         if (isNotMSSQL)
         {
+            // EventSentEvent, TimerCreated, OrchestratorCompleted
             Assert.Equal(EventType.EventSent, subOrchestrationHistoryEvents[6].EventType);
             Assert.Equal(entityId.ToString(), ((EventSentEvent)subOrchestrationHistoryEvents[6]).InstanceId);
             Assert.Equal(EventType.TimerCreated, subOrchestrationHistoryEvents[7].EventType);
             Assert.Equal(EventType.OrchestratorCompleted, subOrchestrationHistoryEvents[8].EventType);
 
+            // OrchestratorStarted, TimerFired, EventSentEvent, OrchestratorCompleted
             Assert.Equal(EventType.OrchestratorStarted, subOrchestrationHistoryEvents[9].EventType);
             Assert.Equal(EventType.TimerFired, subOrchestrationHistoryEvents[10].EventType);
             // Confirm the event ID of the TimerCreatedEvent matches the TimerId field of the TimerFiredEvent
@@ -323,6 +329,7 @@ public class GetOrchestrationHistoryTests
             Assert.Equal(entityId.ToString(), ((EventSentEvent)subOrchestrationHistoryEvents[11]).InstanceId);
             Assert.Equal(EventType.OrchestratorCompleted, subOrchestrationHistoryEvents[12].EventType);
 
+            // OrchestratorStarted, EventRaised, ExecutionCompleted, OrchestratorCompleted
             Assert.Equal(EventType.OrchestratorStarted, subOrchestrationHistoryEvents[13].EventType);
             Assert.Equal(EventType.EventRaised, subOrchestrationHistoryEvents[14].EventType);
             Assert.Equal(EventType.ExecutionCompleted, subOrchestrationHistoryEvents[15].EventType);
@@ -331,10 +338,12 @@ public class GetOrchestrationHistoryTests
         }
         else
         {
+            // TaskScheduled, OrchestratorCompleted
             Assert.Equal(EventType.TaskScheduled, subOrchestrationHistoryEvents[6].EventType);
             Assert.Equal("LargeOutputActivity", ((TaskScheduledEvent)subOrchestrationHistoryEvents[6]).Name);
             Assert.Equal(EventType.OrchestratorCompleted, subOrchestrationHistoryEvents[7].EventType);
 
+            // OrchestratorStarted, TaskCompleted, ExecutionCompleted, OrchestratorCompleted
             Assert.Equal(EventType.OrchestratorStarted, subOrchestrationHistoryEvents[8].EventType);
             taskCompletedEvent = (TaskCompletedEvent)subOrchestrationHistoryEvents[9];
             // Confirm the event ID of the TaskScheduledEvent matches the TaskScheduledId field of the TaskCompletedEvent

--- a/test/e2e/Tests/Tests/GetOrchestrationHistoryTests.cs
+++ b/test/e2e/Tests/Tests/GetOrchestrationHistoryTests.cs
@@ -40,6 +40,7 @@ public class GetOrchestrationHistoryTests
     [Trait("Python", "Skip")] // The GetOrchestrationHistory API is not implemented in Python
     [Trait("PowerShell", "Skip")] // The GetOrchestrationHistory API is not implemented in PowerShell
     [Trait("Node", "Skip")] // The GetOrchestrationHistory API is not implemented in Node
+    /// Tests that the nested failure details of an orchestration and its failed suborchestration can be retrieved successfully
     public async Task GetOrchestrationHistory_FailedOrchestration()
     {
         bool isNotMSSQL = this.fixture.GetDurabilityProvider() != FunctionAppFixture.ConfiguredDurabilityProviderType.MSSQL;
@@ -198,6 +199,8 @@ public class GetOrchestrationHistoryTests
     [Trait("Python", "Skip")] // The GetOrchestrationHistory API is not implemented in Python
     [Trait("PowerShell", "Skip")] // The GetOrchestrationHistory API is not implemented in PowerShell
     [Trait("Node", "Skip")] // The GetOrchestrationHistory API is not implemented in Node
+    /// Tests that an orchestration with a large history that exceeds the maximum size of a single history chunk (2 MB) and requires multiple chunks
+    /// to be streamed can be retrieved successfully
     public async Task GetOrchestrationHistory_LargeHistory()
     {
         bool isNotMSSQL = this.fixture.GetDurabilityProvider() != FunctionAppFixture.ConfiguredDurabilityProviderType.MSSQL;

--- a/test/e2e/Tests/Tests/GetOrchestrationHistoryTests.cs
+++ b/test/e2e/Tests/Tests/GetOrchestrationHistoryTests.cs
@@ -60,7 +60,6 @@ public class GetOrchestrationHistoryTests
             jsonHistory,
             new JsonSerializerSettings()
             {
-                // I had to make the HistoryEventJsonConverter public to use it here. Is this a good reason?
                 Converters = { new HistoryEventJsonConverter() },
             });
         Assert.NotNull(historyEvents);
@@ -130,7 +129,6 @@ public class GetOrchestrationHistoryTests
             subOrchestrationJsonHistory,
             new JsonSerializerSettings()
             {
-                // I had to make the HistoryEventJsonConverter public to use it here. Is this a good reason?
                 Converters = { new HistoryEventJsonConverter() },
             });
         Assert.NotNull(subOrchestrationHistoryEvents);
@@ -220,7 +218,6 @@ public class GetOrchestrationHistoryTests
             jsonHistory,
             new JsonSerializerSettings()
             {
-                // I had to make the HistoryEventJsonConverter public to use it here. Is this a good reason?
                 Converters = { new HistoryEventJsonConverter() },
             });
         Assert.NotNull(historyEvents);
@@ -276,7 +273,6 @@ public class GetOrchestrationHistoryTests
             subOrchestrationJsonHistory,
             new JsonSerializerSettings()
             {
-                // I had to make the HistoryEventJsonConverter public to use it here. Is this a good reason?
                 Converters = { new HistoryEventJsonConverter() },
             });
         Assert.NotNull(subOrchestrationHistoryEvents);

--- a/test/e2e/Tests/Tests/GetOrchestrationHistoryTests.cs
+++ b/test/e2e/Tests/Tests/GetOrchestrationHistoryTests.cs
@@ -156,6 +156,12 @@ public class GetOrchestrationHistoryTests
             Assert.Equal("ParentOrchestration", subOrchestrationExecutionStartedEvent.ParentInstance.Name);
             Assert.Equal(parentExecutionStartedEvent.OrchestrationInstance.ExecutionId, subOrchestrationExecutionStartedEvent.ParentInstance.OrchestrationInstance.ExecutionId);
         }
+        if (checkTagsAndFailureDetails)
+        {
+            Assert.NotNull(subOrchestrationExecutionStartedEvent.Tags);
+            Assert.Contains(TagsKey, subOrchestrationExecutionStartedEvent.Tags.Keys);
+            Assert.Contains(TagsValue, subOrchestrationExecutionStartedEvent.Tags.Values);
+        }
         Assert.Equal(EventType.TaskScheduled, subOrchestrationHistoryEvents[2].EventType);
         var taskScheduledEvent = (TaskScheduledEvent)subOrchestrationHistoryEvents[2];
         Assert.Equal("ThrowExceptionActivity", taskScheduledEvent.Name);

--- a/test/e2e/Tests/Tests/GetOrchestrationHistoryTests.cs
+++ b/test/e2e/Tests/Tests/GetOrchestrationHistoryTests.cs
@@ -1,0 +1,368 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Net;
+using DurableTask.Core;
+using DurableTask.Core.History;
+using Microsoft.Azure.WebJobs.Extensions.DurableTask;
+using Newtonsoft.Json;
+using Xunit;
+using Xunit.Abstractions;
+using static Microsoft.Azure.Durable.Tests.E2E.GetOrchestrationHistory;
+
+namespace Microsoft.Azure.Durable.Tests.DotnetIsolatedE2E;
+
+[Collection(Constants.FunctionAppCollectionName)]
+public class GetOrchestrationHistoryTests
+{
+    private readonly FunctionAppFixture fixture;
+    private readonly ITestOutputHelper output;
+    // Make the results of the activity/entity calls around 1 MB so the orchestration history exceeds the max limit of the history chunk size (2 MB)
+    // We make it slightly smaller than 1 MB to avoid exceeding the current payload size limit in DTS, but just large enough to force chunking
+    private const int OutputSize = 1024 * 1024 - 5;
+    private const string TagsKey = "key";
+    private const string TagsValue = "value";
+
+    private readonly Dictionary<string, string> tags = new() { { TagsKey, TagsValue } };
+
+    public GetOrchestrationHistoryTests(FunctionAppFixture fixture, ITestOutputHelper testOutputHelper)
+    {
+        this.fixture = fixture;
+        this.fixture.TestLogs.UseTestLogger(testOutputHelper);
+        this.output = testOutputHelper;
+    }
+
+    [Fact]
+    [Trait("Java", "Skip")] // The GetOrchestrationHistory API is not implemented in Java
+    [Trait("Python", "Skip")] // The GetOrchestrationHistory API is not implemented in Python
+    [Trait("PowerShell", "Skip")] // The GetOrchestrationHistory API is not implemented in PowerShell
+    [Trait("Node", "Skip")] // The GetOrchestrationHistory API is not implemented in Node
+    public async Task GetOrchestrationHistory_FailedOrchestration()
+    {
+        bool isNotMSSQL = this.fixture.GetDurabilityProvider() != FunctionAppFixture.ConfiguredDurabilityProviderType.MSSQL;
+        // The other backends currently do not serialize tags when sending the history, or the failure details of an ExecutionCompletedEvent
+        bool checkTagsAndFailureDetails = this.fixture.GetDurabilityProvider() == FunctionAppFixture.ConfiguredDurabilityProviderType.AzureStorage;
+        string subOrchestrationInstanceId = Guid.NewGuid().ToString();
+
+        using HttpResponseMessage response = await HttpHelpers.InvokeHttpTrigger(
+            "GetOrchestrationHistory_HttpStart",
+            $"?orchestrationType=fail&subOrchestrationInstanceId={subOrchestrationInstanceId}&outputSize={OutputSize}&callEntities={isNotMSSQL.ToString().ToLower()}&tagsKey={TagsKey}&tagsValue={TagsValue}");
+        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
+        string instanceId = await DurableHelpers.ParseInstanceIdAsync(response);
+        string statusQueryGetUri = await DurableHelpers.ParseStatusQueryGetUriAsync(response);
+
+        await DurableHelpers.WaitForOrchestrationStateAsync(statusQueryGetUri, "Failed", 30);
+
+        using HttpResponseMessage getOrchestrationHistoryResponse = await HttpHelpers.InvokeHttpTrigger("GetInstanceHistory", $"?instanceId={instanceId}");
+        Assert.Equal(HttpStatusCode.OK, getOrchestrationHistoryResponse.StatusCode);
+        string jsonHistory = await getOrchestrationHistoryResponse.Content.ReadAsStringAsync();
+        List<HistoryEvent>? historyEvents = JsonConvert.DeserializeObject<List<HistoryEvent>>(
+            jsonHistory,
+            new JsonSerializerSettings()
+            {
+                // I had to make the HistoryEventJsonConverter public to use it here. Is this a good reason?
+                Converters = { new HistoryEventJsonConverter() },
+            });
+        Assert.NotNull(historyEvents);
+
+        // Confirm the correct count and sequence of events
+        Assert.Equal(8, historyEvents.Count);
+        Assert.Equal(EventType.OrchestratorStarted, historyEvents[0].EventType);
+        Assert.Equal(EventType.ExecutionStarted, historyEvents[1].EventType);
+
+        // Confirm the fields of the ExecutionStartedEvent (name, orchestration input, and orchestration tags)
+        var parentExecutionStartedEvent = (ExecutionStartedEvent)historyEvents[1];
+        Assert.Equal("ParentOrchestration", parentExecutionStartedEvent.Name);
+        Assert.Equal(new ComplexInput("fail", subOrchestrationInstanceId, OutputSize, isNotMSSQL, this.tags),
+            JsonConvert.DeserializeObject<ComplexInput>(parentExecutionStartedEvent.Input));
+        if (checkTagsAndFailureDetails)
+        {
+            Assert.NotNull(parentExecutionStartedEvent.Tags);
+            Assert.Contains(TagsKey, parentExecutionStartedEvent.Tags.Keys);
+            Assert.Contains(TagsValue, parentExecutionStartedEvent.Tags.Values);
+        }
+
+        Assert.Equal(EventType.SubOrchestrationInstanceCreated, historyEvents[2].EventType);
+        var subOrchestrationInstanceCreatedEvent = (SubOrchestrationInstanceCreatedEvent)historyEvents[2];
+        Assert.Equal("FailSubOrchestration", subOrchestrationInstanceCreatedEvent.Name);
+        // MSSQL does not include the instance ID field in the SubOrchestrationInstanceCreatedEvent
+        if (isNotMSSQL)
+        {
+            Assert.Equal(subOrchestrationInstanceId, subOrchestrationInstanceCreatedEvent.InstanceId);
+        }
+        Assert.Equal(EventType.OrchestratorCompleted, historyEvents[3].EventType);
+
+        Assert.Equal(EventType.OrchestratorStarted, historyEvents[4].EventType);
+        Assert.Equal(EventType.SubOrchestrationInstanceFailed, historyEvents[5].EventType);
+        Assert.Equal(subOrchestrationInstanceCreatedEvent.EventId, ((SubOrchestrationInstanceFailedEvent)historyEvents[5]).TaskScheduledId);
+        Assert.Equal(EventType.ExecutionCompleted, historyEvents[6].EventType);
+        Assert.Equal(EventType.OrchestratorCompleted, historyEvents[7].EventType);
+
+        // Now confirm the failure details field of the SubOrchestrationInstanceFailed and ExecutionCompleted events
+        FailureDetails? parentFailureDetails = ((ExecutionCompletedEvent)historyEvents[6]).FailureDetails;
+        FailureDetails? subOrchestrationFailureDetails = ((SubOrchestrationInstanceFailedEvent)historyEvents[5]).FailureDetails;
+
+        Assert.NotNull(subOrchestrationFailureDetails);
+        Assert.Equal("Microsoft.DurableTask.TaskFailedException", subOrchestrationFailureDetails.ErrorType);
+        Assert.NotNull(subOrchestrationFailureDetails.InnerFailure);
+        // The inner failure for the suborchestration failed event will be the actual exception thrown by the Activity, whereas the inner failure of the
+        // execution completed event will be the suborchestration task failing
+        Assert.Equal("System.Exception", subOrchestrationFailureDetails.InnerFailure.ErrorType);
+        Assert.Equal("Failure!", subOrchestrationFailureDetails.InnerFailure.ErrorMessage);
+
+        if (checkTagsAndFailureDetails)
+        {
+            Assert.NotNull(parentFailureDetails);
+            Assert.Equal("Microsoft.DurableTask.TaskFailedException", parentFailureDetails.ErrorType);
+            Assert.NotNull(parentFailureDetails.InnerFailure);
+            Assert.Equal("Microsoft.DurableTask.TaskFailedException", parentFailureDetails.InnerFailure.ErrorType);
+            Assert.Equal(subOrchestrationFailureDetails.ErrorMessage, parentFailureDetails.InnerFailure.ErrorMessage);
+            // Finally, the doubly nested inner failure of the execution completed event will correspond to the Activity failing
+            Assert.NotNull(parentFailureDetails.InnerFailure.InnerFailure);
+            Assert.Equal("Failure!", parentFailureDetails.InnerFailure.InnerFailure.ErrorMessage);
+        }
+
+        using HttpResponseMessage getSubOrchestrationHistoryResponse = await HttpHelpers.InvokeHttpTrigger("GetInstanceHistory", $"?instanceId={subOrchestrationInstanceId}");
+        Assert.Equal(HttpStatusCode.OK, getSubOrchestrationHistoryResponse.StatusCode);
+        string subOrchestrationJsonHistory = await getSubOrchestrationHistoryResponse.Content.ReadAsStringAsync();
+        List<HistoryEvent>? subOrchestrationHistoryEvents = JsonConvert.DeserializeObject<List<HistoryEvent>>(
+            subOrchestrationJsonHistory,
+            new JsonSerializerSettings()
+            {
+                // I had to make the HistoryEventJsonConverter public to use it here. Is this a good reason?
+                Converters = { new HistoryEventJsonConverter() },
+            });
+        Assert.NotNull(subOrchestrationHistoryEvents);
+
+        // Confirm the correct count and sequence of events for the suborchestration
+        Assert.Equal(8, subOrchestrationHistoryEvents.Count);
+        Assert.Equal(EventType.OrchestratorStarted, subOrchestrationHistoryEvents[0].EventType);
+        Assert.Equal(EventType.ExecutionStarted, subOrchestrationHistoryEvents[1].EventType);
+
+        // Confirm the fields of the ExecutionStartedEvent for the suborchestration (name, orchestration input, parent information, task ID)
+        var subOrchestrationExecutionStartedEvent = (ExecutionStartedEvent)subOrchestrationHistoryEvents[1];
+        Assert.Equal("FailSubOrchestration", subOrchestrationExecutionStartedEvent.Name);
+        Assert.Equal(new ComplexInput(null, subOrchestrationInstanceId, OutputSize, isNotMSSQL, this.tags),
+            JsonConvert.DeserializeObject<ComplexInput>(subOrchestrationExecutionStartedEvent.Input));
+        Assert.Equal(parentExecutionStartedEvent.OrchestrationInstance.InstanceId, subOrchestrationExecutionStartedEvent.ParentInstance.OrchestrationInstance.InstanceId);
+        Assert.Equal(subOrchestrationInstanceCreatedEvent.EventId, subOrchestrationExecutionStartedEvent.ParentInstance.TaskScheduleId);
+        // MSSQL currently only adds the instance ID and task scheduled ID fields to the parent instance object
+        if (isNotMSSQL)
+        {
+            Assert.Equal("ParentOrchestration", subOrchestrationExecutionStartedEvent.ParentInstance.Name);
+            Assert.Equal(parentExecutionStartedEvent.OrchestrationInstance.ExecutionId, subOrchestrationExecutionStartedEvent.ParentInstance.OrchestrationInstance.ExecutionId);
+        }
+
+        Assert.Equal(EventType.TaskScheduled, subOrchestrationHistoryEvents[2].EventType);
+        var taskScheduledEvent = (TaskScheduledEvent)subOrchestrationHistoryEvents[2];
+        Assert.Equal("ThrowExceptionActivity", taskScheduledEvent.Name);
+        if (checkTagsAndFailureDetails)
+        {
+            Assert.NotNull(taskScheduledEvent.Tags);
+            Assert.Contains(TagsKey, taskScheduledEvent.Tags.Keys);
+            Assert.Contains(TagsValue, taskScheduledEvent.Tags.Values);
+        }
+        Assert.Equal(EventType.OrchestratorCompleted, subOrchestrationHistoryEvents[3].EventType);
+
+        Assert.Equal(EventType.OrchestratorStarted, subOrchestrationHistoryEvents[4].EventType);
+        Assert.Equal(EventType.TaskFailed, subOrchestrationHistoryEvents[5].EventType);
+        // Confirm the event ID of the TaskScheduledEvent matches the TaskScheduledId field of the TaskFailedEvent
+        Assert.Equal(taskScheduledEvent.EventId, ((TaskFailedEvent)subOrchestrationHistoryEvents[5]).TaskScheduledId);
+        Assert.Equal(EventType.ExecutionCompleted, subOrchestrationHistoryEvents[6].EventType);
+        Assert.Equal(EventType.OrchestratorCompleted, subOrchestrationHistoryEvents[7].EventType);
+
+        // Now confirm the failure details field of the TaskFailed and ExecutionCompleted events
+        subOrchestrationFailureDetails = ((ExecutionCompletedEvent)subOrchestrationHistoryEvents[6]).FailureDetails;
+        FailureDetails? taskFailureDetails = ((TaskFailedEvent)subOrchestrationHistoryEvents[5]).FailureDetails;
+
+        Assert.NotNull(taskFailureDetails);
+        Assert.Equal("System.Exception", taskFailureDetails.ErrorType);
+        Assert.Equal("Failure!", taskFailureDetails.ErrorMessage);
+
+        if (checkTagsAndFailureDetails)
+        {
+            Assert.NotNull(subOrchestrationFailureDetails);
+            Assert.Equal("Microsoft.DurableTask.TaskFailedException", subOrchestrationFailureDetails.ErrorType);
+            Assert.NotNull(subOrchestrationFailureDetails.InnerFailure);
+            // The inner failure for the suborchestration failed event will be the actual exception thrown by the Activity
+            Assert.Equal(taskFailureDetails.ErrorType, subOrchestrationFailureDetails.InnerFailure.ErrorType);
+            Assert.Equal(taskFailureDetails.ErrorMessage, subOrchestrationFailureDetails.InnerFailure.ErrorMessage);
+        }
+    }
+
+    [Fact]
+    [Trait("Java", "Skip")] // The GetOrchestrationHistory API is not implemented in Java
+    [Trait("Python", "Skip")] // The GetOrchestrationHistory API is not implemented in Python
+    [Trait("PowerShell", "Skip")] // The GetOrchestrationHistory API is not implemented in PowerShell
+    [Trait("Node", "Skip")] // The GetOrchestrationHistory API is not implemented in Node
+    public async Task GetOrchestrationHistory_LargeHistory()
+    {
+        bool isNotMSSQL = this.fixture.GetDurabilityProvider() != FunctionAppFixture.ConfiguredDurabilityProviderType.MSSQL;
+        // The other backends currently do not serialize tags when sending the history, or the failure details of an ExecutionCompletedEvent
+        bool checkTagsAndFailureDetails = this.fixture.GetDurabilityProvider() == FunctionAppFixture.ConfiguredDurabilityProviderType.AzureStorage;
+        string subOrchestrationInstanceId = Guid.NewGuid().ToString();
+
+        using HttpResponseMessage response = await HttpHelpers.InvokeHttpTrigger(
+            "GetOrchestrationHistory_HttpStart",
+            $"?orchestrationType=succeed&subOrchestrationInstanceId={subOrchestrationInstanceId}&outputSize={OutputSize}&callEntities={isNotMSSQL.ToString().ToLower()}&tagsKey={TagsKey}&tagsValue={TagsValue}");
+        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
+        string instanceId = await DurableHelpers.ParseInstanceIdAsync(response);
+        string statusQueryGetUri = await DurableHelpers.ParseStatusQueryGetUriAsync(response);
+
+        await DurableHelpers.WaitForOrchestrationStateAsync(statusQueryGetUri, "Completed", 30);
+
+        using HttpResponseMessage getOrchestrationHistoryResponse = await HttpHelpers.InvokeHttpTrigger("GetInstanceHistory", $"?instanceId={instanceId}");
+        Assert.Equal(HttpStatusCode.OK, getOrchestrationHistoryResponse.StatusCode);
+        string jsonHistory = await getOrchestrationHistoryResponse.Content.ReadAsStringAsync();
+        List<HistoryEvent>? historyEvents = JsonConvert.DeserializeObject<List<HistoryEvent>>(
+            jsonHistory,
+            new JsonSerializerSettings()
+            {
+                // I had to make the HistoryEventJsonConverter public to use it here. Is this a good reason?
+                Converters = { new HistoryEventJsonConverter() },
+            });
+        Assert.NotNull(historyEvents);
+
+        // Confirm the correct count and sequence of events
+        Assert.Equal(8, historyEvents.Count);
+        Assert.Equal(EventType.OrchestratorStarted, historyEvents[0].EventType);
+        Assert.Equal(EventType.ExecutionStarted, historyEvents[1].EventType);
+
+        // Confirm the fields of the ExecutionStartedEvent (name, orchestration input, and orchestration tags)
+        var parentExecutionStartedEvent = (ExecutionStartedEvent)historyEvents[1];
+        Assert.Equal("ParentOrchestration", parentExecutionStartedEvent.Name);
+        Assert.Equal(new ComplexInput("succeed", subOrchestrationInstanceId, OutputSize, isNotMSSQL, this.tags),
+            JsonConvert.DeserializeObject<ComplexInput>(parentExecutionStartedEvent.Input));
+        if (checkTagsAndFailureDetails)
+        {
+            Assert.NotNull(parentExecutionStartedEvent.Tags);
+            Assert.Contains(TagsKey, parentExecutionStartedEvent.Tags.Keys);
+            Assert.Contains(TagsValue, parentExecutionStartedEvent.Tags.Values);
+        }
+
+        Assert.Equal(EventType.SubOrchestrationInstanceCreated, historyEvents[2].EventType);
+        var subOrchestrationInstanceCreatedEvent = (SubOrchestrationInstanceCreatedEvent)historyEvents[2];
+        Assert.Equal("CallLargeOutputTasksSubOrchestration", subOrchestrationInstanceCreatedEvent.Name);
+        // MSSQL does not include the instance ID field in the SubOrchestrationInstanceCreatedEvent
+        if (isNotMSSQL)
+        {
+            Assert.Equal(subOrchestrationInstanceId, subOrchestrationInstanceCreatedEvent.InstanceId);
+        }
+        Assert.Equal(EventType.OrchestratorCompleted, historyEvents[3].EventType);
+
+        Assert.Equal(EventType.OrchestratorStarted, historyEvents[4].EventType);
+        Assert.Equal(EventType.SubOrchestrationInstanceCompleted, historyEvents[5].EventType);
+        Assert.Equal(EventType.ExecutionCompleted, historyEvents[6].EventType);
+        Assert.Equal(EventType.OrchestratorCompleted, historyEvents[7].EventType);
+
+        // Now confirm the fields of the SubOrchestrationInstanceCompleted and ExecutionCompleted events (the result, task ID, and absence of failure details)
+        var executionCompletedEvent = (ExecutionCompletedEvent)historyEvents[6];
+        var subOrchestrationCompletedEvent = (SubOrchestrationInstanceCompletedEvent)historyEvents[5];
+        ComplexInput result = new("succeed", subOrchestrationInstanceId, OutputSize, isNotMSSQL, null);
+        Assert.Null(executionCompletedEvent.FailureDetails);
+        Assert.NotNull(executionCompletedEvent.Result);
+        Assert.Equal(result, JsonConvert.DeserializeObject<ComplexInput>(executionCompletedEvent.Result));
+        Assert.Equal(subOrchestrationInstanceCreatedEvent.EventId, subOrchestrationCompletedEvent.TaskScheduledId);
+        Assert.Equal(result, JsonConvert.DeserializeObject<ComplexInput>(subOrchestrationCompletedEvent.Result));
+
+        // The suborchestration calls Activities/entities with large outputs, so it should force multiple history chunks in the streaming process
+        using HttpResponseMessage getSubOrchestrationHistoryResponse = await HttpHelpers.InvokeHttpTrigger("GetInstanceHistory", $"?instanceId={subOrchestrationInstanceId}");
+        Assert.Equal(HttpStatusCode.OK, getSubOrchestrationHistoryResponse.StatusCode);
+        string subOrchestrationJsonHistory = await getSubOrchestrationHistoryResponse.Content.ReadAsStringAsync();
+        List<HistoryEvent>? subOrchestrationHistoryEvents = JsonConvert.DeserializeObject<List<HistoryEvent>>(
+            subOrchestrationJsonHistory,
+            new JsonSerializerSettings()
+            {
+                // I had to make the HistoryEventJsonConverter public to use it here. Is this a good reason?
+                Converters = { new HistoryEventJsonConverter() },
+            });
+        Assert.NotNull(subOrchestrationHistoryEvents);
+
+        // Confirm the correct count and sequence of events for the suborchestration
+        Assert.Equal(isNotMSSQL ? 17 : 12, subOrchestrationHistoryEvents.Count);
+        Assert.Equal(EventType.OrchestratorStarted, subOrchestrationHistoryEvents[0].EventType);
+        Assert.Equal(EventType.ExecutionStarted, subOrchestrationHistoryEvents[1].EventType);
+
+        // Confirm the fields of the ExecutionStartedEvent for the suborchestration (name, orchestration input, parent information, task ID)
+        var subOrchestrationExecutionStartedEvent = (ExecutionStartedEvent)subOrchestrationHistoryEvents[1];
+        Assert.Equal("CallLargeOutputTasksSubOrchestration", subOrchestrationExecutionStartedEvent.Name);
+        Assert.Equal(result, JsonConvert.DeserializeObject<ComplexInput>(subOrchestrationExecutionStartedEvent.Input));
+        Assert.Equal(parentExecutionStartedEvent.OrchestrationInstance.InstanceId, subOrchestrationExecutionStartedEvent.ParentInstance.OrchestrationInstance.InstanceId);
+        Assert.Equal(subOrchestrationInstanceCreatedEvent.EventId, subOrchestrationExecutionStartedEvent.ParentInstance.TaskScheduleId);
+        // MSSQL currently only adds the instance ID and task scheduled ID fields to the parent instance object
+        if (isNotMSSQL)
+        {
+            Assert.Equal("ParentOrchestration", subOrchestrationExecutionStartedEvent.ParentInstance.Name);
+            Assert.Equal(parentExecutionStartedEvent.OrchestrationInstance.ExecutionId, subOrchestrationExecutionStartedEvent.ParentInstance.OrchestrationInstance.ExecutionId);
+        }
+
+        Assert.Equal(EventType.TaskScheduled, subOrchestrationHistoryEvents[2].EventType);
+        Assert.Equal("LargeOutputActivity", ((TaskScheduledEvent)subOrchestrationHistoryEvents[2]).Name);
+        Assert.Equal(EventType.OrchestratorCompleted, subOrchestrationHistoryEvents[3].EventType);
+
+        Assert.Equal(EventType.OrchestratorStarted, subOrchestrationHistoryEvents[4].EventType);
+        Assert.Equal(EventType.TaskCompleted, subOrchestrationHistoryEvents[5].EventType);
+        var taskCompletedEvent = (TaskCompletedEvent)subOrchestrationHistoryEvents[5];
+        // Confirm the event ID of the TaskScheduledEvent matches the TaskScheduledId field of the TaskCompletedEvent
+        Assert.Equal(subOrchestrationHistoryEvents[2].EventId, taskCompletedEvent.TaskScheduledId);
+        Assert.Equal($"\"{new string('a', OutputSize)}\"", taskCompletedEvent.Result);
+
+        ExecutionCompletedEvent subOrchestrationExecutionCompletedEvent;
+        if (isNotMSSQL)
+        {
+            Assert.Equal(EventType.EventSent, subOrchestrationHistoryEvents[6].EventType);
+            Assert.Equal(entityId.ToString(), ((EventSentEvent)subOrchestrationHistoryEvents[6]).InstanceId);
+            Assert.Equal(EventType.TimerCreated, subOrchestrationHistoryEvents[7].EventType);
+            Assert.Equal(EventType.OrchestratorCompleted, subOrchestrationHistoryEvents[8].EventType);
+
+            Assert.Equal(EventType.OrchestratorStarted, subOrchestrationHistoryEvents[9].EventType);
+            Assert.Equal(EventType.TimerFired, subOrchestrationHistoryEvents[10].EventType);
+            // Confirm the event ID of the TimerCreatedEvent matches the TimerId field of the TimerFiredEvent
+            Assert.Equal(subOrchestrationHistoryEvents[7].EventId, ((TimerFiredEvent)subOrchestrationHistoryEvents[10]).TimerId);
+            Assert.Equal(EventType.EventSent, subOrchestrationHistoryEvents[11].EventType);
+            Assert.Equal(entityId.ToString(), ((EventSentEvent)subOrchestrationHistoryEvents[11]).InstanceId);
+            Assert.Equal(EventType.OrchestratorCompleted, subOrchestrationHistoryEvents[12].EventType);
+
+            Assert.Equal(EventType.OrchestratorStarted, subOrchestrationHistoryEvents[13].EventType);
+            Assert.Equal(EventType.EventRaised, subOrchestrationHistoryEvents[14].EventType);
+            Assert.Equal(EventType.ExecutionCompleted, subOrchestrationHistoryEvents[15].EventType);
+            Assert.Equal(EventType.OrchestratorCompleted, subOrchestrationHistoryEvents[16].EventType);
+            subOrchestrationExecutionCompletedEvent = (ExecutionCompletedEvent)subOrchestrationHistoryEvents[15];
+        }
+        else
+        {
+            Assert.Equal(EventType.TaskScheduled, subOrchestrationHistoryEvents[6].EventType);
+            Assert.Equal("LargeOutputActivity", ((TaskScheduledEvent)subOrchestrationHistoryEvents[6]).Name);
+            Assert.Equal(EventType.OrchestratorCompleted, subOrchestrationHistoryEvents[7].EventType);
+
+            Assert.Equal(EventType.OrchestratorStarted, subOrchestrationHistoryEvents[8].EventType);
+            taskCompletedEvent = (TaskCompletedEvent)subOrchestrationHistoryEvents[9];
+            // Confirm the event ID of the TaskScheduledEvent matches the TaskScheduledId field of the TaskCompletedEvent
+            Assert.Equal(subOrchestrationHistoryEvents[6].EventId, taskCompletedEvent.TaskScheduledId);
+            Assert.Equal($"\"{new string('a', OutputSize)}\"", taskCompletedEvent.Result);
+            Assert.Equal(EventType.ExecutionCompleted, subOrchestrationHistoryEvents[10].EventType);
+            Assert.Equal(EventType.OrchestratorCompleted, subOrchestrationHistoryEvents[11].EventType);
+            subOrchestrationExecutionCompletedEvent = (ExecutionCompletedEvent)subOrchestrationHistoryEvents[10];
+        }
+
+        // Confirm the details of the ExecutionCompleted event for the suborchestration (the result and absence of failure details)
+        Assert.Null(subOrchestrationExecutionCompletedEvent.FailureDetails);
+        Assert.NotNull(subOrchestrationExecutionCompletedEvent.Result);
+        Assert.Equal(result, JsonConvert.DeserializeObject<ComplexInput>(subOrchestrationExecutionCompletedEvent.Result));
+    }
+
+    [Fact]
+    [Trait("Java", "Skip")] // The GetOrchestrationHistory API is not implemented in Java
+    [Trait("Python", "Skip")] // The GetOrchestrationHistory API is not implemented in Python
+    [Trait("PowerShell", "Skip")] // The GetOrchestrationHistory API is not implemented in PowerShell
+    [Trait("Node", "Skip")] // The GetOrchestrationHistory API is not implemented in Node
+    public async Task GetOrchestrationHistory_InvalidInstanceId_ThrowsArgumentException()
+    {
+        string nonExistentInstanceId = Guid.NewGuid().ToString();
+        HttpResponseMessage getOrchestrationHistoryResponse = await HttpHelpers.InvokeHttpTrigger("GetInstanceHistory", $"?instanceId={nonExistentInstanceId}");
+        Assert.Equal(HttpStatusCode.NotFound, getOrchestrationHistoryResponse.StatusCode);
+        getOrchestrationHistoryResponse = await HttpHelpers.InvokeHttpTrigger("GetInstanceHistory", $"?instanceId={entityId}");
+        Assert.Equal(HttpStatusCode.NotFound, getOrchestrationHistoryResponse.StatusCode);
+        getOrchestrationHistoryResponse.Dispose();
+    }
+}

--- a/test/e2e/Tests/Tests/GetOrchestrationHistoryTests.cs
+++ b/test/e2e/Tests/Tests/GetOrchestrationHistoryTests.cs
@@ -370,8 +370,11 @@ public class GetOrchestrationHistoryTests
     public async Task GetOrchestrationHistory_InvalidInstanceId_ThrowsArgumentException()
     {
         string nonExistentInstanceId = Guid.NewGuid().ToString();
+        // Try to get the history for a non-existent orchestration instance ID
         HttpResponseMessage getOrchestrationHistoryResponse = await HttpHelpers.InvokeHttpTrigger("GetInstanceHistory", $"?instanceId={nonExistentInstanceId}");
         Assert.Equal(HttpStatusCode.NotFound, getOrchestrationHistoryResponse.StatusCode);
+        getOrchestrationHistoryResponse.Dispose();
+        // Try to get the history for an entity instance ID
         getOrchestrationHistoryResponse = await HttpHelpers.InvokeHttpTrigger("GetInstanceHistory", $"?instanceId={entityId}");
         Assert.Equal(HttpStatusCode.NotFound, getOrchestrationHistoryResponse.StatusCode);
         getOrchestrationHistoryResponse.Dispose();


### PR DESCRIPTION
<!-- Start the PR description with some context for the change. -->
This PR introduces the server-side implementation of a new API to retrieve orchestration history in .NET isolated. The client-side implementation is in this [PR](https://github.com/microsoft/durabletask-dotnet/pull/516).

The server-side call is implemented in the `TaskHubGrpcServer`. We also introduce a new method to stream the orchestration history in the `DurabilityProvider`. If the backend (so far only DTS) has an orchestration history streaming API implemented, then we will use that. If not, we will fall back to the "old method" (retrieving a JSON string of the orchestration history, deserializing it, converting it to protos, and sending that). 

[PR](https://msazure.visualstudio.com/One/_git/AAPT-DTMB/pullrequest/14211671?path=/src/SDK/Microsoft.DurableTask.AzureManagedBackend/AzureManagedOrchestrationService.cs) to expose the history streaming API in the orchestration service in DTS (currently in draft-mode until the new WebJobs package is released).

<!-- Make sure to delete the markdown comments and the below sections when squash merging -->
### Issue describing the changes in this PR

resolves #issue_for_this_pr

### Pull request checklist

* [ ] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)
* [ ] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk
* [ ] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
    * [ ] Otherwise: major or minor version updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
* [ ] My changes **do not** add EventIds to our EventSource logs
    * [ ] Otherwise: Ensure the EventIds are within the supported range in our existing Windows infrastructure. You may validate this with a deployed app's telemetry. You may also extend the range by completing a PR such as [this one](https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files).
* [ ] My changes **should** be added to **v2.x** branch.
    * [ ] Otherwise: This change applies exclusively to WebJobs.Extensions.DurableTask v3.x. It will be retained only in the `dev` and `main` branches and will not be merged into the `v2.x` branch.
