### PR TITLE
Add New AzureStorage "UseInstanceTableEtag" Option

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,9 +13,9 @@
     <PackageVersion Include="Grpc.Net.Client" Version="2.71.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.WebApiCompatShim" Version="2.2.0" />
-    <PackageVersion Include="Microsoft.Azure.DurableTask.ApplicationInsights" Version="0.8.0" />
-    <PackageVersion Include="Microsoft.Azure.DurableTask.AzureStorage" Version="2.7.0" />
-    <PackageVersion Include="Microsoft.Azure.DurableTask.Core" Version="3.6.0" />
+    <PackageVersion Include="Microsoft.Azure.DurableTask.ApplicationInsights" Version="0.8.1" />
+    <PackageVersion Include="Microsoft.Azure.DurableTask.AzureStorage" Version="2.7.1" />
+    <PackageVersion Include="Microsoft.Azure.DurableTask.Core" Version="3.6.1" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Core" Version="2.2.0" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Abstractions" Version="1.3.0" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Storage.Blobs" Version="6.7.0" />

--- a/src/WebJobs.Extensions.DurableTask/AzureStorageDurabilityProviderFactory.cs
+++ b/src/WebJobs.Extensions.DurableTask/AzureStorageDurabilityProviderFactory.cs
@@ -223,6 +223,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 #pragma warning restore CS0618 // Type or member is obsolete
                 PartitionTableOperationTimeout = this.azureStorageOptions.PartitionTableOperationTimeout,
                 QueueClientMessageEncoding = this.azureStorageOptions.QueueClientMessageEncoding,
+                UseInstanceTableEtag = this.azureStorageOptions.UseInstanceTableEtag,
             };
 
             if (this.inConsumption)

--- a/src/WebJobs.Extensions.DurableTask/Options/AzureStorageOptions.cs
+++ b/src/WebJobs.Extensions.DurableTask/Options/AzureStorageOptions.cs
@@ -241,6 +241,23 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         public QueueClientMessageEncoding QueueClientMessageEncoding { get; set; } = QueueClientMessageEncoding.UTF8;
 
         /// <summary>
+        /// When true, an etag is used when attempting to make instance table updates upon completing an orchestration work item.
+        /// </summary>
+        /// <remarks>
+        /// By default, etags are only used when updating the history table upon completing an orchestration work item. This can lead 
+        /// to subtle race conditions where the instance table is incorrectly updated. Consider the following scenario:
+        /// 1. Worker A completes an orchestration work item, sends outgoing messages, updates the history table, then stalls.
+        /// 2. Worker B picks up the next and final orchestration work item for the same instance and completes it, updating the history 
+        /// table and instance table with the new terminal status.
+        /// 3. Worker A resumes and overrides the terminal status in the instance table with an incorrect non-terminal status.
+        /// This will leave the instance status of the orchestration permanently as "Running" even though it has actually completed.
+        /// To prevent such scenarios, enabling this setting will ensure that instance table updates also use etags. This would prevent
+        /// worker A's update in step 3 from completing. Enabling this setting will also introduce a performance overhead since the instance
+        /// table must now be read before processing every orchestration work item to obtain the latest etag.
+        /// </remarks>
+        public bool UseInstanceTableEtag { get; set; } = false;
+
+        /// <summary>
         /// Throws an exception if the provided hub name violates any naming conventions for the storage provider.
         /// </summary>
         public void ValidateHubName(string hubName)

--- a/src/WebJobs.Extensions.DurableTask/Options/AzureStorageOptions.cs
+++ b/src/WebJobs.Extensions.DurableTask/Options/AzureStorageOptions.cs
@@ -244,10 +244,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// When true, an etag is used when attempting to make instance table updates upon completing an orchestration work item.
         /// </summary>
         /// <remarks>
-        /// By default, etags are only used when updating the history table upon completing an orchestration work item. This can lead 
+        /// By default, etags are only used when updating the history table upon completing an orchestration work item. This can lead
         /// to subtle race conditions where the instance table is incorrectly updated. Consider the following scenario:
         /// 1. Worker A completes an orchestration work item, sends outgoing messages, updates the history table, then stalls.
-        /// 2. Worker B picks up the next and final orchestration work item for the same instance and completes it, updating the history 
+        /// 2. Worker B picks up the next and final orchestration work item for the same instance and completes it, updating the history
         /// table and instance table with the new terminal status.
         /// 3. Worker A resumes and overrides the terminal status in the instance table with an incorrect non-terminal status.
         /// This will leave the instance status of the orchestration permanently as "Running" even though it has actually completed.

--- a/src/Worker.Extensions.DurableTask/AssemblyInfo.cs
+++ b/src/Worker.Extensions.DurableTask/AssemblyInfo.cs
@@ -5,5 +5,5 @@ using System.Runtime.CompilerServices;
 using Microsoft.Azure.Functions.Worker.Extensions.Abstractions;
 
 // TODO: Find a way to generate this dynamically at build-time
