### PR TITLE
Update dependencies to fix CVE issues

### DIFF
--- a/samples/Directory.Packages.props
+++ b/samples/Directory.Packages.props
@@ -16,7 +16,6 @@
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="3.1.3" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="3.1.3" />
     <PackageVersion Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.1.2" />
-    <PackageVersion Include="Swashbuckle.AspNetCore" Version="5.4.0" />
     <PackageVersion Include="TaskBuilder.fs" Version="1.0.0" />
   </ItemGroup>
 

--- a/samples/csx/extensions.csproj
+++ b/samples/csx/extensions.csproj
@@ -12,6 +12,6 @@
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Twilio" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" VersionOverride="5.7.0" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="5.7.0" />
   </ItemGroup>
 </Project>

--- a/samples/csx/extensions.csproj
+++ b/samples/csx/extensions.csproj
@@ -12,5 +12,6 @@
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Twilio" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" VersionOverride="5.7.0" />
   </ItemGroup>
 </Project>

--- a/samples/durable-client-managed-identity/aspnetcore-app/Startup.cs
+++ b/samples/durable-client-managed-identity/aspnetcore-app/Startup.cs
@@ -4,7 +4,6 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.OpenApi.Models;
 using TodoApi.Models;
 using Microsoft.Azure.WebJobs.Extensions.DurableTask;
 
@@ -28,11 +27,7 @@ namespace TodoApi
 
             services.AddControllers();
 
-            // Register the Swagger generator, defining 1 or more Swagger documents
-            services.AddSwaggerGen(c =>
-            {
-                c.SwaggerDoc("v1", new OpenApiInfo { Title = "My API", Version = "v1" });
-            });
+            services.AddEndpointsApiExplorer();
 
             services.AddDbContext<TodoContext>(options => options.UseInMemoryDatabase("TodoList"));
         }
@@ -40,16 +35,6 @@ namespace TodoApi
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
         public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
         {
-            // Enable middleware to serve generated Swagger as a JSON endpoint.
-            app.UseSwagger();
-
-            // Enable middleware to serve swagger-ui (HTML, JS, CSS, etc.),
-            // specifying the Swagger JSON endpoint.
-            app.UseSwaggerUI(c =>
-            {
-                c.SwaggerEndpoint("/swagger/v1/swagger.json", "My API V1");
-            });
-
             if (env.IsDevelopment())
             {
                 app.UseDeveloperExceptionPage();

--- a/samples/durable-client-managed-identity/aspnetcore-app/Startup.cs
+++ b/samples/durable-client-managed-identity/aspnetcore-app/Startup.cs
@@ -27,8 +27,6 @@ namespace TodoApi
 
             services.AddControllers();
 
-            services.AddEndpointsApiExplorer();
-
             services.AddDbContext<TodoContext>(options => options.UseInMemoryDatabase("TodoList"));
         }
 

--- a/samples/durable-client-managed-identity/aspnetcore-app/ToDoList.csproj
+++ b/samples/durable-client-managed-identity/aspnetcore-app/ToDoList.csproj
@@ -16,7 +16,6 @@
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" />
-    <PackageReference Include="Swashbuckle.AspNetCore" />
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" />
   </ItemGroup>
 </Project>

--- a/samples/precompiled/VSSample.csproj
+++ b/samples/precompiled/VSSample.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="Microsoft.NET.Sdk.Functions" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Twilio" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" VersionOverride="5.7.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/precompiled/VSSample.csproj
+++ b/samples/precompiled/VSSample.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Microsoft.NET.Sdk.Functions" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Twilio" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" VersionOverride="5.7.0" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="5.7.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/todolist-aspnetcore/Startup.cs
+++ b/samples/todolist-aspnetcore/Startup.cs
@@ -4,7 +4,6 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.OpenApi.Models;
 using TodoApi.Models;
 using Microsoft.Azure.WebJobs.Extensions.DurableTask;
 
@@ -28,11 +27,7 @@ namespace TodoApi
 
             services.AddControllers();
 
-            // Register the Swagger generator, defining 1 or more Swagger documents
-            services.AddSwaggerGen(c =>
-            {
-                c.SwaggerDoc("v1", new OpenApiInfo { Title = "My API", Version = "v1" });
-            });
+            services.AddEndpointsApiExplorer();
 
             services.AddDbContext<TodoContext>(options => options.UseInMemoryDatabase("TodoList"));
         }
