### PR TITLE
Allow E2E apps to build w/o running script

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
+++ b/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
@@ -89,10 +89,10 @@
     </Content>
   </ItemGroup>
 
-  <Target Name="GetVersion" Returns="$(Version)">
-    <PropertyGroup>
-      <VersionOutput>$(Version)</VersionOutput>
-    </PropertyGroup>
+  <Target Name="GetVersion" Returns="@(VersionValue)">
+    <ItemGroup>
+      <VersionValue Include="$(Version)" />
+    </ItemGroup>
   </Target>
 
 </Project>

--- a/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
+++ b/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
@@ -88,11 +88,4 @@
       <PackagePath>content/SBOM</PackagePath>
     </Content>
   </ItemGroup>
-
-  <Target Name="GetVersion" Returns="@(VersionValue)">
-    <ItemGroup>
-      <VersionValue Include="$(Version)" />
-    </ItemGroup>
-  </Target>
-
 </Project>

--- a/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
+++ b/src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
@@ -89,4 +89,10 @@
     </Content>
   </ItemGroup>
 
+  <Target Name="GetVersion" Returns="$(Version)">
+    <PropertyGroup>
+      <VersionOutput>$(Version)</VersionOutput>
+    </PropertyGroup>
+  </Target>
+
 </Project>

--- a/test/DFPerfScenarios/DFPerfScenarios.sln
+++ b/test/DFPerfScenarios/DFPerfScenarios.sln
@@ -3,7 +3,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.29324.140
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DFPerfScenarios", "DFPerfScenarios.csproj", "{59185532-DA62-4870-BED0-4D7E7871BA6A}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DFPerfScenariosV4", "DFPerfScenariosV4.csproj", "{59185532-DA62-4870-BED0-4D7E7871BA6A}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WebJobs.Extensions.DurableTask", "..\..\src\WebJobs.Extensions.DurableTask\WebJobs.Extensions.DurableTask.csproj", "{0D3C23B4-49AA-4D03-9869-E693687A432A}"
 EndProject

--- a/test/e2e/Apps/BasicDotNetIsolated/app.csproj
+++ b/test/e2e/Apps/BasicDotNetIsolated/app.csproj
@@ -8,8 +8,8 @@
     <RootNamespace>Microsoft.Azure.Durable.Tests.E2E</RootNamespace>
   </PropertyGroup>
     <!--For dotnet-isolated, we don't reference the WebJobs package directly so no need to update the version, just make sure the nupkg is available-->
-    <Exec Command="dotnet build &quot;$(MSBuildProjectDirectory)\..\..\..\..\src\WebJobs.Extensions.DurableTask\WebJobs.Extensions.DurableTask.csproj&quot; --configuration Release" />
-    <Exec Command="dotnet pack &quot;$(MSBuildProjectDirectory)\..\..\..\..\src\WebJobs.Extensions.DurableTask\WebJobs.Extensions.DurableTask.csproj&quot; --configuration Release --no-build --output &quot;$(MSBuildProjectDirectory)\packages&quot;" />
+    <Exec Command="dotnet build &quot;$(MSBuildProjectDirectory)/../../../../src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj&quot; --configuration Release" />
+    <Exec Command="dotnet pack &quot;$(MSBuildProjectDirectory)/../../../../src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj&quot; --configuration Release --no-build --output &quot;$(MSBuildProjectDirectory)/packages&quot;" />
   </Target>
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />

--- a/test/e2e/Apps/BasicDotNetIsolated/app.csproj
+++ b/test/e2e/Apps/BasicDotNetIsolated/app.csproj
@@ -7,9 +7,11 @@
     <Nullable>enable</Nullable>
     <RootNamespace>Microsoft.Azure.Durable.Tests.E2E</RootNamespace>
   </PropertyGroup>
+  <Target>
     <!--For dotnet-isolated, we don't reference the WebJobs package directly so no need to update the version, just make sure the nupkg is available-->
-    <Exec Command="dotnet build &quot;$(MSBuildProjectDirectory)/../../../../src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj&quot; --configuration Release" />
-    <Exec Command="dotnet pack &quot;$(MSBuildProjectDirectory)/../../../../src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj&quot; --configuration Release --no-build --output &quot;$(MSBuildProjectDirectory)/packages&quot;" />
+    <MSBuild Projects="$(MSBuildProjectDirectory)/../../../../src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj"
+             Targets="Build;Pack"
+             Properties="Configuration=$(Configuration);PackageOutputPath=$(MSBuildProjectDirectory)/packages" />
   </Target>
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />

--- a/test/e2e/Apps/BasicDotNetIsolated/app.csproj
+++ b/test/e2e/Apps/BasicDotNetIsolated/app.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>Microsoft.Azure.Durable.Tests.E2E</RootNamespace>
   </PropertyGroup>
   <Target Name="PreBuild" BeforeTargets="Build;BeforeResolveReferences">
-    <!--For dotnet-isolated, we don't reference the WebJobs package directly so no need to update the version, just make sure the nupkg is available-->
+    <!-- Build and pack the source project -->
     <MSBuild Projects="$(MSBuildProjectDirectory)/../../../../src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj"
              Targets="Build;Pack"
              Properties="Configuration=$(Configuration);PackageOutputPath=$(MSBuildProjectDirectory)/packages" />

--- a/test/e2e/Apps/BasicDotNetIsolated/app.csproj
+++ b/test/e2e/Apps/BasicDotNetIsolated/app.csproj
@@ -7,6 +7,10 @@
     <Nullable>enable</Nullable>
     <RootNamespace>Microsoft.Azure.Durable.Tests.E2E</RootNamespace>
   </PropertyGroup>
+    <!--For dotnet-isolated, we don't reference the WebJobs package directly so no need to update the version, just make sure the nupkg is available-->
+    <Exec Command="dotnet build &quot;$(MSBuildProjectDirectory)\..\..\..\..\src\WebJobs.Extensions.DurableTask\WebJobs.Extensions.DurableTask.csproj&quot; --configuration Release" />
+    <Exec Command="dotnet pack &quot;$(MSBuildProjectDirectory)\..\..\..\..\src\WebJobs.Extensions.DurableTask\WebJobs.Extensions.DurableTask.csproj&quot; --configuration Release --no-build --output &quot;$(MSBuildProjectDirectory)\packages&quot;" />
+  </Target>
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker" />

