### PR TITLE
Add FunctionInvocationId correlation for client operations

### DIFF
--- a/.github/workflows/E2ETest.yml
+++ b/.github/workflows/E2ETest.yml
@@ -1,4 +1,6 @@
 name: End to End Test - .NET Isolated/Func V4
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:

--- a/.github/workflows/smoketest-dotnet-isolated-v4.yml
+++ b/.github/workflows/smoketest-dotnet-isolated-v4.yml
@@ -1,5 +1,8 @@
 name: Smoke Test - .NET Isolated on Functions V4
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
   push:

--- a/release_notes.md
+++ b/release_notes.md
@@ -1,8 +1,10 @@
 # Release Notes
 
-## Microsoft.Azure.Functions.Worker.Extensions.DurableTask (version)
+## Microsoft.Azure.Functions.Worker.Extensions.DurableTask
 
 ### New Features
+
+- Added client operation correlation logging: Out-of-process workers (.NET isolated, Python, JavaScript, Java) now propagate `FunctionInvocationId` to the host when making client operations (start, terminate, suspend, resume, raise event, rewind, purge). This enables correlating worker-side function invocations with host-side orchestration events in extension logs. (#3317)
 
 ### Bug Fixes
 
@@ -12,11 +14,12 @@
 
 ### Dependency Updates
 
-## Microsoft.Azure.WebJobs.Extensions.DurableTask 2.13.7
+## Microsoft.Azure.WebJobs.Extensions.DurableTask
 
 ### New Features
 
 - Allow overriding orchestration version when starting orchestrations via APIs in PowerShell, Python, and Node.js (https://github.com/Azure/azure-functions-durable-extension/pull/3213)
+- Added `ClientOperationReceived` trace event to `DurableFunctionsEvents` for correlating out-of-process worker invocations with orchestration events. The event includes `FunctionInvocationId`, `OperationType`, and `InstanceId` fields for cross-log correlation. (#3317)
 
 ### Bug Fixes
 

--- a/src/WebJobs.Extensions.DurableTask/EndToEndTraceHelper.cs
+++ b/src/WebJobs.Extensions.DurableTask/EndToEndTraceHelper.cs
@@ -152,6 +152,37 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             this.logger.LogWarning(message);
         }
 
+        public void ClientOperationReceived(
+            string hubName,
+            string operationType,
+            string instanceId,
+            string? functionInvocationId)
+        {
+            // Only log if a function invocation ID was provided (for correlation purposes)
+            if (!string.IsNullOrEmpty(functionInvocationId))
+            {
+                EtwEventSource.Instance.ClientOperationReceived(
+                    hubName,
+                    LocalAppName,
+                    LocalSlotName,
+                    operationType,
+                    instanceId,
+                    functionInvocationId,
+                    ExtensionVersion);
+
+                this.logger.LogInformation(
+                    "Client operation '{operationType}' received for instance '{instanceId}'. FunctionInvocationId: {functionInvocationId}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}. SequenceNumber: {sequenceNumber}.",
+                    operationType,
+                    instanceId,
+                    functionInvocationId,
+                    hubName,
+                    LocalAppName,
+                    LocalSlotName,
+                    ExtensionVersion,
+                    this.sequenceNumber++);
+            }
+        }
+
         public void FunctionScheduled(
             string hubName,
             string functionName,

--- a/src/WebJobs.Extensions.DurableTask/EtwEventSource.cs
+++ b/src/WebJobs.Extensions.DurableTask/EtwEventSource.cs
@@ -553,6 +553,19 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             this.WriteEvent(234, TaskHub, AppName, SlotName, FunctionName, InstanceId, TraceFlags, Details, FunctionType, ExtensionVersion);
         }
 
+        [Event(235, Level = EventLevel.Informational, Version = 1)]
+        public void ClientOperationReceived(
+            string TaskHub,
+            string AppName,
+            string SlotName,
+            string OperationType,
+            string InstanceId,
+            string FunctionInvocationId,
+            string ExtensionVersion)
+        {
+            this.WriteEvent(235, TaskHub, AppName, SlotName, OperationType, InstanceId, FunctionInvocationId, ExtensionVersion);
+        }
+
 #pragma warning restore SA1313 // Parameter names should begin with lower-case letter
     }
 }

--- a/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
+++ b/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
@@ -66,6 +66,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
         private const string EmptyEntityKeySymbol = "$";
 
+        // HTTP Header for correlating client operations with function invocations
+        private const string FunctionInvocationIdHeader = "X-Azure-Functions-InvocationId";
+
         // API Routes
         private static readonly TemplateMatcher StartOrchestrationRoute = GetStartOrchestrationRoute();
         private static readonly TemplateMatcher EntityRoute = GetEntityRoute();
@@ -567,6 +570,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     "Instance ID provided to the purge instance history request must not be null or empty.");
             }
 
+            // Extract function invocation ID for correlation logging
+            string functionInvocationId = GetHeaderValueFromHeaders(FunctionInvocationIdHeader, request.Headers);
+            this.traceHelper.ClientOperationReceived(
+                this.durableTaskOptions.HubName,
+                "PurgeInstanceHistory",
+                instanceId,
+                functionInvocationId);
+
             // We need to confirm that the instance is an orchestration before checking that it has a terminal runtime status,
             // since entities can also be purged and have runtime status "Running". All entities have instance IDs that start with
             // '@', but orchestrations can also have such instance IDs. This runtime status check will therefore not necessarily be