@@ -40,16 +35,6 @@ namespace TodoApi
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
         public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
         {
-            // Enable middleware to serve generated Swagger as a JSON endpoint.
-            app.UseSwagger();
-
-            // Enable middleware to serve swagger-ui (HTML, JS, CSS, etc.),
-            // specifying the Swagger JSON endpoint.
-            app.UseSwaggerUI(c =>
-            {
-                c.SwaggerEndpoint("/swagger/v1/swagger.json", "My API V1");
-            });
-
             if (env.IsDevelopment())
             {
                 app.UseDeveloperExceptionPage();

--- a/samples/todolist-aspnetcore/Startup.cs
+++ b/samples/todolist-aspnetcore/Startup.cs
@@ -27,8 +27,6 @@ namespace TodoApi
 
             services.AddControllers();
 
-            services.AddEndpointsApiExplorer();
-
             services.AddDbContext<TodoContext>(options => options.UseInMemoryDatabase("TodoList"));
         }
 

--- a/samples/todolist-aspnetcore/ToDoList.csproj
+++ b/samples/todolist-aspnetcore/ToDoList.csproj
@@ -16,7 +16,6 @@
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" />
-    <PackageReference Include="Swashbuckle.AspNetCore" />
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" />
   </ItemGroup>
 </Project>

--- a/test/Directory.Packages.props
+++ b/test/Directory.Packages.props
@@ -13,7 +13,7 @@
     <PackageVersion Include="Microsoft.Build" Version="17.3.2" />
     <PackageVersion Include="Microsoft.Build.Framework" Version="17.3.2" />
     <PackageVersion Include="Microsoft.Build.Locator" Version="1.4.1" />
-    <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="17.3.2" />
+    <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="17.8.29" />
     <PackageVersion Include="Microsoft.CodeAnalysis" Version="3.9.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="3.9.0" />
     <PackageVersion Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.65" />

--- a/test/Directory.Packages.props
+++ b/test/Directory.Packages.props
@@ -10,10 +10,10 @@
     <PackageVersion Include="coverlet.collector" Version="6.0.0" />
     <PackageVersion Include="FluentAssertions" Version="4.19.4" />
     <PackageVersion Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" Version="3.0.41" />
-    <PackageVersion Include="Microsoft.Build" Version="17.3.2" />
-    <PackageVersion Include="Microsoft.Build.Framework" Version="17.3.2" />
+    <PackageVersion Include="Microsoft.Build" Version="17.8.43" />
+    <PackageVersion Include="Microsoft.Build.Framework" Version="17.8.43" />
     <PackageVersion Include="Microsoft.Build.Locator" Version="1.4.1" />
-    <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="17.8.29" />
+    <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="17.8.43" />
     <PackageVersion Include="Microsoft.CodeAnalysis" Version="3.9.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="3.9.0" />
     <PackageVersion Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.65" />
@@ -32,7 +32,8 @@
     <PackageVersion Update="Azure.Identity" Version="1.17.1" />
     <PackageVersion Update="Microsoft.Bcl.AsyncInterfaces" Version="10.0.1"/>
     <PackageVersion Update="Microsoft.Extensions.Azure" Version="1.10.0" />
-    <PackageVersion Update="System.Drawing.Common" Version="6.0.0" />
+    <PackageVersion Update="System.Drawing.Common" Version="7.0.0" />
+    <PackageVersion Update="System.Formats.Asn1" Version="8.0.1" />
     <PackageVersion Update="System.Text.Json" Version="10.0.0" />
   </ItemGroup>
 

--- a/test/Directory.Packages.props
+++ b/test/Directory.Packages.props
@@ -10,10 +10,10 @@
     <PackageVersion Include="coverlet.collector" Version="6.0.0" />
     <PackageVersion Include="FluentAssertions" Version="4.19.4" />
     <PackageVersion Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" Version="3.0.41" />
-    <PackageVersion Include="Microsoft.Build" Version="17.8.43" />
-    <PackageVersion Include="Microsoft.Build.Framework" Version="17.8.43" />
+    <PackageVersion Include="Microsoft.Build" Version="17.8.29" />
+    <PackageVersion Include="Microsoft.Build.Framework" Version="17.8.29" />
     <PackageVersion Include="Microsoft.Build.Locator" Version="1.4.1" />
-    <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="17.8.43" />
+    <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="17.8.29" />
     <PackageVersion Include="Microsoft.CodeAnalysis" Version="3.9.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="3.9.0" />
     <PackageVersion Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.65" />

--- a/test/PerfTests/JavaScript/package-lock.json
+++ b/test/PerfTests/JavaScript/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "durablejs",
       "version": "1.0.0",
       "dependencies": {
         "durable-functions": "^3.1.0",
@@ -33,13 +34,13 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
-      "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
+      "version": "1.13.5",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
+      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.4",
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
         "proxy-from-env": "^1.1.0"
       }
     },