--- a/test/e2e/Apps/BasicDotNetIsolated/app.csproj
+++ b/test/e2e/Apps/BasicDotNetIsolated/app.csproj
@@ -7,7 +7,7 @@
     <Nullable>enable</Nullable>
     <RootNamespace>Microsoft.Azure.Durable.Tests.E2E</RootNamespace>
   </PropertyGroup>
-  <Target>
+  <Target Name="PreBuild" BeforeTargets="Build;BeforeResolveReferences">
     <!--For dotnet-isolated, we don't reference the WebJobs package directly so no need to update the version, just make sure the nupkg is available-->
     <MSBuild Projects="$(MSBuildProjectDirectory)/../../../../src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj"
              Targets="Build;Pack"

--- a/test/e2e/Apps/BasicJava/extensions.csproj
+++ b/test/e2e/Apps/BasicJava/extensions.csproj
@@ -15,8 +15,6 @@
     <Move SourceFiles="$(OutDir)/extensions.deps.json" DestinationFiles="$(OutDir)/function.deps.json" />
   </Target>
   <ItemGroup>
-    <!-- This reference will be dynamically updated by build-e2e-tests.ps1 as part of test setup. -->
-    <!-- Do not commit changes to this line unless necessary -->
     <PackageReference Include="Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator" Version="1.1.3" />
     <PackageReference Include="Microsoft.DurableTask.SqlServer.AzureFunctions" Version="1.5.1" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.2" />

--- a/test/e2e/Apps/BasicJava/extensions.csproj
+++ b/test/e2e/Apps/BasicJava/extensions.csproj
@@ -8,15 +8,15 @@
   </PropertyGroup>
   <Target Name="PreBuild" BeforeTargets="Build;BeforeResolveReferences">
     <!-- Get version from source project -->
-    <MSBuild Projects="$(MSBuildProjectDirectory)\..\..\..\..\src\WebJobs.Extensions.DurableTask\WebJobs.Extensions.DurableTask.csproj" 
+    <MSBuild Projects="$(MSBuildProjectDirectory)/../../../../src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj" 
              Targets="GetVersion" 
              Properties="Configuration=Release">
       <Output TaskParameter="TargetOutputs" PropertyName="DurableTaskVersion" />
     </MSBuild>
     
     <!-- Build and pack the source project -->
-    <Exec Command="dotnet build &quot;$(MSBuildProjectDirectory)\..\..\..\..\src\WebJobs.Extensions.DurableTask\WebJobs.Extensions.DurableTask.csproj&quot; --configuration Release" />
-    <Exec Command="dotnet pack &quot;$(MSBuildProjectDirectory)\..\..\..\..\src\WebJobs.Extensions.DurableTask\WebJobs.Extensions.DurableTask.csproj&quot; --configuration Release --no-build --output &quot;$(MSBuildProjectDirectory)\packages&quot;" />
+    <Exec Command="dotnet build &quot;$(MSBuildProjectDirectory)/../../../../src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj&quot; --configuration Release" />
+    <Exec Command="dotnet pack &quot;$(MSBuildProjectDirectory)/../../../../src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj&quot; --configuration Release --no-build --output &quot;$(MSBuildProjectDirectory)/packages&quot;" />
     
     <!-- Update PackageReference version dynamically -->
     <ItemGroup>

--- a/test/e2e/Apps/BasicJava/extensions.csproj
+++ b/test/e2e/Apps/BasicJava/extensions.csproj
@@ -4,7 +4,6 @@
     <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
 	<WarningsAsErrors></WarningsAsErrors>
 	<DefaultItemExcludes>**</DefaultItemExcludes>
-	<RestoreSources>$(RestoreSources);$(MSBuildProjectDirectory)\packages;https://api.nuget.org/v3/index.json</RestoreSources>
   </PropertyGroup>
   <Target Name="PreBuild" BeforeTargets="Build;BeforeResolveReferences">
     <!-- Build and pack the source project -->

--- a/test/e2e/Apps/BasicJava/extensions.csproj
+++ b/test/e2e/Apps/BasicJava/extensions.csproj
@@ -7,22 +7,10 @@
 	<RestoreSources>$(RestoreSources);$(MSBuildProjectDirectory)\packages;https://api.nuget.org/v3/index.json</RestoreSources>
   </PropertyGroup>
   <Target Name="PreBuild" BeforeTargets="Build;BeforeResolveReferences">
-    <!-- Get version from source project -->
-    <MSBuild Projects="$(MSBuildProjectDirectory)/../../../../src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj" 
-             Targets="GetVersion" 
-             Properties="Configuration=$(Configuration)">
-      <Output TaskParameter="TargetOutputs" PropertyName="DurableTaskVersion" />
-    </MSBuild>
-    
     <!-- Build and pack the source project -->
     <MSBuild Projects="$(MSBuildProjectDirectory)/../../../../src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj"
              Targets="Build;Pack"
              Properties="Configuration=$(Configuration);PackageOutputPath=$(MSBuildProjectDirectory)/packages" />
-
-    <!-- Update PackageReference version dynamically -->
-    <ItemGroup>
-      <PackageReference Update="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="$(DurableTaskVersion)" />
-    </ItemGroup>
   </Target>
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
     <Move SourceFiles="$(OutDir)/extensions.deps.json" DestinationFiles="$(OutDir)/function.deps.json" />
@@ -30,10 +18,11 @@
   <ItemGroup>
     <!-- This reference will be dynamically updated by build-e2e-tests.ps1 as part of test setup. -->
     <!-- Do not commit changes to this line unless necessary -->
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="3.4.1" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator" Version="1.1.3" />
     <PackageReference Include="Microsoft.DurableTask.SqlServer.AzureFunctions" Version="1.5.1" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.2" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureManaged" Version="0.4.2-alpha" />
+
+    <ProjectReference Include="..\..\..\..\src\WebJobs.Extensions.DurableTask\WebJobs.Extensions.DurableTask.csproj" />
   </ItemGroup>
 </Project>

--- a/test/e2e/Apps/BasicJava/extensions.csproj
+++ b/test/e2e/Apps/BasicJava/extensions.csproj
@@ -4,7 +4,25 @@
     <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
 	<WarningsAsErrors></WarningsAsErrors>
 	<DefaultItemExcludes>**</DefaultItemExcludes>
+	<RestoreSources>$(RestoreSources);$(MSBuildProjectDirectory)\packages;https://api.nuget.org/v3/index.json</RestoreSources>
   </PropertyGroup>