-[assembly: ExtensionInformation("Microsoft.Azure.WebJobs.Extensions.DurableTask", "3.8.1")]
+[assembly: ExtensionInformation("Microsoft.Azure.WebJobs.Extensions.DurableTask", "3.8.2")]
 [assembly: InternalsVisibleTo("Worker.Extensions.DurableTask.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100cd1dabd5a893b40e75dc901fe7293db4a3caf9cd4d3e3ed6178d49cd476969abe74a9e0b7f4a0bb15edca48758155d35a4f05e6e852fff1b319d103b39ba04acbadd278c2753627c95e1f6f6582425374b92f51cca3deb0d2aab9de3ecda7753900a31f70a236f163006beefffe282888f85e3c76d1205ec7dfef7fa472a17b1")]

--- a/src/Worker.Extensions.DurableTask/AssemblyInfo.cs
+++ b/src/Worker.Extensions.DurableTask/AssemblyInfo.cs
@@ -5,5 +5,5 @@ using System.Runtime.CompilerServices;
 using Microsoft.Azure.Functions.Worker.Extensions.Abstractions;
 
 // TODO: Find a way to generate this dynamically at build-time
-[assembly: ExtensionInformation("Microsoft.Azure.WebJobs.Extensions.DurableTask", "3.8.2")]
+[assembly: ExtensionInformation("Microsoft.Azure.WebJobs.Extensions.DurableTask", "3.8.1")]
 [assembly: InternalsVisibleTo("Worker.Extensions.DurableTask.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100cd1dabd5a893b40e75dc901fe7293db4a3caf9cd4d3e3ed6178d49cd476969abe74a9e0b7f4a0bb15edca48758155d35a4f05e6e852fff1b319d103b39ba04acbadd278c2753627c95e1f6f6582425374b92f51cca3deb0d2aab9de3ecda7753900a31f70a236f163006beefffe282888f85e3c76d1205ec7dfef7fa472a17b1")]

--- a/src/Worker.Extensions.DurableTask/Worker.Extensions.DurableTask.csproj
+++ b/src/Worker.Extensions.DurableTask/Worker.Extensions.DurableTask.csproj
@@ -29,7 +29,7 @@
     <AssemblyOriginatorKeyFile>..\..\sign.snk</AssemblyOriginatorKeyFile>
 
     <!-- Version information -->
-    <VersionPrefix>1.12.0</VersionPrefix>
+    <VersionPrefix>1.10.1</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <AssemblyVersion>$(VersionPrefix).0</AssemblyVersion>
     <!-- FileVersionRevision is expected to be set by the CI.  -->


### PR DESCRIPTION
# Summary
## What changed?
This PR introduces the option to specify the "UseInstanceTableEtag" option in host.json and bumps the DT.Core dependencies to leverage this new option.

## Why is this change needed?
This makes it possible for customers to leverage the new `AzureStorageOrchestrationServiceOptions.UseInstanceTableEtag` setting, elaborated on in this [PR](https://github.com/Azure/durabletask/pull/1280).

# Project checklist
- [x] Documentation changes are not required
  - [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
- [ ] Release notes are not required for the next release
  - [x] Otherwise: Notes added to `release_notes.md`
- [x] Backport is not required
  - [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
- [x] All required tests have been added/updated (unit tests, E2E tests)
- [x] No extra work is required to be leveraged by OutOfProc SDKs
  - [ ] Otherwise: Work tracked here: #issue_or_pr_in_each_sdk
- [ ] No change to the version of the `WebJobs.Extensions.DurableTask` package
  - [x] Otherwise: Major/minor updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
- [x] No EventIds were added to `EventSource` logs
  - [ ] Otherwise: Ensure EventIds are within the supported range in the existing Windows infrastructure (validate via deployed telemetry). If needed, extend the range via a PR such as https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files
- [ ] This change should be added to the `v2.x` branch
  - [ ] Otherwise: This change applies exclusively to `WebJobs.Extensions.DurableTask` v3.x and will be retained only in the `dev` and `main` branches
- [ ] Breaking change?
  - [ ] If yes:
    - Impact:
    - Migration guidance:
---

# AI-assisted code disclosure (required)
## Was an AI tool used? (select one)
- [x] No
- [ ] Yes, AI helped write parts of this PR (e.g., GitHub Copilot)
- [ ] Yes, an AI agent generated most of this PR

If AI was used:
- Tool(s):
- AI-assisted areas/files:
- What you changed after AI output:

AI verification (required if AI was used):
- [ ] I understand the code and can explain it
- [ ] I verified referenced APIs/types exist and are correct
- [ ] I reviewed edge cases/failure paths (timeouts, retries, cancellation, exceptions)
- [ ] I reviewed concurrency/async behavior
- [ ] I checked for unintended breaking or behavior changes

---

# Testing

## Manual validation (only if runtime/behavior changed)
- Environment (OS, .NET version, components):
- Steps + observed results:
1. Tried setting the "useInstanceTableEtag" option to true and false in host.json and confirmed that the corresponding setting in `AzureStorageOrchestrationServiceOptions` was set accordingly, i.e.
  
```
    "extensions": {
        "durableTask": {
            "storageProvider": {
                "useInstanceTableEtag": false
            }
        }
    }
```
Also confirmed that if nothing is specified the default is used (false).


# Notes for reviewers
- N/A