@@ -172,9 +173,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
       "funding": [
         {
           "type": "individual",
@@ -192,9 +193,9 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -305,9 +306,10 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "license": "MIT"
     },
     "node_modules/long": {
       "version": "4.0.0",
@@ -380,9 +382,9 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "7.10.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.10.0.tgz",
-      "integrity": "sha512-u5otvFBOBZvmdjWLVW+5DAc9Nkq8f24g0O9oY7qw2JVIF1VocIFoyz9JFkuVOS2j41AufeO0xnlweJ2RLT8nGw==",
+      "version": "7.22.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.22.0.tgz",
+      "integrity": "sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"
@@ -398,9 +400,10 @@
       }
     },
     "node_modules/validator": {
-      "version": "13.7.0",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-13.7.0.tgz",
-      "integrity": "sha512-nYXQLCBkpJ8X6ltALua9dRrZDHVYxjJ1wgskNt1lH9fzGjs3tgojGSCBjmEPwkWS1y29+DrizMTW19Pr9uB2nw==",
+      "version": "13.15.22",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.22.tgz",
+      "integrity": "sha512-uT/YQjiyLJP7HSrv/dPZqK9L28xf8hsNca01HSz1dfmI0DgMfjopp1rO/z13NeGF1tVystF0Ejx3y4rUKPw+bQ==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.10"
       }

--- a/test/PerfTests/JavaScript/package.json
+++ b/test/PerfTests/JavaScript/package.json
@@ -10,5 +10,8 @@
     "durable-functions": "^3.1.0",
     "p-limit": "^3.1.0"
   },
-  "devDependencies": {}
+  "devDependencies": {},
+  "overrides": {
+    "validator": "13.15.22"
+  }
 }

--- a/test/SmokeTests/BackendSmokeTests/MSSQL/MSSQL.csproj
+++ b/test/SmokeTests/BackendSmokeTests/MSSQL/MSSQL.csproj
@@ -13,7 +13,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.6.0" />
     <PackageReference Include="Microsoft.DurableTask.SqlServer.AzureFunctions" Version="1.5.1" />
-    <PackageReference Include="System.Drawing.Common" Version="4.7.3" />
+    <PackageReference Include="System.Drawing.Common" Version="7.0.0" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">

--- a/test/SmokeTests/BackendSmokeTests/MSSQL/MSSQL.csproj
+++ b/test/SmokeTests/BackendSmokeTests/MSSQL/MSSQL.csproj
@@ -13,6 +13,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.6.0" />
     <PackageReference Include="Microsoft.DurableTask.SqlServer.AzureFunctions" Version="1.5.1" />
+    <PackageReference Include="System.Drawing.Common" Version="4.7.2" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">

--- a/test/SmokeTests/BackendSmokeTests/MSSQL/MSSQL.csproj
+++ b/test/SmokeTests/BackendSmokeTests/MSSQL/MSSQL.csproj
@@ -13,7 +13,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.6.0" />
     <PackageReference Include="Microsoft.DurableTask.SqlServer.AzureFunctions" Version="1.5.1" />