+  <Target Name="PreBuild" BeforeTargets="Build;BeforeResolveReferences">
+    <!-- Get version from source project -->
+    <MSBuild Projects="$(MSBuildProjectDirectory)\..\..\..\..\src\WebJobs.Extensions.DurableTask\WebJobs.Extensions.DurableTask.csproj" 
+             Targets="GetVersion" 
+             Properties="Configuration=Release">
+      <Output TaskParameter="TargetOutputs" PropertyName="DurableTaskVersion" />
+    </MSBuild>
+    
+    <!-- Build and pack the source project -->
+    <Exec Command="dotnet build &quot;$(MSBuildProjectDirectory)\..\..\..\..\src\WebJobs.Extensions.DurableTask\WebJobs.Extensions.DurableTask.csproj&quot; --configuration Release" />
+    <Exec Command="dotnet pack &quot;$(MSBuildProjectDirectory)\..\..\..\..\src\WebJobs.Extensions.DurableTask\WebJobs.Extensions.DurableTask.csproj&quot; --configuration Release --no-build --output &quot;$(MSBuildProjectDirectory)\packages&quot;" />
+    
+    <!-- Update PackageReference version dynamically -->
+    <ItemGroup>
+      <PackageReference Update="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="$(DurableTaskVersion)" />
+    </ItemGroup>
+  </Target>
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
     <Move SourceFiles="$(OutDir)/extensions.deps.json" DestinationFiles="$(OutDir)/function.deps.json" />
   </Target>

--- a/test/e2e/Apps/BasicJava/extensions.csproj
+++ b/test/e2e/Apps/BasicJava/extensions.csproj
@@ -10,14 +10,15 @@
     <!-- Get version from source project -->
     <MSBuild Projects="$(MSBuildProjectDirectory)/../../../../src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj" 
              Targets="GetVersion" 
-             Properties="Configuration=Release">
+             Properties="Configuration=$(Configuration)">
       <Output TaskParameter="TargetOutputs" PropertyName="DurableTaskVersion" />
     </MSBuild>
     
     <!-- Build and pack the source project -->
-    <Exec Command="dotnet build &quot;$(MSBuildProjectDirectory)/../../../../src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj&quot; --configuration Release" />
-    <Exec Command="dotnet pack &quot;$(MSBuildProjectDirectory)/../../../../src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj&quot; --configuration Release --no-build --output &quot;$(MSBuildProjectDirectory)/packages&quot;" />
-    
+    <MSBuild Projects="$(MSBuildProjectDirectory)/../../../../src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj"
+             Targets="Build;Pack"
+             Properties="Configuration=$(Configuration);PackageOutputPath=$(MSBuildProjectDirectory)/packages" />
+
     <!-- Update PackageReference version dynamically -->
     <ItemGroup>
       <PackageReference Update="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="$(DurableTaskVersion)" />

--- a/test/e2e/Apps/BasicNode/extensions.csproj
+++ b/test/e2e/Apps/BasicNode/extensions.csproj
@@ -8,15 +8,15 @@
   </PropertyGroup>
   <Target Name="PreBuild" BeforeTargets="Build;BeforeResolveReferences">
     <!-- Get version from source project -->
-    <MSBuild Projects="$(MSBuildProjectDirectory)\..\..\..\..\src\WebJobs.Extensions.DurableTask\WebJobs.Extensions.DurableTask.csproj" 
+    <MSBuild Projects="$(MSBuildProjectDirectory)/../../../../src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj" 
              Targets="GetVersion" 
              Properties="Configuration=Release">
       <Output TaskParameter="TargetOutputs" PropertyName="DurableTaskVersion" />
     </MSBuild>
     
     <!-- Build and pack the source project -->
-    <Exec Command="dotnet build &quot;$(MSBuildProjectDirectory)\..\..\..\..\src\WebJobs.Extensions.DurableTask\WebJobs.Extensions.DurableTask.csproj&quot; --configuration Release" />
-    <Exec Command="dotnet pack &quot;$(MSBuildProjectDirectory)\..\..\..\..\src\WebJobs.Extensions.DurableTask\WebJobs.Extensions.DurableTask.csproj&quot; --configuration Release --no-build --output &quot;$(MSBuildProjectDirectory)\packages&quot;" />
+    <Exec Command="dotnet build &quot;$(MSBuildProjectDirectory)/../../../../src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj&quot; --configuration Release" />
+    <Exec Command="dotnet pack &quot;$(MSBuildProjectDirectory)/../../../../src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj&quot; --configuration Release --no-build --output &quot;$(MSBuildProjectDirectory)/packages&quot;" />
     
     <!-- Update PackageReference version dynamically -->
     <ItemGroup>

--- a/test/e2e/Apps/BasicNode/extensions.csproj
+++ b/test/e2e/Apps/BasicNode/extensions.csproj
@@ -5,6 +5,23 @@
 	<WarningsAsErrors></WarningsAsErrors>
 	<DefaultItemExcludes>**</DefaultItemExcludes>
   </PropertyGroup>
+  <Target Name="PreBuild" BeforeTargets="Build;BeforeResolveReferences">
+    <!-- Get version from source project -->
+    <MSBuild Projects="$(MSBuildProjectDirectory)\..\..\..\..\src\WebJobs.Extensions.DurableTask\WebJobs.Extensions.DurableTask.csproj" 
+             Targets="GetVersion" 
+             Properties="Configuration=Release">
+      <Output TaskParameter="TargetOutputs" PropertyName="DurableTaskVersion" />
+    </MSBuild>
+    
+    <!-- Build and pack the source project -->
+    <Exec Command="dotnet build &quot;$(MSBuildProjectDirectory)\..\..\..\..\src\WebJobs.Extensions.DurableTask\WebJobs.Extensions.DurableTask.csproj&quot; --configuration Release" />
+    <Exec Command="dotnet pack &quot;$(MSBuildProjectDirectory)\..\..\..\..\src\WebJobs.Extensions.DurableTask\WebJobs.Extensions.DurableTask.csproj&quot; --configuration Release --no-build --output &quot;$(MSBuildProjectDirectory)\packages&quot;" />
+    
+    <!-- Update PackageReference version dynamically -->
+    <ItemGroup>
+      <PackageReference Update="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="$(DurableTaskVersion)" />
+    </ItemGroup>
+  </Target>
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
     <Move SourceFiles="$(OutDir)/extensions.deps.json" DestinationFiles="$(OutDir)/function.deps.json" />
   </Target>

