### PR TITLE
Fix CVE issues

### DIFF
--- a/samples/Directory.Packages.props
+++ b/samples/Directory.Packages.props
@@ -41,7 +41,7 @@
     <PackageVersion Update="Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator" Version="4.0.1" />
     <PackageVersion Update="Microsoft.Bcl.AsyncInterfaces" Version="10.0.1" />
     <PackageVersion Update="Microsoft.Extensions.Logging.Debug" Version="10.0.0" />
-    <PackageVersion Update="System.Drawing.Common" Version="6.0.0" />
+    <PackageVersion Update="System.Drawing.Common" Version="4.7.3" />
     <PackageVersion Update="System.Text.Json" Version="10.0.0" />
    </ItemGroup>
 

--- a/samples/durable-client-managed-identity/aspnetcore-app/ToDoList.csproj
+++ b/samples/durable-client-managed-identity/aspnetcore-app/ToDoList.csproj
@@ -8,6 +8,7 @@
   <!-- To specify a version in the package reference below, simply add `Version = ""`. -->
   <ItemGroup>
     <PackageReference Include="EntityFramework" />
+    <PackageReference Include="System.Drawing.Common" VersionOverride="6.0.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" >

--- a/samples/isolated-unit-tests/IsolatedUnitTest.csproj
+++ b/samples/isolated-unit-tests/IsolatedUnitTest.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" />
+    <PackageReference Include="System.Drawing.Common" VersionOverride="6.0.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" />

--- a/samples/todolist-aspnetcore/ToDoList.csproj
+++ b/samples/todolist-aspnetcore/ToDoList.csproj
@@ -8,6 +8,7 @@
   <!-- To specify a version in the package reference below, simply add `Version = ""`. -->
   <ItemGroup>
     <PackageReference Include="EntityFramework" />
+    <PackageReference Include="System.Drawing.Common" VersionOverride="6.0.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design"  />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" >

--- a/test/CodeGen.SourceGenerator.Test/DurableFunctions.TypedInterfaces.SourceGenerator.Test.csproj
+++ b/test/CodeGen.SourceGenerator.Test/DurableFunctions.TypedInterfaces.SourceGenerator.Test.csproj
@@ -19,6 +19,10 @@
     <PackageReference Include="Microsoft.Build.Framework" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.Build.Locator" />
     <PackageReference Include="Microsoft.Build.Tasks.Core" ExcludeAssets="runtime" />
+    <!-- Microsoft.Build 17.8.43 transitively requires System.Drawing.Common >= 7.0.0,
+         which conflicts with the central pin of 4.7.3. Override here since this test
+         project does not ship to customers. -->
+    <PackageReference Include="System.Drawing.Common" VersionOverride="7.0.0" />
     <PackageReference Include="Microsoft.CodeAnalysis" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" />

--- a/test/Directory.Packages.props
+++ b/test/Directory.Packages.props
@@ -33,7 +33,7 @@
     <PackageVersion Update="Azure.Identity" Version="1.17.1" />
     <PackageVersion Update="Microsoft.Bcl.AsyncInterfaces" Version="10.0.1" />
     <PackageVersion Update="Microsoft.Extensions.Azure" Version="1.10.0" />
-    <PackageVersion Update="System.Drawing.Common" Version="7.0.0" />
+    <PackageVersion Update="System.Drawing.Common" Version="4.7.3" />
     <PackageVersion Update="System.Formats.Asn1" Version="8.0.1" />
     <PackageVersion Update="System.Text.Json" Version="10.0.0" />
   </ItemGroup>

--- a/test/Directory.Packages.props
+++ b/test/Directory.Packages.props
@@ -10,10 +10,10 @@
     <PackageVersion Include="coverlet.collector" Version="6.0.0" />
     <PackageVersion Include="FluentAssertions" Version="4.19.4" />
     <PackageVersion Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" Version="3.0.41" />
-    <PackageVersion Include="Microsoft.Build" Version="17.8.29" />
-    <PackageVersion Include="Microsoft.Build.Framework" Version="17.8.29" />
+    <PackageVersion Include="Microsoft.Build" Version="17.8.43" />
+    <PackageVersion Include="Microsoft.Build.Framework" Version="17.8.43" />
     <PackageVersion Include="Microsoft.Build.Locator" Version="1.4.1" />
-    <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="17.8.29" />
+    <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="17.8.43" />
     <PackageVersion Include="Microsoft.CodeAnalysis" Version="3.9.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="3.9.0" />
     <PackageVersion Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.65" />

--- a/test/SmokeTests/BackendSmokeTests/MSSQL/MSSQL.csproj
+++ b/test/SmokeTests/BackendSmokeTests/MSSQL/MSSQL.csproj
@@ -13,7 +13,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.6.0" />
     <PackageReference Include="Microsoft.DurableTask.SqlServer.AzureFunctions" Version="1.5.1" />
-    <PackageReference Include="System.Drawing.Common" Version="7.0.0" />
+    <PackageReference Include="System.Drawing.Common" Version="4.7.3" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">

--- a/test/e2e/Apps/BasicDotNetIsolated/Directory.Build.targets
+++ b/test/e2e/Apps/BasicDotNetIsolated/Directory.Build.targets
@@ -14,6 +14,6 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(AssemblyName)' == 'Microsoft.Azure.Functions.Worker.Extensions'">
-    <PackageReference Include="System.Drawing.Common" Version="4.7.2" />
+    <PackageReference Include="System.Drawing.Common" Version="4.7.3" />
   </ItemGroup>
 </Project>