-    <PackageReference Include="System.Drawing.Common" Version="4.7.2" />
+    <PackageReference Include="System.Drawing.Common" Version="4.7.3" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">

--- a/test/SmokeTests/OOProcSmokeTests/durableJS/package-lock.json
+++ b/test/SmokeTests/OOProcSmokeTests/durableJS/package-lock.json
@@ -305,9 +305,10 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "license": "MIT"
     },
     "node_modules/long": {
       "version": "4.0.0",

--- a/test/SmokeTests/OOProcSmokeTests/durableJS/package.json
+++ b/test/SmokeTests/OOProcSmokeTests/durableJS/package.json
@@ -11,5 +11,8 @@
     "durable-functions": "^3.3.0"
   },
   "main": "src/{index.js,functions/*.js}",
-  "devDependencies": {}
+  "devDependencies": {},
+  "overrides": {
+    "lodash": "4.17.23"
+  }
 }

--- a/test/e2e/Apps/BasicDotNetIsolated/app.csproj
+++ b/test/e2e/Apps/BasicDotNetIsolated/app.csproj
@@ -18,6 +18,7 @@
     <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask.SqlServer" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask.AzureManaged" />
+    <PackageReference Include="System.Drawing.Common" VersionOverride="4.7.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/e2e/Apps/BasicDotNetIsolated/app.csproj
+++ b/test/e2e/Apps/BasicDotNetIsolated/app.csproj
@@ -24,7 +24,6 @@
     <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask.SqlServer" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask.AzureManaged" />
-    <PackageReference Include="System.Drawing.Common" VersionOverride="4.7.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/e2e/Apps/BasicNode/package-lock.json
+++ b/test/e2e/Apps/BasicNode/package-lock.json
@@ -18,26 +18,25 @@
       }
     },
     "node_modules/@azure/functions": {
-      "version": "4.7.2",
-      "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.7.2.tgz",
-      "integrity": "sha512-5ps8yz4gn6oZSzeQbpUreWHFYl/YS03F1Sk/pz7YJphfctRcHuLF5tcrdm9AyRiYzja4Bkd63bju+g/E27opPQ==",
+      "version": "4.11.2",
+      "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.11.2.tgz",
+      "integrity": "sha512-U7qpPo0pUxDfdP3Q8gO5GLtust94nh8+RtIUvEKE4qU9yuDhL2vU1zzanuzkaV2j/TFv+EEmN8QDtchAgpeffw==",
       "license": "MIT",
       "dependencies": {
-        "cookie": "^0.7.0",
-        "long": "^4.0.0",
-        "undici": "^5.29.0"
+        "@azure/functions-extensions-base": "0.2.0",
+        "cookie": "^0.7.0"
       },
       "engines": {
-        "node": ">=18.0"
+        "node": ">=20.0"
       }
     },
-    "node_modules/@fastify/busboy": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
-      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
+    "node_modules/@azure/functions-extensions-base": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@azure/functions-extensions-base/-/functions-extensions-base-0.2.0.tgz",
+      "integrity": "sha512-ncCkHBNQYJa93dBIh+toH0v1iSgCzSo9tr94s6SMBe7DPWREkaWh8cq33A5P4rPSFX1g5W+3SPvIzDr/6/VOWQ==",
       "license": "MIT",
       "engines": {
-        "node": ">=14"
+        "node": ">=18.0"
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -112,13 +111,13 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
-      "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
+      "version": "1.13.5",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
+      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.4",
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
         "proxy-from-env": "^1.1.0"
       }
     },
@@ -318,9 +317,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
       "funding": [
         {
           "type": "individual",
@@ -355,9 +354,9 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -522,16 +521,10 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
       "license": "MIT"
-    },
-    "node_modules/long": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
-      "license": "Apache-2.0"
     },
     "node_modules/lru-cache": {
       "version": "10.4.3",
@@ -821,18 +814,6 @@
         "node": ">=4.2.0"
       }
     },
