### PR TITLE
Dispose durable trigger scale providers to prevent Azure Managed listener leaks

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/DurabilityProvider.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurabilityProvider.cs
@@ -27,8 +27,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         IOrchestrationServiceClient,
         IOrchestrationServiceQueryClient,
         IOrchestrationServicePurgeClient,
-        IEntityOrchestrationService,
-        IDisposable
+        IEntityOrchestrationService
     {
         internal const string NoConnectionDetails = "default";
 
@@ -619,24 +618,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         public virtual void SetUseSeparateQueueForEntityWorkItems(bool newValue)
         {
             throw this.GetNotImplementedException(nameof(this.SetUseSeparateQueueForEntityWorkItems));
-        }
-
-        /// <summary>
-        /// Disposes resources held by this provider, including the underlying
-        /// <see cref="IOrchestrationService"/> if it implements <see cref="IDisposable"/>.
-        /// Subclasses that own additional disposable resources should override this method,
-        /// dispose their own resources, and call <c>base.Dispose()</c>.
-        /// </summary>
-        public virtual void Dispose()
-        {
-            (this.innerService as IDisposable)?.Dispose();
-
-            // Avoid double-disposing when the same object serves both roles
-            // (e.g., AzureManagedOrchestrationService is both IOrchestrationService and IOrchestrationServiceClient).
-            if (!object.ReferenceEquals(this.innerService, this.innerServiceClient))
-            {
-                (this.innerServiceClient as IDisposable)?.Dispose();
-            }
         }
     }
 }

--- a/src/WebJobs.Extensions.DurableTask/DurabilityProvider.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurabilityProvider.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
@@ -27,7 +27,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         IOrchestrationServiceClient,
         IOrchestrationServiceQueryClient,
         IOrchestrationServicePurgeClient,
-        IEntityOrchestrationService
+        IEntityOrchestrationService,
+        IDisposable
     {
         internal const string NoConnectionDetails = "default";
 
@@ -618,6 +619,24 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         public virtual void SetUseSeparateQueueForEntityWorkItems(bool newValue)
         {
             throw this.GetNotImplementedException(nameof(this.SetUseSeparateQueueForEntityWorkItems));
+        }
+
+        /// <summary>
+        /// Disposes resources held by this provider, including the underlying
+        /// <see cref="IOrchestrationService"/> if it implements <see cref="IDisposable"/>.
+        /// Subclasses that own additional disposable resources should override this method,
+        /// dispose their own resources, and call <c>base.Dispose()</c>.
+        /// </summary>
+        public virtual void Dispose()
+        {
+            (this.innerService as IDisposable)?.Dispose();
+
+            // Avoid double-disposing when the same object serves both roles
+            // (e.g., AzureManagedOrchestrationService is both IOrchestrationService and IOrchestrationServiceClient).
+            if (!object.ReferenceEquals(this.innerService, this.innerServiceClient))
+            {
+                (this.innerServiceClient as IDisposable)?.Dispose();
+            }
         }
     }
 }

--- a/src/WebJobs.Extensions.DurableTask/Scale/DurableTaskTriggersScaleProvider.cs
+++ b/src/WebJobs.Extensions.DurableTask/Scale/DurableTaskTriggersScaleProvider.cs
@@ -140,7 +140,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Scale
 
         public void Dispose()
         {
-            this.durabilityProvider?.Dispose();
+            (this.durabilityProvider as IDisposable)?.Dispose();
         }
 
         /// <summary>

--- a/src/WebJobs.Extensions.DurableTask/Scale/DurableTaskTriggersScaleProvider.cs
+++ b/src/WebJobs.Extensions.DurableTask/Scale/DurableTaskTriggersScaleProvider.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 #nullable enable
 
@@ -12,7 +12,7 @@ using Newtonsoft.Json;
 
 namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Scale
 {
-    internal class DurableTaskTriggersScaleProvider : IScaleMonitorProvider, ITargetScalerProvider
+    internal class DurableTaskTriggersScaleProvider : IScaleMonitorProvider, ITargetScalerProvider, IDisposable
     {
         private const string AzureManagedProviderName = "azureManaged";
 
@@ -22,6 +22,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Scale
         private readonly INameResolver nameResolver;
         private readonly ILoggerFactory loggerFactory;
         private readonly IEnumerable<IDurabilityProviderFactory> durabilityProviderFactories;
+        private readonly DurabilityProvider durabilityProvider;
 
         public DurableTaskTriggersScaleProvider(
             IOptions<DurableTaskOptions> durableTaskOptions,
@@ -42,14 +43,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Scale
 
             IDurabilityProviderFactory durabilityProviderFactory = this.GetDurabilityProviderFactory();
 
-            DurabilityProvider defaultDurabilityProvider;
             if (string.Equals(durabilityProviderFactory.Name, AzureManagedProviderName, StringComparison.OrdinalIgnoreCase))
             {
-                defaultDurabilityProvider = durabilityProviderFactory.GetDurabilityProvider(attribute: null, triggerMetadata);
+                this.durabilityProvider = durabilityProviderFactory.GetDurabilityProvider(attribute: null, triggerMetadata);
             }
             else
             {
-                defaultDurabilityProvider = durabilityProviderFactory.GetDurabilityProvider();
+                this.durabilityProvider = durabilityProviderFactory.GetDurabilityProvider();
             }
 
             // Note: `this.options` is populated from the trigger metadata above
@@ -62,14 +62,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Scale
                 connectionName);
 
             this.targetScaler = ScaleUtils.GetTargetScaler(
-                defaultDurabilityProvider,
+                this.durabilityProvider,
                 functionId,
                 functionName,
                 connectionName,
                 this.options.HubName);
 
             this.monitor = ScaleUtils.GetScaleMonitor(
-                defaultDurabilityProvider,
+                this.durabilityProvider,
                 functionId,
                 functionName,
                 connectionName,
@@ -136,6 +136,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Scale
         public ITargetScaler GetTargetScaler()
         {
             return this.targetScaler;
+        }
+
+        public void Dispose()
+        {
+            this.durabilityProvider?.Dispose();
         }
 
         /// <summary>


### PR DESCRIPTION
This change makes `DurableTaskTriggersScaleProvider` and `DurabilityProvider` disposable so backend resources are released when scale hosts are rebuilt.

For Azure Managed backends, this ensures `EventSourceListener` instances are disposed , preventing memory/thread growth across repeated scale-controller reinitializations.