### PR TITLE
Potential fix for code scanning alert no. 19: Use of a known vulnerable action

### DIFF
--- a/.github/workflows/smoketest-java8-v4.yml
+++ b/.github/workflows/smoketest-java8-v4.yml
@@ -24,7 +24,7 @@ jobs:
           java-version: '8'
           distribution: 'temurin'
       - name: Build azure functions sample
-        uses: gradle/gradle-build-action@bc3340afc5e3cc44f2321809ac090d731c13c514
+        uses: gradle/gradle-build-action@v2.4.2
         with:
           gradle-version: 6.5
           arguments: azureFunctionsPackage -p test/SmokeTests/OOProcSmokeTests/durableJava/


### PR DESCRIPTION
Potential fix for [https://github.com/Azure/azure-functions-durable-extension/security/code-scanning/19](https://github.com/Azure/azure-functions-durable-extension/security/code-scanning/19)

In general, to fix a “known vulnerable action” in a GitHub Actions workflow, you should change the `uses:` reference to point to a non‑vulnerable version (typically the latest patched minor release), preferably via a stable tag or a secure commit that corresponds to that version. You should not remove the action unless it is unnecessary, because that would change functionality.

Here, the vulnerable reference is `gradle/gradle-build-action@bc3340afc5e3cc44f2321809ac090d731c13c514` in `.github/workflows/smoketest-java8-v4.yml`, under the step named `Build azure functions sample`. The best fix that preserves existing functionality is to update this `uses:` line to the recommended version tag `v2.4.2`, i.e., `uses: gradle/gradle-build-action@v2.4.2`. The rest of the step parameters (`gradle-version: 6.5`, `arguments: ...`, `continue-on-error: true`) remain unchanged. No additional methods, imports, or definitions are required because this is a YAML workflow change only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