@@ -814,6 +825,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         {
             IDurableOrchestrationClient client = this.GetClient(request);
 
+            // Extract function invocation ID for correlation logging
+            string functionInvocationId = GetHeaderValueFromHeaders(FunctionInvocationIdHeader, request.Headers);
+            this.traceHelper.ClientOperationReceived(
+                this.durableTaskOptions.HubName,
+                "Terminate",
+                instanceId,
+                functionInvocationId);
+
             DurableOrchestrationStatus status = await client.GetStatusAsync(instanceId);
             if (status == null)
             {
@@ -838,6 +857,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         {
             IDurableOrchestrationClient client = this.GetClient(request);
 
+            // Extract function invocation ID for correlation logging
+            string functionInvocationId = GetHeaderValueFromHeaders(FunctionInvocationIdHeader, request.Headers);
+            this.traceHelper.ClientOperationReceived(
+                this.durableTaskOptions.HubName,
+                "Suspend",
+                instanceId,
+                functionInvocationId);
+
             DurableOrchestrationStatus status = await client.GetStatusAsync(instanceId);
             if (status == null)
             {
@@ -861,6 +888,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             string instanceId)
         {
             IDurableOrchestrationClient client = this.GetClient(request);
+
+            // Extract function invocation ID for correlation logging
+            string functionInvocationId = GetHeaderValueFromHeaders(FunctionInvocationIdHeader, request.Headers);
+            this.traceHelper.ClientOperationReceived(
+                this.durableTaskOptions.HubName,
+                "Resume",
+                instanceId,
+                functionInvocationId);
 
             DurableOrchestrationStatus status = await client.GetStatusAsync(instanceId);
             if (status == null)
@@ -901,6 +936,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 }
 
                 string id = string.IsNullOrEmpty(instanceId) ? Guid.NewGuid().ToString("N") : instanceId;
+
+                // Extract function invocation ID for correlation logging
+                string functionInvocationId = GetHeaderValueFromHeaders(FunctionInvocationIdHeader, request.Headers);
+                this.traceHelper.ClientOperationReceived(
+                    this.durableTaskOptions.HubName,
+                    "StartOrchestration",
+                    id,
+                    functionInvocationId);
 
                 if (client is DurableClient durableClient)
                 {
@@ -1034,6 +1077,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         {
             IDurableOrchestrationClient client = this.GetClient(request);
 
+            // Extract function invocation ID for correlation logging
+            string functionInvocationId = GetHeaderValueFromHeaders(FunctionInvocationIdHeader, request.Headers);
+            this.traceHelper.ClientOperationReceived(
+                this.durableTaskOptions.HubName,
+                "Rewind",
+                instanceId,
+                functionInvocationId);
+
             DurableOrchestrationStatus status = await client.GetStatusAsync(instanceId);
             if (status == null)
             {
@@ -1071,6 +1122,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             string eventName)
         {
             IDurableOrchestrationClient client = this.GetClient(request);
+
+            // Extract function invocation ID for correlation logging
+            string functionInvocationId = GetHeaderValueFromHeaders(FunctionInvocationIdHeader, request.Headers);
+            this.traceHelper.ClientOperationReceived(
+                this.durableTaskOptions.HubName,
+                "RaiseEvent",
+                instanceId,
+                functionInvocationId);
 
             DurableOrchestrationStatus status = await client.GetStatusAsync(instanceId);
             if (status == null)
@@ -1138,6 +1197,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             EntityId entityId)
         {
             IDurableEntityClient client = this.GetClient(request);
+
+            // Extract function invocation ID for correlation logging
+            string functionInvocationId = GetHeaderValueFromHeaders(FunctionInvocationIdHeader, request.Headers);
+            this.traceHelper.ClientOperationReceived(
+                this.durableTaskOptions.HubName,
+                "SignalEntity",
+                entityId.ToString(),
+                functionInvocationId);
 
             string operationName;
 

--- a/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
+++ b/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
@@ -458,6 +458,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         private async Task<HttpResponseMessage> HandleGetStatusRequestAsync(
             HttpRequestMessage request)
         {
+            this.LogClientOperationReceived(request, "QueryInstances", string.Empty);
+
             IDurableOrchestrationClient client = this.GetClient(request);
             var queryNameValuePairs = request.GetQueryNameValuePairs();
 
@@ -519,6 +521,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         private async Task<HttpResponseMessage> HandleListEntitiesRequestAsync(
             HttpRequestMessage request, string entityName)
         {
+            this.LogClientOperationReceived(request, "QueryEntities", string.Empty);
+
             IDurableEntityClient client = this.GetClient(request);
             NameValueCollection queryNameValuePairs = request.GetQueryNameValuePairs();
 
@@ -600,6 +604,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
         private async Task<HttpResponseMessage> HandleDeleteHistoryWithFiltersRequestAsync(HttpRequestMessage request)
         {
+            this.LogClientOperationReceived(request, "PurgeInstances", "(filter)");
+
             IDurableOrchestrationClient client = this.GetClient(request);
             var queryNameValuePairs = request.GetQueryNameValuePairs();
             if (!TryGetDateTimeQueryParameterValue(queryNameValuePairs, CreatedTimeFromParameter, out DateTime createdTimeFrom))
@@ -633,6 +639,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             bool? returnInternalServerErrorOnFailure = null,
             IDurableOrchestrationClient existingClient = null)
         {
+            this.LogClientOperationReceived(request, "GetInstance", instanceId);
+
             IDurableOrchestrationClient client = existingClient ?? this.GetClient(request);
             var queryNameValuePairs = request.GetQueryNameValuePairs();
 
@@ -1001,6 +1009,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         private void LogClientOperationReceived(HttpRequestMessage request, string operationType, string instanceId)
         {
             string functionInvocationId = GetHeaderValueFromHeaders(FunctionInvocationIdHeader, request.Headers);
+
+            // Validate the header value since it comes from an HTTP request that may be from an external client.
+            // Only accept well-formed GUID values to prevent log injection or oversized log entries.
+            if (!string.IsNullOrEmpty(functionInvocationId) && !Guid.TryParse(functionInvocationId, out _))
+            {
+                functionInvocationId = null;
+            }
+
             this.traceHelper.ClientOperationReceived(
                 this.durableTaskOptions.HubName,
                 operationType,
@@ -1012,6 +1028,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             HttpRequestMessage request,
             string instanceId)
         {
+            this.LogClientOperationReceived(request, "Restart", instanceId);
+
             try
             {
                 IDurableOrchestrationClient client = this.GetClient(request);
@@ -1147,6 +1165,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             HttpRequestMessage request,
             EntityId entityId)
         {
+            this.LogClientOperationReceived(request, "GetEntity", entityId.ToString());
+
             IDurableEntityClient client = this.GetClient(request);
 
             // This input for entity key parameter means that entity key is an empty string.

--- a/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
+++ b/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
@@ -570,13 +570,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     "Instance ID provided to the purge instance history request must not be null or empty.");
             }
 
-            // Extract function invocation ID for correlation logging
-            string functionInvocationId = GetHeaderValueFromHeaders(FunctionInvocationIdHeader, request.Headers);
-            this.traceHelper.ClientOperationReceived(
-                this.durableTaskOptions.HubName,
-                "PurgeInstanceHistory",
-                instanceId,
-                functionInvocationId);
+            // Log correlation information for client operations
+            this.LogClientOperationReceived(request, "PurgeInstances", instanceId);
 
             // We need to confirm that the instance is an orchestration before checking that it has a terminal runtime status,
             // since entities can also be purged and have runtime status "Running". All entities have instance IDs that start with
@@ -825,13 +820,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         {
             IDurableOrchestrationClient client = this.GetClient(request);
 
-            // Extract function invocation ID for correlation logging
-            string functionInvocationId = GetHeaderValueFromHeaders(FunctionInvocationIdHeader, request.Headers);
-            this.traceHelper.ClientOperationReceived(
-                this.durableTaskOptions.HubName,
-                "Terminate",
-                instanceId,
-                functionInvocationId);
+            // Log correlation information for client operations
+            this.LogClientOperationReceived(request, "Terminate", instanceId);
 
             DurableOrchestrationStatus status = await client.GetStatusAsync(instanceId);
             if (status == null)
@@ -857,13 +847,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         {
             IDurableOrchestrationClient client = this.GetClient(request);
 
-            // Extract function invocation ID for correlation logging
-            string functionInvocationId = GetHeaderValueFromHeaders(FunctionInvocationIdHeader, request.Headers);
-            this.traceHelper.ClientOperationReceived(
-                this.durableTaskOptions.HubName,
-                "Suspend",
-                instanceId,
-                functionInvocationId);
+            // Log correlation information for client operations
+            this.LogClientOperationReceived(request, "Suspend", instanceId);
 
             DurableOrchestrationStatus status = await client.GetStatusAsync(instanceId);
             if (status == null)
@@ -889,13 +874,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         {
             IDurableOrchestrationClient client = this.GetClient(request);
 
-            // Extract function invocation ID for correlation logging
-            string functionInvocationId = GetHeaderValueFromHeaders(FunctionInvocationIdHeader, request.Headers);
-            this.traceHelper.ClientOperationReceived(
-                this.durableTaskOptions.HubName,
-                "Resume",
-                instanceId,
-                functionInvocationId);
+            // Log correlation information for client operations
+            this.LogClientOperationReceived(request, "Resume", instanceId);
 
             DurableOrchestrationStatus status = await client.GetStatusAsync(instanceId);
             if (status == null)
@@ -937,13 +917,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
                 string id = string.IsNullOrEmpty(instanceId) ? Guid.NewGuid().ToString("N") : instanceId;
 
-                // Extract function invocation ID for correlation logging
-                string functionInvocationId = GetHeaderValueFromHeaders(FunctionInvocationIdHeader, request.Headers);
-                this.traceHelper.ClientOperationReceived(
-                    this.durableTaskOptions.HubName,
-                    "StartOrchestration",
-                    id,
-                    functionInvocationId);
+                // Log correlation information for client operations
+                this.LogClientOperationReceived(request, "StartOrchestration", id);
 
                 if (client is DurableClient durableClient)
                 {
@@ -1023,6 +998,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             return null;
         }
 
+        private void LogClientOperationReceived(HttpRequestMessage request, string operationType, string instanceId)
+        {
+            string functionInvocationId = GetHeaderValueFromHeaders(FunctionInvocationIdHeader, request.Headers);
+            this.traceHelper.ClientOperationReceived(
+                this.durableTaskOptions.HubName,
+                operationType,
+                instanceId,
+                functionInvocationId);
+        }
+
         private async Task<HttpResponseMessage> HandleRestartInstanceRequestAsync(
             HttpRequestMessage request,
             string instanceId)
@@ -1077,13 +1062,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         {
             IDurableOrchestrationClient client = this.GetClient(request);
 
-            // Extract function invocation ID for correlation logging
-            string functionInvocationId = GetHeaderValueFromHeaders(FunctionInvocationIdHeader, request.Headers);
-            this.traceHelper.ClientOperationReceived(
-                this.durableTaskOptions.HubName,
-                "Rewind",
-                instanceId,
-                functionInvocationId);
+            // Log correlation information for client operations
+            this.LogClientOperationReceived(request, "Rewind", instanceId);
 
             DurableOrchestrationStatus status = await client.GetStatusAsync(instanceId);
             if (status == null)
@@ -1123,13 +1103,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         {
             IDurableOrchestrationClient client = this.GetClient(request);
 
-            // Extract function invocation ID for correlation logging
-            string functionInvocationId = GetHeaderValueFromHeaders(FunctionInvocationIdHeader, request.Headers);
-            this.traceHelper.ClientOperationReceived(
-                this.durableTaskOptions.HubName,
-                "RaiseEvent",
-                instanceId,
-                functionInvocationId);
+            // Log correlation information for client operations
+            this.LogClientOperationReceived(request, "RaiseEvent", instanceId);
 
             DurableOrchestrationStatus status = await client.GetStatusAsync(instanceId);
             if (status == null)
@@ -1198,13 +1173,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         {
             IDurableEntityClient client = this.GetClient(request);
 
-            // Extract function invocation ID for correlation logging
-            string functionInvocationId = GetHeaderValueFromHeaders(FunctionInvocationIdHeader, request.Headers);
-            this.traceHelper.ClientOperationReceived(
-                this.durableTaskOptions.HubName,
-                "SignalEntity",
-                entityId.ToString(),
-                functionInvocationId);
+            // Log correlation information for client operations
+            this.LogClientOperationReceived(request, "SignalEntity", entityId.ToString());
 
             string operationName;
 

--- a/src/WebJobs.Extensions.DurableTask/TaskHubGrpcServer.cs
+++ b/src/WebJobs.Extensions.DurableTask/TaskHubGrpcServer.cs
@@ -209,6 +209,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
         public async override Task<P.GetEntityResponse> GetEntity(P.GetEntityRequest request, ServerCallContext context)
         {
+            this.LogClientOperationReceived(context, "GetEntity", request.InstanceId);
             this.CheckEntitySupport(context, out var durabilityProvider, out var entityOrchestrationService);
 
             EntityBackendQueries.EntityMetadata? metaData = await entityOrchestrationService.EntityBackendQueries!.GetEntityAsync(
@@ -226,6 +227,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
         public async override Task<P.QueryEntitiesResponse> QueryEntities(P.QueryEntitiesRequest request, ServerCallContext context)
         {
+            this.LogClientOperationReceived(context, "QueryEntities", string.Empty);
             this.CheckEntitySupport(context, out var durabilityProvider, out var entityOrchestrationService);
 
             P.EntityQuery query = request.Query;
@@ -257,6 +259,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
         public async override Task<P.CleanEntityStorageResponse> CleanEntityStorage(P.CleanEntityStorageRequest request, ServerCallContext context)
         {
+            this.LogClientOperationReceived(context, "CleanEntityStorage", string.Empty);
             this.CheckEntitySupport(context, out var durabilityProvider, out var entityOrchestrationService);
 
             EntityBackendQueries.CleanEntityStorageResult result = await entityOrchestrationService.EntityBackendQueries!.CleanEntityStorageAsync(
@@ -363,6 +366,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
         public async override Task<P.GetInstanceResponse> GetInstance(P.GetInstanceRequest request, ServerCallContext context)
         {
+            this.LogClientOperationReceived(context, "GetInstance", request.InstanceId);
+
             OrchestrationState state = await this.GetDurabilityProvider(context)
                 .GetOrchestrationStateAsync(request.InstanceId, executionId: null);
             if (state == null)
@@ -375,6 +380,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
         public async override Task<P.QueryInstancesResponse> QueryInstances(P.QueryInstancesRequest request, ServerCallContext context)
         {
+            this.LogClientOperationReceived(context, "QueryInstances", string.Empty);
+
             var query = ProtobufUtils.ToOrchestrationQuery(request);
             var queryClient = (IOrchestrationServiceQueryClient)this.GetDurabilityProvider(context);
             OrchestrationQueryResult result = await queryClient.GetOrchestrationWithQueryAsync(query, context.CancellationToken);
@@ -462,6 +469,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
         public async override Task<P.GetInstanceResponse> WaitForInstanceStart(P.GetInstanceRequest request, ServerCallContext context)
         {
+            this.LogClientOperationReceived(context, "WaitForInstanceStart", request.InstanceId);
+
             int retryCount = 0;
             while (true)
             {
@@ -484,6 +493,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
         public async override Task<P.GetInstanceResponse> WaitForInstanceCompletion(P.GetInstanceRequest request, ServerCallContext context)
         {
+            this.LogClientOperationReceived(context, "WaitForInstanceCompletion", request.InstanceId);
+
             OrchestrationState state = await this.GetDurabilityProvider(context).WaitForOrchestrationAsync(
                 request.InstanceId,
                 executionId: null,
@@ -500,6 +511,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
         public override async Task<P.RestartInstanceResponse> RestartInstance(P.RestartInstanceRequest request, ServerCallContext context)
         {
+            this.LogClientOperationReceived(context, "Restart", request.InstanceId);
+
             try
             {
                 string newInstanceId = await this.GetClient(context).RestartAsync(request.InstanceId, request.RestartWithNewInstanceId);
@@ -553,6 +566,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             IServerStreamWriter<P.HistoryChunk> responseStream,
             ServerCallContext context)
         {
+            this.LogClientOperationReceived(context, "StreamInstanceHistory", request.InstanceId);
+
             if (await this.GetClient(context).GetStatusAsync(request.InstanceId, showInput: false) is null)
             {
                 throw new RpcException(new Status(StatusCode.NotFound, $"Orchestration instance with ID {request.InstanceId} was not found."));
@@ -673,6 +688,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         private void LogClientOperationReceived(ServerCallContext context, string operationType, string instanceId)
         {
             string? functionInvocationId = GetFunctionInvocationId(context);
+
+            // Validate the metadata value to prevent malformed or oversized values from creating noisy logs.
+            if (!string.IsNullOrEmpty(functionInvocationId) && !Guid.TryParse(functionInvocationId, out _))
+            {
+                functionInvocationId = null;
+            }
+
             this.extension.TraceHelper.ClientOperationReceived(
                 this.extension.Options.HubName,
                 operationType,

--- a/src/WebJobs.Extensions.DurableTask/TaskHubGrpcServer.cs
+++ b/src/WebJobs.Extensions.DurableTask/TaskHubGrpcServer.cs
@@ -66,12 +66,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 };
 
                 // Log correlation information for client operations
-                string? functionInvocationId = GetFunctionInvocationId(context);
-                this.extension.TraceHelper.ClientOperationReceived(
-                    this.extension.Options.HubName,
-                    "StartOrchestration",
-                    instance.InstanceId,
-                    functionInvocationId);
+                this.LogClientOperationReceived(context, "StartOrchestration", instance.InstanceId);
 
                 // Create the ExecutionStartedEvent
                 ExecutionStartedEvent executionStartedEvent = new ExecutionStartedEvent(-1, request.Input)
@@ -135,12 +130,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             bool throwStatusExceptionsOnRaiseEvent = this.extension.Options.ThrowStatusExceptionsOnRaiseEvent ?? this.extension.DefaultDurabilityProvider.CheckStatusBeforeRaiseEvent;
 
             // Log correlation information for client operations
-            string? functionInvocationId = GetFunctionInvocationId(context);
-            this.extension.TraceHelper.ClientOperationReceived(
-                this.extension.Options.HubName,
-                "RaiseEvent",
-                request.InstanceId,
-                functionInvocationId);
+            this.LogClientOperationReceived(context, "RaiseEvent", request.InstanceId);
 
             try
             {
@@ -181,12 +171,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             this.CheckEntitySupport(context, out var durabilityProvider, out var entityOrchestrationService);
 
             // Log correlation information for client operations
-            string? functionInvocationId = GetFunctionInvocationId(context);
-            this.extension.TraceHelper.ClientOperationReceived(
-                this.extension.Options.HubName,
-                "SignalEntity",
-                request.InstanceId,
-                functionInvocationId);
+            this.LogClientOperationReceived(context, "SignalEntity", request.InstanceId);
 
             Activity? signalEntityActivity = null;
 
@@ -294,12 +279,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         public async override Task<P.TerminateResponse> TerminateInstance(P.TerminateRequest request, ServerCallContext context)
         {
             // Log correlation information for client operations
-            string? functionInvocationId = GetFunctionInvocationId(context);
-            this.extension.TraceHelper.ClientOperationReceived(
-                this.extension.Options.HubName,
-                "Terminate",
-                request.InstanceId,
-                functionInvocationId);
+            this.LogClientOperationReceived(context, "Terminate", request.InstanceId);
 
             try
             {
@@ -331,12 +311,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         public async override Task<P.SuspendResponse> SuspendInstance(P.SuspendRequest request, ServerCallContext context)
         {
             // Log correlation information for client operations
-            string? functionInvocationId = GetFunctionInvocationId(context);
-            this.extension.TraceHelper.ClientOperationReceived(
-                this.extension.Options.HubName,
-                "Suspend",
-                request.InstanceId,
-                functionInvocationId);
+            this.LogClientOperationReceived(context, "Suspend", request.InstanceId);
 
             await this.GetClient(context).SuspendAsync(request.InstanceId, request.Reason);
             return new P.SuspendResponse();
@@ -345,12 +320,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         public async override Task<P.ResumeResponse> ResumeInstance(P.ResumeRequest request, ServerCallContext context)
         {
             // Log correlation information for client operations
-            string? functionInvocationId = GetFunctionInvocationId(context);
-            this.extension.TraceHelper.ClientOperationReceived(
-                this.extension.Options.HubName,
-                "Resume",
-                request.InstanceId,
-                functionInvocationId);
+            this.LogClientOperationReceived(context, "Resume", request.InstanceId);
 
             await this.GetClient(context).ResumeAsync(request.InstanceId, request.Reason);
             return new P.ResumeResponse();
@@ -359,12 +329,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         public async override Task<P.RewindInstanceResponse> RewindInstance(P.RewindInstanceRequest request, ServerCallContext context)
         {
             // Log correlation information for client operations
-            string? functionInvocationId = GetFunctionInvocationId(context);
-            this.extension.TraceHelper.ClientOperationReceived(
-                this.extension.Options.HubName,
-                "Rewind",
-                request.InstanceId,
-                functionInvocationId);
+            this.LogClientOperationReceived(context, "Rewind", request.InstanceId);
 
             try
             {
@@ -420,16 +385,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         {
             var purgeClient = (IOrchestrationServicePurgeClient)this.GetDurabilityProvider(context);
 
-            // Extract function invocation ID for correlation logging
-            string? functionInvocationId = GetFunctionInvocationId(context);
+            // Log correlation information for client operations
             string instanceId = request.RequestCase == P.PurgeInstancesRequest.RequestOneofCase.InstanceId
                 ? request.InstanceId
                 : "(filter)";
-            this.extension.TraceHelper.ClientOperationReceived(
-                this.extension.Options.HubName,
-                "PurgeInstances",
-                instanceId,
-                functionInvocationId);
+            this.LogClientOperationReceived(context, "PurgeInstances", instanceId);
 
             PurgeResult result;
             try
@@ -708,6 +668,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             Metadata.Entry? entry = context.RequestHeaders.FirstOrDefault(
                 e => string.Equals(e.Key, FunctionInvocationIdMetadataKey, StringComparison.OrdinalIgnoreCase));
             return entry?.Value;
+        }
+
+        private void LogClientOperationReceived(ServerCallContext context, string operationType, string instanceId)
+        {
+            string? functionInvocationId = GetFunctionInvocationId(context);
+            this.extension.TraceHelper.ClientOperationReceived(
+                this.extension.Options.HubName,
+                operationType,
+                instanceId,
+                functionInvocationId);
         }
 
         private void CheckEntitySupport(ServerCallContext context, out DurabilityProvider durabilityProvider, out IEntityOrchestrationService entityOrchestrationService)

--- a/src/WebJobs.Extensions.DurableTask/TaskHubGrpcServer.cs
+++ b/src/WebJobs.Extensions.DurableTask/TaskHubGrpcServer.cs
@@ -26,6 +26,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
     internal class TaskHubGrpcServer : P.TaskHubSidecarService.TaskHubSidecarServiceBase
     {
         private const int MaxHistoryChunkSizeInBytes = 2 * 1024 * 1024; // 2 MB
+
+        // gRPC metadata key for correlating client operations with function invocations
+        private const string FunctionInvocationIdMetadataKey = "x-azure-functions-invocationid";
+
         private readonly DurableTaskExtension extension;
 
         public TaskHubGrpcServer(DurableTaskExtension extension)
@@ -60,6 +64,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     InstanceId = string.IsNullOrEmpty(request.InstanceId) ? Guid.NewGuid().ToString("N") : request.InstanceId,
                     ExecutionId = Guid.NewGuid().ToString(),
                 };
+
+                // Log correlation information for client operations
+                string? functionInvocationId = GetFunctionInvocationId(context);
+                this.extension.TraceHelper.ClientOperationReceived(
+                    this.extension.Options.HubName,
+                    "StartOrchestration",
+                    instance.InstanceId,
+                    functionInvocationId);
 
                 // Create the ExecutionStartedEvent
                 ExecutionStartedEvent executionStartedEvent = new ExecutionStartedEvent(-1, request.Input)
@@ -122,6 +134,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         {
             bool throwStatusExceptionsOnRaiseEvent = this.extension.Options.ThrowStatusExceptionsOnRaiseEvent ?? this.extension.DefaultDurabilityProvider.CheckStatusBeforeRaiseEvent;
 
+            // Log correlation information for client operations
+            string? functionInvocationId = GetFunctionInvocationId(context);
+            this.extension.TraceHelper.ClientOperationReceived(
+                this.extension.Options.HubName,
+                "RaiseEvent",
+                request.InstanceId,
+                functionInvocationId);
+
             try
             {
                 await this.GetClient(context).RaiseEventAsync(request.InstanceId, request.Name, Raw(request.Input));
@@ -159,6 +179,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         public async override Task<P.SignalEntityResponse> SignalEntity(P.SignalEntityRequest request, ServerCallContext context)
         {
             this.CheckEntitySupport(context, out var durabilityProvider, out var entityOrchestrationService);
+
+            // Log correlation information for client operations
+            string? functionInvocationId = GetFunctionInvocationId(context);
+            this.extension.TraceHelper.ClientOperationReceived(
+                this.extension.Options.HubName,
+                "SignalEntity",
+                request.InstanceId,
+                functionInvocationId);
 
             Activity? signalEntityActivity = null;
 
@@ -265,6 +293,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
         public async override Task<P.TerminateResponse> TerminateInstance(P.TerminateRequest request, ServerCallContext context)
         {
+            // Log correlation information for client operations
+            string? functionInvocationId = GetFunctionInvocationId(context);
+            this.extension.TraceHelper.ClientOperationReceived(
+                this.extension.Options.HubName,
+                "Terminate",
+                request.InstanceId,
+                functionInvocationId);
+
             try
             {
                 await this.GetClient(context).TerminateAsync(request.InstanceId, request.Output);
@@ -294,18 +330,42 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
         public async override Task<P.SuspendResponse> SuspendInstance(P.SuspendRequest request, ServerCallContext context)
         {
+            // Log correlation information for client operations
+            string? functionInvocationId = GetFunctionInvocationId(context);
+            this.extension.TraceHelper.ClientOperationReceived(
+                this.extension.Options.HubName,
+                "Suspend",
+                request.InstanceId,
+                functionInvocationId);
+
             await this.GetClient(context).SuspendAsync(request.InstanceId, request.Reason);
             return new P.SuspendResponse();
         }
 
         public async override Task<P.ResumeResponse> ResumeInstance(P.ResumeRequest request, ServerCallContext context)
         {
+            // Log correlation information for client operations
+            string? functionInvocationId = GetFunctionInvocationId(context);
+            this.extension.TraceHelper.ClientOperationReceived(
+                this.extension.Options.HubName,
+                "Resume",
+                request.InstanceId,
+                functionInvocationId);
+
             await this.GetClient(context).ResumeAsync(request.InstanceId, request.Reason);
             return new P.ResumeResponse();
         }
 
         public async override Task<P.RewindInstanceResponse> RewindInstance(P.RewindInstanceRequest request, ServerCallContext context)
         {
+            // Log correlation information for client operations
+            string? functionInvocationId = GetFunctionInvocationId(context);
+            this.extension.TraceHelper.ClientOperationReceived(
+                this.extension.Options.HubName,
+                "Rewind",
+                request.InstanceId,
+                functionInvocationId);
+
             try
             {
 #pragma warning disable CS0618 // Type or member is obsolete
@@ -359,6 +419,17 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         public async override Task<P.PurgeInstancesResponse> PurgeInstances(P.PurgeInstancesRequest request, ServerCallContext context)
         {
             var purgeClient = (IOrchestrationServicePurgeClient)this.GetDurabilityProvider(context);
+
+            // Extract function invocation ID for correlation logging
+            string? functionInvocationId = GetFunctionInvocationId(context);
+            string instanceId = request.RequestCase == P.PurgeInstancesRequest.RequestOneofCase.InstanceId
+                ? request.InstanceId
+                : "(filter)";
+            this.extension.TraceHelper.ClientOperationReceived(
+                this.extension.Options.HubName,
+                "PurgeInstances",
+                instanceId,
+                functionInvocationId);
 
             PurgeResult result;
             try
@@ -630,6 +701,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         private IDurableClient GetClient(ServerCallContext context)
         {
             return this.extension.GetClient(this.GetAttribute(context));
+        }
+
+        private static string? GetFunctionInvocationId(ServerCallContext context)
+        {
+            Metadata.Entry? entry = context.RequestHeaders.FirstOrDefault(
+                e => string.Equals(e.Key, FunctionInvocationIdMetadataKey, StringComparison.OrdinalIgnoreCase));
+            return entry?.Value;
         }
 
         private void CheckEntitySupport(ServerCallContext context, out DurabilityProvider durabilityProvider, out IEntityOrchestrationService entityOrchestrationService)

--- a/src/Worker.Extensions.DurableTask/DurableTaskFunctionsMiddleware.cs
+++ b/src/Worker.Extensions.DurableTask/DurableTaskFunctionsMiddleware.cs
@@ -14,19 +14,26 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.DurableTask;
 internal class DurableTaskFunctionsMiddleware(DurableFunctionExecutor invoker) : IFunctionsWorkerMiddleware
 {
     /// <inheritdoc />
-    public Task Invoke(FunctionContext functionContext, FunctionExecutionDelegate next)
+    public async Task Invoke(FunctionContext functionContext, FunctionExecutionDelegate next)
     {
         // Set the function invocation ID for correlation with host-side logs.
         // This is used by the gRPC call invoker to add correlation headers.
         InvocationIdCallInvoker.SetCurrentInvocationId(functionContext.InvocationId);
-
-        // If the function is a Durable Task function and there is no executor registered yet,
-        // register the Durable Function executor.
-        if (functionContext.Features.Get<IFunctionExecutor>() is null && functionContext.IsDurableTaskFunction())
+        try
         {
-            functionContext.Features.Set<IFunctionExecutor>(invoker);
-        }
+            // If the function is a Durable Task function and there is no executor registered yet,
+            // register the Durable Function executor.
+            if (functionContext.Features.Get<IFunctionExecutor>() is null && functionContext.IsDurableTaskFunction())
+            {
+                functionContext.Features.Set<IFunctionExecutor>(invoker);
+            }
 
-        return next(functionContext);
+            await next(functionContext);
+        }
+        finally
+        {
+            // Clear the invocation ID to prevent leaking to subsequent executions
+            InvocationIdCallInvoker.SetCurrentInvocationId(null);
+        }
     }
 }

--- a/src/Worker.Extensions.DurableTask/DurableTaskFunctionsMiddleware.cs
+++ b/src/Worker.Extensions.DurableTask/DurableTaskFunctionsMiddleware.cs
@@ -16,6 +16,10 @@ internal class DurableTaskFunctionsMiddleware(DurableFunctionExecutor invoker) :
     /// <inheritdoc />
     public Task Invoke(FunctionContext functionContext, FunctionExecutionDelegate next)
     {
+        // Set the function invocation ID for correlation with host-side logs.
+        // This is used by the gRPC call invoker to add correlation headers.
+        InvocationIdCallInvoker.SetCurrentInvocationId(functionContext.InvocationId);
+
         // If the function is a Durable Task function and there is no executor registered yet,
         // register the Durable Function executor.
         if (functionContext.Features.Get<IFunctionExecutor>() is null && functionContext.IsDurableTaskFunction())

--- a/src/Worker.Extensions.DurableTask/FunctionsDurableClientProvider.cs
+++ b/src/Worker.Extensions.DurableTask/FunctionsDurableClientProvider.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Grpc.Core;
 using Microsoft.DurableTask.Client;
 using Microsoft.DurableTask.Client.Grpc;
 using Microsoft.Extensions.Logging;
@@ -135,9 +136,13 @@ internal partial class FunctionsDurableClientProvider : IAsyncDisposable
                 connectionName);
 
             GrpcChannel channel = CreateChannel(key, maxGrpcMessageSizeInBytes, grpcHttpClientTimeout);
+
+            // Wrap the channel's call invoker with our InvocationIdCallInvoker to add correlation headers
+            CallInvoker callInvoker = new InvocationIdCallInvoker(channel.CreateCallInvoker());
+
             GrpcDurableTaskClientOptions options = new()
             {
-                Channel = channel,
+                CallInvoker = callInvoker,
                 DataConverter = this.options.DataConverter,
                 EnableEntitySupport = this.options.EnableEntitySupport,
             };

--- a/src/Worker.Extensions.DurableTask/InvocationIdCallInvoker.cs
+++ b/src/Worker.Extensions.DurableTask/InvocationIdCallInvoker.cs
@@ -91,7 +91,20 @@ internal sealed class InvocationIdCallInvoker : CallInvoker
             return options;
         }
 
-        Metadata headers = options.Headers ?? new Metadata();
+        // Clone existing headers to avoid mutating caller-provided metadata
+        // and filter out any existing invocation ID to prevent duplicates
+        Metadata headers = new Metadata();
+        if (options.Headers is not null)
+        {
+            foreach (var entry in options.Headers)
+            {
+                if (!string.Equals(entry.Key, InvocationIdMetadataKey, StringComparison.OrdinalIgnoreCase))
+                {
+                    headers.Add(entry);
+                }
+            }
+        }
+
         headers.Add(InvocationIdMetadataKey, invocationId);
         return options.WithHeaders(headers);
     }

--- a/src/Worker.Extensions.DurableTask/InvocationIdCallInvoker.cs
+++ b/src/Worker.Extensions.DurableTask/InvocationIdCallInvoker.cs
@@ -1,0 +1,98 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+using Grpc.Core;
+
+namespace Microsoft.Azure.Functions.Worker.Extensions.DurableTask;
+
+/// <summary>
+/// A call invoker that adds the function invocation ID to gRPC metadata for correlation purposes.
+/// </summary>
+internal sealed class InvocationIdCallInvoker : CallInvoker
+{
+    private const string InvocationIdMetadataKey = "x-azure-functions-invocationid";
+
+    private static readonly AsyncLocal<string?> CurrentInvocationId = new();
+
+    private readonly CallInvoker inner;
+
+    public InvocationIdCallInvoker(CallInvoker inner)
+    {
+        this.inner = inner ?? throw new ArgumentNullException(nameof(inner));
+    }
+
+    /// <summary>
+    /// Sets the current function invocation ID for the current async context.
+    /// This will be propagated to gRPC calls made within this context.
+    /// </summary>
+    public static void SetCurrentInvocationId(string? invocationId)
+    {
+        CurrentInvocationId.Value = invocationId;
+    }
+
+    /// <summary>
+    /// Gets the current function invocation ID from the async context.
+    /// </summary>
+    public static string? GetCurrentInvocationId()
+    {
+        return CurrentInvocationId.Value;
+    }
+
+    public override TResponse BlockingUnaryCall<TRequest, TResponse>(
+        Method<TRequest, TResponse> method,
+        string? host,
+        CallOptions options,
+        TRequest request)
+    {
+        return this.inner.BlockingUnaryCall(method, host, AddInvocationIdToOptions(options), request);
+    }
+
+    public override AsyncUnaryCall<TResponse> AsyncUnaryCall<TRequest, TResponse>(
+        Method<TRequest, TResponse> method,
+        string? host,
+        CallOptions options,
+        TRequest request)
+    {
+        return this.inner.AsyncUnaryCall(method, host, AddInvocationIdToOptions(options), request);
+    }
+
+    public override AsyncServerStreamingCall<TResponse> AsyncServerStreamingCall<TRequest, TResponse>(
+        Method<TRequest, TResponse> method,
+        string? host,
+        CallOptions options,
+        TRequest request)
+    {
+        return this.inner.AsyncServerStreamingCall(method, host, AddInvocationIdToOptions(options), request);
+    }
+
+    public override AsyncClientStreamingCall<TRequest, TResponse> AsyncClientStreamingCall<TRequest, TResponse>(
+        Method<TRequest, TResponse> method,
+        string? host,
+        CallOptions options)
+    {
+        return this.inner.AsyncClientStreamingCall<TRequest, TResponse>(method, host, AddInvocationIdToOptions(options));
+    }
+
+    public override AsyncDuplexStreamingCall<TRequest, TResponse> AsyncDuplexStreamingCall<TRequest, TResponse>(
+        Method<TRequest, TResponse> method,
+        string? host,
+        CallOptions options)
+    {
+        return this.inner.AsyncDuplexStreamingCall<TRequest, TResponse>(method, host, AddInvocationIdToOptions(options));
+    }
+
+    private static CallOptions AddInvocationIdToOptions(CallOptions options)
+    {
+        string? invocationId = CurrentInvocationId.Value;
+        if (string.IsNullOrEmpty(invocationId))
+        {
+            return options;
+        }
+
+        Metadata headers = options.Headers ?? new Metadata();
+        headers.Add(InvocationIdMetadataKey, invocationId);
+        return options.WithHeaders(headers);
+    }
+}

--- a/src/Worker.Extensions.DurableTask/InvocationIdCallInvoker.cs
+++ b/src/Worker.Extensions.DurableTask/InvocationIdCallInvoker.cs
@@ -105,7 +105,7 @@ internal sealed class InvocationIdCallInvoker : CallInvoker
             }
         }
 
-        headers.Add(InvocationIdMetadataKey, invocationId);
+        headers.Add(InvocationIdMetadataKey, invocationId!);
         return options.WithHeaders(headers);
     }
 }

--- a/test/FunctionsV2/EndToEndTraceHelperTests.cs
+++ b/test/FunctionsV2/EndToEndTraceHelperTests.cs
@@ -188,7 +188,8 @@ namespace WebJobs.Extensions.DurableTask.Tests.V2
                 this.messages = messages;
             }
 
-            public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+            public IDisposable? BeginScope<TState>(TState state)
+                where TState : notnull => null;
 
             public bool IsEnabled(LogLevel logLevel) => true;
 

--- a/test/FunctionsV2/EndToEndTraceHelperTests.cs
+++ b/test/FunctionsV2/EndToEndTraceHelperTests.cs
@@ -3,8 +3,10 @@
 
 #nullable enable
 using System;
+using System.Collections.Generic;
 using Microsoft.Azure.WebJobs.Extensions.DurableTask;
 using Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
@@ -102,6 +104,102 @@ namespace WebJobs.Extensions.DurableTask.Tests.V2
                 // If raw data is not being traced,
                 // kusto and the ilogger should get the same data
                 Assert.Equal(iLoggerString, kustoTableString);
+            }
+        }
+
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public void ClientOperationReceived_LogsWhenInvocationIdProvided()
+        {
+            // Arrange
+            var logMessages = new List<string>();
+            var testLogger = new TestLogger(logMessages);
+            var traceHelper = new EndToEndTraceHelper(
+                logger: testLogger,
+                traceReplayEvents: false);
+
+            // Act
+            traceHelper.ClientOperationReceived(
+                hubName: "TestHub",
+                operationType: "StartOrchestration",
+                instanceId: "test-instance-123",
+                functionInvocationId: "invocation-456");
+
+            // Assert
+            Assert.Single(logMessages);
+            Assert.Contains("StartOrchestration", logMessages[0]);
+            Assert.Contains("test-instance-123", logMessages[0]);
+            Assert.Contains("invocation-456", logMessages[0]);
+        }
+
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public void ClientOperationReceived_DoesNotLogWhenInvocationIdNull()
+        {
+            // Arrange
+            var logMessages = new List<string>();
+            var testLogger = new TestLogger(logMessages);
+            var traceHelper = new EndToEndTraceHelper(
+                logger: testLogger,
+                traceReplayEvents: false);
+
+            // Act
+            traceHelper.ClientOperationReceived(
+                hubName: "TestHub",
+                operationType: "StartOrchestration",
+                instanceId: "test-instance-123",
+                functionInvocationId: null);
+
+            // Assert - should not log when invocation ID is null
+            Assert.Empty(logMessages);
+        }
+
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public void ClientOperationReceived_DoesNotLogWhenInvocationIdEmpty()
+        {
+            // Arrange
+            var logMessages = new List<string>();
+            var testLogger = new TestLogger(logMessages);
+            var traceHelper = new EndToEndTraceHelper(
+                logger: testLogger,
+                traceReplayEvents: false);
+
+            // Act
+            traceHelper.ClientOperationReceived(
+                hubName: "TestHub",
+                operationType: "Terminate",
+                instanceId: "test-instance-123",
+                functionInvocationId: string.Empty);
+
+            // Assert - should not log when invocation ID is empty
+            Assert.Empty(logMessages);
+        }
+
+        /// <summary>
+        /// Simple test logger that captures log messages.
+        /// </summary>
+        private class TestLogger : ILogger
+        {
+            private readonly List<string> messages;
+
+            public TestLogger(List<string> messages)
+            {
+                this.messages = messages;
+            }
+
+            public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+            public bool IsEnabled(LogLevel logLevel) => true;
+
+            public void Log<TState>(
+                LogLevel logLevel,
+                EventId eventId,
+                TState state,
+                Exception? exception,
+                Func<TState, Exception?, string> formatter)
+            {
+                this.messages.Add(formatter(state, exception));
             }
         }
     }

--- a/test/Worker.Extensions.DurableTask.Tests/InvocationIdCallInvokerTests.cs
+++ b/test/Worker.Extensions.DurableTask.Tests/InvocationIdCallInvokerTests.cs
@@ -1,13 +1,19 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System;
+using System.Linq;
+using System.Threading.Tasks;
 using Grpc.Core;
+using Moq;
 using Xunit;
 
 namespace Microsoft.Azure.Functions.Worker.Extensions.DurableTask.Tests;
 
 public class InvocationIdCallInvokerTests
 {
+    private const string InvocationIdMetadataKey = "x-azure-functions-invocationid";
+
     [Fact]
     public void SetCurrentInvocationId_SetsValueInAsyncLocal()
     {
@@ -69,5 +75,201 @@ public class InvocationIdCallInvokerTests
 
         // Cleanup
         InvocationIdCallInvoker.SetCurrentInvocationId(null);
+    }
+
+    [Fact]
+    public void BlockingUnaryCall_AddsInvocationIdToMetadata()
+    {
+        // Arrange
+        const string expectedInvocationId = "test-invocation-id";
+        CallOptions capturedOptions = default;
+
+        var mockInner = new Mock<CallInvoker>();
+        mockInner
+            .Setup(x => x.BlockingUnaryCall(
+                It.IsAny<Method<string, string>>(),
+                It.IsAny<string>(),
+                It.IsAny<CallOptions>(),
+                It.IsAny<string>()))
+            .Callback<Method<string, string>, string, CallOptions, string>((m, h, o, r) => capturedOptions = o)
+            .Returns("response");
+
+        var invoker = new InvocationIdCallInvoker(mockInner.Object);
+        var method = new Method<string, string>(MethodType.Unary, "TestService", "TestMethod", Marshallers.StringMarshaller, Marshallers.StringMarshaller);
+
+        InvocationIdCallInvoker.SetCurrentInvocationId(expectedInvocationId);
+
+        try
+        {
+            // Act
+            invoker.BlockingUnaryCall(method, null, new CallOptions(), "request");
+
+            // Assert
+            Assert.NotNull(capturedOptions.Headers);
+            var header = capturedOptions.Headers.FirstOrDefault(h => h.Key == InvocationIdMetadataKey);
+            Assert.NotNull(header);
+            Assert.Equal(expectedInvocationId, header.Value);
+        }
+        finally
+        {
+            InvocationIdCallInvoker.SetCurrentInvocationId(null);
+        }
+    }
+
+    [Fact]
+    public void BlockingUnaryCall_PreservesExistingHeaders()
+    {
+        // Arrange
+        const string expectedInvocationId = "test-invocation-id";
+        const string existingHeaderKey = "existing-header";
+        const string existingHeaderValue = "existing-value";
+        CallOptions capturedOptions = default;
+
+        var mockInner = new Mock<CallInvoker>();
+        mockInner
+            .Setup(x => x.BlockingUnaryCall(
+                It.IsAny<Method<string, string>>(),
+                It.IsAny<string>(),
+                It.IsAny<CallOptions>(),
+                It.IsAny<string>()))
+            .Callback<Method<string, string>, string, CallOptions, string>((m, h, o, r) => capturedOptions = o)
+            .Returns("response");
+
+        var invoker = new InvocationIdCallInvoker(mockInner.Object);
+        var method = new Method<string, string>(MethodType.Unary, "TestService", "TestMethod", Marshallers.StringMarshaller, Marshallers.StringMarshaller);
+        var originalHeaders = new Metadata { { existingHeaderKey, existingHeaderValue } };
+
+        InvocationIdCallInvoker.SetCurrentInvocationId(expectedInvocationId);
+
+        try
+        {
+            // Act
+            invoker.BlockingUnaryCall(method, null, new CallOptions(headers: originalHeaders), "request");
+
+            // Assert
+            Assert.NotNull(capturedOptions.Headers);
+
+            // Verify invocation ID was added
+            var invocationHeader = capturedOptions.Headers.FirstOrDefault(h => h.Key == InvocationIdMetadataKey);
+            Assert.NotNull(invocationHeader);
+            Assert.Equal(expectedInvocationId, invocationHeader.Value);
+
+            // Verify existing header was preserved
+            var existingHeader = capturedOptions.Headers.FirstOrDefault(h => h.Key == existingHeaderKey);
+            Assert.NotNull(existingHeader);
+            Assert.Equal(existingHeaderValue, existingHeader.Value);
+        }
+        finally
+        {
+            InvocationIdCallInvoker.SetCurrentInvocationId(null);
+        }
+    }
+
+    [Fact]
+    public void BlockingUnaryCall_DoesNotMutateOriginalHeaders()
+    {
+        // Arrange
+        const string expectedInvocationId = "test-invocation-id";
+        CallOptions capturedOptions = default;
+
+        var mockInner = new Mock<CallInvoker>();
+        mockInner
+            .Setup(x => x.BlockingUnaryCall(
+                It.IsAny<Method<string, string>>(),
+                It.IsAny<string>(),
+                It.IsAny<CallOptions>(),
+                It.IsAny<string>()))
+            .Callback<Method<string, string>, string, CallOptions, string>((m, h, o, r) => capturedOptions = o)
+            .Returns("response");
+
+        var invoker = new InvocationIdCallInvoker(mockInner.Object);
+        var method = new Method<string, string>(MethodType.Unary, "TestService", "TestMethod", Marshallers.StringMarshaller, Marshallers.StringMarshaller);
+        var originalHeaders = new Metadata { { "original-key", "original-value" } };
+        int originalCount = originalHeaders.Count;
+
+        InvocationIdCallInvoker.SetCurrentInvocationId(expectedInvocationId);
+
+        try
+        {
+            // Act
+            invoker.BlockingUnaryCall(method, null, new CallOptions(headers: originalHeaders), "request");
+
+            // Assert - original headers should not be mutated
+            Assert.Equal(originalCount, originalHeaders.Count);
+            Assert.DoesNotContain(originalHeaders, h => h.Key == InvocationIdMetadataKey);
+        }
+        finally
+        {
+            InvocationIdCallInvoker.SetCurrentInvocationId(null);
+        }
+    }
+
+    [Fact]
+    public void BlockingUnaryCall_DoesNotAddHeaderWhenNoInvocationId()
+    {
+        // Arrange
+        CallOptions capturedOptions = default;
+
+        var mockInner = new Mock<CallInvoker>();
+        mockInner
+            .Setup(x => x.BlockingUnaryCall(
+                It.IsAny<Method<string, string>>(),
+                It.IsAny<string>(),
+                It.IsAny<CallOptions>(),
+                It.IsAny<string>()))
+            .Callback<Method<string, string>, string, CallOptions, string>((m, h, o, r) => capturedOptions = o)
+            .Returns("response");
+
+        var invoker = new InvocationIdCallInvoker(mockInner.Object);
+        var method = new Method<string, string>(MethodType.Unary, "TestService", "TestMethod", Marshallers.StringMarshaller, Marshallers.StringMarshaller);
+
+        InvocationIdCallInvoker.SetCurrentInvocationId(null);
+
+        // Act
+        invoker.BlockingUnaryCall(method, null, new CallOptions(), "request");
+
+        // Assert - no headers should be added when invocation ID is null
+        Assert.Null(capturedOptions.Headers);
+    }
+
+    [Fact]
+    public void BlockingUnaryCall_ReplacesExistingInvocationIdHeader()
+    {
+        // Arrange
+        const string newInvocationId = "new-invocation-id";
+        const string oldInvocationId = "old-invocation-id";
+        CallOptions capturedOptions = default;
+
+        var mockInner = new Mock<CallInvoker>();
+        mockInner
+            .Setup(x => x.BlockingUnaryCall(
+                It.IsAny<Method<string, string>>(),
+                It.IsAny<string>(),
+                It.IsAny<CallOptions>(),
+                It.IsAny<string>()))
+            .Callback<Method<string, string>, string, CallOptions, string>((m, h, o, r) => capturedOptions = o)
+            .Returns("response");
+
+        var invoker = new InvocationIdCallInvoker(mockInner.Object);
+        var method = new Method<string, string>(MethodType.Unary, "TestService", "TestMethod", Marshallers.StringMarshaller, Marshallers.StringMarshaller);
+        var originalHeaders = new Metadata { { InvocationIdMetadataKey, oldInvocationId } };
+
+        InvocationIdCallInvoker.SetCurrentInvocationId(newInvocationId);
+
+        try
+        {
+            // Act
+            invoker.BlockingUnaryCall(method, null, new CallOptions(headers: originalHeaders), "request");
+
+            // Assert - should have exactly one invocation ID header with the new value
+            Assert.NotNull(capturedOptions.Headers);
+            var invocationHeaders = capturedOptions.Headers.Where(h => h.Key == InvocationIdMetadataKey).ToList();
+            Assert.Single(invocationHeaders);
+            Assert.Equal(newInvocationId, invocationHeaders[0].Value);
+        }
+        finally
+        {
+            InvocationIdCallInvoker.SetCurrentInvocationId(null);
+        }
     }
 }

--- a/test/Worker.Extensions.DurableTask.Tests/InvocationIdCallInvokerTests.cs
+++ b/test/Worker.Extensions.DurableTask.Tests/InvocationIdCallInvokerTests.cs
@@ -369,4 +369,127 @@ public class InvocationIdCallInvokerTests
             InvocationIdCallInvoker.SetCurrentInvocationId(null);
         }
     }
+
+    [Fact]
+    public void AsyncUnaryCall_DoesNotMutateOriginalHeaders()
+    {
+        // Arrange
+        const string expectedInvocationId = "test-invocation-id-async";
+        CallOptions capturedOptions = default;
+
+        var mockInner = new Mock<CallInvoker>();
+        mockInner
+            .Setup(x => x.AsyncUnaryCall(
+                It.IsAny<Method<string, string>>(),
+                It.IsAny<string>(),
+                It.IsAny<CallOptions>(),
+                It.IsAny<string>()))
+            .Callback<Method<string, string>, string, CallOptions, string>((m, h, o, r) => capturedOptions = o)
+            .Returns(new AsyncUnaryCall<string>(
+                Task.FromResult("response"),
+                Task.FromResult(new Metadata()),
+                () => Status.DefaultSuccess,
+                () => new Metadata(),
+                () => { }));
+
+        var invoker = new InvocationIdCallInvoker(mockInner.Object);
+        var method = new Method<string, string>(MethodType.Unary, "TestService", "TestMethod", Marshallers.StringMarshaller, Marshallers.StringMarshaller);
+        var originalHeaders = new Metadata { { "original-key", "original-value" } };
+        int originalCount = originalHeaders.Count;
+
+        InvocationIdCallInvoker.SetCurrentInvocationId(expectedInvocationId);
+
+        try
+        {
+            // Act
+            invoker.AsyncUnaryCall(method, null, new CallOptions(headers: originalHeaders), "request");
+
+            // Assert - original headers should not be mutated
+            Assert.Equal(originalCount, originalHeaders.Count);
+            Assert.DoesNotContain(originalHeaders, h => h.Key == InvocationIdMetadataKey);
+        }
+        finally
+        {
+            InvocationIdCallInvoker.SetCurrentInvocationId(null);
+        }
+    }
+
+    [Fact]
+    public void AsyncUnaryCall_DoesNotAddHeaderWhenNoInvocationId()
+    {
+        // Arrange
+        CallOptions capturedOptions = default;
+
+        var mockInner = new Mock<CallInvoker>();
+        mockInner
+            .Setup(x => x.AsyncUnaryCall(
+                It.IsAny<Method<string, string>>(),
+                It.IsAny<string>(),
+                It.IsAny<CallOptions>(),
+                It.IsAny<string>()))
+            .Callback<Method<string, string>, string, CallOptions, string>((m, h, o, r) => capturedOptions = o)
+            .Returns(new AsyncUnaryCall<string>(
+                Task.FromResult("response"),
+                Task.FromResult(new Metadata()),
+                () => Status.DefaultSuccess,
+                () => new Metadata(),
+                () => { }));
+
+        var invoker = new InvocationIdCallInvoker(mockInner.Object);
+        var method = new Method<string, string>(MethodType.Unary, "TestService", "TestMethod", Marshallers.StringMarshaller, Marshallers.StringMarshaller);
+
+        InvocationIdCallInvoker.SetCurrentInvocationId(null);
+
+        // Act
+        invoker.AsyncUnaryCall(method, null, new CallOptions(), "request");
+
+        // Assert - no headers should be added when invocation ID is null
+        Assert.Null(capturedOptions.Headers);
+    }
+
+    [Fact]
+    public void AsyncUnaryCall_ReplacesExistingInvocationIdHeader()
+    {
+        // Arrange
+        const string newInvocationId = "new-invocation-id";
+        const string oldInvocationId = "old-invocation-id";
+        CallOptions capturedOptions = default;
+
+        var mockInner = new Mock<CallInvoker>();
+        mockInner
+            .Setup(x => x.AsyncUnaryCall(
+                It.IsAny<Method<string, string>>(),
+                It.IsAny<string>(),
+                It.IsAny<CallOptions>(),
+                It.IsAny<string>()))
+            .Callback<Method<string, string>, string, CallOptions, string>((m, h, o, r) => capturedOptions = o)
+            .Returns(new AsyncUnaryCall<string>(
+                Task.FromResult("response"),
+                Task.FromResult(new Metadata()),
+                () => Status.DefaultSuccess,
+                () => new Metadata(),
+                () => { }));
+
+        var invoker = new InvocationIdCallInvoker(mockInner.Object);
+        var method = new Method<string, string>(MethodType.Unary, "TestService", "TestMethod", Marshallers.StringMarshaller, Marshallers.StringMarshaller);
+        var originalHeaders = new Metadata { { InvocationIdMetadataKey, oldInvocationId } };
+
+        InvocationIdCallInvoker.SetCurrentInvocationId(newInvocationId);
+
+        try
+        {
+            // Act
+            invoker.AsyncUnaryCall(method, null, new CallOptions(headers: originalHeaders), "request");
+
+            // Assert - should have exactly one invocation ID header with the new value
+            Assert.NotNull(capturedOptions.Headers);
+            var invocationHeaders = capturedOptions.Headers.Where(h => h.Key == InvocationIdMetadataKey).ToList();
+            Assert.Single(invocationHeaders);
+            Assert.Equal(newInvocationId, invocationHeaders[0].Value);
+        }
+        finally
+        {
+            InvocationIdCallInvoker.SetCurrentInvocationId(null);
+        }
+    }
 }

--- a/test/Worker.Extensions.DurableTask.Tests/InvocationIdCallInvokerTests.cs
+++ b/test/Worker.Extensions.DurableTask.Tests/InvocationIdCallInvokerTests.cs
@@ -34,8 +34,7 @@ public class InvocationIdCallInvokerTests
     [Fact]
     public void GetCurrentInvocationId_ReturnsNullByDefault()
     {
-        // Arrange - ensure clean state
-        InvocationIdCallInvoker.SetCurrentInvocationId(null);
+        // Arrange - nothing to do
 
         // Act
         var actualId = InvocationIdCallInvoker.GetCurrentInvocationId();

--- a/test/Worker.Extensions.DurableTask.Tests/InvocationIdCallInvokerTests.cs
+++ b/test/Worker.Extensions.DurableTask.Tests/InvocationIdCallInvokerTests.cs
@@ -14,6 +14,16 @@ public class InvocationIdCallInvokerTests
 {
     private const string InvocationIdMetadataKey = "x-azure-functions-invocationid";
 
+    private static AsyncUnaryCall<string> CreateAsyncUnaryCallResponse(string response = "response")
+    {
+        return new AsyncUnaryCall<string>(
+            Task.FromResult(response),
+            Task.FromResult(new Metadata()),
+            () => Status.DefaultSuccess,
+            () => new Metadata(),
+            () => { });
+    }
+
     [Fact]
     public void SetCurrentInvocationId_SetsValueInAsyncLocal()
     {
@@ -287,12 +297,7 @@ public class InvocationIdCallInvokerTests
                 It.IsAny<CallOptions>(),
                 It.IsAny<string>()))
             .Callback<Method<string, string>, string, CallOptions, string>((m, h, o, r) => capturedOptions = o)
-            .Returns(new AsyncUnaryCall<string>(
-                Task.FromResult("response"),
-                Task.FromResult(new Metadata()),
-                () => Status.DefaultSuccess,
-                () => new Metadata(),
-                () => { }));
+            .Returns(CreateAsyncUnaryCallResponse());
 
         var invoker = new InvocationIdCallInvoker(mockInner.Object);
         var method = new Method<string, string>(MethodType.Unary, "TestService", "TestMethod", Marshallers.StringMarshaller, Marshallers.StringMarshaller);
@@ -302,7 +307,7 @@ public class InvocationIdCallInvokerTests
         try
         {
             // Act
-            invoker.AsyncUnaryCall(method, null, new CallOptions(), "request");
+            using var call = invoker.AsyncUnaryCall(method, null, new CallOptions(), "request");
 
             // Assert
             Assert.NotNull(capturedOptions.Headers);
@@ -333,12 +338,7 @@ public class InvocationIdCallInvokerTests
                 It.IsAny<CallOptions>(),
                 It.IsAny<string>()))
             .Callback<Method<string, string>, string, CallOptions, string>((m, h, o, r) => capturedOptions = o)
-            .Returns(new AsyncUnaryCall<string>(
-                Task.FromResult("response"),
-                Task.FromResult(new Metadata()),
-                () => Status.DefaultSuccess,
-                () => new Metadata(),
-                () => { }));
+            .Returns(CreateAsyncUnaryCallResponse());
 
         var invoker = new InvocationIdCallInvoker(mockInner.Object);
         var method = new Method<string, string>(MethodType.Unary, "TestService", "TestMethod", Marshallers.StringMarshaller, Marshallers.StringMarshaller);
@@ -349,7 +349,7 @@ public class InvocationIdCallInvokerTests
         try
         {
             // Act
-            invoker.AsyncUnaryCall(method, null, new CallOptions(headers: originalHeaders), "request");
+            using var call = invoker.AsyncUnaryCall(method, null, new CallOptions(headers: originalHeaders), "request");
 
             // Assert
             Assert.NotNull(capturedOptions.Headers);
@@ -385,12 +385,7 @@ public class InvocationIdCallInvokerTests
                 It.IsAny<CallOptions>(),
                 It.IsAny<string>()))
             .Callback<Method<string, string>, string, CallOptions, string>((m, h, o, r) => capturedOptions = o)
-            .Returns(new AsyncUnaryCall<string>(
-                Task.FromResult("response"),
-                Task.FromResult(new Metadata()),
-                () => Status.DefaultSuccess,
-                () => new Metadata(),
-                () => { }));
+            .Returns(CreateAsyncUnaryCallResponse());
 
         var invoker = new InvocationIdCallInvoker(mockInner.Object);
         var method = new Method<string, string>(MethodType.Unary, "TestService", "TestMethod", Marshallers.StringMarshaller, Marshallers.StringMarshaller);
@@ -402,7 +397,7 @@ public class InvocationIdCallInvokerTests
         try
         {
             // Act
-            invoker.AsyncUnaryCall(method, null, new CallOptions(headers: originalHeaders), "request");
+            using var call = invoker.AsyncUnaryCall(method, null, new CallOptions(headers: originalHeaders), "request");
 
             // Assert - original headers should not be mutated
             Assert.Equal(originalCount, originalHeaders.Count);
@@ -428,12 +423,7 @@ public class InvocationIdCallInvokerTests
                 It.IsAny<CallOptions>(),
                 It.IsAny<string>()))
             .Callback<Method<string, string>, string, CallOptions, string>((m, h, o, r) => capturedOptions = o)
-            .Returns(new AsyncUnaryCall<string>(
-                Task.FromResult("response"),
-                Task.FromResult(new Metadata()),
-                () => Status.DefaultSuccess,
-                () => new Metadata(),
-                () => { }));
+            .Returns(CreateAsyncUnaryCallResponse());
 
         var invoker = new InvocationIdCallInvoker(mockInner.Object);
         var method = new Method<string, string>(MethodType.Unary, "TestService", "TestMethod", Marshallers.StringMarshaller, Marshallers.StringMarshaller);
@@ -441,7 +431,7 @@ public class InvocationIdCallInvokerTests
         InvocationIdCallInvoker.SetCurrentInvocationId(null);
 
         // Act
-        invoker.AsyncUnaryCall(method, null, new CallOptions(), "request");
+        using var call = invoker.AsyncUnaryCall(method, null, new CallOptions(), "request");
 
         // Assert - no headers should be added when invocation ID is null
         Assert.Null(capturedOptions.Headers);
@@ -463,12 +453,7 @@ public class InvocationIdCallInvokerTests
                 It.IsAny<CallOptions>(),
                 It.IsAny<string>()))
             .Callback<Method<string, string>, string, CallOptions, string>((m, h, o, r) => capturedOptions = o)
-            .Returns(new AsyncUnaryCall<string>(
-                Task.FromResult("response"),
-                Task.FromResult(new Metadata()),
-                () => Status.DefaultSuccess,
-                () => new Metadata(),
-                () => { }));
+            .Returns(CreateAsyncUnaryCallResponse());
 
         var invoker = new InvocationIdCallInvoker(mockInner.Object);
         var method = new Method<string, string>(MethodType.Unary, "TestService", "TestMethod", Marshallers.StringMarshaller, Marshallers.StringMarshaller);
@@ -479,7 +464,7 @@ public class InvocationIdCallInvokerTests
         try
         {
             // Act
-            invoker.AsyncUnaryCall(method, null, new CallOptions(headers: originalHeaders), "request");
+            using var call = invoker.AsyncUnaryCall(method, null, new CallOptions(headers: originalHeaders), "request");
 
             // Assert - should have exactly one invocation ID header with the new value
             Assert.NotNull(capturedOptions.Headers);

--- a/test/Worker.Extensions.DurableTask.Tests/InvocationIdCallInvokerTests.cs
+++ b/test/Worker.Extensions.DurableTask.Tests/InvocationIdCallInvokerTests.cs
@@ -1,0 +1,73 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Grpc.Core;
+using Xunit;
+
+namespace Microsoft.Azure.Functions.Worker.Extensions.DurableTask.Tests;
+
+public class InvocationIdCallInvokerTests
+{
+    [Fact]
+    public void SetCurrentInvocationId_SetsValueInAsyncLocal()
+    {
+        // Arrange
+        const string expectedId = "test-invocation-id-123";
+
+        // Act
+        InvocationIdCallInvoker.SetCurrentInvocationId(expectedId);
+        var actualId = InvocationIdCallInvoker.GetCurrentInvocationId();
+
+        // Assert
+        Assert.Equal(expectedId, actualId);
+
+        // Cleanup
+        InvocationIdCallInvoker.SetCurrentInvocationId(null);
+    }
+
+    [Fact]
+    public void GetCurrentInvocationId_ReturnsNullByDefault()
+    {
+        // Arrange - ensure clean state
+        InvocationIdCallInvoker.SetCurrentInvocationId(null);
+
+        // Act
+        var actualId = InvocationIdCallInvoker.GetCurrentInvocationId();
+
+        // Assert
+        Assert.Null(actualId);
+    }
+
+    [Fact]
+    public void SetCurrentInvocationId_CanBeCleared()
+    {
+        // Arrange
+        InvocationIdCallInvoker.SetCurrentInvocationId("some-id");
+
+        // Act
+        InvocationIdCallInvoker.SetCurrentInvocationId(null);
+        var actualId = InvocationIdCallInvoker.GetCurrentInvocationId();
+
+        // Assert
+        Assert.Null(actualId);
+    }
+
+    [Fact]
+    public void SetCurrentInvocationId_CanBeOverwritten()
+    {
+        // Arrange
+        const string firstId = "first-id";
+        const string secondId = "second-id";
+
+        // Act
+        InvocationIdCallInvoker.SetCurrentInvocationId(firstId);
+        InvocationIdCallInvoker.SetCurrentInvocationId(secondId);
+        var actualId = InvocationIdCallInvoker.GetCurrentInvocationId();
+
+        // Assert
+        Assert.Equal(secondId, actualId);
+
+        // Cleanup
+        InvocationIdCallInvoker.SetCurrentInvocationId(null);
+    }
+}

--- a/test/Worker.Extensions.DurableTask.Tests/InvocationIdCallInvokerTests.cs
+++ b/test/Worker.Extensions.DurableTask.Tests/InvocationIdCallInvokerTests.cs
@@ -272,4 +272,102 @@ public class InvocationIdCallInvokerTests
             InvocationIdCallInvoker.SetCurrentInvocationId(null);
         }
     }
+
+    [Fact]
+    public void AsyncUnaryCall_AddsInvocationIdToMetadata()
+    {
+        // Arrange
+        const string expectedInvocationId = "test-invocation-id-async";
+        CallOptions capturedOptions = default;
+
+        var mockInner = new Mock<CallInvoker>();
+        mockInner
+            .Setup(x => x.AsyncUnaryCall(
+                It.IsAny<Method<string, string>>(),
+                It.IsAny<string>(),
+                It.IsAny<CallOptions>(),
+                It.IsAny<string>()))
+            .Callback<Method<string, string>, string, CallOptions, string>((m, h, o, r) => capturedOptions = o)
+            .Returns(new AsyncUnaryCall<string>(
+                Task.FromResult("response"),
+                Task.FromResult(new Metadata()),
+                () => Status.DefaultSuccess,
+                () => new Metadata(),
+                () => { }));
+
+        var invoker = new InvocationIdCallInvoker(mockInner.Object);
+        var method = new Method<string, string>(MethodType.Unary, "TestService", "TestMethod", Marshallers.StringMarshaller, Marshallers.StringMarshaller);
+
+        InvocationIdCallInvoker.SetCurrentInvocationId(expectedInvocationId);
+
+        try
+        {
+            // Act
+            invoker.AsyncUnaryCall(method, null, new CallOptions(), "request");
+
+            // Assert
+            Assert.NotNull(capturedOptions.Headers);
+            var header = capturedOptions.Headers.FirstOrDefault(h => h.Key == InvocationIdMetadataKey);
+            Assert.NotNull(header);
+            Assert.Equal(expectedInvocationId, header.Value);
+        }
+        finally
+        {
+            InvocationIdCallInvoker.SetCurrentInvocationId(null);
+        }
+    }
+
+    [Fact]
+    public void AsyncUnaryCall_PreservesExistingHeaders()
+    {
+        // Arrange
+        const string expectedInvocationId = "test-invocation-id-async";
+        const string existingHeaderKey = "existing-header";
+        const string existingHeaderValue = "existing-value";
+        CallOptions capturedOptions = default;
+
+        var mockInner = new Mock<CallInvoker>();
+        mockInner
+            .Setup(x => x.AsyncUnaryCall(
+                It.IsAny<Method<string, string>>(),
+                It.IsAny<string>(),
+                It.IsAny<CallOptions>(),
+                It.IsAny<string>()))
+            .Callback<Method<string, string>, string, CallOptions, string>((m, h, o, r) => capturedOptions = o)
+            .Returns(new AsyncUnaryCall<string>(
+                Task.FromResult("response"),
+                Task.FromResult(new Metadata()),
+                () => Status.DefaultSuccess,
+                () => new Metadata(),
+                () => { }));
+
+        var invoker = new InvocationIdCallInvoker(mockInner.Object);
+        var method = new Method<string, string>(MethodType.Unary, "TestService", "TestMethod", Marshallers.StringMarshaller, Marshallers.StringMarshaller);
+        var originalHeaders = new Metadata { { existingHeaderKey, existingHeaderValue } };
+
+        InvocationIdCallInvoker.SetCurrentInvocationId(expectedInvocationId);
+
+        try
+        {
+            // Act
+            invoker.AsyncUnaryCall(method, null, new CallOptions(headers: originalHeaders), "request");
+
+            // Assert
+            Assert.NotNull(capturedOptions.Headers);
+
+            // Verify invocation ID was added
+            var invocationHeader = capturedOptions.Headers.FirstOrDefault(h => h.Key == InvocationIdMetadataKey);
+            Assert.NotNull(invocationHeader);
+            Assert.Equal(expectedInvocationId, invocationHeader.Value);
+
+            // Verify existing header was preserved
+            var existingHeader = capturedOptions.Headers.FirstOrDefault(h => h.Key == existingHeaderKey);
+            Assert.NotNull(existingHeader);
+            Assert.Equal(existingHeaderValue, existingHeader.Value);
+        }
+        finally
+        {
+            InvocationIdCallInvoker.SetCurrentInvocationId(null);
+        }
+    }
 }

--- a/test/e2e/Tests/Helpers/ClientOperationLogHelpers.cs
+++ b/test/e2e/Tests/Helpers/ClientOperationLogHelpers.cs
@@ -22,13 +22,23 @@ internal static class ClientOperationLogHelpers
     /// <param name="getLogs">A function that returns the current collection of Core Tools logs (re-evaluated on each poll).</param>
     /// <param name="operationType">The expected operation type (e.g., "StartOrchestration", "Terminate").</param>
     /// <param name="instanceId">The expected instance ID.</param>
+    /// <param name="languageType">The language type of the function app under test. Non-DotnetIsolated languages skip polling.</param>
     /// <param name="maxWaitSeconds">Maximum time to wait for the log to appear (default: 5 seconds).</param>
     public static void AssertClientOperationLogExists(
         Func<IEnumerable<string>> getLogs,
         string operationType,
         string instanceId,
+        LanguageType languageType,
         int maxWaitSeconds = 5)
     {
+        // Only the .NET isolated worker SDK currently emits the FunctionInvocationId header.
+        // Skip entirely for other languages to avoid unnecessary test delays.
+        // Tracking issue: https://github.com/Azure/azure-functions-durable-extension/issues/3327
+        if (languageType != LanguageType.DotnetIsolated)
+        {
+            return;
+        }
+
         // Poll for the log to appear, giving Core Tools time to flush logs.
         // Re-fetch logs on each iteration since CoreToolsLogs returns a snapshot.
         bool hasClientOperationLog = WaitForCondition(
@@ -37,17 +47,15 @@ internal static class ClientOperationLogHelpers
                 log.Contains($"for instance '{instanceId}'")),
             maxWaitSeconds);
 
-        // TODO: Remove this conditional check once all SDKs are released with FunctionInvocationId support.
-        // Tracking issue: https://github.com/Azure/azure-functions-durable-extension/issues/3327
-        if (hasClientOperationLog)
-        {
-            // Verify the log has a valid FunctionInvocationId (not empty)
-            Assert.Contains(getLogs(), log =>
-                log.Contains($"Client operation '{operationType}' received") &&
-                log.Contains($"for instance '{instanceId}'") &&
-                log.Contains("FunctionInvocationId:") &&
-                !log.Contains("FunctionInvocationId: ."));  // Ensure the FunctionInvocationId is not empty
-        }
+        Assert.True(hasClientOperationLog,
+            $"Expected ClientOperationReceived log for '{operationType}' on instance '{instanceId}' was not found.");
+
+        // Verify the log has a valid FunctionInvocationId (not empty)
+        Assert.Contains(getLogs(), log =>
+            log.Contains($"Client operation '{operationType}' received") &&
+            log.Contains($"for instance '{instanceId}'") &&
+            log.Contains("FunctionInvocationId:") &&
+            !log.Contains("FunctionInvocationId: ."));  // Ensure the FunctionInvocationId is not empty
 
         // For StartOrchestration operations, also verify a function log exists for correlation
         // Note: gRPC clients emit 'started' logs (FunctionStarting), HTTP clients emit 'scheduled' logs (FunctionScheduled)

--- a/test/e2e/Tests/Helpers/ClientOperationLogHelpers.cs
+++ b/test/e2e/Tests/Helpers/ClientOperationLogHelpers.cs
@@ -15,25 +15,26 @@ namespace Microsoft.Azure.Durable.Tests.DotnetIsolatedE2E;
 internal static class ClientOperationLogHelpers
 {
     /// <summary>
-    /// Asserts that a ClientOperationReceived log was emitted for the specified operation and instance,
-    /// and that a corresponding FunctionScheduled log exists for the same instance (enabling correlation).
-    /// Note: This assertion is skipped if the SDK doesn't propagate the FunctionInvocationId header yet,
-    /// which happens when testing against older SDK versions that don't have this feature.
+    /// Waits for Core Tools logs to be flushed, then asserts that a ClientOperationReceived log
+    /// was emitted for the specified operation and instance. Retries with polling to avoid flaky
+    /// tests caused by log flush timing.
     /// </summary>
     /// <param name="logs">The collection of Core Tools logs.</param>
     /// <param name="operationType">The expected operation type (e.g., "StartOrchestration", "TerminateInstance").</param>
     /// <param name="instanceId">The expected instance ID.</param>
+    /// <param name="maxWaitSeconds">Maximum time to wait for the log to appear (default: 5 seconds).</param>
     public static void AssertClientOperationLogExists(
         IEnumerable<string> logs,
         string operationType,
-        string instanceId)
+        string instanceId,
+        int maxWaitSeconds = 5)
     {
-        // Log format: "Client operation '{operationType}' received for instance '{instanceId}'. FunctionInvocationId: {functionInvocationId}. ..."
-        // Note: The ClientOperationReceived log is only emitted when the SDK sends the FunctionInvocationId header.
-        // If the SDK doesn't support this yet (e.g., older versions), we skip the assertion.
-        bool hasClientOperationLog = logs.Any(log =>
-            log.Contains($"Client operation '{operationType}' received") &&
-            log.Contains($"for instance '{instanceId}'"));
+        // Poll for the log to appear, giving Core Tools time to flush logs
+        bool hasClientOperationLog = WaitForCondition(
+            () => logs.Any(log =>
+                log.Contains($"Client operation '{operationType}' received") &&
+                log.Contains($"for instance '{instanceId}'")),
+            maxWaitSeconds);
 
         // TODO: Remove this conditional check once all SDKs are released with FunctionInvocationId support.
         // Tracking issue: https://github.com/Azure/azure-functions-durable-extension/issues/3327
@@ -136,5 +137,24 @@ internal static class ClientOperationLogHelpers
             log.Contains($"Client operation '{operationType}' received") &&
             log.Contains($"for instance '{instanceId}'") &&
             log.Contains("FunctionInvocationId:"));
+    }
+
+    /// <summary>
+    /// Polls a condition with a 250ms interval, returning true if it becomes true within the timeout.
+    /// </summary>
+    private static bool WaitForCondition(Func<bool> condition, int maxWaitSeconds)
+    {
+        DateTime deadline = DateTime.UtcNow.AddSeconds(maxWaitSeconds);
+        while (DateTime.UtcNow < deadline)
+        {
+            if (condition())
+            {
+                return true;
+            }
+
+            Thread.Sleep(250);
+        }
+
+        return condition();
     }
 }

--- a/test/e2e/Tests/Helpers/ClientOperationLogHelpers.cs
+++ b/test/e2e/Tests/Helpers/ClientOperationLogHelpers.cs
@@ -1,0 +1,131 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace Microsoft.Azure.Durable.Tests.DotnetIsolatedE2E;
+
+/// <summary>
+/// Helper methods for verifying client operation correlation logs in e2e tests.
+/// These logs are emitted when client operations (StartOrchestration, TerminateInstance, etc.)
+/// are received with a FunctionInvocationId header, enabling correlation between out-of-process
+/// workers and host-side orchestration events.
+/// </summary>
+internal static class ClientOperationLogHelpers
+{
+    /// <summary>
+    /// The log message prefix for client operation correlation logs.
+    /// </summary>
+    private const string ClientOperationLogPrefix = "Client operation '";
+
+    /// <summary>
+    /// Asserts that a ClientOperationReceived log was emitted for the specified operation and instance,
+    /// and that a corresponding FunctionScheduled log exists for the same instance (enabling correlation).
+    /// </summary>
+    /// <param name="logs">The collection of Core Tools logs.</param>
+    /// <param name="operationType">The expected operation type (e.g., "StartOrchestration", "TerminateInstance").</param>
+    /// <param name="instanceId">The expected instance ID.</param>
+    public static void AssertClientOperationLogExists(
+        IEnumerable<string> logs,
+        string operationType,
+        string instanceId)
+    {
+        // Log format: "Client operation '{operationType}' received for instance '{instanceId}'. FunctionInvocationId: {functionInvocationId}. ..."
+        Assert.Contains(logs, log =>
+            log.Contains($"Client operation '{operationType}' received") &&
+            log.Contains($"for instance '{instanceId}'") &&
+            log.Contains("FunctionInvocationId:") &&
+            !log.Contains("FunctionInvocationId: ."));  // Ensure the FunctionInvocationId is not empty
+
+        // For StartOrchestration operations, also verify a function log exists for correlation
+        // Note: gRPC clients emit 'started' logs (FunctionStarting), HTTP clients emit 'scheduled' logs (FunctionScheduled)
+        if (operationType == "StartOrchestration")
+        {
+            // FunctionStarting log format: "{instanceId}: Function '{functionName} ({functionType})' started. ..."
+            // FunctionScheduled log format: "{instanceId}: Function '{functionName} ({functionType})' scheduled. ..."
+            Assert.Contains(logs, log =>
+                log.Contains($"{instanceId}: Function '") &&
+                (log.Contains("started") || log.Contains("scheduled")));
+        }
+    }
+
+    /// <summary>
+    /// Asserts that a ClientOperationReceived log was emitted for the specified operation type.
+    /// This overload is useful when the instance ID is not known ahead of time.
+    /// </summary>
+    /// <param name="logs">The collection of Core Tools logs.</param>
+    /// <param name="operationType">The expected operation type (e.g., "StartOrchestration", "TerminateInstance").</param>
+    public static void AssertClientOperationLogExists(
+        IEnumerable<string> logs,
+        string operationType)
+    {
+        // Log format: "Client operation '{operationType}' received for instance '{instanceId}'. FunctionInvocationId: {functionInvocationId}. ..."
+        Assert.Contains(logs, log =>
+            log.Contains($"Client operation '{operationType}' received") &&
+            log.Contains("FunctionInvocationId:") &&
+            !log.Contains("FunctionInvocationId: ."));  // Ensure the FunctionInvocationId is not empty
+    }
+
+    /// <summary>
+    /// Extracts the FunctionInvocationId from a ClientOperationReceived log entry.
+    /// </summary>
+    /// <param name="log">The log entry to extract from.</param>
+    /// <returns>The extracted FunctionInvocationId, or null if not found.</returns>
+    public static string? ExtractFunctionInvocationId(string log)
+    {
+        // Log format: "... FunctionInvocationId: {functionInvocationId}. HubName: ..."
+        var match = Regex.Match(log, @"FunctionInvocationId:\s*([a-f0-9\-]+)\.", RegexOptions.IgnoreCase);
+        return match.Success ? match.Groups[1].Value : null;
+    }
+
+    /// <summary>
+    /// Checks if any ClientOperationReceived log exists (without asserting).
+    /// Useful for scenarios where logging is optional or to determine if correlation is working.
+    /// </summary>
+    /// <param name="logs">The collection of Core Tools logs.</param>
+    /// <param name="operationType">The expected operation type.</param>
+    /// <returns>True if a matching log exists, false otherwise.</returns>
+    public static bool HasClientOperationLog(
+        IEnumerable<string> logs,
+        string operationType)
+    {
+        return logs.Any(log =>
+            log.Contains($"Client operation '{operationType}' received") &&
+            log.Contains("FunctionInvocationId:") &&
+            !log.Contains("FunctionInvocationId: ."));
+    }
+
+    /// <summary>
+    /// Gets the count of ClientOperationReceived logs for a specific operation type.
+    /// </summary>
+    /// <param name="logs">The collection of Core Tools logs.</param>
+    /// <param name="operationType">The operation type to count.</param>
+    /// <returns>The number of matching logs.</returns>
+    public static int GetClientOperationLogCount(
+        IEnumerable<string> logs,
+        string operationType)
+    {
+        return logs.Count(log =>
+            log.Contains($"Client operation '{operationType}' received") &&
+            log.Contains("FunctionInvocationId:"));
+    }
+
+    /// <summary>
+    /// Gets the count of ClientOperationReceived logs for a specific operation type and instance ID.
+    /// </summary>
+    /// <param name="logs">The collection of Core Tools logs.</param>
+    /// <param name="operationType">The operation type to count.</param>
+    /// <param name="instanceId">The instance ID to filter by.</param>
+    /// <returns>The number of matching logs.</returns>
+    public static int GetClientOperationLogCount(
+        IEnumerable<string> logs,
+        string operationType,
+        string instanceId)
+    {
+        return logs.Count(log =>
+            log.Contains($"Client operation '{operationType}' received") &&
+            log.Contains($"for instance '{instanceId}'") &&
+            log.Contains("FunctionInvocationId:"));
+    }
+}

--- a/test/e2e/Tests/Helpers/ClientOperationLogHelpers.cs
+++ b/test/e2e/Tests/Helpers/ClientOperationLogHelpers.cs
@@ -22,6 +22,8 @@ internal static class ClientOperationLogHelpers
     /// <summary>
     /// Asserts that a ClientOperationReceived log was emitted for the specified operation and instance,
     /// and that a corresponding FunctionScheduled log exists for the same instance (enabling correlation).
+    /// Note: This assertion is skipped if the SDK doesn't propagate the FunctionInvocationId header yet,
+    /// which happens when testing against older SDK versions that don't have this feature.
     /// </summary>
     /// <param name="logs">The collection of Core Tools logs.</param>
     /// <param name="operationType">The expected operation type (e.g., "StartOrchestration", "TerminateInstance").</param>
@@ -32,11 +34,23 @@ internal static class ClientOperationLogHelpers
         string instanceId)
     {
         // Log format: "Client operation '{operationType}' received for instance '{instanceId}'. FunctionInvocationId: {functionInvocationId}. ..."
-        Assert.Contains(logs, log =>
+        // Note: The ClientOperationReceived log is only emitted when the SDK sends the FunctionInvocationId header.
+        // If the SDK doesn't support this yet (e.g., older versions), we skip the assertion.
+        bool hasClientOperationLog = logs.Any(log =>
             log.Contains($"Client operation '{operationType}' received") &&
-            log.Contains($"for instance '{instanceId}'") &&
-            log.Contains("FunctionInvocationId:") &&
-            !log.Contains("FunctionInvocationId: ."));  // Ensure the FunctionInvocationId is not empty
+            log.Contains($"for instance '{instanceId}'"));
+
+        // TODO: Remove this conditional check once all SDKs are released with FunctionInvocationId support.
+        // Tracking issue: https://github.com/Azure/azure-functions-durable-extension/issues/3327
+        if (hasClientOperationLog)
+        {
+            // Verify the log has a valid FunctionInvocationId (not empty)
+            Assert.Contains(logs, log =>
+                log.Contains($"Client operation '{operationType}' received") &&
+                log.Contains($"for instance '{instanceId}'") &&
+                log.Contains("FunctionInvocationId:") &&
+                !log.Contains("FunctionInvocationId: ."));  // Ensure the FunctionInvocationId is not empty
+        }
 
         // For StartOrchestration operations, also verify a function log exists for correlation
         // Note: gRPC clients emit 'started' logs (FunctionStarting), HTTP clients emit 'scheduled' logs (FunctionScheduled)

--- a/test/e2e/Tests/Helpers/ClientOperationLogHelpers.cs
+++ b/test/e2e/Tests/Helpers/ClientOperationLogHelpers.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Azure.Durable.Tests.DotnetIsolatedE2E;
 
 /// <summary>
 /// Helper methods for verifying client operation correlation logs in e2e tests.
-/// These logs are emitted when client operations (StartOrchestration, TerminateInstance, etc.)
+/// These logs are emitted when client operations (StartOrchestration, Terminate, etc.)
 /// are received with a FunctionInvocationId header, enabling correlation between out-of-process
 /// workers and host-side orchestration events.
 /// </summary>
@@ -20,7 +20,7 @@ internal static class ClientOperationLogHelpers
     /// tests caused by log flush timing.
     /// </summary>
     /// <param name="getLogs">A function that returns the current collection of Core Tools logs (re-evaluated on each poll).</param>
-    /// <param name="operationType">The expected operation type (e.g., "StartOrchestration", "TerminateInstance").</param>
+    /// <param name="operationType">The expected operation type (e.g., "StartOrchestration", "Terminate").</param>
     /// <param name="instanceId">The expected instance ID.</param>
     /// <param name="maxWaitSeconds">Maximum time to wait for the log to appear (default: 5 seconds).</param>
     public static void AssertClientOperationLogExists(
@@ -66,7 +66,7 @@ internal static class ClientOperationLogHelpers
     /// This overload is useful when the instance ID is not known ahead of time.
     /// </summary>
     /// <param name="logs">The collection of Core Tools logs.</param>
-    /// <param name="operationType">The expected operation type (e.g., "StartOrchestration", "TerminateInstance").</param>
+    /// <param name="operationType">The expected operation type (e.g., "StartOrchestration", "Terminate").</param>
     public static void AssertClientOperationLogExists(
         IEnumerable<string> logs,
         string operationType)

--- a/test/e2e/Tests/Helpers/ClientOperationLogHelpers.cs
+++ b/test/e2e/Tests/Helpers/ClientOperationLogHelpers.cs
@@ -19,19 +19,20 @@ internal static class ClientOperationLogHelpers
     /// was emitted for the specified operation and instance. Retries with polling to avoid flaky
     /// tests caused by log flush timing.
     /// </summary>
-    /// <param name="logs">The collection of Core Tools logs.</param>
+    /// <param name="getLogs">A function that returns the current collection of Core Tools logs (re-evaluated on each poll).</param>
     /// <param name="operationType">The expected operation type (e.g., "StartOrchestration", "TerminateInstance").</param>
     /// <param name="instanceId">The expected instance ID.</param>
     /// <param name="maxWaitSeconds">Maximum time to wait for the log to appear (default: 5 seconds).</param>
     public static void AssertClientOperationLogExists(
-        IEnumerable<string> logs,
+        Func<IEnumerable<string>> getLogs,
         string operationType,
         string instanceId,
         int maxWaitSeconds = 5)
     {
-        // Poll for the log to appear, giving Core Tools time to flush logs
+        // Poll for the log to appear, giving Core Tools time to flush logs.
+        // Re-fetch logs on each iteration since CoreToolsLogs returns a snapshot.
         bool hasClientOperationLog = WaitForCondition(
-            () => logs.Any(log =>
+            () => getLogs().Any(log =>
                 log.Contains($"Client operation '{operationType}' received") &&
                 log.Contains($"for instance '{instanceId}'")),
             maxWaitSeconds);
@@ -41,7 +42,7 @@ internal static class ClientOperationLogHelpers
         if (hasClientOperationLog)
         {
             // Verify the log has a valid FunctionInvocationId (not empty)
-            Assert.Contains(logs, log =>
+            Assert.Contains(getLogs(), log =>
                 log.Contains($"Client operation '{operationType}' received") &&
                 log.Contains($"for instance '{instanceId}'") &&
                 log.Contains("FunctionInvocationId:") &&
@@ -54,7 +55,7 @@ internal static class ClientOperationLogHelpers
         {
             // FunctionStarting log format: "{instanceId}: Function '{functionName} ({functionType})' started. ..."
             // FunctionScheduled log format: "{instanceId}: Function '{functionName} ({functionType})' scheduled. ..."
-            Assert.Contains(logs, log =>
+            Assert.Contains(getLogs(), log =>
                 log.Contains($"{instanceId}: Function '") &&
                 (log.Contains("started") || log.Contains("scheduled")));
         }

--- a/test/e2e/Tests/Helpers/ClientOperationLogHelpers.cs
+++ b/test/e2e/Tests/Helpers/ClientOperationLogHelpers.cs
@@ -15,11 +15,6 @@ namespace Microsoft.Azure.Durable.Tests.DotnetIsolatedE2E;
 internal static class ClientOperationLogHelpers
 {
     /// <summary>
-    /// The log message prefix for client operation correlation logs.
-    /// </summary>
-    private const string ClientOperationLogPrefix = "Client operation '";
-
-    /// <summary>
     /// Asserts that a ClientOperationReceived log was emitted for the specified operation and instance,
     /// and that a corresponding FunctionScheduled log exists for the same instance (enabling correlation).
     /// Note: This assertion is skipped if the SDK doesn't propagate the FunctionInvocationId header yet,

--- a/test/e2e/Tests/Tests/ClassBasedEntityTests.cs
+++ b/test/e2e/Tests/Tests/ClassBasedEntityTests.cs
@@ -32,6 +32,7 @@ public class ClassBasedEntityTests
             queryString: "?orchestrationName=ClassBasedEntityOrchestration");
         Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
 
+        string instanceId = await DurableHelpers.ParseInstanceIdAsync(response);
         string statusQueryGetUri = await DurableHelpers.ParseStatusQueryGetUriAsync(response);
         await DurableHelpers.WaitForOrchestrationStateAsync(statusQueryGetUri, "Completed", 30);
 
@@ -42,5 +43,11 @@ public class ClassBasedEntityTests
 
         string expectedOutput = "IConfiguration: yes, MyInjectedService: yes, BlobContainerClient: yes, Number: 42";
         Assert.Equal(expectedOutput, orchestrationDetails.Output);
+
+        // Verify that the ClientOperationReceived log was emitted with a FunctionInvocationId
+        ClientOperationLogHelpers.AssertClientOperationLogExists(
+            () => this.fixture.TestLogs.CoreToolsLogs,
+            "StartOrchestration",
+            instanceId);
     }
 }

--- a/test/e2e/Tests/Tests/ClassBasedEntityTests.cs
+++ b/test/e2e/Tests/Tests/ClassBasedEntityTests.cs
@@ -48,6 +48,7 @@ public class ClassBasedEntityTests
         ClientOperationLogHelpers.AssertClientOperationLogExists(
             () => this.fixture.TestLogs.CoreToolsLogs,
             "StartOrchestration",
-            instanceId);
+            instanceId,
+            this.fixture.functionLanguageLocalizer.GetLanguageType());
     }
 }

--- a/test/e2e/Tests/Tests/DistributedTracingEntitiesTests.cs
+++ b/test/e2e/Tests/Tests/DistributedTracingEntitiesTests.cs
@@ -114,12 +114,5 @@ public class DistributedTracingEntitiesTests
         Assert.NotNull(ids);
         Assert.Equal(5, ids.Count);
         Assert.True(ids.All(traceId => traceId.Equals(activity.TraceId.ToString())));
-
-        // Verify that the ClientOperationReceived log was emitted for the SignalEntity call
-        ClientOperationLogHelpers.AssertClientOperationLogExists(
-            () => _fixture.TestLogs.CoreToolsLogs,
-            "SignalEntity",
-            "@ActivityRecorderEntity@mainEntity",
-            _fixture.functionLanguageLocalizer.GetLanguageType());
     }
 }

--- a/test/e2e/Tests/Tests/DistributedTracingEntitiesTests.cs
+++ b/test/e2e/Tests/Tests/DistributedTracingEntitiesTests.cs
@@ -119,6 +119,7 @@ public class DistributedTracingEntitiesTests
         ClientOperationLogHelpers.AssertClientOperationLogExists(
             () => _fixture.TestLogs.CoreToolsLogs,
             "SignalEntity",
-            "@ActivityRecorderEntity@mainEntity");
+            "@ActivityRecorderEntity@mainEntity",
+            _fixture.functionLanguageLocalizer.GetLanguageType());
     }
 }

--- a/test/e2e/Tests/Tests/DistributedTracingEntitiesTests.cs
+++ b/test/e2e/Tests/Tests/DistributedTracingEntitiesTests.cs
@@ -114,5 +114,13 @@ public class DistributedTracingEntitiesTests
         Assert.NotNull(ids);
         Assert.Equal(5, ids.Count);
         Assert.True(ids.All(traceId => traceId.Equals(activity.TraceId.ToString())));
+
+        // Verify that the ClientOperationReceived log was emitted for the SignalEntity call.
+        // Note: Entity names are lowercased by the SDK's EntityInstanceId constructor.
+        ClientOperationLogHelpers.AssertClientOperationLogExists(
+            () => _fixture.TestLogs.CoreToolsLogs,
+            "SignalEntity",
+            "@activityrecorderentity@mainEntity",
+            _fixture.functionLanguageLocalizer.GetLanguageType());
     }
 }

--- a/test/e2e/Tests/Tests/DistributedTracingEntitiesTests.cs
+++ b/test/e2e/Tests/Tests/DistributedTracingEntitiesTests.cs
@@ -114,5 +114,11 @@ public class DistributedTracingEntitiesTests
         Assert.NotNull(ids);
         Assert.Equal(5, ids.Count);
         Assert.True(ids.All(traceId => traceId.Equals(activity.TraceId.ToString())));
+
+        // Verify that the ClientOperationReceived log was emitted for the SignalEntity call
+        ClientOperationLogHelpers.AssertClientOperationLogExists(
+            () => _fixture.TestLogs.CoreToolsLogs,
+            "SignalEntity",
+            "@ActivityRecorderEntity@mainEntity");
     }
 }

--- a/test/e2e/Tests/Tests/ExternalEventTests.cs
+++ b/test/e2e/Tests/Tests/ExternalEventTests.cs
@@ -39,6 +39,19 @@ public class ExternalEventTests
         // Make sure orchestration instance completes successfully.
         await DurableHelpers.WaitForOrchestrationStateAsync(statusQueryGetUri, "Completed", 30);
 
+        // Give some time for Core Tools to write logs out
+        Thread.Sleep(500);
+
+        // Verify that the ClientOperationReceived logs were emitted with a FunctionInvocationId
+        ClientOperationLogHelpers.AssertClientOperationLogExists(
+            this.fixture.TestLogs.CoreToolsLogs,
+            "StartOrchestration",
+            instanceId);
+        ClientOperationLogHelpers.AssertClientOperationLogExists(
+            this.fixture.TestLogs.CoreToolsLogs,
+            "RaiseEvent",
+            instanceId);
+
         // Send external event again to the completed orchestrator, which we will get a exception back.
         HttpResponseMessage resendEventResponse = await HttpHelpers.InvokeHttpTriggerWithBody("SendExternalEvent_HttpStart", jsonContent, "application/json");
         string responseContent = await resendEventResponse.Content.ReadAsStringAsync();

--- a/test/e2e/Tests/Tests/ExternalEventTests.cs
+++ b/test/e2e/Tests/Tests/ExternalEventTests.cs
@@ -41,11 +41,11 @@ public class ExternalEventTests
 
         // Verify that the ClientOperationReceived logs were emitted with a FunctionInvocationId
         ClientOperationLogHelpers.AssertClientOperationLogExists(
-            this.fixture.TestLogs.CoreToolsLogs,
+            () => this.fixture.TestLogs.CoreToolsLogs,
             "StartOrchestration",
             instanceId);
         ClientOperationLogHelpers.AssertClientOperationLogExists(
-            this.fixture.TestLogs.CoreToolsLogs,
+            () => this.fixture.TestLogs.CoreToolsLogs,
             "RaiseEvent",
             instanceId);
 

--- a/test/e2e/Tests/Tests/ExternalEventTests.cs
+++ b/test/e2e/Tests/Tests/ExternalEventTests.cs
@@ -39,9 +39,6 @@ public class ExternalEventTests
         // Make sure orchestration instance completes successfully.
         await DurableHelpers.WaitForOrchestrationStateAsync(statusQueryGetUri, "Completed", 30);
 
-        // Give some time for Core Tools to write logs out
-        Thread.Sleep(500);
-
         // Verify that the ClientOperationReceived logs were emitted with a FunctionInvocationId
         ClientOperationLogHelpers.AssertClientOperationLogExists(
             this.fixture.TestLogs.CoreToolsLogs,

--- a/test/e2e/Tests/Tests/ExternalEventTests.cs
+++ b/test/e2e/Tests/Tests/ExternalEventTests.cs
@@ -43,11 +43,13 @@ public class ExternalEventTests
         ClientOperationLogHelpers.AssertClientOperationLogExists(
             () => this.fixture.TestLogs.CoreToolsLogs,
             "StartOrchestration",
-            instanceId);
+            instanceId,
+            this.fixture.functionLanguageLocalizer.GetLanguageType());
         ClientOperationLogHelpers.AssertClientOperationLogExists(
             () => this.fixture.TestLogs.CoreToolsLogs,
             "RaiseEvent",
-            instanceId);
+            instanceId,
+            this.fixture.functionLanguageLocalizer.GetLanguageType());
 
         // Send external event again to the completed orchestrator, which we will get a exception back.
         HttpResponseMessage resendEventResponse = await HttpHelpers.InvokeHttpTriggerWithBody("SendExternalEvent_HttpStart", jsonContent, "application/json");

--- a/test/e2e/Tests/Tests/GetOrchestrationHistoryTests.cs
+++ b/test/e2e/Tests/Tests/GetOrchestrationHistoryTests.cs
@@ -198,6 +198,16 @@ public class GetOrchestrationHistoryTests
             Assert.Equal(taskFailureDetails.ErrorType, subOrchestrationFailureDetails.InnerFailure.ErrorType);
             Assert.Equal(taskFailureDetails.ErrorMessage, subOrchestrationFailureDetails.InnerFailure.ErrorMessage);
         }
+
+        // Verify that the ClientOperationReceived logs were emitted with a FunctionInvocationId
+        ClientOperationLogHelpers.AssertClientOperationLogExists(
+            () => this.fixture.TestLogs.CoreToolsLogs,
+            "StartOrchestration",
+            instanceId);
+        ClientOperationLogHelpers.AssertClientOperationLogExists(
+            () => this.fixture.TestLogs.CoreToolsLogs,
+            "StreamInstanceHistory",
+            instanceId);
     }
 
     [Fact]
@@ -276,6 +286,16 @@ public class GetOrchestrationHistoryTests
         Assert.Equal(result, JsonConvert.DeserializeObject<ComplexInput>(executionCompletedEvent.Result));
         Assert.Equal(subOrchestrationInstanceCreatedEvent.EventId, subOrchestrationCompletedEvent.TaskScheduledId);
         Assert.Equal(result, JsonConvert.DeserializeObject<ComplexInput>(subOrchestrationCompletedEvent.Result));
+
+        // Verify that the ClientOperationReceived logs were emitted with a FunctionInvocationId
+        ClientOperationLogHelpers.AssertClientOperationLogExists(
+            () => this.fixture.TestLogs.CoreToolsLogs,
+            "StartOrchestration",
+            instanceId);
+        ClientOperationLogHelpers.AssertClientOperationLogExists(
+            () => this.fixture.TestLogs.CoreToolsLogs,
+            "StreamInstanceHistory",
+            instanceId);
 
         // The suborchestration calls Activities/entities with large outputs, so it should force multiple history chunks in the streaming process
         using HttpResponseMessage getSubOrchestrationHistoryResponse = await HttpHelpers.InvokeHttpTrigger("GetInstanceHistory", $"?instanceId={subOrchestrationInstanceId}");

--- a/test/e2e/Tests/Tests/GetOrchestrationHistoryTests.cs
+++ b/test/e2e/Tests/Tests/GetOrchestrationHistoryTests.cs
@@ -203,11 +203,13 @@ public class GetOrchestrationHistoryTests
         ClientOperationLogHelpers.AssertClientOperationLogExists(
             () => this.fixture.TestLogs.CoreToolsLogs,
             "StartOrchestration",
-            instanceId);
+            instanceId,
+            this.fixture.functionLanguageLocalizer.GetLanguageType());
         ClientOperationLogHelpers.AssertClientOperationLogExists(
             () => this.fixture.TestLogs.CoreToolsLogs,
             "StreamInstanceHistory",
-            instanceId);
+            instanceId,
+            this.fixture.functionLanguageLocalizer.GetLanguageType());
     }
 
     [Fact]
@@ -291,11 +293,13 @@ public class GetOrchestrationHistoryTests
         ClientOperationLogHelpers.AssertClientOperationLogExists(
             () => this.fixture.TestLogs.CoreToolsLogs,
             "StartOrchestration",
-            instanceId);
+            instanceId,
+            this.fixture.functionLanguageLocalizer.GetLanguageType());
         ClientOperationLogHelpers.AssertClientOperationLogExists(
             () => this.fixture.TestLogs.CoreToolsLogs,
             "StreamInstanceHistory",
-            instanceId);
+            instanceId,
+            this.fixture.functionLanguageLocalizer.GetLanguageType());
 
         // The suborchestration calls Activities/entities with large outputs, so it should force multiple history chunks in the streaming process
         using HttpResponseMessage getSubOrchestrationHistoryResponse = await HttpHelpers.InvokeHttpTrigger("GetInstanceHistory", $"?instanceId={subOrchestrationInstanceId}");

--- a/test/e2e/Tests/Tests/HelloCitiesTest.cs
+++ b/test/e2e/Tests/Tests/HelloCitiesTest.cs
@@ -35,9 +35,6 @@ public class HttpEndToEndTests
         var orchestrationDetails = await DurableHelpers.GetRunningOrchestrationDetailsAsync(statusQueryGetUri);
         Assert.Contains(partialExpectedOutput, orchestrationDetails.Output);
 
-        // Give some time for Core Tools to write logs out
-        Thread.Sleep(500);
-
         // Verify that the ClientOperationReceived log was emitted with a FunctionInvocationId
         ClientOperationLogHelpers.AssertClientOperationLogExists(
             this.fixture.TestLogs.CoreToolsLogs,

--- a/test/e2e/Tests/Tests/HelloCitiesTest.cs
+++ b/test/e2e/Tests/Tests/HelloCitiesTest.cs
@@ -37,7 +37,7 @@ public class HttpEndToEndTests
 
         // Verify that the ClientOperationReceived log was emitted with a FunctionInvocationId
         ClientOperationLogHelpers.AssertClientOperationLogExists(
-            this.fixture.TestLogs.CoreToolsLogs,
+            () => this.fixture.TestLogs.CoreToolsLogs,
             "StartOrchestration",
             instanceId);
     }

--- a/test/e2e/Tests/Tests/HelloCitiesTest.cs
+++ b/test/e2e/Tests/Tests/HelloCitiesTest.cs
@@ -39,6 +39,7 @@ public class HttpEndToEndTests
         ClientOperationLogHelpers.AssertClientOperationLogExists(
             () => this.fixture.TestLogs.CoreToolsLogs,
             "StartOrchestration",
-            instanceId);
+            instanceId,
+            this.fixture.functionLanguageLocalizer.GetLanguageType());
     }
 }

--- a/test/e2e/Tests/Tests/HelloCitiesTest.cs
+++ b/test/e2e/Tests/Tests/HelloCitiesTest.cs
@@ -28,10 +28,20 @@ public class HttpEndToEndTests
 
         Assert.Equal(expectedStatusCode, response.StatusCode);
         string statusQueryGetUri = await DurableHelpers.ParseStatusQueryGetUriAsync(response);
+        string instanceId = await DurableHelpers.ParseInstanceIdAsync(response);
 
         await DurableHelpers.WaitForOrchestrationStateAsync(statusQueryGetUri, "Completed", 30);
 
         var orchestrationDetails = await DurableHelpers.GetRunningOrchestrationDetailsAsync(statusQueryGetUri);
         Assert.Contains(partialExpectedOutput, orchestrationDetails.Output);
+
+        // Give some time for Core Tools to write logs out
+        Thread.Sleep(500);
+
+        // Verify that the ClientOperationReceived log was emitted with a FunctionInvocationId
+        ClientOperationLogHelpers.AssertClientOperationLogExists(
+            this.fixture.TestLogs.CoreToolsLogs,
+            "StartOrchestration",
+            instanceId);
     }
 }

--- a/test/e2e/Tests/Tests/PurgeInstancesTests.cs
+++ b/test/e2e/Tests/Tests/PurgeInstancesTests.cs
@@ -159,9 +159,6 @@ public class PurgeInstancesTests
         Assert.Equal(HttpStatusCode.OK, purgeCompleted.StatusCode);
         await AssertPurgeCount(purgeCompleted, 1);
 
-        // Give some time for Core Tools to write logs out
-        Thread.Sleep(500);
-
         // Verify that the ClientOperationReceived logs were emitted with a FunctionInvocationId
         ClientOperationLogHelpers.AssertClientOperationLogExists(
             this.fixture.TestLogs.CoreToolsLogs,

--- a/test/e2e/Tests/Tests/PurgeInstancesTests.cs
+++ b/test/e2e/Tests/Tests/PurgeInstancesTests.cs
@@ -161,7 +161,7 @@ public class PurgeInstancesTests
 
         // Verify that the ClientOperationReceived logs were emitted with a FunctionInvocationId
         ClientOperationLogHelpers.AssertClientOperationLogExists(
-            this.fixture.TestLogs.CoreToolsLogs,
+            () => this.fixture.TestLogs.CoreToolsLogs,
             "StartOrchestration",
             completedInstanceId);
 

--- a/test/e2e/Tests/Tests/PurgeInstancesTests.cs
+++ b/test/e2e/Tests/Tests/PurgeInstancesTests.cs
@@ -164,6 +164,10 @@ public class PurgeInstancesTests
             () => this.fixture.TestLogs.CoreToolsLogs,
             "StartOrchestration",
             completedInstanceId);
+        ClientOperationLogHelpers.AssertClientOperationLogExists(
+            () => this.fixture.TestLogs.CoreToolsLogs,
+            "PurgeInstances",
+            completedInstanceId);
 
         // Terminated orchestration, should succeed
         if (this.fixture.functionLanguageLocalizer.GetLanguageType() != LanguageType.Java

--- a/test/e2e/Tests/Tests/PurgeInstancesTests.cs
+++ b/test/e2e/Tests/Tests/PurgeInstancesTests.cs
@@ -163,11 +163,13 @@ public class PurgeInstancesTests
         ClientOperationLogHelpers.AssertClientOperationLogExists(
             () => this.fixture.TestLogs.CoreToolsLogs,
             "StartOrchestration",
-            completedInstanceId);
+            completedInstanceId,
+            this.fixture.functionLanguageLocalizer.GetLanguageType());
         ClientOperationLogHelpers.AssertClientOperationLogExists(
             () => this.fixture.TestLogs.CoreToolsLogs,
             "PurgeInstances",
-            completedInstanceId);
+            completedInstanceId,
+            this.fixture.functionLanguageLocalizer.GetLanguageType());
 
         // Terminated orchestration, should succeed
         if (this.fixture.functionLanguageLocalizer.GetLanguageType() != LanguageType.Java

--- a/test/e2e/Tests/Tests/PurgeInstancesTests.cs
+++ b/test/e2e/Tests/Tests/PurgeInstancesTests.cs
@@ -159,6 +159,15 @@ public class PurgeInstancesTests
         Assert.Equal(HttpStatusCode.OK, purgeCompleted.StatusCode);
         await AssertPurgeCount(purgeCompleted, 1);
 
+        // Give some time for Core Tools to write logs out
+        Thread.Sleep(500);
+
+        // Verify that the ClientOperationReceived logs were emitted with a FunctionInvocationId
+        ClientOperationLogHelpers.AssertClientOperationLogExists(
+            this.fixture.TestLogs.CoreToolsLogs,
+            "StartOrchestration",
+            completedInstanceId);
+
         // Terminated orchestration, should succeed
         if (this.fixture.functionLanguageLocalizer.GetLanguageType() != LanguageType.Java
             && this.fixture.GetDurabilityProvider() != FunctionAppFixture.ConfiguredDurabilityProviderType.MSSQL) // Bug: https://github.com/microsoft/durabletask-java/issues/237

--- a/test/e2e/Tests/Tests/RestartOrchestrationTests.cs
+++ b/test/e2e/Tests/Tests/RestartOrchestrationTests.cs
@@ -39,7 +39,7 @@ public class RestartOrchestrationTests
         string statusQueryGetUri = await DurableHelpers.ParseStatusQueryGetUriAsync(response);
         string instanceId = await DurableHelpers.ParseInstanceIdAsync(response);
 
-        await DurableHelpers.WaitForOrchestrationStateAsync(statusQueryGetUri, "Completed", 10);
+        await DurableHelpers.WaitForOrchestrationStateAsync(statusQueryGetUri, "Completed", 30);
         var orchestrationDetails = await DurableHelpers.GetRunningOrchestrationDetailsAsync(statusQueryGetUri);
         string output1 = orchestrationDetails.Output;
         DateTime createdTime1 = orchestrationDetails.CreatedTime;
@@ -61,7 +61,7 @@ public class RestartOrchestrationTests
         string restartStatusQueryGetUri = await DurableHelpers.ParseStatusQueryGetUriAsync(restartResponse);
         string restartInstanceId = await DurableHelpers.ParseInstanceIdAsync(restartResponse);
 
-        await DurableHelpers.WaitForOrchestrationStateAsync(restartStatusQueryGetUri, "Completed", 10);
+        await DurableHelpers.WaitForOrchestrationStateAsync(restartStatusQueryGetUri, "Completed", 30);
         var restartOrchestrationDetails = await DurableHelpers.GetRunningOrchestrationDetailsAsync(restartStatusQueryGetUri);
         string output2 = restartOrchestrationDetails.Output;
         DateTime createdTime2 = restartOrchestrationDetails.CreatedTime;

--- a/test/e2e/Tests/Tests/RewindOrchestratorTests.cs
+++ b/test/e2e/Tests/Tests/RewindOrchestratorTests.cs
@@ -71,7 +71,8 @@ public class RewindOrchestratorTests
         ClientOperationLogHelpers.AssertClientOperationLogExists(
             () => this.fixture.TestLogs.CoreToolsLogs,
             "StartOrchestration",
-            instanceId);
+            instanceId,
+            this.fixture.functionLanguageLocalizer.GetLanguageType());
         // Should have numFailures rewind operations logged for this instance (if SDK supports the header)
         int rewindLogCount = ClientOperationLogHelpers.GetClientOperationLogCount(
             this.fixture.TestLogs.CoreToolsLogs,

--- a/test/e2e/Tests/Tests/RewindOrchestratorTests.cs
+++ b/test/e2e/Tests/Tests/RewindOrchestratorTests.cs
@@ -70,15 +70,22 @@ public class RewindOrchestratorTests
         Thread.Sleep(500);
 
         // Verify that the ClientOperationReceived logs were emitted with a FunctionInvocationId
+        // Note: These assertions are conditional - they only verify IF the SDK supports the header
         ClientOperationLogHelpers.AssertClientOperationLogExists(
             this.fixture.TestLogs.CoreToolsLogs,
             "StartOrchestration",
             instanceId);
-        // Should have numFailures rewind operations logged for this instance
-        Assert.Equal(numFailures, ClientOperationLogHelpers.GetClientOperationLogCount(
+        // Should have numFailures rewind operations logged for this instance (if SDK supports the header)
+        int rewindLogCount = ClientOperationLogHelpers.GetClientOperationLogCount(
             this.fixture.TestLogs.CoreToolsLogs,
             "Rewind",
-            instanceId));
+            instanceId);
+        // TODO: Remove this conditional check once all SDKs are released with FunctionInvocationId support.
+        // Tracking issue: https://github.com/Azure/azure-functions-durable-extension/issues/3327
+        if (rewindLogCount > 0)
+        {
+            Assert.Equal(numFailures, rewindLogCount);
+        }
     }
 
     [Fact]

--- a/test/e2e/Tests/Tests/RewindOrchestratorTests.cs
+++ b/test/e2e/Tests/Tests/RewindOrchestratorTests.cs
@@ -66,9 +66,6 @@ public class RewindOrchestratorTests
             }
         }
 
-        // Give some time for Core Tools to write logs out
-        Thread.Sleep(500);
-
         // Verify that the ClientOperationReceived logs were emitted with a FunctionInvocationId
         // Note: These assertions are conditional - they only verify IF the SDK supports the header
         ClientOperationLogHelpers.AssertClientOperationLogExists(

--- a/test/e2e/Tests/Tests/RewindOrchestratorTests.cs
+++ b/test/e2e/Tests/Tests/RewindOrchestratorTests.cs
@@ -65,6 +65,20 @@ public class RewindOrchestratorTests
                 Assert.Equal(1, kvp.Value);
             }
         }
