### PR TITLE
Support Tags when RestartInstance

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -27,9 +27,9 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="3.9.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.9.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="3.9.0" />
-    <PackageVersion Include="Microsoft.DurableTask.Client.Grpc" Version="1.19.1" />
-    <PackageVersion Include="Microsoft.DurableTask.Worker.Grpc" Version="1.19.1" />
-    <PackageVersion Include="Microsoft.DurableTask.Abstractions" Version="1.19.1" />
+    <PackageVersion Include="Microsoft.DurableTask.Client.Grpc" Version="1.20.1" />
+    <PackageVersion Include="Microsoft.DurableTask.Worker.Grpc" Version="1.20.1" />
+    <PackageVersion Include="Microsoft.DurableTask.Abstractions" Version="1.20.1" />
     <PackageVersion Include="Microsoft.DurableTask.Analyzers" Version="0.2.0" />
     <PackageVersion Include="Microsoft.Extensions.Azure" Version="1.7.0" />
     <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.0" />

--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableClient.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableClient.cs
@@ -174,7 +174,21 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         }
 
         /// <inheritdoc />
-        async Task<string> IDurableOrchestrationClient.StartNewAsync<T>(string orchestratorFunctionName, string instanceId, T input)
+        Task<string> IDurableOrchestrationClient.StartNewAsync<T>(string orchestratorFunctionName, string instanceId, T input)
+        {
+            return this.StartNewAsync<T>(orchestratorFunctionName, instanceId, input, tags: null);
+        }
+
+        /// <summary>
+        /// Starts a new instance of the specified orchestrator function with optional tags.
+        /// </summary>
+        /// <param name="orchestratorFunctionName">The name of the orchestrator function to start.</param>
+        /// <param name="instanceId">The ID to use for the new orchestration instance.</param>
+        /// <param name="input">JSON-serializable input value for the orchestrator function.</param>
+        /// <param name="tags">A dictionary of key-value pairs to associate with the orchestration instance.</param>
+        /// <typeparam name="T">The type of the input value for the orchestrator function.</typeparam>
+        /// <returns>A task that completes when the orchestration is started.</returns>
+        public async Task<string> StartNewAsync<T>(string orchestratorFunctionName, string instanceId, T input, IDictionary<string, string> tags)
         {
             if (this.ClientReferencesCurrentApp(this))
             {
@@ -201,7 +215,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
             OrchestrationStatus[] dedupeStatuses = this.GetStatusesNotToOverride();
             Task<OrchestrationInstance> createTask = this.client.CreateOrchestrationInstanceAsync(
-                orchestratorFunctionName, this.durableTaskOptions.DefaultVersion, instanceId, input, null, dedupeStatuses);
+                orchestratorFunctionName, this.durableTaskOptions.DefaultVersion, instanceId, input, tags, dedupeStatuses);
 
             this.traceHelper.FunctionScheduled(
                 this.TaskHubName,
@@ -1150,25 +1164,26 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
         async Task<string> IDurableOrchestrationClient.RestartAsync(string instanceId, bool restartWithNewInstanceId)
         {
-            DurableOrchestrationStatus status = await ((IDurableOrchestrationClient)this).GetStatusAsync(instanceId, showHistory: false, showHistoryOutput: false, showInput: true);
+            OrchestrationState state = await this.GetOrchestrationInstanceStateAsync(instanceId);
 
-            if (status == null)
+            if (state == null)
             {
                 throw new ArgumentException($"An orchestrastion with the instanceId {instanceId} was not found.");
             }
 
-            bool isInstaceNotCompleted = status.RuntimeStatus == OrchestrationRuntimeStatus.Running ||
-                                        status.RuntimeStatus == OrchestrationRuntimeStatus.Pending ||
-                                        status.RuntimeStatus == OrchestrationRuntimeStatus.Suspended;
+            bool isInstaceNotCompleted = state.OrchestrationStatus == OrchestrationStatus.Running ||
+                                        state.OrchestrationStatus == OrchestrationStatus.Pending ||
+                                        state.OrchestrationStatus == OrchestrationStatus.Suspended;
 
             if (isInstaceNotCompleted && !restartWithNewInstanceId)
             {
-                throw new InvalidOperationException($"Instance '{instanceId}' cannot be restarted while it is in state '{status.RuntimeStatus}'. " +
+                throw new InvalidOperationException($"Instance '{instanceId}' cannot be restarted while it is in state '{state.OrchestrationStatus}'. " +
                     "Wait until it has completed, or restart with a new instance ID.");
             }
 
-            return restartWithNewInstanceId ? await ((IDurableOrchestrationClient)this).StartNewAsync(orchestratorFunctionName: status.Name, status.Input)
-                : await ((IDurableOrchestrationClient)this).StartNewAsync(orchestratorFunctionName: status.Name, instanceId: status.InstanceId, status.Input);
+            JToken input = ParseToJToken(state.Input);
+            return restartWithNewInstanceId ? await ((IDurableOrchestrationClient)this).StartNewAsync(orchestratorFunctionName: state.Name, input)
+                : await ((IDurableOrchestrationClient)this).StartNewAsync(orchestratorFunctionName: state.Name, instanceId: state.OrchestrationInstance.InstanceId, input);
         }
 
         /// <inheritdoc/>

--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableClient.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableClient.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
@@ -199,20 +199,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 throw new ArgumentException($"Instance ID lengths must not exceed {MaxInstanceIdLength} characters.");
             }
 
-            OrchestrationStatus[] dedupeStatuses = this.GetStatusesNotToOverride();
-            Task<OrchestrationInstance> createTask = this.client.CreateOrchestrationInstanceAsync(
-                orchestratorFunctionName, this.durableTaskOptions.DefaultVersion, instanceId, input, null, dedupeStatuses);
-
-            this.traceHelper.FunctionScheduled(
-                this.TaskHubName,
-                orchestratorFunctionName,
-                instanceId,
-                reason: "NewInstance",
-                functionType: FunctionType.Orchestrator,
-                isReplay: false);
-
-            OrchestrationInstance instance = await createTask;
-            return instance.InstanceId;
+            return await this.CreateOrchestrationInstanceAndTraceAsync(orchestratorFunctionName, instanceId, input, tags: null, "NewInstance");
         }
 
         private OrchestrationStatus[] GetStatusesNotToOverride()
@@ -1150,18 +1137,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
         async Task<string> IDurableOrchestrationClient.RestartAsync(string instanceId, bool restartWithNewInstanceId)
         {
+            // GetOrchestrationInstanceStateAsync will throw ArgumentException if the provided instanceid is not found.
             OrchestrationState state = await this.GetOrchestrationInstanceStateAsync(instanceId);
 
-            if (state == null)
-            {
-                throw new ArgumentException($"An orchestrastion with the instanceId {instanceId} was not found.");
-            }
-
-            bool isInstaceNotCompleted = state.OrchestrationStatus == OrchestrationStatus.Running ||
+            bool isInstanceNotCompleted = state.OrchestrationStatus == OrchestrationStatus.Running ||
                                         state.OrchestrationStatus == OrchestrationStatus.Pending ||
                                         state.OrchestrationStatus == OrchestrationStatus.Suspended;
 
-            if (isInstaceNotCompleted && !restartWithNewInstanceId)
+            if (isInstanceNotCompleted && !restartWithNewInstanceId)
             {
                 throw new InvalidOperationException($"Instance '{instanceId}' cannot be restarted while it is in state '{state.OrchestrationStatus}'. " +
                     "Wait until it has completed, or restart with a new instance ID.");
@@ -1176,25 +1159,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 newInstanceId = Guid.NewGuid().ToString("N");
             }
 
-            OrchestrationStatus[] dedupeStatuses = this.GetStatusesNotToOverride();
-            Task<OrchestrationInstance> createTask = this.client.CreateOrchestrationInstanceAsync(
-                name: state.Name,
-                version: this.durableTaskOptions.DefaultVersion,
+            return await this.CreateOrchestrationInstanceAndTraceAsync(
+                orchestratorFunctionName: state.Name,
                 instanceId: restartWithNewInstanceId ? newInstanceId : instanceId,
                 input: input,
                 tags: state.Tags,
-                dedupeStatuses: dedupeStatuses);
-
-            this.traceHelper.FunctionScheduled(
-                this.TaskHubName,
-                state.Name,
-                instanceId,
-                reason: "NewInstance",
-                functionType: FunctionType.Orchestrator,
-                isReplay: false);
-
-            OrchestrationInstance instance = await createTask;
-            return instance.InstanceId;
+                reason: "RestartInstance");
         }
 
         /// <inheritdoc/>
@@ -1250,6 +1220,34 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             }
 
             return this.durabilityProvider.MakeCurrentAppPrimaryAsync();
