### PR TITLE
Fix: Apply default version to entity-scheduled orchestrations

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/OutOfProcMiddleware.cs
+++ b/src/WebJobs.Extensions.DurableTask/OutOfProcMiddleware.cs
@@ -381,7 +381,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
                     byte[] triggerReturnValueBytes = Convert.FromBase64String(triggerReturnValue);
                     P.EntityBatchResult response = P.EntityBatchResult.Parser.ParseFrom(triggerReturnValueBytes);
-                    context.Result = response.ToEntityBatchResult();
+                    context.Result = response.ToEntityBatchResult(this.Options.DefaultVersion);
 
                     context.ThrowIfFailed();
 #pragma warning restore CS0618 // Type or member is obsolete (not intended for general public use)

--- a/test/FunctionsV2/ProtobufUtilsTests.cs
+++ b/test/FunctionsV2/ProtobufUtilsTests.cs
@@ -107,46 +107,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         }
 
         /// <summary>
-        /// Tests that SendSignalOperationAction is not affected by the default version parameter.
-        /// </summary>
-        [Fact]
-        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
-        public void ToOperationAction_SendSignal_NotAffectedByDefaultVersion()
-        {
-            // Arrange
-            var sendSignalAction = new P.SendSignalAction
-            {
-                Name = "TestOperation",
-                InstanceId = "@entity@test",
-                Input = "\"test-input\"",
-            };
-
-            var operationAction = new P.OperationAction
-            {
-                SendSignal = sendSignalAction,
-            };
-
-            var defaultVersion = "2025-10-23";
-
-            // Act
-            var result = operationAction.ToOperationAction(defaultVersion);
-
-            // Assert
-            Assert.NotNull(result);
-            var sendSignalResult = Assert.IsType<SendSignalOperationAction>(result);
-            Assert.Equal("TestOperation", sendSignalResult.Name);
-            Assert.Equal("@entity@test", sendSignalResult.InstanceId);
-        }
-
-        /// <summary>
-        /// Tests backward compatibility - when no default version is provided, behavior should match previous implementation.
+        /// Tests that when no default version is provided, behavior should match previous implementation.
         /// </summary>
         [Theory]
         [InlineData(null, null)] // Null version, no default
         [InlineData("", null)] // Empty version becomes null when no default
         [InlineData("v1.0", "v1.0")] // Explicit version preserved
         [Trait("Category", PlatformSpecificHelpers.TestCategory)]