+
+        // Give some time for Core Tools to write logs out
+        Thread.Sleep(500);
+
+        // Verify that the ClientOperationReceived logs were emitted with a FunctionInvocationId
+        ClientOperationLogHelpers.AssertClientOperationLogExists(
+            this.fixture.TestLogs.CoreToolsLogs,
+            "StartOrchestration",
+            instanceId);
+        // Should have numFailures rewind operations logged for this instance
+        Assert.Equal(numFailures, ClientOperationLogHelpers.GetClientOperationLogCount(
+            this.fixture.TestLogs.CoreToolsLogs,
+            "Rewind",
+            instanceId));
     }
 
     [Fact]

--- a/test/e2e/Tests/Tests/RewindOrchestratorTests.cs
+++ b/test/e2e/Tests/Tests/RewindOrchestratorTests.cs
@@ -69,7 +69,7 @@ public class RewindOrchestratorTests
         // Verify that the ClientOperationReceived logs were emitted with a FunctionInvocationId
         // Note: These assertions are conditional - they only verify IF the SDK supports the header
         ClientOperationLogHelpers.AssertClientOperationLogExists(
-            this.fixture.TestLogs.CoreToolsLogs,
+            () => this.fixture.TestLogs.CoreToolsLogs,
             "StartOrchestration",
             instanceId);
         // Should have numFailures rewind operations logged for this instance (if SDK supports the header)

