### PR TITLE
Adding `GetFunctionContext` extension method on `TaskOrchestrationContext`

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -4,6 +4,8 @@
 
 ### New Features
 
+- Add `GetFunctionContext` extension method on `TaskOrchestrationContext` to retrieve the underlying `FunctionContext` in Azure Functions orchestrations.
+
 ### Bug Fixes
 
 - Check if function invocation already has an executor before registering durable executor. (#3265)

--- a/src/Worker.Extensions.DurableTask/FunctionsOrchestrationContext.cs
+++ b/src/Worker.Extensions.DurableTask/FunctionsOrchestrationContext.cs
@@ -26,6 +26,8 @@ internal sealed partial class FunctionsOrchestrationContext : TaskOrchestrationC
     private InputConverter? inputConverter;
     private EntityFeature? entities;
 
+    internal FunctionContext FunctionContext => this.functionContext;
+
     public FunctionsOrchestrationContext(TaskOrchestrationContext innerContext, FunctionContext functionContext)
     {
         this.innerContext = innerContext;

--- a/src/Worker.Extensions.DurableTask/TaskOrchestrationContextExtensionMethods.cs
+++ b/src/Worker.Extensions.DurableTask/TaskOrchestrationContextExtensionMethods.cs
@@ -8,6 +8,7 @@ using System.Net.Http;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Extensions.DurableTask;
 using Microsoft.Azure.Functions.Worker.Extensions.DurableTask.Http;
 using Microsoft.Extensions.Logging;
@@ -166,6 +167,32 @@ public static class TaskOrchestrationContextExtensionMethods
         };
 
         return context.CallHttpAsync(request);
+    }
+
+    /// <summary>
+    /// Gets the <see cref="FunctionContext"/> associated with the current orchestration context.
+    /// </summary>
+    /// <remarks>
+    /// This method is intended for use in Azure Functions environments where additional function-level
+    /// context is needed. If the <paramref name="context"/> is not backed by an Azure Functions
+    /// orchestration, the method returns <c>null</c>.
+    /// </remarks>
+    /// <param name="context">The <see cref="TaskOrchestrationContext"/> from which to obtain the <see cref="FunctionContext"/>.</param>
+    /// <returns>The <see cref="FunctionContext"/> if available; otherwise, <c>null</c>.</returns>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="context"/> is <c>null</c>.</exception>
+    public static FunctionContext? GetFunctionContext(this TaskOrchestrationContext context)
+    {
+        if (context is null)
+        {
+            throw new ArgumentNullException(nameof(context));
+        }
+
+        if (context is FunctionsOrchestrationContext functionsContext)
+        {
+            return functionsContext.FunctionContext;
+        }
+
+        return null;
     }
 
     private static DurableHttpRequest CreateLocationPollRequest(DurableHttpRequest durableHttpRequest, string locationUri)

--- a/src/Worker.Extensions.DurableTask/Worker.Extensions.DurableTask.csproj
+++ b/src/Worker.Extensions.DurableTask/Worker.Extensions.DurableTask.csproj
@@ -29,7 +29,7 @@
     <AssemblyOriginatorKeyFile>..\..\sign.snk</AssemblyOriginatorKeyFile>
 
     <!-- Version information -->
-    <VersionPrefix>1.13.1</VersionPrefix>
+    <VersionPrefix>1.13.2</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <AssemblyVersion>$(VersionPrefix).0</AssemblyVersion>
     <!-- FileVersionRevision is expected to be set by the CI.  -->

--- a/src/Worker.Extensions.DurableTask/Worker.Extensions.DurableTask.csproj
+++ b/src/Worker.Extensions.DurableTask/Worker.Extensions.DurableTask.csproj
@@ -29,7 +29,7 @@
     <AssemblyOriginatorKeyFile>..\..\sign.snk</AssemblyOriginatorKeyFile>
 
     <!-- Version information -->
-    <VersionPrefix>1.13.2</VersionPrefix>
+    <VersionPrefix>1.14.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <AssemblyVersion>$(VersionPrefix).0</AssemblyVersion>
     <!-- FileVersionRevision is expected to be set by the CI.  -->