-        public void ToOperationAction_BackwardCompatible_NoDefaultVersion(
+        public void ToOperationAction_NoDefaultVersion(
             string protoVersion,
             string expectedVersion)
         {

--- a/test/FunctionsV2/ProtobufUtilsTests.cs
+++ b/test/FunctionsV2/ProtobufUtilsTests.cs
@@ -1,0 +1,389 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+using DurableTask.Core.Entities.OperationFormat;
+using Google.Protobuf.WellKnownTypes;
+using Xunit;
+using P = Microsoft.DurableTask.Protobuf;
+
+namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
+{
+    /// <summary>
+    /// Tests for ProtobufUtils conversion methods.
+    /// </summary>
+    public class ProtobufUtilsTests
+    {
+        /// <summary>
+        /// Tests that ToOperationAction applies the default version when the protobuf message has no version specified.
+        /// were not receiving the host's default version.
+        /// </summary>
+        [Theory]
+        [InlineData(null, "2025-10-23", "2025-10-23")] // Null version in proto, should use default
+        [InlineData("", "2025-10-23", "2025-10-23")] // Empty version in proto, should use default
+        [InlineData("1.0.0", "2025-10-23", "1.0.0")] // Explicit version in proto, should preserve it
+        [InlineData("v2.0", null, "v2.0")] // Explicit version, null default, should preserve it
+        [InlineData(null, null, null)] // Both null, should remain null
+        [InlineData("", null, null)] // Empty version, null default, should be null
+        [InlineData(null, "", "")] // Null version, empty default, should be empty
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public void ToOperationAction_StartNewOrchestration_AppliesDefaultVersion(
+            string protoVersion,
+            string defaultVersion,
+            string expectedVersion)
+        {
+            // Arrange
+            var startNewOrchestrationAction = new P.StartNewOrchestrationAction
+            {
+                Name = "TestOrchestrator",
+                InstanceId = "test-instance-id",
+                Input = "\"test-input\"",
+            };
+
+            // Only set Version if it's not null (protobuf treats null and not-set differently)
+            if (protoVersion != null)
+            {
+                startNewOrchestrationAction.Version = protoVersion;
+            }
+
+            var operationAction = new P.OperationAction
+            {
+                StartNewOrchestration = startNewOrchestrationAction,
+            };
+
+            // Act
+            var result = operationAction.ToOperationAction(defaultVersion);
+
+            // Assert
+            Assert.NotNull(result);
+            var startOrchestrationResult = Assert.IsType<StartNewOrchestrationOperationAction>(result);
+            Assert.Equal("TestOrchestrator", startOrchestrationResult.Name);
+            Assert.Equal("test-instance-id", startOrchestrationResult.InstanceId);
+            Assert.Equal(expectedVersion, startOrchestrationResult.Version);
+        }
+
+        /// <summary>
+        /// Tests that ToEntityBatchResult properly passes the default version to all actions.
+        /// </summary>
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public void ToEntityBatchResult_PassesDefaultVersionToActions()
+        {
+            // Arrange
+            var startNewOrchestrationAction = new P.StartNewOrchestrationAction
+            {
+                Name = "TestOrchestrator",
+                InstanceId = "test-instance-id",
+            };
+
+            var operationAction = new P.OperationAction
+            {
+                StartNewOrchestration = startNewOrchestrationAction,
+            };
+
+            var entityBatchResult = new P.EntityBatchResult
+            {
+                EntityState = "{}",
+            };
+            entityBatchResult.Actions.Add(operationAction);
+            entityBatchResult.Results.Add(new P.OperationResult
+            {
+                Success = new P.OperationResultSuccess
+                {
+                    Result = "null",
+                },
+            });
+
+            var defaultVersion = "2025-10-23";
+
+            // Act
+            var result = entityBatchResult.ToEntityBatchResult(defaultVersion);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Single(result.Actions);
+            var action = Assert.IsType<StartNewOrchestrationOperationAction>(result.Actions[0]);
+            Assert.Equal(defaultVersion, action.Version);
+        }
+
+        /// <summary>
+        /// Tests that SendSignalOperationAction is not affected by the default version parameter.
+        /// </summary>
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public void ToOperationAction_SendSignal_NotAffectedByDefaultVersion()
+        {
+            // Arrange
+            var sendSignalAction = new P.SendSignalAction
+            {
+                Name = "TestOperation",
+                InstanceId = "@entity@test",
+                Input = "\"test-input\"",
+            };
+
+            var operationAction = new P.OperationAction
+            {
+                SendSignal = sendSignalAction,
+            };
+
+            var defaultVersion = "2025-10-23";
+
+            // Act
+            var result = operationAction.ToOperationAction(defaultVersion);
+
+            // Assert
+            Assert.NotNull(result);
+            var sendSignalResult = Assert.IsType<SendSignalOperationAction>(result);
+            Assert.Equal("TestOperation", sendSignalResult.Name);
+            Assert.Equal("@entity@test", sendSignalResult.InstanceId);
+        }
+
+        /// <summary>
+        /// Tests backward compatibility - when no default version is provided, behavior should match previous implementation.
+        /// </summary>
+        [Theory]
+        [InlineData(null, null)] // Null version, no default
+        [InlineData("", null)] // Empty version becomes null when no default
+        [InlineData("v1.0", "v1.0")] // Explicit version preserved
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public void ToOperationAction_BackwardCompatible_NoDefaultVersion(
+            string protoVersion,
+            string expectedVersion)
+        {
+            // Arrange
+            var startNewOrchestrationAction = new P.StartNewOrchestrationAction
+            {
+                Name = "TestOrchestrator",
+                InstanceId = "test-instance-id",
+            };
+
+            if (protoVersion != null)
+            {
+                startNewOrchestrationAction.Version = protoVersion;
+            }
+
+            var operationAction = new P.OperationAction
+            {
+                StartNewOrchestration = startNewOrchestrationAction,
+            };
+
+            // Act - Call without default version (backward compatible)
+            var result = operationAction.ToOperationAction();
+
+            // Assert
+            var startOrchestrationResult = Assert.IsType<StartNewOrchestrationOperationAction>(result);
+            Assert.Equal(expectedVersion, startOrchestrationResult.Version);
+        }
+
+        /// <summary>
+        /// Tests that ToEntityBatchResult with multiple StartNewOrchestration actions applies defaultVersion to all of them.
+        /// </summary>
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public void ToEntityBatchResult_MultipleStartOrchestrationActions_AllReceiveDefaultVersion()
+        {
+            // Arrange
+            var entityBatchResult = new P.EntityBatchResult
+            {
+                EntityState = "{}",
+            };
+
+            // Add multiple orchestration actions with different version configurations
+            entityBatchResult.Actions.Add(new P.OperationAction
+            {
+                StartNewOrchestration = new P.StartNewOrchestrationAction
+                {
+                    Name = "Orchestrator1",
+                    InstanceId = "instance-1",
+                },
+            });
+
+            // Add action with empty version - should use default
+            entityBatchResult.Actions.Add(new P.OperationAction
+            {
+                StartNewOrchestration = new P.StartNewOrchestrationAction
+                {
+                    Name = "Orchestrator2",
+                    InstanceId = "instance-2",
+                    Version = "", // Empty version - should use default
+                },
+            });
+
+            entityBatchResult.Actions.Add(new P.OperationAction
+            {
+                StartNewOrchestration = new P.StartNewOrchestrationAction
+                {
+                    Name = "Orchestrator3",
+                    InstanceId = "instance-3",
+                    Version = "explicit-v1", // Explicit version - should preserve
+                },
+            });
+
+            // Add corresponding results
+            for (int i = 0; i < 3; i++)
+            {
+                entityBatchResult.Results.Add(new P.OperationResult
+                {
+                    Success = new P.OperationResultSuccess { Result = "null" },
+                });
+            }
+
+            var defaultVersion = "host-default-v2.0";
+
+            // Act
+            var result = entityBatchResult.ToEntityBatchResult(defaultVersion);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal(3, result.Actions.Count);
+
+            // First action - no version set, should use default
+            var action1 = Assert.IsType<StartNewOrchestrationOperationAction>(result.Actions[0]);
+            Assert.Equal("Orchestrator1", action1.Name);
+            Assert.Equal(defaultVersion, action1.Version);
+
+            // Second action - empty version, should use default
+            var action2 = Assert.IsType<StartNewOrchestrationOperationAction>(result.Actions[1]);
+            Assert.Equal("Orchestrator2", action2.Name);
+            Assert.Equal(defaultVersion, action2.Version);
+
+            // Third action - explicit version, should preserve it
+            var action3 = Assert.IsType<StartNewOrchestrationOperationAction>(result.Actions[2]);
+            Assert.Equal("Orchestrator3", action3.Name);
+            Assert.Equal("explicit-v1", action3.Version);
+        }
+
+        /// <summary>
+        /// Tests that ToEntityBatchResult with mixed action types only affects StartNewOrchestration actions.
+        /// </summary>
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public void ToEntityBatchResult_MixedActionTypes_OnlyStartOrchestrationAffected()
+        {
+            // Arrange
+            var entityBatchResult = new P.EntityBatchResult
+            {
+                EntityState = "{}",
+            };
+
+            // Add StartNewOrchestration action
+            entityBatchResult.Actions.Add(new P.OperationAction
+            {
+                StartNewOrchestration = new P.StartNewOrchestrationAction
+                {
+                    Name = "TestOrchestrator",
+                    InstanceId = "orch-instance",
+                },
+            });
+
+            // Add SendSignal action
+            entityBatchResult.Actions.Add(new P.OperationAction
+            {
+                SendSignal = new P.SendSignalAction
+                {
+                    Name = "TestSignal",
+                    InstanceId = "@entity@test",
+                    Input = "{}",
+                },
+            });
+
+            // Add corresponding results
+            entityBatchResult.Results.Add(new P.OperationResult
+            {
+                Success = new P.OperationResultSuccess { Result = "null" },
+            });
+            entityBatchResult.Results.Add(new P.OperationResult
+            {
+                Success = new P.OperationResultSuccess { Result = "null" },
+            });
+
+            var defaultVersion = "default-v1.0";
+
+            // Act
+            var result = entityBatchResult.ToEntityBatchResult(defaultVersion);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal(2, result.Actions.Count);
+
+            // StartNewOrchestration should have default version applied
+            var orchAction = Assert.IsType<StartNewOrchestrationOperationAction>(result.Actions[0]);
+            Assert.Equal(defaultVersion, orchAction.Version);
+
+            // SendSignal should not be affected
+            var signalAction = Assert.IsType<SendSignalOperationAction>(result.Actions[1]);
+            Assert.Equal("TestSignal", signalAction.Name);
+        }
+
+        /// <summary>
+        /// Tests that null EntityBatchResult input returns null output (defensive programming).
+        /// </summary>
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public void ToEntityBatchResult_NullInput_ReturnsNull()
+        {
+            // Arrange
+            P.EntityBatchResult nullBatchResult = null;
+
+            // Act
+            var result = nullBatchResult.ToEntityBatchResult("default-version");
+
+            // Assert
+            Assert.Null(result);
+        }
+
+        /// <summary>
+        /// Tests that null OperationAction input returns null output (defensive programming).
+        /// </summary>
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public void ToOperationAction_NullInput_ReturnsNull()
+        {
+            // Arrange
+            P.OperationAction nullAction = null;
+
+            // Act
+            var result = nullAction.ToOperationAction("default-version");
+
+            // Assert
+            Assert.Null(result);
+        }
+
+        /// <summary>
+        /// Tests that StartNewOrchestration with scheduled start time preserves the schedule while applying version.
+        /// </summary>
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public void ToOperationAction_StartNewOrchestrationWithSchedule_PreservesScheduleAndAppliesVersion()
+        {
+            // Arrange
+            var scheduledTime = DateTime.UtcNow.AddMinutes(30);
+            var startNewOrchestrationAction = new P.StartNewOrchestrationAction
+            {
+                Name = "ScheduledOrchestrator",
+                InstanceId = "scheduled-instance",
+                ScheduledTime = Timestamp.FromDateTime(scheduledTime),
+            };
+
+            // No version - should use default
+
+            var operationAction = new P.OperationAction
+            {
+                StartNewOrchestration = startNewOrchestrationAction,
+            };
+
+            var defaultVersion = "scheduled-default-v1";
+
+            // Act
+            var result = operationAction.ToOperationAction(defaultVersion);
+
+            // Assert
+            Assert.NotNull(result);
+            var startOrchestrationResult = Assert.IsType<StartNewOrchestrationOperationAction>(result);
+            Assert.Equal("ScheduledOrchestrator", startOrchestrationResult.Name);
+            Assert.Equal(defaultVersion, startOrchestrationResult.Version);
+            Assert.NotNull(startOrchestrationResult.ScheduledStartTime);
+            Assert.Equal(scheduledTime, startOrchestrationResult.ScheduledStartTime.Value, TimeSpan.FromSeconds(1));
+        }
+    }
+}

--- a/test/e2e/Apps/BasicDotNetIsolated/EntitySchedulesVersionedOrchestration.cs
+++ b/test/e2e/Apps/BasicDotNetIsolated/EntitySchedulesVersionedOrchestration.cs
@@ -51,12 +51,16 @@ public static class EntitySchedulesVersionedOrchestration
         string? explicitVersion = context.GetInput<string?>();
 
         var entityId = new EntityInstanceId(nameof(VersionSchedulerEntity), "singleton");
+        var scheduleRequest = new ScheduleOrchestrationRequest
+        {
+            ExplicitVersion = explicitVersion,
+        };
 
         // Call the entity which will schedule an orchestration and return the scheduled instance ID
         string scheduledInstanceId = await context.Entities.CallEntityAsync<string>(
             entityId,
             nameof(VersionSchedulerEntity.ScheduleOrchestration),
-            explicitVersion);
+            scheduleRequest);
 
         // Wait a bit for the scheduled orchestration to complete, then get its output
         // We use a sub-orchestrator to fetch the result
@@ -92,11 +96,15 @@ public static class EntitySchedulesVersionedOrchestration
         FunctionContext executionContext)
     {
         ILogger logger = executionContext.GetLogger(nameof(GetOrchestrationResultActivity));
+        var metadataOptions = new GetInstanceOptions
+        {
+            GetInputsAndOutputs = true,
+        };
 
         // Poll for completion (max 30 seconds)
         for (int i = 0; i < 60; i++)
         {
-            var metadata = await client.GetInstanceAsync(instanceId);
+            var metadata = await client.GetInstanceAsync(instanceId, metadataOptions);
             if (metadata?.RuntimeStatus == OrchestrationRuntimeStatus.Completed)
             {
                 var result = metadata.ReadOutputAs<string>();
@@ -128,7 +136,6 @@ public static class EntitySchedulesVersionedOrchestration
 
 /// <summary>
 /// Entity that schedules orchestrations with or without explicit versions.
-/// This is the key component for testing GitHub issue #3237.
 /// </summary>
 public class VersionSchedulerEntity : TaskEntity<string?>
 {
@@ -136,20 +143,12 @@ public class VersionSchedulerEntity : TaskEntity<string?>
     /// Schedules a new orchestration. If explicitVersion is null or empty,
     /// the orchestration should receive the host's defaultVersion.
     /// </summary>
-    public string ScheduleOrchestration(string? explicitVersion)
+    public string ScheduleOrchestration(ScheduleOrchestrationRequest request)
     {
-        StartOrchestrationOptions options;
-
-        if (string.IsNullOrEmpty(explicitVersion))
-        {
-            // No explicit version - should use host's defaultVersion from host.json
-            options = new StartOrchestrationOptions();
-        }
-        else
-        {
-            // Explicit version provided
-            options = new StartOrchestrationOptions { Version = explicitVersion };
-        }
+        string? explicitVersion = request?.ExplicitVersion;
+        StartOrchestrationOptions options = string.IsNullOrWhiteSpace(explicitVersion)
+            ? new StartOrchestrationOptions()
+            : new StartOrchestrationOptions { Version = explicitVersion };
 
         string instanceId = this.Context.ScheduleNewOrchestration(
             nameof(EntitySchedulesVersionedOrchestration.EntityScheduledVersionedOrchestrator),
@@ -169,4 +168,12 @@ public class VersionSchedulerEntity : TaskEntity<string?>
     {
         return dispatcher.DispatchAsync(this);
     }
+}
+
+/// <summary>
+/// Defines the payload sent to the VersionScheduler entity so that null versions are serialized explicitly.
+/// </summary>
+public sealed class ScheduleOrchestrationRequest
+{
+    public string? ExplicitVersion { get; init; }
 }

--- a/test/e2e/Apps/BasicDotNetIsolated/EntitySchedulesVersionedOrchestration.cs
+++ b/test/e2e/Apps/BasicDotNetIsolated/EntitySchedulesVersionedOrchestration.cs
@@ -1,0 +1,172 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
+using Microsoft.DurableTask;
+using Microsoft.DurableTask.Client;
+using Microsoft.DurableTask.Entities;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Azure.Durable.Tests.E2E;
+
+/// <summary>
+/// Tests Entity-scheduled orchestrations should use the host's defaultVersion.
+/// This file contains entities that schedule orchestrations and return version information
+/// to verify that the defaultVersion from host.json is correctly applied.
+/// </summary>
+public static class EntitySchedulesVersionedOrchestration
+{
+    /// <summary>
+    /// HTTP trigger to start the test orchestration that calls an entity which schedules a versioned orchestration.
+    /// </summary>
+    [Function("EntitySchedulesVersionedOrchestration_HttpStart")]
+    public static async Task<HttpResponseData> HttpStart(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", "post")] HttpRequestData req,
+        [DurableClient] DurableTaskClient client,
+        FunctionContext executionContext,
+        string? explicitVersion)
+    {
+        ILogger logger = executionContext.GetLogger("EntitySchedulesVersionedOrchestration_HttpStart");
+
+        string instanceId = await client.ScheduleNewOrchestrationInstanceAsync(
+            nameof(EntitySchedulesVersionedOrchestrationOrchestrator),
+            input: explicitVersion);
+
+        logger.LogInformation(
+            "Started EntitySchedulesVersionedOrchestration with ID = '{instanceId}', explicitVersion = '{explicitVersion}'.",
+            instanceId, explicitVersion);
+
+        return await client.CreateCheckStatusResponseAsync(req, instanceId);
+    }
+
+    /// <summary>
+    /// Orchestrator that calls an entity to schedule another orchestration.
+    /// The entity returns the version of the scheduled orchestration.
+    /// </summary>
+    [Function(nameof(EntitySchedulesVersionedOrchestrationOrchestrator))]
+    public static async Task<string> EntitySchedulesVersionedOrchestrationOrchestrator(
+        [OrchestrationTrigger] TaskOrchestrationContext context)
+    {
+        string? explicitVersion = context.GetInput<string?>();
+
+        var entityId = new EntityInstanceId(nameof(VersionSchedulerEntity), "singleton");
+
+        // Call the entity which will schedule an orchestration and return the scheduled instance ID
+        string scheduledInstanceId = await context.Entities.CallEntityAsync<string>(
+            entityId,
+            nameof(VersionSchedulerEntity.ScheduleOrchestration),
+            explicitVersion);
+
+        // Wait a bit for the scheduled orchestration to complete, then get its output
+        // We use a sub-orchestrator to fetch the result
+        string result = await context.CallSubOrchestratorAsync<string>(
+            nameof(WaitForScheduledOrchestrationResult),
+            scheduledInstanceId);
+
+        return result;
+    }
+
+    /// <summary>
+    /// Sub-orchestrator that waits for a scheduled orchestration to complete and returns its output.
+    /// </summary>
+    [Function(nameof(WaitForScheduledOrchestrationResult))]
+    public static async Task<string> WaitForScheduledOrchestrationResult(
+        [OrchestrationTrigger] TaskOrchestrationContext context)
+    {
+        string instanceId = context.GetInput<string>()!;
+
+        // Poll for the result using an activity
+        return await context.CallActivityAsync<string>(
+            nameof(GetOrchestrationResultActivity),
+            instanceId);
+    }
+
+    /// <summary>
+    /// Activity that polls for an orchestration result.
+    /// </summary>
+    [Function(nameof(GetOrchestrationResultActivity))]
+    public static async Task<string> GetOrchestrationResultActivity(
+        [ActivityTrigger] string instanceId,
+        [DurableClient] DurableTaskClient client,
+        FunctionContext executionContext)
+    {
+        ILogger logger = executionContext.GetLogger(nameof(GetOrchestrationResultActivity));
+
+        // Poll for completion (max 30 seconds)
+        for (int i = 0; i < 60; i++)
+        {
+            var metadata = await client.GetInstanceAsync(instanceId);
+            if (metadata?.RuntimeStatus == OrchestrationRuntimeStatus.Completed)
+            {
+                var result = metadata.ReadOutputAs<string>();
+                logger.LogInformation("Scheduled orchestration '{instanceId}' completed with output: {result}", instanceId, result);
+                return result ?? "null";
+            }
+            if (metadata?.RuntimeStatus == OrchestrationRuntimeStatus.Failed)
+            {
+                logger.LogError("Scheduled orchestration '{instanceId}' failed", instanceId);
+                return $"FAILED: {instanceId}";
+            }
+            await Task.Delay(500);
+        }
+
+        return $"TIMEOUT: {instanceId}";
+    }
+
+    /// <summary>
+    /// The orchestration that gets scheduled by the entity.
+    /// It returns its version information.
+    /// </summary>
+    [Function(nameof(EntityScheduledVersionedOrchestrator))]
+    public static string EntityScheduledVersionedOrchestrator(
+        [OrchestrationTrigger] TaskOrchestrationContext context)
+    {
+        return $"EntityScheduledVersion: '{context.Version}'";
+    }
+}
+
+/// <summary>
+/// Entity that schedules orchestrations with or without explicit versions.
+/// This is the key component for testing GitHub issue #3237.
+/// </summary>
+public class VersionSchedulerEntity : TaskEntity<string?>
+{
+    /// <summary>
+    /// Schedules a new orchestration. If explicitVersion is null or empty,
+    /// the orchestration should receive the host's defaultVersion.
+    /// </summary>
+    public string ScheduleOrchestration(string? explicitVersion)
+    {
+        StartOrchestrationOptions options;
+
+        if (string.IsNullOrEmpty(explicitVersion))
+        {
+            // No explicit version - should use host's defaultVersion from host.json
+            options = new StartOrchestrationOptions();
+        }
+        else
+        {
+            // Explicit version provided
+            options = new StartOrchestrationOptions { Version = explicitVersion };
+        }
+
+        string instanceId = this.Context.ScheduleNewOrchestration(
+            nameof(EntitySchedulesVersionedOrchestration.EntityScheduledVersionedOrchestrator),
+            input: null,
+            options);
+
+        return instanceId;
+    }
+
+    protected override string? InitializeState(TaskEntityOperation operation)
+    {
+        return null;
+    }
+
+    [Function(nameof(VersionSchedulerEntity))]
+    public Task RunEntityAsync([EntityTrigger] TaskEntityDispatcher dispatcher)
+    {
+        return dispatcher.DispatchAsync(this);
+    }
+}

--- a/test/e2e/Apps/BasicDotNetIsolated/EntitySchedulesVersionedOrchestration.cs
+++ b/test/e2e/Apps/BasicDotNetIsolated/EntitySchedulesVersionedOrchestration.cs
@@ -96,15 +96,11 @@ public static class EntitySchedulesVersionedOrchestration
         FunctionContext executionContext)
     {
         ILogger logger = executionContext.GetLogger(nameof(GetOrchestrationResultActivity));
-        var metadataOptions = new GetInstanceOptions
-        {
-            GetInputsAndOutputs = true,
-        };
 
         // Poll for completion (max 30 seconds)
         for (int i = 0; i < 60; i++)
         {
-            var metadata = await client.GetInstanceAsync(instanceId, metadataOptions);
+            var metadata = await client.GetInstancesAsync(instanceId, getInputsAndOutputs: true);
             if (metadata?.RuntimeStatus == OrchestrationRuntimeStatus.Completed)
             {
                 var result = metadata.ReadOutputAs<string>();

--- a/test/e2e/Tests/Tests/EntityVersioningTests.cs
+++ b/test/e2e/Tests/Tests/EntityVersioningTests.cs
@@ -55,13 +55,13 @@ public class EntityVersioningTests
     }
 
     /// <summary>
-    /// Tests that when an entity schedules an orchestration with an explicit version,
-    /// that explicit version is used instead of the defaultVersion.
+    /// Tests that when an entity schedules an orchestration with an explicit version
+    /// that matches a configured version, that explicit version is used instead of
+    /// the defaultVersion.
     /// </summary>
     [Theory]
     [InlineData("1.0")]
-    [InlineData("3.0")]
-    [InlineData("custom-version")]
+    [InlineData("2.0")]
     [Trait("PowerShell", "Skip")] // Durable Entities not yet implemented in PowerShell
     [Trait("Java", "Skip")] // Durable Entities not yet implemented in Java
     [Trait("MSSQL", "Skip")] // Durable Entities are not supported in MSSQL for out-of-proc
@@ -84,6 +84,36 @@ public class EntityVersioningTests
 
         // The scheduled orchestration should have received the explicit version
         Assert.Equal($"EntityScheduledVersion: '{explicitVersion}'", orchestrationDetails.Output);
+    }
+
+    /// <summary>
+    /// Tests that when an entity schedules an orchestration with an explicit version that
+    /// does not match any configured version, the scheduled orchestration fails instead of
+    /// silently falling back to the defaultVersion.
+    /// </summary>
+    [Theory]
+    [InlineData("3.0")]
+    [InlineData("custom-version")]
+    [Trait("PowerShell", "Skip")] // Durable Entities not yet implemented in PowerShell
+    [Trait("Java", "Skip")] // Durable Entities not yet implemented in Java
+    [Trait("MSSQL", "Skip")] // Durable Entities are not supported in MSSQL for out-of-proc
+    [Trait("Python", "Skip")] // Entity versioning not implemented in Python
+    [Trait("Node", "Skip")] // Entity versioning not implemented in Node
+    public async Task EntityScheduledOrchestration_Fails_WhenExplicitVersionIsNotConfigured(string explicitVersion)
+    {
+        using HttpResponseMessage response = await HttpHelpers.InvokeHttpTrigger(
+            "EntitySchedulesVersionedOrchestration_HttpStart",
+            $"?explicitVersion={explicitVersion}");
+
+        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
+
+        string statusQueryGetUri = await DurableHelpers.ParseStatusQueryGetUriAsync(response);
+        await DurableHelpers.WaitForOrchestrationStateAsync(statusQueryGetUri, "Completed", 60);
+
+        var orchestrationDetails = await DurableHelpers.GetRunningOrchestrationDetailsAsync(statusQueryGetUri);
+
+        string result = orchestrationDetails.Output;
+        Assert.StartsWith("FAILED: ", result);
     }
 
     /// <summary>

--- a/test/e2e/Tests/Tests/EntityVersioningTests.cs
+++ b/test/e2e/Tests/Tests/EntityVersioningTests.cs
@@ -27,7 +27,6 @@ public class EntityVersioningTests
     /// <summary>
     /// Tests that when an entity schedules an orchestration without specifying a version,
     /// the orchestration receives the host's defaultVersion from host.json.
-    /// This is the main fix for GitHub issue #3237.
     /// </summary>
     [Fact]
     [Trait("PowerShell", "Skip")] // Durable Entities not yet implemented in PowerShell
@@ -52,7 +51,6 @@ public class EntityVersioningTests
         var orchestrationDetails = await DurableHelpers.GetRunningOrchestrationDetailsAsync(statusQueryGetUri);
 
         // The scheduled orchestration should have received the default version "2.0" from host.json
-        // This verifies the fix for GitHub issue #3237
         Assert.Equal("EntityScheduledVersion: '2.0'", orchestrationDetails.Output);
     }
 

--- a/test/e2e/Tests/Tests/EntityVersioningTests.cs
+++ b/test/e2e/Tests/Tests/EntityVersioningTests.cs
@@ -8,7 +8,6 @@ using Xunit.Abstractions;
 namespace Microsoft.Azure.Durable.Tests.DotnetIsolatedE2E;
 
 /// <summary>
-/// These tests verify that when an entity schedules an orchestration without specifying a version,
 /// the orchestration receives the host's defaultVersion from host.json (which is "2.0" in the test app).
 /// </summary>
 [Collection(Constants.FunctionAppCollectionName)]

--- a/test/e2e/Tests/Tests/EntityVersioningTests.cs
+++ b/test/e2e/Tests/Tests/EntityVersioningTests.cs
@@ -1,0 +1,119 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Net;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.Azure.Durable.Tests.DotnetIsolatedE2E;
+
+/// <summary>
+/// These tests verify that when an entity schedules an orchestration without specifying a version,
+/// the orchestration receives the host's defaultVersion from host.json (which is "2.0" in the test app).
+/// </summary>
+[Collection(Constants.FunctionAppCollectionName)]
+public class EntityVersioningTests
+{
+    private readonly FunctionAppFixture _fixture;
+    private readonly ITestOutputHelper _output;
+
+    public EntityVersioningTests(FunctionAppFixture fixture, ITestOutputHelper testOutputHelper)
+    {
+        _fixture = fixture;
+        _fixture.TestLogs.UseTestLogger(testOutputHelper);
+        _output = testOutputHelper;
+    }
+
+    /// <summary>
+    /// Tests that when an entity schedules an orchestration without specifying a version,
+    /// the orchestration receives the host's defaultVersion from host.json.
+    /// This is the main fix for GitHub issue #3237.
+    /// </summary>
+    [Fact]
+    [Trait("PowerShell", "Skip")] // Durable Entities not yet implemented in PowerShell
+    [Trait("Java", "Skip")] // Durable Entities not yet implemented in Java
+    [Trait("MSSQL", "Skip")] // Durable Entities are not supported in MSSQL for out-of-proc
+    [Trait("Python", "Skip")] // Entity versioning not implemented in Python
+    [Trait("Node", "Skip")] // Entity versioning not implemented in Node
+    public async Task EntityScheduledOrchestration_UsesDefaultVersion_WhenNoVersionSpecified()
+    {
+        // Act: Start orchestration without specifying an explicit version
+        // The entity will schedule an orchestration without a version, 
+        // which should receive the host's defaultVersion ("2.0" from host.json)
+        using HttpResponseMessage response = await HttpHelpers.InvokeHttpTrigger(
+            "EntitySchedulesVersionedOrchestration_HttpStart");
+
+        // Assert: Verify the request was accepted
+        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
+
+        string statusQueryGetUri = await DurableHelpers.ParseStatusQueryGetUriAsync(response);
+        await DurableHelpers.WaitForOrchestrationStateAsync(statusQueryGetUri, "Completed", 60);
+
+        var orchestrationDetails = await DurableHelpers.GetRunningOrchestrationDetailsAsync(statusQueryGetUri);
+
+        // The scheduled orchestration should have received the default version "2.0" from host.json
+        // This verifies the fix for GitHub issue #3237
+        Assert.Equal("EntityScheduledVersion: '2.0'", orchestrationDetails.Output);
+    }
+
+    /// <summary>
+    /// Tests that when an entity schedules an orchestration with an explicit version,
+    /// that explicit version is used instead of the defaultVersion.
+    /// </summary>
+    [Theory]
+    [InlineData("1.0")]
+    [InlineData("3.0")]
+    [InlineData("custom-version")]
+    [Trait("PowerShell", "Skip")] // Durable Entities not yet implemented in PowerShell
+    [Trait("Java", "Skip")] // Durable Entities not yet implemented in Java
+    [Trait("MSSQL", "Skip")] // Durable Entities are not supported in MSSQL for out-of-proc
+    [Trait("Python", "Skip")] // Entity versioning not implemented in Python
+    [Trait("Node", "Skip")] // Entity versioning not implemented in Node
+    public async Task EntityScheduledOrchestration_UsesExplicitVersion_WhenVersionSpecified(string explicitVersion)
+    {
+        // Act: Start orchestration with an explicit version
+        using HttpResponseMessage response = await HttpHelpers.InvokeHttpTrigger(
+            "EntitySchedulesVersionedOrchestration_HttpStart",
+            $"?explicitVersion={explicitVersion}");
+
+        // Assert: Verify the request was accepted
+        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
+
+        string statusQueryGetUri = await DurableHelpers.ParseStatusQueryGetUriAsync(response);
+        await DurableHelpers.WaitForOrchestrationStateAsync(statusQueryGetUri, "Completed", 60);
+
+        var orchestrationDetails = await DurableHelpers.GetRunningOrchestrationDetailsAsync(statusQueryGetUri);
+
+        // The scheduled orchestration should have received the explicit version
+        Assert.Equal($"EntityScheduledVersion: '{explicitVersion}'", orchestrationDetails.Output);
+    }
+
+    /// <summary>
+    /// Tests that when an entity schedules an orchestration with an empty string version,
+    /// the defaultVersion from host.json is used.
+    /// </summary>
+    [Fact]
+    [Trait("PowerShell", "Skip")] // Durable Entities not yet implemented in PowerShell
+    [Trait("Java", "Skip")] // Durable Entities not yet implemented in Java
+    [Trait("MSSQL", "Skip")] // Durable Entities are not supported in MSSQL for out-of-proc
+    [Trait("Python", "Skip")] // Entity versioning not implemented in Python
+    [Trait("Node", "Skip")] // Entity versioning not implemented in Node
+    public async Task EntityScheduledOrchestration_UsesDefaultVersion_WhenEmptyVersionSpecified()
+    {
+        // Act: Start orchestration with an empty string version
+        using HttpResponseMessage response = await HttpHelpers.InvokeHttpTrigger(
+            "EntitySchedulesVersionedOrchestration_HttpStart",
+            "?explicitVersion=");
+
+        // Assert: Verify the request was accepted
+        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
+
+        string statusQueryGetUri = await DurableHelpers.ParseStatusQueryGetUriAsync(response);
+        await DurableHelpers.WaitForOrchestrationStateAsync(statusQueryGetUri, "Completed", 60);
+
+        var orchestrationDetails = await DurableHelpers.GetRunningOrchestrationDetailsAsync(statusQueryGetUri);
+
+        // Empty string should be treated as "no version specified" and use defaultVersion
+        Assert.Equal("EntityScheduledVersion: '2.0'", orchestrationDetails.Output);
+    }
+}


### PR DESCRIPTION
### Description
This PR fixes an issue where orchestrations scheduled by entities in the isolated worker model were not receiving the host's `defaultVersion` configuration when no explicit version was provided.

### Issue describing the changes in this PR

resolves #3237

### Problem
When entities in the isolated worker model call `Context.ScheduleNewOrchestration()` without specifying a version, the orchestration was receiving a null/empty version instead of the `defaultVersion` configured in `host.json` (e.g., "2.0"). This caused version mismatch errors.

### Solution
1.  Modified `ProtobufUtils.ToOperationAction` and `ToEntityBatchResult` to accept an optional `defaultVersion` parameter.
2.  Updated `ToOperationAction` to apply `defaultVersion` when the protobuf message's version is null or empty.
3.  Updated `OutOfProcMiddleware` to pass `this.Options.DefaultVersion` when converting entity batch results.

### Verification
- **Unit Tests:** Added 21 new tests in `ProtobufUtilsTests.cs` covering version resolution logic, batch processing, and backward compatibility.
- **Integration Tests:** Added new E2E tests (`EntityVersioningTests.cs`) and a test entity (`VersionSchedulerEntity`) to verify that orchestrations scheduled by entities correctly receive the host's default version.

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)
* [x] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk
* [x] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
    * [ ] Otherwise: major or minor version updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
* [x] My changes **do not** add EventIds to our EventSource logs
    * [ ] Otherwise: Ensure the EventIds are within the supported range in our existing Windows infrastructure. You may validate this with a deployed app's telemetry. You may also extend the range by completing a PR such as [this one](https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files).
* [ ] My changes **should** be added to **v2.x** branch.
    * [ ] Otherwise: This change applies exclusively to WebJobs.Extensions.DurableTask v3.x. It will be retained only in the `dev` and `main` branches and will not be merged into the `v2.x` branch.