--- a/test/e2e/Apps/BasicNode/extensions.csproj
+++ b/test/e2e/Apps/BasicNode/extensions.csproj
@@ -4,7 +4,6 @@
     <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
 	<WarningsAsErrors></WarningsAsErrors>
 	<DefaultItemExcludes>**</DefaultItemExcludes>
-	<RestoreSources>$(RestoreSources);$(MSBuildProjectDirectory)\packages;https://api.nuget.org/v3/index.json</RestoreSources>
   </PropertyGroup>
   <Target Name="PreBuild" BeforeTargets="Build;BeforeResolveReferences">
     <!-- Build and pack the source project -->

--- a/test/e2e/Apps/BasicNode/extensions.csproj
+++ b/test/e2e/Apps/BasicNode/extensions.csproj
@@ -7,33 +7,20 @@
 	<RestoreSources>$(RestoreSources);$(MSBuildProjectDirectory)\packages;https://api.nuget.org/v3/index.json</RestoreSources>
   </PropertyGroup>
   <Target Name="PreBuild" BeforeTargets="Build;BeforeResolveReferences">
-    <!-- Get version from source project -->
-    <MSBuild Projects="$(MSBuildProjectDirectory)/../../../../src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj" 
-             Targets="GetVersion" 
-             Properties="Configuration=$(Configuration)">
-      <Output TaskParameter="TargetOutputs" PropertyName="DurableTaskVersion" />
-    </MSBuild>
-    
     <!-- Build and pack the source project -->
     <MSBuild Projects="$(MSBuildProjectDirectory)/../../../../src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj"
              Targets="Build;Pack"
              Properties="Configuration=$(Configuration);PackageOutputPath=$(MSBuildProjectDirectory)/packages" />
-
-    <!-- Update PackageReference version dynamically -->
-    <ItemGroup>
-      <PackageReference Update="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="$(DurableTaskVersion)" />
-    </ItemGroup>
   </Target>
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
     <Move SourceFiles="$(OutDir)/extensions.deps.json" DestinationFiles="$(OutDir)/function.deps.json" />
   </Target>
   <ItemGroup>
-    <!-- This reference will be dynamically updated by build-e2e-tests.ps1 as part of test setup. -->
-    <!-- Do not commit changes to this line unless necessary -->
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="3.4.1" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator" Version="1.1.3" />
     <PackageReference Include="Microsoft.DurableTask.SqlServer.AzureFunctions" Version="1.5.1" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.2" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureManaged" Version="0.4.2-alpha" />
+
+    <ProjectReference Include="..\..\..\..\src\WebJobs.Extensions.DurableTask\WebJobs.Extensions.DurableTask.csproj" />
   </ItemGroup>
 </Project>

--- a/test/e2e/Apps/BasicNode/extensions.csproj
+++ b/test/e2e/Apps/BasicNode/extensions.csproj
@@ -10,14 +10,15 @@
     <!-- Get version from source project -->
     <MSBuild Projects="$(MSBuildProjectDirectory)/../../../../src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj" 
              Targets="GetVersion" 
-             Properties="Configuration=Release">
+             Properties="Configuration=$(Configuration)">
       <Output TaskParameter="TargetOutputs" PropertyName="DurableTaskVersion" />
     </MSBuild>
     
     <!-- Build and pack the source project -->
-    <Exec Command="dotnet build &quot;$(MSBuildProjectDirectory)/../../../../src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj&quot; --configuration Release" />
-    <Exec Command="dotnet pack &quot;$(MSBuildProjectDirectory)/../../../../src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj&quot; --configuration Release --no-build --output &quot;$(MSBuildProjectDirectory)/packages&quot;" />
-    
+    <MSBuild Projects="$(MSBuildProjectDirectory)/../../../../src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj"
+             Targets="Build;Pack"
+             Properties="Configuration=$(Configuration);PackageOutputPath=$(MSBuildProjectDirectory)/packages" />
+
     <!-- Update PackageReference version dynamically -->
     <ItemGroup>
       <PackageReference Update="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="$(DurableTaskVersion)" />

--- a/test/e2e/Apps/BasicNode/extensions.csproj
+++ b/test/e2e/Apps/BasicNode/extensions.csproj
@@ -4,6 +4,7 @@
     <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
 	<WarningsAsErrors></WarningsAsErrors>
 	<DefaultItemExcludes>**</DefaultItemExcludes>
+	<RestoreSources>$(RestoreSources);$(MSBuildProjectDirectory)\packages;https://api.nuget.org/v3/index.json</RestoreSources>
   </PropertyGroup>
   <Target Name="PreBuild" BeforeTargets="Build;BeforeResolveReferences">
     <!-- Get version from source project -->

--- a/test/e2e/Apps/BasicPowerShell/extensions.csproj
+++ b/test/e2e/Apps/BasicPowerShell/extensions.csproj
@@ -8,15 +8,15 @@
   </PropertyGroup>
   <Target Name="PreBuild" BeforeTargets="Build;BeforeResolveReferences">
     <!-- Get version from source project -->
-    <MSBuild Projects="$(MSBuildProjectDirectory)\..\..\..\..\src\WebJobs.Extensions.DurableTask\WebJobs.Extensions.DurableTask.csproj" 
+    <MSBuild Projects="$(MSBuildProjectDirectory)/../../../../src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj" 
              Targets="GetVersion" 
              Properties="Configuration=Release">
       <Output TaskParameter="TargetOutputs" PropertyName="DurableTaskVersion" />
     </MSBuild>
     
     <!-- Build and pack the source project -->
-    <Exec Command="dotnet build &quot;$(MSBuildProjectDirectory)\..\..\..\..\src\WebJobs.Extensions.DurableTask\WebJobs.Extensions.DurableTask.csproj&quot; --configuration Release" />
-    <Exec Command="dotnet pack &quot;$(MSBuildProjectDirectory)\..\..\..\..\src\WebJobs.Extensions.DurableTask\WebJobs.Extensions.DurableTask.csproj&quot; --configuration Release --no-build --output &quot;$(MSBuildProjectDirectory)\packages&quot;" />
+    <Exec Command="dotnet build &quot;$(MSBuildProjectDirectory)/../../../../src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj&quot; --configuration Release" />
+    <Exec Command="dotnet pack &quot;$(MSBuildProjectDirectory)/../../../../src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj&quot; --configuration Release --no-build --output &quot;$(MSBuildProjectDirectory)/packages&quot;" />
     
     <!-- Update PackageReference version dynamically -->
     <ItemGroup>