+        }
+
+        private async Task<string> CreateOrchestrationInstanceAndTraceAsync(
+            string orchestratorFunctionName,
+            string instanceId,
+            object input,
+            IDictionary<string, string> tags,
+            string reason)
+        {
+            OrchestrationStatus[] dedupeStatuses = this.GetStatusesNotToOverride();
+            Task<OrchestrationInstance> createTask = this.client.CreateOrchestrationInstanceAsync(
+                orchestratorFunctionName,
+                this.durableTaskOptions.DefaultVersion,
+                instanceId,
+                input,
+                tags,
+                dedupeStatuses);
+
+            this.traceHelper.FunctionScheduled(
+                this.TaskHubName,
+                orchestratorFunctionName,
+                instanceId,
+                reason: reason,
+                functionType: FunctionType.Orchestrator,
+                isReplay: false);
+
+            OrchestrationInstance instance = await createTask;
+            return instance.InstanceId;
         }
 
         private class EventIndexDateMapping

--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableClient.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableClient.cs
@@ -174,7 +174,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         }
 
         /// <inheritdoc />
-        public async Task<string> StartNewAsync<T>(string orchestratorFunctionName, string instanceId, T input)
+        async Task<string> IDurableOrchestrationClient.StartNewAsync<T>(string orchestratorFunctionName, string instanceId, T input)
         {
             if (this.ClientReferencesCurrentApp(this))
             {

--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableClient.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableClient.cs
@@ -174,21 +174,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         }
 
         /// <inheritdoc />
-        Task<string> IDurableOrchestrationClient.StartNewAsync<T>(string orchestratorFunctionName, string instanceId, T input)
-        {
-            return this.StartNewAsync<T>(orchestratorFunctionName, instanceId, input, tags: null);
-        }
-
-        /// <summary>
-        /// Starts a new instance of the specified orchestrator function with optional tags.
-        /// </summary>
-        /// <param name="orchestratorFunctionName">The name of the orchestrator function to start.</param>
-        /// <param name="instanceId">The ID to use for the new orchestration instance.</param>
-        /// <param name="input">JSON-serializable input value for the orchestrator function.</param>
-        /// <param name="tags">A dictionary of key-value pairs to associate with the orchestration instance.</param>
-        /// <typeparam name="T">The type of the input value for the orchestrator function.</typeparam>
-        /// <returns>A task that completes when the orchestration is started.</returns>
-        public async Task<string> StartNewAsync<T>(string orchestratorFunctionName, string instanceId, T input, IDictionary<string, string> tags)
+        public async Task<string> StartNewAsync<T>(string orchestratorFunctionName, string instanceId, T input)
         {
             if (this.ClientReferencesCurrentApp(this))
             {
@@ -215,7 +201,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
             OrchestrationStatus[] dedupeStatuses = this.GetStatusesNotToOverride();
             Task<OrchestrationInstance> createTask = this.client.CreateOrchestrationInstanceAsync(
-                orchestratorFunctionName, this.durableTaskOptions.DefaultVersion, instanceId, input, tags, dedupeStatuses);
+                orchestratorFunctionName, this.durableTaskOptions.DefaultVersion, instanceId, input, null, dedupeStatuses);
 
             this.traceHelper.FunctionScheduled(
                 this.TaskHubName,
@@ -1182,8 +1168,33 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             }
 
             JToken input = ParseToJToken(state.Input);
-            return restartWithNewInstanceId ? await ((IDurableOrchestrationClient)this).StartNewAsync(orchestratorFunctionName: state.Name, input)
-                : await ((IDurableOrchestrationClient)this).StartNewAsync(orchestratorFunctionName: state.Name, instanceId: state.OrchestrationInstance.InstanceId, input);
+
+            string newInstanceId = null;
+
+            if (restartWithNewInstanceId)
+            {
+                newInstanceId = Guid.NewGuid().ToString("N");
+            }
+
+            OrchestrationStatus[] dedupeStatuses = this.GetStatusesNotToOverride();
+            Task<OrchestrationInstance> createTask = this.client.CreateOrchestrationInstanceAsync(
+                name: state.Name,
+                version: this.durableTaskOptions.DefaultVersion,
+                instanceId: restartWithNewInstanceId ? newInstanceId : instanceId,
+                input: input,
+                tags: state.Tags,
+                dedupeStatuses: dedupeStatuses);
+
+            this.traceHelper.FunctionScheduled(
+                this.TaskHubName,
+                state.Name,
+                instanceId,
+                reason: "NewInstance",
+                functionType: FunctionType.Orchestrator,
+                isReplay: false);
+
+            OrchestrationInstance instance = await createTask;
+            return instance.InstanceId;
         }
 
         /// <inheritdoc/>

--- a/src/WebJobs.Extensions.DurableTask/TaskHubGrpcServer.cs
+++ b/src/WebJobs.Extensions.DurableTask/TaskHubGrpcServer.cs
@@ -499,21 +499,31 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
         private static P.GetInstanceResponse CreateGetInstanceResponse(OrchestrationState state, P.GetInstanceRequest request)
         {
+            var orchestrationState = new P.OrchestrationState
+            {
+                InstanceId = state.OrchestrationInstance.InstanceId,
+                Name = state.Name,
+                OrchestrationStatus = (P.OrchestrationStatus)state.OrchestrationStatus,
+                CreatedTimestamp = Timestamp.FromDateTime(state.CreatedTime),
+                LastUpdatedTimestamp = Timestamp.FromDateTime(state.LastUpdatedTime),
+                Input = request.GetInputsAndOutputs ? state.Input : null,
+                Output = request.GetInputsAndOutputs ? state.Output : null,
+                CustomStatus = request.GetInputsAndOutputs ? state.Status : null,
+                FailureDetails = request.GetInputsAndOutputs ? GetFailureDetails(state.FailureDetails) : null,
+            };
+
+            if (state.Tags != null)
+            {
+                foreach (var tag in state.Tags)
+                {
+                    orchestrationState.Tags[tag.Key] = tag.Value;
+                }
+            }
+
             return new P.GetInstanceResponse
             {
                 Exists = true,
-                OrchestrationState = new P.OrchestrationState
-                {
-                    InstanceId = state.OrchestrationInstance.InstanceId,
-                    Name = state.Name,
-                    OrchestrationStatus = (P.OrchestrationStatus)state.OrchestrationStatus,
-                    CreatedTimestamp = Timestamp.FromDateTime(state.CreatedTime),
-                    LastUpdatedTimestamp = Timestamp.FromDateTime(state.LastUpdatedTime),
-                    Input = request.GetInputsAndOutputs ? state.Input : null,
-                    Output = request.GetInputsAndOutputs ? state.Output : null,
-                    CustomStatus = request.GetInputsAndOutputs ? state.Status : null,
-                    FailureDetails = request.GetInputsAndOutputs ? GetFailureDetails(state.FailureDetails) : null,
-                },
+                OrchestrationState = orchestrationState,
             };
         }
 

--- a/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
+++ b/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
@@ -6,7 +6,7 @@
     <RootNamespace>Microsoft.Azure.WebJobs.Extensions.DurableTask</RootNamespace>
     <MajorVersion>3</MajorVersion>
     <MinorVersion>10</MinorVersion>
-    <PatchVersion>0</PatchVersion>
+    <PatchVersion>1</PatchVersion>
     <VersionPrefix>$(MajorVersion).$(MinorVersion).$(PatchVersion)</VersionPrefix>
     <FileVersion>$(MajorVersion).$(MinorVersion).$(PatchVersion)</FileVersion>
     <AssemblyVersion>$(MajorVersion).0.0.0</AssemblyVersion>

--- a/src/Worker.Extensions.DurableTask/AssemblyInfo.cs
+++ b/src/Worker.Extensions.DurableTask/AssemblyInfo.cs
@@ -5,5 +5,5 @@ using System.Runtime.CompilerServices;
 using Microsoft.Azure.Functions.Worker.Extensions.Abstractions;
 
 // TODO: Find a way to generate this dynamically at build-time
-[assembly: ExtensionInformation("Microsoft.Azure.WebJobs.Extensions.DurableTask", "3.10.0")]
+[assembly: ExtensionInformation("Microsoft.Azure.WebJobs.Extensions.DurableTask", "3.10.1")]
 [assembly: InternalsVisibleTo("Worker.Extensions.DurableTask.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100cd1dabd5a893b40e75dc901fe7293db4a3caf9cd4d3e3ed6178d49cd476969abe74a9e0b7f4a0bb15edca48758155d35a4f05e6e852fff1b319d103b39ba04acbadd278c2753627c95e1f6f6582425374b92f51cca3deb0d2aab9de3ecda7753900a31f70a236f163006beefffe282888f85e3c76d1205ec7dfef7fa472a17b1")]

--- a/src/Worker.Extensions.DurableTask/Worker.Extensions.DurableTask.csproj
+++ b/src/Worker.Extensions.DurableTask/Worker.Extensions.DurableTask.csproj
@@ -29,7 +29,7 @@
     <AssemblyOriginatorKeyFile>..\..\sign.snk</AssemblyOriginatorKeyFile>
 
     <!-- Version information -->
-    <VersionPrefix>1.14.0</VersionPrefix>
+    <VersionPrefix>1.14.1</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <AssemblyVersion>$(VersionPrefix).0</AssemblyVersion>
     <!-- FileVersionRevision is expected to be set by the CI.  -->

--- a/test/Common/DurableTaskEndToEndTests.cs
+++ b/test/Common/DurableTaskEndToEndTests.cs
@@ -4739,8 +4739,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                         await client.InnerClient.RestartAsync(nonExistentId);
                     });
 