--- a/test/e2e/Tests/Tests/ScheduledOrchestrationTests.cs
+++ b/test/e2e/Tests/Tests/ScheduledOrchestrationTests.cs
@@ -82,7 +82,8 @@ public class ScheduledOrchestrationTests
         ClientOperationLogHelpers.AssertClientOperationLogExists(
             () => this.fixture.TestLogs.CoreToolsLogs,
             "StartOrchestration",
-            instanceId);
+            instanceId,
+            this.fixture.functionLanguageLocalizer.GetLanguageType());
     }
 
     [Theory]
@@ -138,6 +139,7 @@ public class ScheduledOrchestrationTests
         ClientOperationLogHelpers.AssertClientOperationLogExists(
             () => this.fixture.TestLogs.CoreToolsLogs,
             "StartOrchestration",
-            instanceId);
+            instanceId,
+            this.fixture.functionLanguageLocalizer.GetLanguageType());
     }
 }

--- a/test/e2e/Tests/Tests/ScheduledOrchestrationTests.cs
+++ b/test/e2e/Tests/Tests/ScheduledOrchestrationTests.cs
@@ -45,11 +45,10 @@ public class ScheduledOrchestrationTests
         string urlQueryString = $"?ScheduledStartTime={scheduledStartTime.ToString("o")}";
 
         using HttpResponseMessage response = await HttpHelpers.InvokeHttpTrigger(functionName, urlQueryString);