--- a/test/e2e/Apps/BasicPowerShell/extensions.csproj
+++ b/test/e2e/Apps/BasicPowerShell/extensions.csproj
@@ -5,6 +5,23 @@
 	<WarningsAsErrors></WarningsAsErrors>
 	<DefaultItemExcludes>**</DefaultItemExcludes>
   </PropertyGroup>
+  <Target Name="PreBuild" BeforeTargets="Build;BeforeResolveReferences">
+    <!-- Get version from source project -->
+    <MSBuild Projects="$(MSBuildProjectDirectory)\..\..\..\..\src\WebJobs.Extensions.DurableTask\WebJobs.Extensions.DurableTask.csproj" 
+             Targets="GetVersion" 
+             Properties="Configuration=Release">
+      <Output TaskParameter="TargetOutputs" PropertyName="DurableTaskVersion" />
+    </MSBuild>
+    
+    <!-- Build and pack the source project -->
+    <Exec Command="dotnet build &quot;$(MSBuildProjectDirectory)\..\..\..\..\src\WebJobs.Extensions.DurableTask\WebJobs.Extensions.DurableTask.csproj&quot; --configuration Release" />
+    <Exec Command="dotnet pack &quot;$(MSBuildProjectDirectory)\..\..\..\..\src\WebJobs.Extensions.DurableTask\WebJobs.Extensions.DurableTask.csproj&quot; --configuration Release --no-build --output &quot;$(MSBuildProjectDirectory)\packages&quot;" />
+    
+    <!-- Update PackageReference version dynamically -->
+    <ItemGroup>
+      <PackageReference Update="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="$(DurableTaskVersion)" />
+    </ItemGroup>
+  </Target>
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
     <Move SourceFiles="$(OutDir)/extensions.deps.json" DestinationFiles="$(OutDir)/function.deps.json" />
   </Target>

--- a/test/e2e/Apps/BasicPowerShell/extensions.csproj
+++ b/test/e2e/Apps/BasicPowerShell/extensions.csproj
@@ -4,7 +4,6 @@
     <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
 	<WarningsAsErrors></WarningsAsErrors>
 	<DefaultItemExcludes>**</DefaultItemExcludes>
-	<RestoreSources>$(RestoreSources);$(MSBuildProjectDirectory)\packages;https://api.nuget.org/v3/index.json</RestoreSources>
   </PropertyGroup>
   <Target Name="PreBuild" BeforeTargets="Build;BeforeResolveReferences">
     <!-- Build and pack the source project -->

--- a/test/e2e/Apps/BasicPowerShell/extensions.csproj
+++ b/test/e2e/Apps/BasicPowerShell/extensions.csproj
@@ -7,33 +7,20 @@
 	<RestoreSources>$(RestoreSources);$(MSBuildProjectDirectory)\packages;https://api.nuget.org/v3/index.json</RestoreSources>
   </PropertyGroup>
   <Target Name="PreBuild" BeforeTargets="Build;BeforeResolveReferences">
-    <!-- Get version from source project -->
-    <MSBuild Projects="$(MSBuildProjectDirectory)/../../../../src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj" 
-             Targets="GetVersion" 
-             Properties="Configuration=$(Configuration)">
-      <Output TaskParameter="TargetOutputs" PropertyName="DurableTaskVersion" />
-    </MSBuild>
-
     <!-- Build and pack the source project -->
     <MSBuild Projects="$(MSBuildProjectDirectory)/../../../../src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj"
              Targets="Build;Pack"
              Properties="Configuration=$(Configuration);PackageOutputPath=$(MSBuildProjectDirectory)/packages" />
-
-    <!-- Update PackageReference version dynamically -->
-    <ItemGroup>
-      <PackageReference Update="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="$(DurableTaskVersion)" />
-    </ItemGroup>
   </Target>
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
     <Move SourceFiles="$(OutDir)/extensions.deps.json" DestinationFiles="$(OutDir)/function.deps.json" />
   </Target>
   <ItemGroup>
-    <!-- This reference will be dynamically updated by build-e2e-tests.ps1 as part of test setup. -->
-    <!-- Do not commit changes to this line unless necessary -->
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="3.4.1" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator" Version="1.1.3" />
     <PackageReference Include="Microsoft.DurableTask.SqlServer.AzureFunctions" Version="1.5.1" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.2" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureManaged" Version="0.4.2-alpha" />
+
+    <ProjectReference Include="..\..\..\..\src\WebJobs.Extensions.DurableTask\WebJobs.Extensions.DurableTask.csproj" />
   </ItemGroup>
 </Project>

--- a/test/e2e/Apps/BasicPowerShell/extensions.csproj
+++ b/test/e2e/Apps/BasicPowerShell/extensions.csproj
@@ -10,14 +10,15 @@
     <!-- Get version from source project -->
     <MSBuild Projects="$(MSBuildProjectDirectory)/../../../../src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj" 
              Targets="GetVersion" 
-             Properties="Configuration=Release">
+             Properties="Configuration=$(Configuration)">
       <Output TaskParameter="TargetOutputs" PropertyName="DurableTaskVersion" />
     </MSBuild>
-    
+
     <!-- Build and pack the source project -->
-    <Exec Command="dotnet build &quot;$(MSBuildProjectDirectory)/../../../../src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj&quot; --configuration Release" />
-    <Exec Command="dotnet pack &quot;$(MSBuildProjectDirectory)/../../../../src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj&quot; --configuration Release --no-build --output &quot;$(MSBuildProjectDirectory)/packages&quot;" />
-    
+    <MSBuild Projects="$(MSBuildProjectDirectory)/../../../../src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj"
+             Targets="Build;Pack"
+             Properties="Configuration=$(Configuration);PackageOutputPath=$(MSBuildProjectDirectory)/packages" />
+
     <!-- Update PackageReference version dynamically -->
     <ItemGroup>
       <PackageReference Update="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="$(DurableTaskVersion)" />

--- a/test/e2e/Apps/BasicPowerShell/extensions.csproj
+++ b/test/e2e/Apps/BasicPowerShell/extensions.csproj
@@ -4,6 +4,7 @@
     <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
 	<WarningsAsErrors></WarningsAsErrors>
 	<DefaultItemExcludes>**</DefaultItemExcludes>