-                Assert.Equal(
-                    $"An orchestrastion with the instanceId {nonExistentId} was not found.",
+                Assert.Contains(
+                    $"No instance with ID '{nonExistentId}' was found.",
                     exception.Message);
             }
         }

--- a/test/e2e/Apps/BasicDotNetIsolated/RestartOrchestration.cs
+++ b/test/e2e/Apps/BasicDotNetIsolated/RestartOrchestration.cs
@@ -1,13 +1,13 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using Grpc.Core;
+using System.Net;
+using System.Text.Json;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.DurableTask;
 using Microsoft.DurableTask.Client;
 using Microsoft.Extensions.Logging;
-using System.Net;
 
 namespace Microsoft.Azure.Durable.Tests.E2E;
 
@@ -50,8 +50,16 @@ public static class RestartOrchestration
     {
         ILogger logger = executionContext.GetLogger("Function1_HttpStart");
 
+        var options = new StartOrchestrationOptions
+        {
+            Tags = new Dictionary<string, string>
+                {
+                    { "testtag", "true" }
+                }
+        };
+
         string instanceId = await client.ScheduleNewOrchestrationInstanceAsync(
-            orchestratorName);
+            orchestratorName, options: options, CancellationToken.None);
 
         logger.LogInformation("Started orchestration with ID = '{instanceId}'.", instanceId);
         return await client.CreateCheckStatusResponseAsync(req, instanceId);
