### PR TITLE
Respect chosen .NET framework for non-dotnet e2e apps

### DIFF
--- a/test/e2e/Apps/BasicJava/extensions.csproj
+++ b/test/e2e/Apps/BasicJava/extensions.csproj
@@ -4,13 +4,17 @@
     <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
 	<WarningsAsErrors></WarningsAsErrors>
 	<DefaultItemExcludes>**</DefaultItemExcludes>
+    <!-- Output directly to bin/ so the Functions host can find extensions at runtime,
+         matching the behavior of 'func extensions sync' -->
+    <OutputPath>bin</OutputPath>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
   <Target Name="PreBuild" BeforeTargets="Build;BeforeResolveReferences">
-    <!-- Build and pack the source project. Pin to net8.0 to avoid MSB3277 assembly conflicts
-    when the source project multi-targets net8.0;net10.0 -->
+    <!-- Build and pack the source project. Pin to a single TFM to avoid MSB3277 assembly conflicts
+    when the source project multi-targets (e.g. net8.0;net10.0) -->
     <MSBuild Projects="$(MSBuildProjectDirectory)/../../../../src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj"
              Targets="Build;Pack"
-             Properties="Configuration=$(Configuration);PackageOutputPath=$(MSBuildProjectDirectory)/packages;TargetFramework=net8.0" />
+             Properties="Configuration=$(Configuration);PackageOutputPath=$(MSBuildProjectDirectory)/packages;TargetFramework=$(TargetFramework)" />
   </Target>
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
     <Move SourceFiles="$(OutDir)/extensions.deps.json" DestinationFiles="$(OutDir)/function.deps.json" />

--- a/test/e2e/Apps/BasicNode/extensions.csproj
+++ b/test/e2e/Apps/BasicNode/extensions.csproj
@@ -4,13 +4,17 @@
     <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
 	<WarningsAsErrors></WarningsAsErrors>
 	<DefaultItemExcludes>**</DefaultItemExcludes>
+    <!-- Output directly to bin/ so the Functions host can find extensions at runtime,
+         matching the behavior of 'func extensions sync' -->
+    <OutputPath>bin</OutputPath>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
   <Target Name="PreBuild" BeforeTargets="Build;BeforeResolveReferences">
-    <!-- Build and pack the source project. Pin to net8.0 to avoid MSB3277 assembly conflicts
-    when the source project multi-targets net8.0;net10.0 -->
+    <!-- Build and pack the source project. Pin to a single TFM to avoid MSB3277 assembly conflicts
+    when the source project multi-targets (e.g. net8.0;net10.0) -->
     <MSBuild Projects="$(MSBuildProjectDirectory)/../../../../src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj"
              Targets="Build;Pack"
-             Properties="Configuration=$(Configuration);PackageOutputPath=$(MSBuildProjectDirectory)/packages;TargetFramework=net8.0" />
+             Properties="Configuration=$(Configuration);PackageOutputPath=$(MSBuildProjectDirectory)/packages;TargetFramework=$(TargetFramework)" />
   </Target>
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
     <Move SourceFiles="$(OutDir)/extensions.deps.json" DestinationFiles="$(OutDir)/function.deps.json" />

--- a/test/e2e/Apps/BasicPowerShell/extensions.csproj
+++ b/test/e2e/Apps/BasicPowerShell/extensions.csproj
@@ -4,13 +4,17 @@
     <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
 	<WarningsAsErrors></WarningsAsErrors>
 	<DefaultItemExcludes>**</DefaultItemExcludes>
+    <!-- Output directly to bin/ so the Functions host can find extensions at runtime,
+         matching the behavior of 'func extensions sync' -->
+    <OutputPath>bin</OutputPath>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
   <Target Name="PreBuild" BeforeTargets="Build;BeforeResolveReferences">