--- a/test/Worker.Extensions.DurableTask.Tests/TaskOrchestrationContextExtensionMethodsTests.cs
+++ b/test/Worker.Extensions.DurableTask.Tests/TaskOrchestrationContextExtensionMethodsTests.cs
@@ -1,0 +1,80 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Text.Json;
+using Microsoft.Azure.Functions.Worker.Extensions.DurableTask;
+using Microsoft.DurableTask;
+using Microsoft.DurableTask.Worker;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+
+namespace Microsoft.Azure.Functions.Worker.Tests;
+
+public class TaskOrchestrationContextExtensionMethodsTests
+{
+    [Fact]
+    public void GetFunctionContext_WithNullContext_ShouldThrowArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            TaskOrchestrationContextExtensionMethods.GetFunctionContext(null!));
+    }
+
+    [Fact]
+    public void GetFunctionContext_WithFunctionsOrchestrationContext_ShouldReturnFunctionContext()
+    {
+        FunctionContext expectedFunctionContext = CreateMockFunctionContext();
+        TaskOrchestrationContext innerContext = CreateMockTaskOrchestrationContext();
+        FunctionsOrchestrationContext functionsContext = CreateFunctionsOrchestrationContext(innerContext, expectedFunctionContext);
+
+        FunctionContext? result = functionsContext.GetFunctionContext();
+
+        Assert.NotNull(result);
+        Assert.Same(expectedFunctionContext, result);
+    }
+
+    [Fact]
+    public void GetFunctionContext_WithNonFunctionsOrchestrationContext_ShouldReturnNull()
+    {
+        TaskOrchestrationContext context = CreateMockTaskOrchestrationContext();
+
+        FunctionContext? result = context.GetFunctionContext();
+
+        Assert.Null(result);
+    }
+
+    private static FunctionContext CreateMockFunctionContext()
+    {
+        var serviceCollection = new ServiceCollection();
+        serviceCollection.AddSingleton<ILoggerFactory>(NullLoggerFactory.Instance);
+        serviceCollection.AddSingleton(Options.Create(new DurableTaskWorkerOptions()));
+        serviceCollection.AddSingleton(Options.Create(new JsonSerializerOptions()));
+        IServiceProvider serviceProvider = serviceCollection.BuildServiceProvider();
+
+        var mockFunctionContext = new Mock<FunctionContext>();
+        mockFunctionContext.Setup(c => c.InstanceServices).Returns(serviceProvider);
+
+        return mockFunctionContext.Object;
+    }
+
+    private static TaskOrchestrationContext CreateMockTaskOrchestrationContext()
+    {
+        var mockContext = new Mock<TaskOrchestrationContext>();
+        mockContext.Setup(c => c.Name).Returns(new TaskName("TestOrchestration"));
+        mockContext.Setup(c => c.InstanceId).Returns("test-instance-id");
+        mockContext.Setup(c => c.CurrentUtcDateTime).Returns(DateTime.UtcNow);
+        mockContext.Setup(c => c.IsReplaying).Returns(false);
+        mockContext.Setup(c => c.Properties).Returns(new Dictionary<string, object?>());
+
+        return mockContext.Object;
+    }
+
+    private static FunctionsOrchestrationContext CreateFunctionsOrchestrationContext(
+        TaskOrchestrationContext innerContext,
+        FunctionContext functionContext)
+    {
+        return new FunctionsOrchestrationContext(innerContext, functionContext);
+    }
+}


### PR DESCRIPTION
# Summary

Adding `GetFunctionContext` extension method on `TaskOrchestrationContext`. This returns the `FunctionsContext` instance if the orchestrationcontext is running in Functions hosting context.


## Why is this change needed?
We need to retrieve a registered dependency from the DI container. This can be done via the `InstanceServices` property on FunctionContext. The `AddOrchestratorFunc` is used to register the orchestration to support scenarios where we override the function executor with our custom executor. In those cases, the `TaskOrchestrationContext` parameter fails to bind when used as a function input parameter (because that binding happens in the [DurableFunctionExecutor](https://github.com/Azure/azure-functions-durable-extension/blob/9eec0855d6ae0a57230bca9df0e86d73a2e71170/src/Worker.Extensions.DurableTask/Execution/DurableFunctionExecutor.Orchestration.cs#L24-L39)), particularly for Microsoft Agent Framework support scenarios.
```
functionApplicationBuilder.ConfigureDurableWorker().AddTasks(tasks =>
{
    tasks.AddOrchestratorFunc<string, string>(
        "MyCustomOrchestration",
        async (orchestrationContext, request) =>
        {
            FunctionContext functionContext = orchestrationContext.GetFunctionContext()
                ?? throw new InvalidOperationException("FunctionContext is not available!.");

            var runner = functionContext.InstanceServices.GetRequiredService<DurableWorkflowRunner>();
            ILogger logger = orchestrationContext.CreateReplaySafeLogger("MyCustomOrchestration");

            return await runner.RunWorkflowOrchestrationAsync(orchestrationContext, request, logger);
        });
});
``` 

## Issues / work items
n/a

---

# Project checklist
- [ ] Documentation changes are not required
  - [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
- [ ] Release notes are not required for the next release
  - [x] Otherwise: Notes added to `release_notes.md`
- [ ] Backport is not required
  - [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
- [x] All required tests have been added/updated (unit tests, E2E tests)
- [x] No extra work is required to be leveraged by OutOfProc SDKs
  - [ ] Otherwise: Work tracked here: #issue_or_pr_in_each_sdk
- [ ] No change to the version of the `WebJobs.Extensions.DurableTask` package
  - [x] Otherwise: Major/minor updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
- [x] No EventIds were added to `EventSource` logs
  - [ ] Otherwise: Ensure EventIds are within the supported range in the existing Windows infrastructure (validate via deployed telemetry). If needed, extend the range via a PR such as https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files
- [ ] This change should be added to the `v2.x` branch
  - [ ] Otherwise: This change applies exclusively to `WebJobs.Extensions.DurableTask` v3.x and will be retained only in the `dev` and `main` branches
- [ ] Breaking change?
  - [ ] If yes:
    - Impact:
    - Migration guidance:
---

# AI-assisted code disclosure (required)
## Was an AI tool used? (select one)
- [ ] No
- [x] Yes, AI helped write parts of this PR (e.g., GitHub Copilot)
- [ ] Yes, an AI agent generated most of this PR

If AI was used:
- Tool(s):
- AI-assisted areas/files:
- What you changed after AI output:

AI verification (required if AI was used):
- [x] I understand the code and can explain it
- [x] I verified referenced APIs/types exist and are correct
- [x] I reviewed edge cases/failure paths (timeouts, retries, cancellation, exceptions)
- [x] I reviewed concurrency/async behavior
- [x] I checked for unintended breaking or behavior changes

---

# Testing
## Automated tests
- Result: Passed / Failed (link logs if failed)

## Manual validation (only if runtime/behavior changed)
- Environment (OS, .NET version, components):
- Steps + observed results:
  1.
  2.
  3.
- Evidence (optional):

---

# Notes for reviewers
- N/A