@@ -105,5 +113,32 @@ public static class RestartOrchestration
             await response.WriteStringAsync(message);
             return response;
         }
+    }
+
+    [Function("RestartOrchestrator_Query_Tags")]
+    public static async Task<HttpResponseData> RestartQueryTag(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", "post")] HttpRequestData req,
+        [DurableClient] DurableTaskClient client,
+        string id)
+    {
+        OrchestrationMetadata? metadata = await client.GetInstancesAsync(instanceId: id, getInputsAndOutputs: true);
+
+        HttpResponseData response;
+        if (metadata == null)
+        {
+            response = req.CreateResponse(HttpStatusCode.NotFound);
+            await response.WriteStringAsync("Orchestration metadata not found.");
+            return response; // Return a 404 response if metadata is null
+        }
+
+        // SimpleOrchestrator returns a string, not JsonArray - use ReadOutputAs<string>() to avoid deserialization exception
+        string? output = metadata.ReadOutputAs<string>();
+        string tagsJson = metadata.Tags != null ? JsonSerializer.Serialize(metadata.Tags) : "{}";
+        string payload = $"{{\"output\":{JsonSerializer.Serialize(output ?? string.Empty)},\"tags\":{tagsJson}}}";
+
+        response = req.CreateResponse(HttpStatusCode.OK);
+        response.Headers.Add("Content-Type", "application/json");
+        await response.WriteStringAsync(payload);
+        return response;
     }
 }