-    <!-- Build and pack the source project. Pin to net8.0 to avoid MSB3277 assembly conflicts
-    when the source project multi-targets net8.0;net10.0 -->
+    <!-- Build and pack the source project. Pin to a single TFM to avoid MSB3277 assembly conflicts
+    when the source project multi-targets (e.g. net8.0;net10.0) -->
     <MSBuild Projects="$(MSBuildProjectDirectory)/../../../../src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj"
              Targets="Build;Pack"
-             Properties="Configuration=$(Configuration);PackageOutputPath=$(MSBuildProjectDirectory)/packages;TargetFramework=net8.0" />
+             Properties="Configuration=$(Configuration);PackageOutputPath=$(MSBuildProjectDirectory)/packages;TargetFramework=$(TargetFramework)" />
   </Target>
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
     <Move SourceFiles="$(OutDir)/extensions.deps.json" DestinationFiles="$(OutDir)/function.deps.json" />

--- a/test/e2e/Apps/BasicPython/extensions.csproj
+++ b/test/e2e/Apps/BasicPython/extensions.csproj
@@ -4,13 +4,17 @@
     <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
 	<WarningsAsErrors></WarningsAsErrors>
 	<DefaultItemExcludes>**</DefaultItemExcludes>
+    <!-- Output directly to bin/ so the Functions host can find extensions at runtime,
+         matching the behavior of 'func extensions sync' -->
+    <OutputPath>bin</OutputPath>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
   <Target Name="PreBuild" BeforeTargets="Build;BeforeResolveReferences">
-    <!-- Build and pack the source project. Pin to net8.0 to avoid MSB3277 assembly conflicts
-    when the source project multi-targets net8.0;net10.0 -->
+    <!-- Build and pack the source project. Pin to a single TFM to avoid MSB3277 assembly conflicts
+    when the source project multi-targets (e.g. net8.0;net10.0) -->
     <MSBuild Projects="$(MSBuildProjectDirectory)/../../../../src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj"
              Targets="Build;Pack"
-             Properties="Configuration=$(Configuration);PackageOutputPath=$(MSBuildProjectDirectory)/packages;TargetFramework=net8.0" />
+             Properties="Configuration=$(Configuration);PackageOutputPath=$(MSBuildProjectDirectory)/packages;TargetFramework=$(TargetFramework)" />
   </Target>
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
     <Move SourceFiles="$(OutDir)/extensions.deps.json" DestinationFiles="$(OutDir)/function.deps.json" />

--- a/test/e2e/Tests/build-e2e-test.ps1
+++ b/test/e2e/Tests/build-e2e-test.ps1
@@ -132,12 +132,22 @@ function InstallExtensionAndBuildTestApp($testAppDir) {
     }
 
     if (!(Test-Path ".\app.csproj")) {
-      Write-Host "Syncing extensions"
-      if ((Test-Path (Join-Path $FUNC_CLI_DIRECTORY "func")) -or (Test-Path (Join-Path $FUNC_CLI_DIRECTORY "func.exe"))) {
-        .(Join-Path $FUNC_CLI_DIRECTORY "func") extensions sync
-      }
-      else {
-        Write-Warning "func command not found. Skipping extensions sync."
+      if (Test-Path ".\extensions.csproj") {
+        Write-Host "Building extensions project"
+        dotnet clean extensions.csproj
+        if ($TargetFramework) {
+          dotnet build extensions.csproj -p:TargetFramework=$TargetFramework
+        } else {
+          dotnet build extensions.csproj
+        }
+      } else {
+        Write-Host "Syncing extensions"
+        if ((Test-Path (Join-Path $FUNC_CLI_DIRECTORY "func")) -or (Test-Path (Join-Path $FUNC_CLI_DIRECTORY "func.exe"))) {
+          .(Join-Path $FUNC_CLI_DIRECTORY "func") extensions sync
+        }
+        else {
+          Write-Warning "func command not found. Skipping extensions sync."
+        }
       }
     }
 


### PR DESCRIPTION
Allows non-dotnet e2e apps to build using the correct target framework: