### PR TITLE
Fix thread-safety race condition in EnsureTaskHubWorker

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
@@ -62,6 +62,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
         private readonly AsyncLock taskHubLock = new AsyncLock();
         private readonly object protocolLockObject = new ();
+        private readonly object taskHubWorkerInitLock = new ();
 #pragma warning disable CS0169
         private readonly ITelemetryActivator telemetryActivator;
 #pragma warning restore CS0169
@@ -346,7 +347,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         // us time to call ConfigureForGrpcProtocol() in case the function metadata explicitly requests it.
         internal TaskHubWorker EnsureTaskHubWorker()
         {
-            return this.taskHubWorker ??= this.InitializeTaskHubWorker();
+            if (this.taskHubWorker != null)
+            {
+                return this.taskHubWorker;
+            }
+
+            lock (this.taskHubWorkerInitLock)
+            {
+                return this.taskHubWorker ??= this.InitializeTaskHubWorker();
+            }
         }
 
         // All calls to EnsureTaskHubWorker are guaranteed to happen after indexing. Every other call should use this method

--- a/src/WebJobs.Extensions.DurableTask/Grpc/AspNetCoreLocalGrpcListener.cs
+++ b/src/WebJobs.Extensions.DurableTask/Grpc/AspNetCoreLocalGrpcListener.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Grpc
         private async Task StartInternalAsync(CancellationToken cancellationToken)
         {
             int port = GetFreeTcpPort();
-            this.host = new HostBuilder().ConfigureWebHost(
+            IHost newHost = new HostBuilder().ConfigureWebHost(
                 builder =>
                 {
                     builder.UseKestrel(o => o.Listen(
@@ -92,10 +92,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Grpc
                 })
                 .Build();
 
-            await this.host.StartAsync(cancellationToken);
+            await newHost.StartAsync(cancellationToken);
 
             // Get the actual address we've started on.
-            IServer? server = this.host.Services.GetService<IServer>();
+            IServer? server = newHost.Services.GetService<IServer>();
             IServerAddressesFeature? addressFeature = server?.Features.Get<IServerAddressesFeature>();
             this.ListenAddress = addressFeature?.Addresses.SingleOrDefault();
 
@@ -115,6 +115,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Grpc
                 functionName: string.Empty,
                 message: $"Opened local gRPC endpoint: {this.ListenAddress} (Mode=AspNetCore)",
                 writeToUserLogs: true);
+
+            // Assign only after fully started so the fast-path check in StartAsync
+            // doesn't let concurrent callers return before initialization is complete.
+            this.host = newHost;
         }
 
         public Task StopAsync(CancellationToken cancellationToken)

--- a/src/WebJobs.Extensions.DurableTask/Grpc/AspNetCoreLocalGrpcListener.cs
+++ b/src/WebJobs.Extensions.DurableTask/Grpc/AspNetCoreLocalGrpcListener.cs
@@ -22,6 +22,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Grpc
     {
         private const string HostName = "127.0.0.1";
         private readonly DurableTaskExtension extension;
+        private readonly SemaphoreSlim startLock = new SemaphoreSlim(1, 1);
         private IHost? host;
 
         public AspNetCoreLocalGrpcListener(DurableTaskExtension extension)
@@ -33,12 +34,31 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Grpc
 
         public async Task StartAsync(CancellationToken cancellationToken)
         {
-            // Prevent double-start: if already started, return immediately
+            // Fast check: if already started, return immediately
             if (this.host != null)
             {
                 return;
             }
 
+            await this.startLock.WaitAsync(cancellationToken);
+            try
+            {
+                // Double-check after acquiring the lock
+                if (this.host != null)
+                {
+                    return;
+                }
+
+                await this.StartInternalAsync(cancellationToken);
+            }
+            finally
+            {
+                this.startLock.Release();
+            }
+        }
+
+        private async Task StartInternalAsync(CancellationToken cancellationToken)
+        {
             int port = GetFreeTcpPort();
             this.host = new HostBuilder().ConfigureWebHost(
                 builder =>

--- a/src/WebJobs.Extensions.DurableTask/Grpc/AspNetCoreLocalGrpcListener.cs
+++ b/src/WebJobs.Extensions.DurableTask/Grpc/AspNetCoreLocalGrpcListener.cs
@@ -33,6 +33,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Grpc
 
         public async Task StartAsync(CancellationToken cancellationToken)
         {
+            // Prevent double-start: if already started, return immediately
+            if (this.host != null)
+            {
+                return;
+            }
+
             int port = GetFreeTcpPort();
             this.host = new HostBuilder().ConfigureWebHost(
                 builder =>

--- a/src/WebJobs.Extensions.DurableTask/Grpc/AspNetCoreLocalGrpcListener.cs
+++ b/src/WebJobs.Extensions.DurableTask/Grpc/AspNetCoreLocalGrpcListener.cs
@@ -44,12 +44,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Grpc
             try
             {
                 // Double-check after acquiring the lock
-                if (this.host != null)
+                if (this.host == null)
                 {
-                    return;
+                    await this.StartInternalAsync(cancellationToken);
                 }
-
-                await this.StartInternalAsync(cancellationToken);
             }
             finally
             {

--- a/test/FunctionsV2/DurableTaskExtensionConcurrencyTests.cs
+++ b/test/FunctionsV2/DurableTaskExtensionConcurrencyTests.cs
@@ -1,0 +1,103 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using DurableTask.Core;
+using Microsoft.Azure.WebJobs.Extensions.DurableTask.Grpc;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
+{
+    public class DurableTaskExtensionConcurrencyTests
+    {
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public void EnsureTaskHubWorker_ConcurrentCalls_ReturnsSameInstance()
+        {
+            // Arrange
+            using DurableTaskExtension extension = CreateExtension("ConcurrencyTest");
+            int threadCount = 10;
+            var results = new ConcurrentBag<TaskHubWorker>();
+            using var barrier = new ManualResetEventSlim(false);
+
+            // Act
+            var threads = Enumerable.Range(0, threadCount).Select(_ => new Thread(() =>
+            {
+                barrier.Wait();
+                TaskHubWorker worker = extension.EnsureTaskHubWorker();
+                results.Add(worker);
+            })).ToArray();
+
+            foreach (var thread in threads)
+            {
+                thread.Start();
+            }
+
+            barrier.Set();
+
+            foreach (var thread in threads)
+            {
+                thread.Join();
+            }
+
+            // Assert
+            Assert.Equal(threadCount, results.Count);
+            TaskHubWorker first = results.First();
+            Assert.All(results, worker => Assert.Same(first, worker));
+        }
+
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public async Task AspNetCoreLocalGrpcListener_ConcurrentStartAsync_StartsOnlyOnce()
+        {
+            // Arrange
+            using DurableTaskExtension extension = CreateExtension("GrpcConcurrencyTest");
+            var listener = new AspNetCoreLocalGrpcListener(extension);
+            int taskCount = 10;
+
+            // Act
+            var tasks = Enumerable.Range(0, taskCount)
+                .Select(_ => listener.StartAsync(default))
+                .ToArray();
+
+            await Task.WhenAll(tasks);
+
+            // Assert
+            Assert.NotNull(listener.ListenAddress);
+            Assert.True(Uri.TryCreate(listener.ListenAddress, UriKind.Absolute, out Uri uri));
+            Assert.True(uri.IsLoopback);
+
+            // Cleanup
+            await listener.StopAsync(default);
+        }
+
+        private static DurableTaskExtension CreateExtension(string hubName)
+        {
+            var options = new DurableTaskOptions { HubName = hubName };
+            var wrappedOptions = new OptionsWrapper<DurableTaskOptions>(options);
+            var nameResolver = TestHelpers.GetTestNameResolver();
+            var serviceFactory = new AzureStorageDurabilityProviderFactory(
+                wrappedOptions,
+                new TestStorageServiceClientProviderFactory(),
+                nameResolver,
+                NullLoggerFactory.Instance,
+                TestHelpers.GetMockPlatformInformationService());
+
+            return new DurableTaskExtension(
+                wrappedOptions,
+                new LoggerFactory(),
+                nameResolver,
+                new[] { serviceFactory },
+                new TestHostShutdownNotificationService(),
+                new DurableHttpMessageHandlerFactory(),
+                platformInformationService: TestHelpers.GetMockPlatformInformationService());
+        }
+    }
+}

--- a/test/FunctionsV2/DurableTaskExtensionConcurrencyTests.cs
+++ b/test/FunctionsV2/DurableTaskExtensionConcurrencyTests.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+#nullable enable
+
 using System;
 using System.Collections.Concurrent;
 using System.Linq;
@@ -63,16 +65,27 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             int taskCount = 10;
 
             // Act
+            var listenAddresses = new ConcurrentBag<string?>();
             var tasks = Enumerable.Range(0, taskCount)
-                .Select(_ => listener.StartAsync(default))
+                .Select(async _ =>
+                {
+                    await listener.StartAsync(default);
+
+                    // Each caller should see a valid ListenAddress after StartAsync returns
+                    listenAddresses.Add(listener.ListenAddress);
+                })
                 .ToArray();
 
             await Task.WhenAll(tasks);
 
-            // Assert
-            Assert.NotNull(listener.ListenAddress);
-            Assert.True(Uri.TryCreate(listener.ListenAddress, UriKind.Absolute, out Uri uri));
-            Assert.True(uri.IsLoopback);
+            // Assert: every concurrent caller observed a valid address after StartAsync returned
+            Assert.Equal(taskCount, listenAddresses.Count);
+            Assert.All(listenAddresses, addr =>
+            {
+                Assert.NotNull(addr);
+                Assert.True(Uri.TryCreate(addr, UriKind.Absolute, out Uri? uri));
+                Assert.True(uri!.IsLoopback);
+            });
 
             // Cleanup
             await listener.StopAsync(default);


### PR DESCRIPTION
# Summary
## What changed?
- Made `EnsureTaskHubWorker()` thread-safe by adding a double-check locking pattern with a dedicated `taskHubWorkerInitLock` object. The previous `??=` operator is not atomic and allowed concurrent threads to each create a separate `TaskHubWorker` instance.
- Made `AspNetCoreLocalGrpcListener.StartAsync()` thread-safe using a `SemaphoreSlim`-based double-check locking pattern. Core startup logic extracted into `StartInternalAsync()`.
- Added concurrency unit tests validating both fixes.

## Why is this change needed?
- On Consumption Plan cold starts with multiple triggers (e.g., Timer + CosmosDB + Orchestration), `GetClient()` (called without `taskHubLock`) and `StartTaskHubWorkerIfNotStartedAsync()` (called with `taskHubLock`) can race into `EnsureTaskHubWorker()` simultaneously. Since `??=` is not atomic, two threads can both see `this.taskHubWorker == null`, both call `InitializeTaskHubWorker()`, and the second one overwrites the first. This causes a cascade of errors:
  1. **`NullReferenceException`** — The overwritten `TaskHubWorker` (never started) has null dispatchers
  2. **"The orchestration service has already started"** — The replacement `TaskHubWorker` tries to start the shared `AzureStorageOrchestrationService` that was already started by the first
  3. **"The local RPC address has not been configured"** — gRPC listener state is lost when the second initialization overwrites the first

- This regression was introduced in v3.10.0 by PR #3260 which extracted `TaskHubWorker` creation from `StartTaskHubWorkerIfNotStartedAsync()` (always under `taskHubLock`) into the new `EnsureTaskHubWorker()` method (called from `GetClient()` without any lock).

## Issues / work items
- Resolves #3343

---

# Project checklist
- [x] Documentation changes are not required
- [x] Release notes are not required for the next release
- [ ] Backport is not required
  - [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
- [x] All required tests have been added/updated (unit tests, E2E tests)
- [x] No extra work is required to be leveraged by OutOfProc SDKs
- [x] No change to the version of the `WebJobs.Extensions.DurableTask` package
- [x] No EventIds were added to `EventSource` logs
- [ ] This change should be added to the `v2.x` branch
  - [x] Otherwise: This change applies exclusively to `WebJobs.Extensions.DurableTask` v3.x and will be retained only in the `dev` and `main` branches
- [x] Breaking change? No

---

# AI-assisted code disclosure (required)
## Was an AI tool used? (select one)
- [ ] No
- [x] Yes, AI helped write parts of this PR (e.g., GitHub Copilot)
- [ ] Yes, an AI agent generated most of this PR

If AI was used:
- Tool(s): GitHub Copilot (Claude Opus 4.6)
- AI-assisted areas/files:
  - `src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs` — double-check locking in `EnsureTaskHubWorker()`
  - `src/WebJobs.Extensions.DurableTask/Grpc/AspNetCoreLocalGrpcListener.cs` — `SemaphoreSlim`-based double-check locking in `StartAsync()`
  - `test/FunctionsV2/DurableTaskExtensionConcurrencyTests.cs` — concurrency unit tests
- What you changed after AI output: Reviewed and validated the fix against the race condition analysis

AI verification (required if AI was used):
- [x] I understand the code and can explain it
- [x] I verified referenced APIs/types exist and are correct
- [x] I reviewed edge cases/failure paths (timeouts, retries, cancellation, exceptions)
- [x] I reviewed concurrency/async behavior
- [x] I checked for unintended breaking or behavior changes

---

# Testing
## Automated tests
- Result: Passed — 285 passed (including 2 new concurrency tests), 389 pre-existing failures (DI/config issues unrelated to this change, identical count on `dev` baseline)
- New tests:
  - `EnsureTaskHubWorker_ConcurrentCalls_ReturnsSameInstance` — verifies 10 threads calling `EnsureTaskHubWorker()` simultaneously all get the same instance
  - `AspNetCoreLocalGrpcListener_ConcurrentStartAsync_StartsOnlyOnce` — verifies 10 concurrent `StartAsync()` calls result in a single listener

## Manual validation (only if runtime/behavior changed)
- Not yet performed. Recommend testing on a Consumption Plan app with Timer + CosmosDB + Orchestration triggers to confirm the race condition no longer occurs on cold start.

---

# Notes for reviewers
- The race condition only manifests on Consumption Plan cold starts where multiple non-orchestration triggers (Timer, CosmosDB, etc.) bind `DurableTaskClient` concurrently with the orchestration listener starting up.
- The fix uses the standard double-check locking pattern: a fast-path null check avoids the lock on the hot path, while the lock + `??=` inside ensures only one thread creates the `TaskHubWorker`.
- The `AspNetCoreLocalGrpcListener.StartAsync()` now uses `SemaphoreSlim` (async-compatible) with the same double-check pattern, extracting the core logic into `StartInternalAsync()`.