--- a/test/e2e/Tests/Tests/RestartOrchestrationTests.cs
+++ b/test/e2e/Tests/Tests/RestartOrchestrationTests.cs
@@ -28,6 +28,7 @@ public class RestartOrchestrationTests
     [Trait("Java", "Skip")] // RestartAsync not yet implemented in Java
     [Trait("Python", "Skip")] // RestartAsync not supported in Python
     [Trait("Node", "Skip")] // RestartAsync not supported in Node
+    [Trait("MSSQL", "Skip")] // MSSQL doesn't support tags at ExecutionStarted Event.
     // Test behavior of restartasync of durabletaskclient.
     // When restart with a instanceid and startwithnewinstanceid is false, the orchestration should be restarted with the same instance id.
     // When restart with a instanceid and startwithnewinstanceid is true, the orchestration should be restarted with a new instance id.

--- a/test/e2e/Tests/Tests/RestartOrchestrationTests.cs
+++ b/test/e2e/Tests/Tests/RestartOrchestrationTests.cs
@@ -87,6 +87,7 @@ public class RestartOrchestrationTests
         // Verify that restarted orchestration instance contains tags.
         Assert.Equal(HttpStatusCode.OK, result.StatusCode);
         var content = await result.Content.ReadAsStringAsync();
+        // Content: { "output": "...", "tags": { "testtag": "true" } }
         Assert.Contains("output", content);
         Assert.Contains("testtag", content);
     }