-    "node_modules/undici": {
-      "version": "5.29.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
-      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
-      "license": "MIT",
-      "dependencies": {
-        "@fastify/busboy": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.0"
-      }
-    },
     "node_modules/undici-types": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
@@ -851,9 +832,9 @@
       }
     },
     "node_modules/validator": {
-      "version": "13.7.0",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-13.7.0.tgz",
-      "integrity": "sha512-nYXQLCBkpJ8X6ltALua9dRrZDHVYxjJ1wgskNt1lH9fzGjs3tgojGSCBjmEPwkWS1y29+DrizMTW19Pr9uB2nw==",
+      "version": "13.15.22",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.22.tgz",
+      "integrity": "sha512-uT/YQjiyLJP7HSrv/dPZqK9L28xf8hsNca01HSz1dfmI0DgMfjopp1rO/z13NeGF1tVystF0Ejx3y4rUKPw+bQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"

--- a/test/e2e/Apps/BasicNode/package-lock.json
+++ b/test/e2e/Apps/BasicNode/package-lock.json
@@ -815,9 +815,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.23.0.tgz",
+      "integrity": "sha512-HN7GeXgBUs1StmY/vf9hIH11LrNI5SfqmFVtxKyp9Dhuf1P1cDSRlS+H1NJDaGOWzlI08q+NmiHgu11Vx6QnhA==",
       "dev": true,
       "license": "MIT"
     },

--- a/test/e2e/Apps/BasicNode/package-lock.json
+++ b/test/e2e/Apps/BasicNode/package-lock.json
@@ -18,25 +18,26 @@
       }
     },
     "node_modules/@azure/functions": {
-      "version": "4.11.2",
-      "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.11.2.tgz",
-      "integrity": "sha512-U7qpPo0pUxDfdP3Q8gO5GLtust94nh8+RtIUvEKE4qU9yuDhL2vU1zzanuzkaV2j/TFv+EEmN8QDtchAgpeffw==",
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.7.2.tgz",
+      "integrity": "sha512-5ps8yz4gn6oZSzeQbpUreWHFYl/YS03F1Sk/pz7YJphfctRcHuLF5tcrdm9AyRiYzja4Bkd63bju+g/E27opPQ==",
       "license": "MIT",
       "dependencies": {
-        "@azure/functions-extensions-base": "0.2.0",
-        "cookie": "^0.7.0"
+        "cookie": "^0.7.0",
+        "long": "^4.0.0",
+        "undici": "^5.29.0"
       },
       "engines": {
-        "node": ">=20.0"
+        "node": ">=18.0"
       }
     },
-    "node_modules/@azure/functions-extensions-base": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@azure/functions-extensions-base/-/functions-extensions-base-0.2.0.tgz",
-      "integrity": "sha512-ncCkHBNQYJa93dBIh+toH0v1iSgCzSo9tr94s6SMBe7DPWREkaWh8cq33A5P4rPSFX1g5W+3SPvIzDr/6/VOWQ==",
+    "node_modules/@fastify/busboy": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
+      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
       "license": "MIT",
       "engines": {
-        "node": ">=18.0"
+        "node": ">=14"
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -526,6 +527,12 @@
       "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
       "license": "MIT"
     },
+    "node_modules/long": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
+      "license": "Apache-2.0"
+    },
     "node_modules/lru-cache": {
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
@@ -812,6 +819,18 @@
       },
       "engines": {
         "node": ">=4.2.0"
+      }
+    },
+    "node_modules/undici": {
+      "version": "5.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
+      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/busboy": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
       }
     },
     "node_modules/undici-types": {

--- a/test/e2e/Apps/BasicNode/package.json
+++ b/test/e2e/Apps/BasicNode/package.json
@@ -19,5 +19,8 @@
     "rimraf": "^5.0.0",
     "typescript": "^4.0.0"
   },
+  "overrides": {
+    "validator": "13.15.22"
+  },
   "main": "dist/src/{index.js,functions/*.js}"
 }