+	<RestoreSources>$(RestoreSources);$(MSBuildProjectDirectory)\packages;https://api.nuget.org/v3/index.json</RestoreSources>
   </PropertyGroup>
   <Target Name="PreBuild" BeforeTargets="Build;BeforeResolveReferences">
     <!-- Get version from source project -->

--- a/test/e2e/Apps/BasicPython/extensions.csproj
+++ b/test/e2e/Apps/BasicPython/extensions.csproj
@@ -15,8 +15,6 @@
     <Move SourceFiles="$(OutDir)/extensions.deps.json" DestinationFiles="$(OutDir)/function.deps.json" />
   </Target>
   <ItemGroup>
-    <!-- This reference will be dynamically updated by build-e2e-tests.ps1 as part of test setup. -->
-    <!-- Do not commit changes to this line unless necessary -->
     <PackageReference Include="Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator" Version="1.1.3" />
     <PackageReference Include="Microsoft.DurableTask.SqlServer.AzureFunctions" Version="1.5.1" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.2" />

--- a/test/e2e/Apps/BasicPython/extensions.csproj
+++ b/test/e2e/Apps/BasicPython/extensions.csproj
@@ -8,15 +8,15 @@
   </PropertyGroup>
   <Target Name="PreBuild" BeforeTargets="Build;BeforeResolveReferences">
     <!-- Get version from source project -->
-    <MSBuild Projects="$(MSBuildProjectDirectory)\..\..\..\..\src\WebJobs.Extensions.DurableTask\WebJobs.Extensions.DurableTask.csproj" 
+    <MSBuild Projects="$(MSBuildProjectDirectory)/../../../../src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj" 
              Targets="GetVersion" 
              Properties="Configuration=Release">
       <Output TaskParameter="TargetOutputs" PropertyName="DurableTaskVersion" />
     </MSBuild>
     
     <!-- Build and pack the source project -->
-    <Exec Command="dotnet build &quot;$(MSBuildProjectDirectory)\..\..\..\..\src\WebJobs.Extensions.DurableTask\WebJobs.Extensions.DurableTask.csproj&quot; --configuration Release" />
-    <Exec Command="dotnet pack &quot;$(MSBuildProjectDirectory)\..\..\..\..\src\WebJobs.Extensions.DurableTask\WebJobs.Extensions.DurableTask.csproj&quot; --configuration Release --no-build --output &quot;$(MSBuildProjectDirectory)\packages&quot;" />
+    <Exec Command="dotnet build &quot;$(MSBuildProjectDirectory)/../../../../src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj&quot; --configuration Release" />
+    <Exec Command="dotnet pack &quot;$(MSBuildProjectDirectory)/../../../../src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj&quot; --configuration Release --no-build --output &quot;$(MSBuildProjectDirectory)/packages&quot;" />
     
     <!-- Update PackageReference version dynamically -->
     <ItemGroup>

--- a/test/e2e/Apps/BasicPython/extensions.csproj
+++ b/test/e2e/Apps/BasicPython/extensions.csproj
@@ -5,6 +5,23 @@
 	<WarningsAsErrors></WarningsAsErrors>
 	<DefaultItemExcludes>**</DefaultItemExcludes>
   </PropertyGroup>
+  <Target Name="PreBuild" BeforeTargets="Build;BeforeResolveReferences">
+    <!-- Get version from source project -->
+    <MSBuild Projects="$(MSBuildProjectDirectory)\..\..\..\..\src\WebJobs.Extensions.DurableTask\WebJobs.Extensions.DurableTask.csproj" 
+             Targets="GetVersion" 
+             Properties="Configuration=Release">
+      <Output TaskParameter="TargetOutputs" PropertyName="DurableTaskVersion" />
+    </MSBuild>
+    
+    <!-- Build and pack the source project -->
+    <Exec Command="dotnet build &quot;$(MSBuildProjectDirectory)\..\..\..\..\src\WebJobs.Extensions.DurableTask\WebJobs.Extensions.DurableTask.csproj&quot; --configuration Release" />
+    <Exec Command="dotnet pack &quot;$(MSBuildProjectDirectory)\..\..\..\..\src\WebJobs.Extensions.DurableTask\WebJobs.Extensions.DurableTask.csproj&quot; --configuration Release --no-build --output &quot;$(MSBuildProjectDirectory)\packages&quot;" />
+    
+    <!-- Update PackageReference version dynamically -->
+    <ItemGroup>
+      <PackageReference Update="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="$(DurableTaskVersion)" />
+    </ItemGroup>
+  </Target>
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
     <Move SourceFiles="$(OutDir)/extensions.deps.json" DestinationFiles="$(OutDir)/function.deps.json" />
   </Target>

--- a/test/e2e/Apps/BasicPython/extensions.csproj
+++ b/test/e2e/Apps/BasicPython/extensions.csproj
@@ -4,7 +4,6 @@
     <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
 	<WarningsAsErrors></WarningsAsErrors>
 	<DefaultItemExcludes>**</DefaultItemExcludes>
-	<RestoreSources>$(RestoreSources);$(MSBuildProjectDirectory)\packages;https://api.nuget.org/v3/index.json</RestoreSources>
   </PropertyGroup>
   <Target Name="PreBuild" BeforeTargets="Build;BeforeResolveReferences">
     <!-- Build and pack the source project -->

--- a/test/e2e/Apps/BasicPython/extensions.csproj
+++ b/test/e2e/Apps/BasicPython/extensions.csproj
@@ -7,22 +7,10 @@
 	<RestoreSources>$(RestoreSources);$(MSBuildProjectDirectory)\packages;https://api.nuget.org/v3/index.json</RestoreSources>
   </PropertyGroup>
   <Target Name="PreBuild" BeforeTargets="Build;BeforeResolveReferences">
-    <!-- Get version from source project -->
-    <MSBuild Projects="$(MSBuildProjectDirectory)/../../../../src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj" 
-             Targets="GetVersion" 
-             Properties="Configuration=$(Configuration)">
-      <Output TaskParameter="TargetOutputs" PropertyName="DurableTaskVersion" />
-    </MSBuild>
-
     <!-- Build and pack the source project -->
     <MSBuild Projects="$(MSBuildProjectDirectory)/../../../../src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj"
              Targets="Build;Pack"
              Properties="Configuration=$(Configuration);PackageOutputPath=$(MSBuildProjectDirectory)/packages" />