--- a/test/e2e/Apps/BasicDotNetIsolated/Directory.Build.targets
+++ b/test/e2e/Apps/BasicDotNetIsolated/Directory.Build.targets
@@ -1,0 +1,19 @@
+<Project>
+  <!--
+    The Azure Functions Worker SDK auto-generates a WorkerExtensions.csproj under obj/ with hardcoded
+    PackageReference versions. This conflicts with Central Package Management (CPM), causing NU1008
+    errors and preventing the transitive pin of System.Drawing.Common (in test/Directory.Packages.props)
+    from taking effect. As a result, the vulnerable transitive version 4.7.0 from
+    Microsoft.DurableTask.SqlServer.AzureFunctions remains unpatched (CVE-2021-24112).
+
+    This targets file disables CPM for the generated project and injects a direct PackageReference
+    to override the vulnerable transitive dependency.
+  -->
+  <PropertyGroup Condition="'$(AssemblyName)' == 'Microsoft.Azure.Functions.Worker.Extensions'">
+    <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(AssemblyName)' == 'Microsoft.Azure.Functions.Worker.Extensions'">
+    <PackageReference Include="System.Drawing.Common" Version="4.7.2" />
+  </ItemGroup>
+</Project>

--- a/test/e2e/Apps/BasicDotNetIsolated/app.csproj
+++ b/test/e2e/Apps/BasicDotNetIsolated/app.csproj
@@ -24,6 +24,7 @@
     <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask.SqlServer" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask.AzureManaged" />
+    <PackageReference Include="System.Drawing.Common" VersionOverride="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/e2e/Apps/BasicJava/pom.xml
+++ b/test/e2e/Apps/BasicJava/pom.xml
@@ -45,6 +45,13 @@
             <version>${durabletask.azure.functions}</version>
         </dependency>
 
+        <!-- Override transitive jackson-core to fix GHSA-72hv-8253-57qq (CVE in jackson-core < 2.18.6) -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
+
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>


### PR DESCRIPTION
# Summary
## What changed?
This pull request primarily addresses dependency management and vulnerability mitigation across several test and sample projects. The most significant changes involve updating package versions to patch known security issues, specifically with `System.Drawing.Common` and `jackson-core`, and ensuring compatibility with central package management. Additional updates include bumping `Microsoft.Build` packages to newer versions for consistency and reliability.

**Security and Vulnerability Fixes**

* Downgraded `System.Drawing.Common` to `4.7.3` in multiple `.props` and `.csproj` files to address compatibility and vulnerability concerns.
* Added a custom `Directory.Build.targets` file to forcibly override the vulnerable transitive dependency on `System.Drawing.Common` in auto-generated Azure Functions Worker SDK projects, ensuring version `4.7.3` is used and disabling central package management for the generated project.
* Overrode transitive `jackson-core` dependency in the Java test project to version `2.18.6`, addressing CVE GHSA-72hv-8253-57qq.

**Dependency Management and Compatibility**

* Updated `Microsoft.Build`, `Microsoft.Build.Framework`, and `Microsoft.Build.Tasks.Core` package versions from `17.8.29` to `17.8.43` in test projects for improved consistency and reliability.
* Added an explicit `System.Drawing.Common` reference with `VersionOverride="7.0.0"` in the source generator test project to resolve conflicts with the central pin, since this test project does not ship to customers.

## Why is this change needed?
- Fix CVE issues and vulnerabilities

## Issues / work items
- Resolves #
- Related #

---

# Project checklist
- [x] Documentation changes are not required
  - [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
- [ ] Release notes are not required for the next release
  - [ ] Otherwise: Notes added to `release_notes.md`
- [x] Backport is not required
  - [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
- [x] All required tests have been added/updated (unit tests, E2E tests)
- [x] No extra work is required to be leveraged by OutOfProc SDKs
  - [ ] Otherwise: Work tracked here: #issue_or_pr_in_each_sdk
- [x] No change to the version of the `WebJobs.Extensions.DurableTask` package
  - [ ] Otherwise: Major/minor updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
- [x] No EventIds were added to `EventSource` logs
  - [ ] Otherwise: Ensure EventIds are within the supported range in the existing Windows infrastructure (validate via deployed telemetry). If needed, extend the range via a PR such as https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files
- [x] This change should be added to the `v2.x` branch
  - [ ] Otherwise: This change applies exclusively to `WebJobs.Extensions.DurableTask` v3.x and will be retained only in the `dev` and `main` branches
- [ ] Breaking change?
  - [ ] If yes:
    - Impact:
    - Migration guidance:
---

# AI-assisted code disclosure (required)
## Was an AI tool used? (select one)
- [ ] No
- [ ] Yes, AI helped write parts of this PR (e.g., GitHub Copilot)
- [x] Yes, an AI agent generated most of this PR

If AI was used:
- Tool(s): VS Code GitHub CoPilot
- AI-assisted areas/files:
- What you changed after AI output:

AI verification (required if AI was used):
- [x] I understand the code and can explain it
- [x] I verified referenced APIs/types exist and are correct
- [x] I reviewed edge cases/failure paths (timeouts, retries, cancellation, exceptions)
- [x] I reviewed concurrency/async behavior
- [x] I checked for unintended breaking or behavior changes

---

# Testing
## Automated tests
- Result: Passed / Failed (link logs if failed)

## Manual validation (only if runtime/behavior changed)
- Environment (OS, .NET version, components):
- Steps + observed results:
  1.
  2.
  3.
- Evidence (optional):

---

# Notes for reviewers
- N/A