+        Assert.Equal(expectedStatusCode, response.StatusCode);
 
         string instanceId = await DurableHelpers.ParseInstanceIdAsync(response);
         string statusQueryGetUri = await DurableHelpers.ParseStatusQueryGetUriAsync(response);
-
-        Assert.Equal(expectedStatusCode, response.StatusCode);
 
         if (scheduledStartTime > DateTime.UtcNow + TimeSpan.FromSeconds(1))
         {
@@ -101,11 +100,11 @@ public class ScheduledOrchestrationTests
         string urlQueryString = $"?scheduledStartDelaySeconds={startDelaySeconds}";
 
         using HttpResponseMessage response = await HttpHelpers.InvokeHttpTrigger(functionName, urlQueryString);
+        Assert.Equal(expectedStatusCode, response.StatusCode);
 
         string instanceId = await DurableHelpers.ParseInstanceIdAsync(response);
         string statusQueryGetUri = await DurableHelpers.ParseStatusQueryGetUriAsync(response);
 
-        Assert.Equal(expectedStatusCode, response.StatusCode);
         await DurableHelpers.WaitForOrchestrationStateAsync(statusQueryGetUri, "Completed", Math.Max(startDelaySeconds, 0) + 30);
         var schedulerOrchestrationDetails = await DurableHelpers.GetRunningOrchestrationDetailsAsync(statusQueryGetUri);
         string subOrchestratorInstanceId = schedulerOrchestrationDetails.Output;

--- a/test/e2e/Tests/Tests/ScheduledOrchestrationTests.cs
+++ b/test/e2e/Tests/Tests/ScheduledOrchestrationTests.cs
@@ -46,6 +46,7 @@ public class ScheduledOrchestrationTests
 
         using HttpResponseMessage response = await HttpHelpers.InvokeHttpTrigger(functionName, urlQueryString);
 
+        string instanceId = await DurableHelpers.ParseInstanceIdAsync(response);
         string statusQueryGetUri = await DurableHelpers.ParseStatusQueryGetUriAsync(response);
 
         Assert.Equal(expectedStatusCode, response.StatusCode);
@@ -77,6 +78,12 @@ public class ScheduledOrchestrationTests
         var finalOrchestrationDetails = await DurableHelpers.GetRunningOrchestrationDetailsAsync(statusQueryGetUri);
         WriteOutput($"Last updated at {finalOrchestrationDetails.LastUpdatedTime}, scheduled to complete at {scheduledStartTime}");
         Assert.True(finalOrchestrationDetails.LastUpdatedTime + TimeSpan.FromSeconds(2) >= scheduledStartTime);
+
+        // Verify that the ClientOperationReceived log was emitted with a FunctionInvocationId
+        ClientOperationLogHelpers.AssertClientOperationLogExists(
+            () => this.fixture.TestLogs.CoreToolsLogs,
+            "StartOrchestration",
+            instanceId);
     }
 
     [Theory]