-
-    <!-- Update PackageReference version dynamically -->
-    <ItemGroup>
-      <PackageReference Update="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="$(DurableTaskVersion)" />
-    </ItemGroup>
   </Target>
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
     <Move SourceFiles="$(OutDir)/extensions.deps.json" DestinationFiles="$(OutDir)/function.deps.json" />
@@ -30,10 +18,11 @@
   <ItemGroup>
     <!-- This reference will be dynamically updated by build-e2e-tests.ps1 as part of test setup. -->
     <!-- Do not commit changes to this line unless necessary -->
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="3.4.1" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator" Version="1.1.3" />
     <PackageReference Include="Microsoft.DurableTask.SqlServer.AzureFunctions" Version="1.5.1" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.2" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureManaged" Version="0.4.2-alpha" />
+
+    <ProjectReference Include="..\..\..\..\src\WebJobs.Extensions.DurableTask\WebJobs.Extensions.DurableTask.csproj" />
   </ItemGroup>
 </Project>

--- a/test/e2e/Apps/BasicPython/extensions.csproj
+++ b/test/e2e/Apps/BasicPython/extensions.csproj
@@ -10,14 +10,15 @@
     <!-- Get version from source project -->
     <MSBuild Projects="$(MSBuildProjectDirectory)/../../../../src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj" 
              Targets="GetVersion" 
-             Properties="Configuration=Release">
+             Properties="Configuration=$(Configuration)">
       <Output TaskParameter="TargetOutputs" PropertyName="DurableTaskVersion" />
     </MSBuild>
-    
+
     <!-- Build and pack the source project -->
-    <Exec Command="dotnet build &quot;$(MSBuildProjectDirectory)/../../../../src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj&quot; --configuration Release" />
-    <Exec Command="dotnet pack &quot;$(MSBuildProjectDirectory)/../../../../src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj&quot; --configuration Release --no-build --output &quot;$(MSBuildProjectDirectory)/packages&quot;" />
-    
+    <MSBuild Projects="$(MSBuildProjectDirectory)/../../../../src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj"
+             Targets="Build;Pack"
+             Properties="Configuration=$(Configuration);PackageOutputPath=$(MSBuildProjectDirectory)/packages" />
+
     <!-- Update PackageReference version dynamically -->
     <ItemGroup>
       <PackageReference Update="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="$(DurableTaskVersion)" />

--- a/test/e2e/Apps/BasicPython/extensions.csproj
+++ b/test/e2e/Apps/BasicPython/extensions.csproj
@@ -4,6 +4,7 @@
     <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
 	<WarningsAsErrors></WarningsAsErrors>
 	<DefaultItemExcludes>**</DefaultItemExcludes>
+	<RestoreSources>$(RestoreSources);$(MSBuildProjectDirectory)\packages;https://api.nuget.org/v3/index.json</RestoreSources>
   </PropertyGroup>
   <Target Name="PreBuild" BeforeTargets="Build;BeforeResolveReferences">
     <!-- Get version from source project -->

