### PR TITLE
Add Tags to CreateSubOrchestrationAction

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/Grpc/Protos/orchestrator_service.proto
+++ b/src/WebJobs.Extensions.DurableTask/Grpc/Protos/orchestrator_service.proto
@@ -276,6 +276,7 @@ message CreateSubOrchestrationAction {
     google.protobuf.StringValue version = 3;
     google.protobuf.StringValue input = 4;
     TraceContext parentTraceContext = 5;
+    map<string, string> tags = 6;
 }
 
 message CreateTimerAction {
@@ -356,6 +357,13 @@ message OrchestratorResponse {
 
     // Whether or not a history is required to complete the original OrchestratorRequest and none was provided.
     bool requiresHistory = 7;
+
+    // True if this is a partial (chunked) completion. The backend must keep the work item open until the final chunk (isPartial=false).
+    bool isPartial = 8;
+
+    // Zero-based position of the current chunk within a chunked completion sequence.
+    // This field is omitted for non-chunked completions.
+    google.protobuf.Int32Value chunkIndex = 9;
 }
 
 message CreateInstanceRequest {
@@ -797,6 +805,16 @@ enum WorkerCapability {
     // When set, the service may return work items without any history events as an optimization.
     // It is strongly recommended that all SDKs support this capability.
     WORKER_CAPABILITY_HISTORY_STREAMING = 1;
+
+    // Indicates that the worker supports scheduled tasks.
+    // The service may send schedule-triggered orchestration work items,
+    // and the worker must handle them, including the scheduledTime field.
+    WORKER_CAPABILITY_SCHEDULED_TASKS = 2;
+
+    // Signals that the worker can handle large payloads stored externally (e.g., Blob Storage).
+    // Work items may contain URI references instead of inline data, and the worker must fetch them.
+    // This avoids message size limits and reduces network overhead.
+    WORKER_CAPABILITY_LARGE_PAYLOADS = 3;
 }
 
 message WorkItem {

--- a/src/WebJobs.Extensions.DurableTask/Grpc/Protos/versions.txt
+++ b/src/WebJobs.Extensions.DurableTask/Grpc/Protos/versions.txt
@@ -1,2 +1,2 @@
-# The following files were downloaded from branch main at 2025-11-05 19:08:35 UTC
-https://raw.githubusercontent.com/microsoft/durabletask-protobuf/8c0d166673593700cfa9d0b123cd55e025b2846e/protos/orchestrator_service.proto
+# The following files were downloaded from branch main at 2025-12-12 01:50:12 UTC
+https://raw.githubusercontent.com/microsoft/durabletask-protobuf/b03c06dea21952dcf2a86551fd761b6b78c64d15/protos/orchestrator_service.proto

--- a/src/WebJobs.Extensions.DurableTask/ProtobufUtils.cs
+++ b/src/WebJobs.Extensions.DurableTask/ProtobufUtils.cs
@@ -260,7 +260,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                         Input = a.CreateSubOrchestration.Input,
                         Name = a.CreateSubOrchestration.Name,
                         InstanceId = a.CreateSubOrchestration.InstanceId,
-                        Tags = null, // TODO
+                        Tags = a.CreateSubOrchestration.Tags.ToDictionary(),
                         Version = a.CreateSubOrchestration.Version,
                     };
                 case P.OrchestratorAction.OrchestratorActionTypeOneofCase.CreateTimer:


### PR DESCRIPTION
<!-- Start the PR description with some context for the change. -->
This small PR deserializes the new tags field from the `CreateSubOrchestrationAction` proto to enable adding user tags to suborchestrations.

<!-- Make sure to delete the markdown comments and the below sections when squash merging -->
### Issue describing the changes in this PR

resolves #issue_for_this_pr

### Pull request checklist

* [ ] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)
* [ ] My changes **do not** require any extra work to be leveraged by OutOfProc SDKs
    * [ ] Otherwise: That work is being tracked here: #issue_or_pr_in_each_sdk
* [ ] My changes **do not** change the version of the WebJobs.Extensions.DurableTask package
    * [ ] Otherwise: major or minor version updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
* [ ] My changes **do not** add EventIds to our EventSource logs
    * [ ] Otherwise: Ensure the EventIds are within the supported range in our existing Windows infrastructure. You may validate this with a deployed app's telemetry. You may also extend the range by completing a PR such as [this one](https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files).
* [ ] My changes **should** be added to **v2.x** branch.
    * [ ] Otherwise: This change applies exclusively to WebJobs.Extensions.DurableTask v3.x. It will be retained only in the `dev` and `main` branches and will not be merged into the `v2.x` branch.
