### PR TITLE
Update "Zip .NET in-proc perf tests" step in pipelines

### DIFF
--- a/azure-pipelines-release-nightly.yml
+++ b/azure-pipelines-release-nightly.yml
@@ -164,12 +164,22 @@ steps:
 
 # zip .NET in-proc perf tests
 - task: DotNetCoreCLI@2
-  displayName: 'Zip .NET in-proc perf tests'
+  displayName: 'Zip .NET in-proc perf tests (net8.0)'
   inputs:
     command: 'publish'
     publishWebProjects: false
     projects: '$(System.DefaultWorkingDirectory)/test/PerfTests/DFPerfTests/**/*.csproj'
-    arguments: '-o $(System.DefaultWorkingDirectory)/test/PerfTests/DFPerfTests/Output'
+    arguments: '-f net8.0 -o $(System.DefaultWorkingDirectory)/test/PerfTests/DFPerfTests/Output/net8.0'
+    zipAfterPublish: true
+    modifyOutputPath: true
+
+- task: DotNetCoreCLI@2
+  displayName: 'Zip .NET in-proc perf tests (net10.0)'
+  inputs:
+    command: 'publish'
+    publishWebProjects: false
+    projects: '$(System.DefaultWorkingDirectory)/test/PerfTests/DFPerfTests/**/*.csproj'
+    arguments: '-f net10.0 -o $(System.DefaultWorkingDirectory)/test/PerfTests/DFPerfTests/Output/net10.0'
     zipAfterPublish: true
     modifyOutputPath: true
 

--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -161,12 +161,22 @@ steps:
 
 # zip .NET in-proc perf tests
 - task: DotNetCoreCLI@2
-  displayName: 'Zip .NET in-proc perf tests'
+  displayName: 'Zip .NET in-proc perf tests (net8.0)'
   inputs:
     command: 'publish'
     publishWebProjects: false
     projects: '$(System.DefaultWorkingDirectory)/test/PerfTests/DFPerfTests/**/*.csproj'
-    arguments: '-o $(System.DefaultWorkingDirectory)/test/PerfTests/DFPerfTests/Output'
+    arguments: '-f net8.0 -o $(System.DefaultWorkingDirectory)/test/PerfTests/DFPerfTests/Output/net8.0'
+    zipAfterPublish: true
+    modifyOutputPath: true
+
+- task: DotNetCoreCLI@2
+  displayName: 'Zip .NET in-proc perf tests (net10.0)'
+  inputs:
+    command: 'publish'
+    publishWebProjects: false
+    projects: '$(System.DefaultWorkingDirectory)/test/PerfTests/DFPerfTests/**/*.csproj'
+    arguments: '-f net10.0 -o $(System.DefaultWorkingDirectory)/test/PerfTests/DFPerfTests/Output/net10.0'
     zipAfterPublish: true
     modifyOutputPath: true
 

--- a/eng/templates/build.yml
+++ b/eng/templates/build.yml
@@ -133,12 +133,22 @@ jobs:
             
       # zip .NET in-proc perf tests
       - task: DotNetCoreCLI@2
-        displayName: 'Zip .NET in-proc perf tests'
+        displayName: 'Zip .NET in-proc perf tests (net8.0)'
         inputs:
             command: 'publish'
             publishWebProjects: false
             projects: '$(System.DefaultWorkingDirectory)/test/PerfTests/DFPerfTests/**/*.csproj'
-            arguments: '-o $(System.DefaultWorkingDirectory)/test/PerfTests/DFPerfTests/Output'
+            arguments: '-f net8.0 -o $(System.DefaultWorkingDirectory)/test/PerfTests/DFPerfTests/Output/net8.0'
+            zipAfterPublish: true
+            modifyOutputPath: true
+
+      - task: DotNetCoreCLI@2
+        displayName: 'Zip .NET in-proc perf tests (net10.0)'
+        inputs:
+            command: 'publish'
+            publishWebProjects: false
+            projects: '$(System.DefaultWorkingDirectory)/test/PerfTests/DFPerfTests/**/*.csproj'
+            arguments: '-f net10.0 -o $(System.DefaultWorkingDirectory)/test/PerfTests/DFPerfTests/Output/net10.0'
             zipAfterPublish: true
             modifyOutputPath: true
 


### PR DESCRIPTION
# Summary
## What changed?

This pull request updates the build and release pipelines to add support for .NET 10.0 when publishing and zipping in-proc performance tests, in addition to the existing .NET 8.0 support. The changes ensure that performance test artifacts are built and packaged for both target frameworks in all relevant pipelines.

**Pipeline updates for multi-targeting:**

* The `.NET in-proc perf tests` publish and zip steps in `eng/templates/build.yml`, `azure-pipelines-release.yml`, and `azure-pipelines-release-nightly.yml` have been updated to explicitly target both `net8.0` and `net10.0`, with separate tasks and output directories for each framework.
* The display names for these tasks now indicate the target framework (`net8.0` or `net10.0`) for clarity in pipeline logs.
* The `arguments` for the publish steps now specify the target framework (`-f net8.0` or `-f net10.0`) and output to corresponding subdirectories.
* The `zipAfterPublish` and `modifyOutputPath` options are now set to `true` for both target frameworks to ensure zipped output and consistent output paths. 

## Why is this change needed?
- To fix the official pipeline

## Issues / work items
- Resolves #
- Related #

---

# Project checklist
- [x] Documentation changes are not required
  - [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
- [x] Release notes are not required for the next release
  - [ ] Otherwise: Notes added to `release_notes.md`
- [x] Backport is not required
  - [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
- [x] All required tests have been added/updated (unit tests, E2E tests)
- [x] No extra work is required to be leveraged by OutOfProc SDKs
  - [ ] Otherwise: Work tracked here: #issue_or_pr_in_each_sdk
- [x] No change to the version of the `WebJobs.Extensions.DurableTask` package
  - [ ] Otherwise: Major/minor updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
- [x] No EventIds were added to `EventSource` logs
  - [ ] Otherwise: Ensure EventIds are within the supported range in the existing Windows infrastructure (validate via deployed telemetry). If needed, extend the range via a PR such as https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files
- [ ] This change should be added to the `v2.x` branch
  - [x] Otherwise: This change applies exclusively to `WebJobs.Extensions.DurableTask` v3.x and will be retained only in the `dev` and `main` branches
- [ ] Breaking change?
  - [ ] If yes:
    - Impact:
    - Migration guidance:
---

# AI-assisted code disclosure (required)
## Was an AI tool used? (select one)
- [ ] No
- [ ] Yes, AI helped write parts of this PR (e.g., GitHub Copilot)
- [x] Yes, an AI agent generated most of this PR

If AI was used:
- Tool(s): VS Code GitHub CoPilot
- AI-assisted areas/files:
- What you changed after AI output:

AI verification (required if AI was used):
- [x] I understand the code and can explain it
- [x] I verified referenced APIs/types exist and are correct
- [x] I reviewed edge cases/failure paths (timeouts, retries, cancellation, exceptions)
- [x] I reviewed concurrency/async behavior
- [x] I checked for unintended breaking or behavior changes

---

# Testing
## Automated tests
- Result: Passed / Failed (link logs if failed)

## Manual validation (only if runtime/behavior changed)
- Environment (OS, .NET version, components):
- Steps + observed results:
  1.
  2.
  3.
- Evidence (optional):

---

# Notes for reviewers
- N/A