@@ -95,6 +102,7 @@ public class ScheduledOrchestrationTests
 
         using HttpResponseMessage response = await HttpHelpers.InvokeHttpTrigger(functionName, urlQueryString);
 
+        string instanceId = await DurableHelpers.ParseInstanceIdAsync(response);
         string statusQueryGetUri = await DurableHelpers.ParseStatusQueryGetUriAsync(response);
 
         Assert.Equal(expectedStatusCode, response.StatusCode);
@@ -126,5 +134,11 @@ public class ScheduledOrchestrationTests
         var subOrchestrationDetails = await DurableHelpers.GetRunningOrchestrationDetailsAsync(subOrchestratorStatusQueryGetUri);
         Assert.True(subOrchestrationDetails.LastUpdatedTime + TimeSpan.FromSeconds(2) >= scheduledStartTime);
         Assert.Equal("Success", subOrchestrationDetails.Output);
+
+        // Verify that the ClientOperationReceived log was emitted with a FunctionInvocationId
+        ClientOperationLogHelpers.AssertClientOperationLogExists(
+            () => this.fixture.TestLogs.CoreToolsLogs,
+            "StartOrchestration",
+            instanceId);
     }
 }

--- a/test/e2e/Tests/Tests/SuspendResumeTests.cs
+++ b/test/e2e/Tests/Tests/SuspendResumeTests.cs
@@ -47,15 +47,18 @@ public class SuspendResumeTests
             ClientOperationLogHelpers.AssertClientOperationLogExists(
                 () => this.fixture.TestLogs.CoreToolsLogs,
                 "StartOrchestration",
-                instanceId);
+                instanceId,
+                this.fixture.functionLanguageLocalizer.GetLanguageType());
             ClientOperationLogHelpers.AssertClientOperationLogExists(
                 () => this.fixture.TestLogs.CoreToolsLogs,
                 "Suspend",
-                instanceId);
+                instanceId,
+                this.fixture.functionLanguageLocalizer.GetLanguageType());
             ClientOperationLogHelpers.AssertClientOperationLogExists(
                 () => this.fixture.TestLogs.CoreToolsLogs,
                 "Resume",
-                instanceId);
+                instanceId,
+                this.fixture.functionLanguageLocalizer.GetLanguageType());
         }
         finally
         {

--- a/test/e2e/Tests/Tests/SuspendResumeTests.cs
+++ b/test/e2e/Tests/Tests/SuspendResumeTests.cs
@@ -43,9 +43,6 @@ public class SuspendResumeTests
 
             await DurableHelpers.WaitForOrchestrationStateAsync(statusQueryGetUri, "Running", 5);
 
-            // Give some time for Core Tools to write logs out
-            Thread.Sleep(500);
-
             // Verify that the ClientOperationReceived logs were emitted with a FunctionInvocationId
             ClientOperationLogHelpers.AssertClientOperationLogExists(
                 this.fixture.TestLogs.CoreToolsLogs,

--- a/test/e2e/Tests/Tests/SuspendResumeTests.cs
+++ b/test/e2e/Tests/Tests/SuspendResumeTests.cs
@@ -30,18 +30,18 @@ public class SuspendResumeTests
         string instanceId = await DurableHelpers.ParseInstanceIdAsync(response);
         string statusQueryGetUri = await DurableHelpers.ParseStatusQueryGetUriAsync(response);
 
-        await DurableHelpers.WaitForOrchestrationStateAsync(statusQueryGetUri, "Running", 5);
+        await DurableHelpers.WaitForOrchestrationStateAsync(statusQueryGetUri, "Running", 30);
         try
         {
             using HttpResponseMessage suspendResponse = await HttpHelpers.InvokeHttpTrigger("SuspendInstance", $"?instanceId={instanceId}");
             await AssertRequestSucceedsAsync(suspendResponse);
 
-            await DurableHelpers.WaitForOrchestrationStateAsync(statusQueryGetUri, "Suspended", 5);
+            await DurableHelpers.WaitForOrchestrationStateAsync(statusQueryGetUri, "Suspended", 30);
 
             using HttpResponseMessage resumeResponse = await HttpHelpers.InvokeHttpTrigger("ResumeInstance", $"?instanceId={instanceId}");
             await AssertRequestSucceedsAsync(resumeResponse);
 
-            await DurableHelpers.WaitForOrchestrationStateAsync(statusQueryGetUri, "Running", 5);
+            await DurableHelpers.WaitForOrchestrationStateAsync(statusQueryGetUri, "Running", 30);
 
             // Verify that the ClientOperationReceived logs were emitted with a FunctionInvocationId
             ClientOperationLogHelpers.AssertClientOperationLogExists(
@@ -72,13 +72,13 @@ public class SuspendResumeTests
         string instanceId = await DurableHelpers.ParseInstanceIdAsync(response);
         string statusQueryGetUri = await DurableHelpers.ParseStatusQueryGetUriAsync(response);
 
-        await DurableHelpers.WaitForOrchestrationStateAsync(statusQueryGetUri, "Running", 5);
+        await DurableHelpers.WaitForOrchestrationStateAsync(statusQueryGetUri, "Running", 30);
         try
         {
             using HttpResponseMessage suspendResponse = await HttpHelpers.InvokeHttpTrigger("SuspendInstance", $"?instanceId={instanceId}");
             await AssertRequestSucceedsAsync(suspendResponse);
 
-            await DurableHelpers.WaitForOrchestrationStateAsync(statusQueryGetUri, "Suspended", 5);
+            await DurableHelpers.WaitForOrchestrationStateAsync(statusQueryGetUri, "Suspended", 30);
 
             using HttpResponseMessage resumeResponse = await HttpHelpers.InvokeHttpTrigger("SuspendInstance", $"?instanceId={instanceId}");
             await AssertRequestFailsAsync(resumeResponse, fixture.functionLanguageLocalizer.GetLocalizedStringValue("SuspendSuspendedInstance.FailureMessage"));
@@ -105,7 +105,7 @@ public class SuspendResumeTests
         string instanceId = await DurableHelpers.ParseInstanceIdAsync(response);
         string statusQueryGetUri = await DurableHelpers.ParseStatusQueryGetUriAsync(response);
 
-        await DurableHelpers.WaitForOrchestrationStateAsync(statusQueryGetUri, "Running", 5);
+        await DurableHelpers.WaitForOrchestrationStateAsync(statusQueryGetUri, "Running", 30);
         try
         {
             using HttpResponseMessage resumeResponse = await HttpHelpers.InvokeHttpTrigger("ResumeInstance", $"?instanceId={instanceId}");
@@ -135,7 +135,7 @@ public class SuspendResumeTests
         string instanceId = await DurableHelpers.ParseInstanceIdAsync(response);
         string statusQueryGetUri = await DurableHelpers.ParseStatusQueryGetUriAsync(response);
 
-        await DurableHelpers.WaitForOrchestrationStateAsync(statusQueryGetUri, "Completed", 5);
+        await DurableHelpers.WaitForOrchestrationStateAsync(statusQueryGetUri, "Completed", 30);
         try
         {
             using HttpResponseMessage suspendResponse = await HttpHelpers.InvokeHttpTrigger("SuspendInstance", $"?instanceId={instanceId}");

--- a/test/e2e/Tests/Tests/SuspendResumeTests.cs
+++ b/test/e2e/Tests/Tests/SuspendResumeTests.cs
@@ -42,6 +42,23 @@ public class SuspendResumeTests
             await AssertRequestSucceedsAsync(resumeResponse);
 
             await DurableHelpers.WaitForOrchestrationStateAsync(statusQueryGetUri, "Running", 5);
+
+            // Give some time for Core Tools to write logs out
+            Thread.Sleep(500);
+
+            // Verify that the ClientOperationReceived logs were emitted with a FunctionInvocationId
+            ClientOperationLogHelpers.AssertClientOperationLogExists(
+                this.fixture.TestLogs.CoreToolsLogs,
+                "StartOrchestration",
+                instanceId);
+            ClientOperationLogHelpers.AssertClientOperationLogExists(
+                this.fixture.TestLogs.CoreToolsLogs,
+                "Suspend",
+                instanceId);
+            ClientOperationLogHelpers.AssertClientOperationLogExists(
+                this.fixture.TestLogs.CoreToolsLogs,
+                "Resume",
+                instanceId);
         }
         finally
         {

--- a/test/e2e/Tests/Tests/SuspendResumeTests.cs
+++ b/test/e2e/Tests/Tests/SuspendResumeTests.cs
@@ -45,15 +45,15 @@ public class SuspendResumeTests
 
             // Verify that the ClientOperationReceived logs were emitted with a FunctionInvocationId
             ClientOperationLogHelpers.AssertClientOperationLogExists(
-                this.fixture.TestLogs.CoreToolsLogs,
+                () => this.fixture.TestLogs.CoreToolsLogs,
                 "StartOrchestration",
                 instanceId);
             ClientOperationLogHelpers.AssertClientOperationLogExists(
-                this.fixture.TestLogs.CoreToolsLogs,
+                () => this.fixture.TestLogs.CoreToolsLogs,
                 "Suspend",
                 instanceId);
             ClientOperationLogHelpers.AssertClientOperationLogExists(
-                this.fixture.TestLogs.CoreToolsLogs,
+                () => this.fixture.TestLogs.CoreToolsLogs,
                 "Resume",
                 instanceId);
         }

--- a/test/e2e/Tests/Tests/TerminateOrchestratorTests.cs
+++ b/test/e2e/Tests/Tests/TerminateOrchestratorTests.cs
@@ -42,11 +42,13 @@ public class TerminateOrchestratorTests
         ClientOperationLogHelpers.AssertClientOperationLogExists(
             () => this.fixture.TestLogs.CoreToolsLogs,
             "StartOrchestration",
-            instanceId);
+            instanceId,
+            this.fixture.functionLanguageLocalizer.GetLanguageType());
         ClientOperationLogHelpers.AssertClientOperationLogExists(
             () => this.fixture.TestLogs.CoreToolsLogs,
             "Terminate",
-            instanceId);
+            instanceId,
+            this.fixture.functionLanguageLocalizer.GetLanguageType());
     }
 
 

--- a/test/e2e/Tests/Tests/TerminateOrchestratorTests.cs
+++ b/test/e2e/Tests/Tests/TerminateOrchestratorTests.cs
@@ -38,9 +38,6 @@ public class TerminateOrchestratorTests
 
         await DurableHelpers.WaitForOrchestrationStateAsync(statusQueryGetUri, "Terminated", 30);
 
-        // Give some time for Core Tools to write logs out
-        Thread.Sleep(500);
-
         // Verify that the ClientOperationReceived logs were emitted with a FunctionInvocationId
         ClientOperationLogHelpers.AssertClientOperationLogExists(
             this.fixture.TestLogs.CoreToolsLogs,

--- a/test/e2e/Tests/Tests/TerminateOrchestratorTests.cs
+++ b/test/e2e/Tests/Tests/TerminateOrchestratorTests.cs
@@ -37,6 +37,19 @@ public class TerminateOrchestratorTests
         await AssertTerminateRequestSucceedsAsync(terminateResponse);
 
         await DurableHelpers.WaitForOrchestrationStateAsync(statusQueryGetUri, "Terminated", 30);
+
+        // Give some time for Core Tools to write logs out
+        Thread.Sleep(500);
+
+        // Verify that the ClientOperationReceived logs were emitted with a FunctionInvocationId
+        ClientOperationLogHelpers.AssertClientOperationLogExists(
+            this.fixture.TestLogs.CoreToolsLogs,
+            "StartOrchestration",
+            instanceId);
+        ClientOperationLogHelpers.AssertClientOperationLogExists(
+            this.fixture.TestLogs.CoreToolsLogs,
+            "Terminate",
+            instanceId);
     }
 
 

--- a/test/e2e/Tests/Tests/TerminateOrchestratorTests.cs
+++ b/test/e2e/Tests/Tests/TerminateOrchestratorTests.cs
@@ -40,11 +40,11 @@ public class TerminateOrchestratorTests
 
         // Verify that the ClientOperationReceived logs were emitted with a FunctionInvocationId
         ClientOperationLogHelpers.AssertClientOperationLogExists(
-            this.fixture.TestLogs.CoreToolsLogs,
+            () => this.fixture.TestLogs.CoreToolsLogs,
             "StartOrchestration",
             instanceId);
         ClientOperationLogHelpers.AssertClientOperationLogExists(
-            this.fixture.TestLogs.CoreToolsLogs,
+            () => this.fixture.TestLogs.CoreToolsLogs,
             "Terminate",
             instanceId);
     }


### PR DESCRIPTION
## Summary
This PR implements support for correlating out-of-process worker function invocations with host-side orchestration events by propagating the `FunctionInvocationId` through HTTP headers and gRPC metadata.

## Changes

### Host Extension
- Added new ETW event 235 (`ClientOperationReceived`) for logging correlation information
- Modified `HttpApiHandler` to extract `X-Azure-Functions-InvocationId` header from HTTP requests
- Modified `TaskHubGrpcServer` to extract `x-azure-functions-invocationid` from gRPC metadata
- Updated `EndToEndTraceHelper` with new `ClientOperationReceived` method

### .NET Isolated SDK  
- Added `InvocationIdCallInvoker` that wraps gRPC calls to inject the invocation ID as metadata
- Modified `FunctionsDurableClientProvider` to wrap the gRPC channel with the custom call invoker
- Used `AsyncLocal<string>` for thread-safe context propagation

### Tests
- Added unit tests for `EndToEndTraceHelper.ClientOperationReceived`
- Added unit tests for `InvocationIdCallInvoker`
- Added e2e tests with log assertions to verify correlation works end-to-end

## Log Format

> Client operation '{operationType}' received for instance '{instanceId}'. FunctionInvocationId: {functionInvocationId}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}. SequenceNumber: {sequenceNumber}.


## Correlation Pattern
Users can correlate logs by matching:
1. `ClientOperationReceived` log (has `FunctionInvocationId` and `InstanceId`)
2. `FunctionStarting/FunctionScheduled` logs (have `InstanceId`)

## Related SDK PRs:

- https://github.com/microsoft/durabletask-java/pull/252
- https://github.com/Azure/azure-functions-durable-python/pull/593
- https://github.com/Azure/azure-functions-durable-js/pull/672

Fixes #3317