--- a/test/e2e/Apps/BasicNode/package.json
+++ b/test/e2e/Apps/BasicNode/package.json
@@ -20,7 +20,8 @@
     "typescript": "^4.0.0"
   },
   "overrides": {
-    "validator": "13.15.22"
+    "validator": "13.15.22",
+    "undici-types": "6.23.0"
   },
   "main": "dist/src/{index.js,functions/*.js}"
 }


### PR DESCRIPTION
# Summary
## What changed?

This pull request primarily updates dependencies across multiple sample and test projects, removes Swagger-related packages and configuration from ASP.NET Core samples, and introduces new package overrides for improved security and compatibility.

* Updated several NPM dependencies in JavaScript test projects to newer versions, including `axios`, `follow-redirects`, `form-data`, `lodash`, `undici`, and `validator`, improving security and compatibility. Ran `npm audit fix` on JS test projects.
* Added package overrides for `validator` and `lodash` in relevant `package.json` files to ensure the use of secure versions. 
* Updated `Microsoft.Build.Tasks.Core` to version `17.8.29` in test projects for improved build reliability.
* Removed the `Swashbuckle.AspNetCore` package and all Swagger-related configuration from the `durable-client-managed-identity/aspnetcore-app` and `todolist-aspnetcore` samples, simplifying their setup and switching to `AddEndpointsApiExplorer` for API documentation. (`samples/Directory.Packages.props`, `samples/durable-client-managed-identity/aspnetcore-app/Startup.cs`, `samples/durable-client-managed-identity/aspnetcore-app/ToDoList.csproj`, `samples/todolist-aspnetcore/Startup.cs`, `samples/todolist-aspnetcore/ToDoList.csproj`)
* Added `System.IdentityModel.Tokens.Jwt` and `System.Drawing.Common` package references to various .NET sample and test projects
* Added the `"name": "durablejs"` field to `test/PerfTests/JavaScript/package-lock.json` for proper package identification.


## Why is this change needed?
- To fix CVE issues

## Issues / work items
- Resolves #
- Related #

---

# Project checklist
- [x] Documentation changes are not required
  - [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
- [x] Release notes are not required for the next release
  - [ ] Otherwise: Notes added to `release_notes.md`
- [x] Backport is not required
  - [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
- [x] All required tests have been added/updated (unit tests, E2E tests)
- [x] No extra work is required to be leveraged by OutOfProc SDKs
  - [ ] Otherwise: Work tracked here: #issue_or_pr_in_each_sdk
- [x] No change to the version of the `WebJobs.Extensions.DurableTask` package
  - [ ] Otherwise: Major/minor updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
- [x] No EventIds were added to `EventSource` logs
  - [ ] Otherwise: Ensure EventIds are within the supported range in the existing Windows infrastructure (validate via deployed telemetry). If needed, extend the range via a PR such as https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files
- [ ] This change should be added to the `v2.x` branch
  - [x] Otherwise: This change applies exclusively to `WebJobs.Extensions.DurableTask` v3.x and will be retained only in the `dev` and `main` branches
- [ ] Breaking change?
  - [ ] If yes:
    - Impact:
    - Migration guidance:
---

# AI-assisted code disclosure (required)
## Was an AI tool used? (select one)
- [ ] No
- [x] Yes, AI helped write parts of this PR (e.g., GitHub Copilot)
- [ ] Yes, an AI agent generated most of this PR

If AI was used:
- Tool(s): VSCode Copilot (Claude Opus 4.6 fast)
- AI-assisted areas/files:
- What you changed after AI output:

AI verification (required if AI was used):
- [x] I understand the code and can explain it
- [x] I verified referenced APIs/types exist and are correct
- [x] I reviewed edge cases/failure paths (timeouts, retries, cancellation, exceptions)
- [x] I reviewed concurrency/async behavior
- [x] I checked for unintended breaking or behavior changes

---

# Testing
## Automated tests
- Result: Passed / Failed (link logs if failed)

## Manual validation (only if runtime/behavior changed)
- Environment (OS, .NET version, components):
- Steps + observed results:
  1.
  2.
  3.
- Evidence (optional):

---

# Notes for reviewers
- N/A