--- a/test/e2e/Tests/build-e2e-test.ps1
+++ b/test/e2e/Tests/build-e2e-test.ps1
@@ -117,67 +117,40 @@ else
 }
 
 function InstallExtensionAndBuildTestApp($testAppDir) {
-    Write-Host "Removing old packages from test app $testAppDir"
-
-    $AppPackageLocation = Join-Path $testAppDir 'packages'
-    if (!(Test-Path $AppPackageLocation)) {
-      New-Item -Path $AppPackageLocation -ItemType Directory -ErrorAction SilentlyContinue
-    }
-    $AppPackageLocation = Resolve-Path $AppPackageLocation
-    Get-ChildItem -Path $AppPackageLocation -Include * -File -Recurse | ForEach-Object { $_.Delete()}
-    
-    Write-Host "Moving nupkg from WebJobs extension to $AppPackageLocation"
-    Set-Location $BuildOutputLocation
-    dotnet nuget push *.nupkg --source $AppPackageLocation
-    
-    Write-Host "Updating app .csproj to reference built package versions"
+    Write-Host "Building test app $testAppDir"
     Set-Location $testAppDir
-    $files = Get-ChildItem -Path ./packages -Include * -File -Recurse
-    $files | ForEach-Object {
-      if ($_.Name -match 'Microsoft.Azure.WebJobs.Extensions.DurableTask')
-      {
-        $webJobsExtensionVersion = $_.Name -replace 'Microsoft.Azure.WebJobs.Extensions.DurableTask\.|\.nupkg'
-    
-        Write-Host "Removing cached version $webJobsExtensionVersion of WebJobs extension from nuget cache, if exists"
-        $cachedVersionFolders = Get-ChildItem -Path (Join-Path $LocalNugetCacheDirectory "microsoft.azure.webjobs.extensions.durabletask") -Directory -ErrorAction Continue
-        $cachedVersionFolders | ForEach-Object {
-          if ($_.Name -eq $webJobsExtensionVersion)
-          {
-            Write-Host "Removing cached version $webJobsExtensionVersion from nuget cache"
-            Remove-Item -Recurse -Force $_.FullName -ErrorAction Stop
-          }
-        }
 
-        if (!(Test-Path ".\app.csproj")) {
-          Write-Host "Updating extensions.csproj to reference WebJobs extension version $webJobsExtensionVersion"
-          
-          dotnet add 'extensions.csproj' package 'Microsoft.Azure.WebJobs.Extensions.DurableTask' --version $webJobsExtensionVersion --source ".\packages" --no-restore
+    Write-Host "Removing cached WebJobs extension versions from nuget cache, if exists"
+    $cachedVersionFolders = Get-ChildItem -Path (Join-Path $LocalNugetCacheDirectory "microsoft.azure.webjobs.extensions.durabletask") -Directory -ErrorAction Continue
+    $cachedVersionFolders | ForEach-Object {
+      Write-Host "Removing cached version $($_.Name) from nuget cache"
+      Remove-Item -Recurse -Force $_.FullName -ErrorAction Stop
+    }
 
-          Write-Host "Syncing extensions"
-          if ((Test-Path (Join-Path $FUNC_CLI_DIRECTORY "func")) -or (Test-Path (Join-Path $FUNC_CLI_DIRECTORY "func.exe"))) {
-            .(Join-Path $FUNC_CLI_DIRECTORY "func") extensions sync
-          }
-          else {
-            Write-Warning "func command not found. Skipping extensions sync."
-          }
-        }
-
-        if (Test-Path ".\requirements.txt") {
-          python -m pip install -r requirements.txt
-        }
-
-        if (Test-Path ".\package-lock.json") {
-          Write-Host "Installing npm packages"
-          npm install
-          npm run clean
-          npm run build
-        }
-
-        if (Test-Path ".\pom.xml") {
-          Write-Host "Building Java project"
-          mvn clean package -q
-        }
+    if (!(Test-Path ".\app.csproj")) {
+      Write-Host "Syncing extensions"
+      if ((Test-Path (Join-Path $FUNC_CLI_DIRECTORY "func")) -or (Test-Path (Join-Path $FUNC_CLI_DIRECTORY "func.exe"))) {
+        .(Join-Path $FUNC_CLI_DIRECTORY "func") extensions sync
       }
+      else {
+        Write-Warning "func command not found. Skipping extensions sync."
+      }
+    }
+
+    if (Test-Path ".\requirements.txt") {
+      python -m pip install -r requirements.txt
+    }
+
+    if (Test-Path ".\package-lock.json") {
+      Write-Host "Installing npm packages"
+      npm install
+      npm run clean
+      npm run build
+    }
+
+    if (Test-Path ".\pom.xml") {
+      Write-Host "Building Java project"
+      mvn clean package -q
     }
     
     if (Test-Path ".\app.csproj") {
@@ -190,14 +163,7 @@ function InstallExtensionAndBuildTestApp($testAppDir) {
 if (!$SkipBuild)
 {
   Write-Host "Building WebJobs extension project"
-  
-  $BuildOutputLocation = Join-Path $WebJobsExtensionProjectDirectory 'out'
-  if (!(Test-Path $BuildOutputLocation)) {
-    New-Item -Path $BuildOutputLocation -ItemType Directory -ErrorAction SilentlyContinue
-  }
-  $BuildOutputLocation = Resolve-Path $BuildOutputLocation
-  Get-ChildItem -Path $BuildOutputLocation -Include * -File -Recurse | ForEach-Object { $_.Delete()}
-  dotnet build -c Debug "$WebJobsExtensionProjectDirectory\WebJobs.Extensions.DurableTask.csproj" --output $BuildOutputLocation
+  dotnet build -c Debug "$WebJobsExtensionProjectDirectory\WebJobs.Extensions.DurableTask.csproj"
 
   if ($LASTEXITCODE -ne 0) { Set-Location $PSScriptRoot; throw "WebJobs Extension build failed" }
 

--- a/test/e2e/Tests/build-e2e-test.ps1
+++ b/test/e2e/Tests/build-e2e-test.ps1
@@ -162,6 +162,11 @@ function InstallExtensionAndBuildTestApp($testAppDir) {
 
 if (!$SkipBuild)
 {
+  Write-Host "Building WebJobs extension project"
+  dotnet build -c Debug "$WebJobsExtensionProjectDirectory\WebJobs.Extensions.DurableTask.csproj"
+
+  if ($LASTEXITCODE -ne 0) { Set-Location $PSScriptRoot; throw "WebJobs Extension build failed" }
+
   if ($E2EAppName)
   {
     InstallExtensionAndBuildTestApp (Join-Path $E2EAppParentDirectory $E2EAppName)

--- a/test/e2e/Tests/build-e2e-test.ps1
+++ b/test/e2e/Tests/build-e2e-test.ps1
@@ -162,11 +162,6 @@ function InstallExtensionAndBuildTestApp($testAppDir) {
 
 if (!$SkipBuild)
 {
-  Write-Host "Building WebJobs extension project"
-  dotnet build -c Debug "$WebJobsExtensionProjectDirectory\WebJobs.Extensions.DurableTask.csproj"
-
-  if ($LASTEXITCODE -ne 0) { Set-Location $PSScriptRoot; throw "WebJobs Extension build failed" }
-
   if ($E2EAppName)
   {
     InstallExtensionAndBuildTestApp (Join-Path $E2EAppParentDirectory $E2EAppName)


### PR DESCRIPTION
# Summary
## What changed?
- Allows building the E2E projects without running build-e2e-tests.ps1. This allows automatic/code compliance actions to build these projects without direct modification

## Why is this change needed?
- The Automatic Dependency Submission (NuGet) action added by the org attempts to build these projects but cannot because it does not know to run build-e2e-tests.ps1 beforehand. Need a way for these to build without running external scripts. 

---

# Project checklist
- [x] Documentation changes are not required
  - [] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
- [x] Release notes are not required for the next release
  - [ ] Otherwise: Notes added to `release_notes.md`
- [x] Backport is not required
  - [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
- [x] All required tests have been added/updated (unit tests, E2E tests)
- [x] No extra work is required to be leveraged by OutOfProc SDKs
  - [ ] Otherwise: Work tracked here: #issue_or_pr_in_each_sdk
- [x] No change to the version of the `WebJobs.Extensions.DurableTask` package
  - [ ] Otherwise: Major/minor updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
- [x] No EventIds were added to `EventSource` logs
  - [ ] Otherwise: Ensure EventIds are within the supported range in the existing Windows infrastructure (validate via deployed telemetry). If needed, extend the range via a PR such as https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files
- [x] This change should be added to the `v2.x` branch
  - [ ] Otherwise: This change applies exclusively to `WebJobs.Extensions.DurableTask` v3.x and will be retained only in the `dev` and `main` branches
- [ ] Breaking change?
  - [ ] If yes:
    - Impact:
    - Migration guidance:
---

# AI-assisted code disclosure (required)
## Was an AI tool used? (select one)
- [ ] No
- [ ] Yes, AI helped write parts of this PR (e.g., GitHub Copilot)
- [x] Yes, an AI agent generated most of this PR

If AI was used:
- Tool(s): VS Code Copilot
- AI-assisted areas/files: All
- What you changed after AI output: N/A

AI verification (required if AI was used):
- [x] I understand the code and can explain it
- [x] I verified referenced APIs/types exist and are correct
- [x] I reviewed edge cases/failure paths (timeouts, retries, cancellation, exceptions)
- [x] I reviewed concurrency/async behavior
- [x] I checked for unintended breaking or behavior changes

---

# Testing
## Automated tests
- Result: Passed / Failed (link logs if failed)

## Manual validation (only if runtime/behavior changed)
- Environment (OS, .NET version, components):
- Steps + observed results:
  1.
  2.
  3.
- Evidence (optional):

---

# Notes for reviewers
- N/A