--- a/test/e2e/Tests/Tests/RestartOrchestrationTests.cs
+++ b/test/e2e/Tests/Tests/RestartOrchestrationTests.cs
@@ -80,6 +80,18 @@ public class RestartOrchestrationTests
         {
             Assert.Equal(instanceId, restartInstanceId);
         }
+
+        HttpResponseMessage result = await HttpHelpers.InvokeHttpTrigger("RestartOrchestrator_Query_Tags", $"?id={restartInstanceId}");
+
+        // Verify RestartOrchestrator_Query_Tags endpoint returns OK and response contains output (and tags when backend returns them).
+        Assert.Equal(HttpStatusCode.OK, result.StatusCode);
+        var content = await result.Content.ReadAsStringAsync();
+        Assert.Contains("output", content);
+        // When the durability provider returns tags in GetInstance, verify the restarted instance has the expected tag.
+        if (content.Contains("\"tags\":{}") == false && content.Contains("tags"))
+        {
+            Assert.Contains("testtag", content);
+        }
     }
 
     [Fact]

--- a/test/e2e/Tests/Tests/RestartOrchestrationTests.cs
+++ b/test/e2e/Tests/Tests/RestartOrchestrationTests.cs
@@ -83,15 +83,11 @@ public class RestartOrchestrationTests
 
         HttpResponseMessage result = await HttpHelpers.InvokeHttpTrigger("RestartOrchestrator_Query_Tags", $"?id={restartInstanceId}");
 
-        // Verify RestartOrchestrator_Query_Tags endpoint returns OK and response contains output (and tags when backend returns them).
+        // Verify that restarted orchestration instance contains tags.
         Assert.Equal(HttpStatusCode.OK, result.StatusCode);
         var content = await result.Content.ReadAsStringAsync();
         Assert.Contains("output", content);
-        // When the durability provider returns tags in GetInstance, verify the restarted instance has the expected tag.
-        if (content.Contains("\"tags\":{}") == false && content.Contains("tags"))
-        {
-            Assert.Contains("testtag", content);
-        }
+        Assert.Contains("testtag", content);
     }
 
     [Fact]

--- a/test/e2e/Tests/Tests/SuspendResumeTests.cs
+++ b/test/e2e/Tests/Tests/SuspendResumeTests.cs
@@ -121,7 +121,7 @@ public class SuspendResumeTests
         string instanceId = await DurableHelpers.ParseInstanceIdAsync(response);
         string statusQueryGetUri = await DurableHelpers.ParseStatusQueryGetUriAsync(response);
 
-        await DurableHelpers.WaitForOrchestrationStateAsync(statusQueryGetUri, "Completed", 5);
+        await DurableHelpers.WaitForOrchestrationStateAsync(statusQueryGetUri, "Completed", 15);
         try
         {
             using HttpResponseMessage suspendResponse = await HttpHelpers.InvokeHttpTrigger("SuspendInstance", $"?instanceId={instanceId}");


### PR DESCRIPTION
This PR adds tags at RestartInstane by using the tags at `OrchestrationState`

At `CreateGetInstanceResponse` include `tags` when creating OrchestrationState at `TaskHubGrpcServer`

E2E test has been udpated -- testing tags should be included.