### PR TITLE
Dispose DurableTaskTriggersScaleProvider  to prevent Azure Managed provider leaks

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/Scale/DurableTaskTriggersScaleProvider.cs
+++ b/src/WebJobs.Extensions.DurableTask/Scale/DurableTaskTriggersScaleProvider.cs
@@ -12,7 +12,7 @@ using Newtonsoft.Json;
 
 namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Scale
 {
-    internal class DurableTaskTriggersScaleProvider : IScaleMonitorProvider, ITargetScalerProvider
+    internal class DurableTaskTriggersScaleProvider : IScaleMonitorProvider, ITargetScalerProvider, IDisposable
     {
         private const string AzureManagedProviderName = "azureManaged";
 
@@ -22,6 +22,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Scale
         private readonly INameResolver nameResolver;
         private readonly ILoggerFactory loggerFactory;
         private readonly IEnumerable<IDurabilityProviderFactory> durabilityProviderFactories;
+        private readonly DurabilityProvider durabilityProvider;
 
         public DurableTaskTriggersScaleProvider(
             IOptions<DurableTaskOptions> durableTaskOptions,
@@ -42,14 +43,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Scale
 
             IDurabilityProviderFactory durabilityProviderFactory = this.GetDurabilityProviderFactory();
 
-            DurabilityProvider defaultDurabilityProvider;
             if (string.Equals(durabilityProviderFactory.Name, AzureManagedProviderName, StringComparison.OrdinalIgnoreCase))
             {
-                defaultDurabilityProvider = durabilityProviderFactory.GetDurabilityProvider(attribute: null, triggerMetadata);
+                this.durabilityProvider = durabilityProviderFactory.GetDurabilityProvider(attribute: null, triggerMetadata);
             }
             else
             {
-                defaultDurabilityProvider = durabilityProviderFactory.GetDurabilityProvider();
+                this.durabilityProvider = durabilityProviderFactory.GetDurabilityProvider();
             }
 
             // Note: `this.options` is populated from the trigger metadata above
@@ -62,14 +62,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Scale
                 connectionName);
 
             this.targetScaler = ScaleUtils.GetTargetScaler(
-                defaultDurabilityProvider,
+                this.durabilityProvider,
                 functionId,
                 functionName,
                 connectionName,
                 this.options.HubName);
 
             this.monitor = ScaleUtils.GetScaleMonitor(
-                defaultDurabilityProvider,
+                this.durabilityProvider,
                 functionId,
                 functionName,
                 connectionName,
@@ -119,6 +119,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Scale
             }
 
             DurableTaskOptions.ResolveAppSettingOptions(this.options, this.nameResolver);
+        }
+
+        public void Dispose()
+        {
+            (this.durabilityProvider as IDisposable)?.Dispose();
         }
 
         private IDurabilityProviderFactory GetDurabilityProviderFactory()

--- a/test/FunctionsV2/DurableTaskTargetScalerTests.cs
+++ b/test/FunctionsV2/DurableTaskTargetScalerTests.cs
@@ -1,8 +1,10 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
 using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using DurableTask.AzureStorage;
 using DurableTask.AzureStorage.Monitoring;
@@ -175,6 +177,40 @@ namespace WebJobs.Extensions.DurableTask.Tests.V2
 
                 bool containsExpectedLog = this.loggerProvider.GetAllLogMessages().Select(p => p.FormattedMessage ?? "").Any(p => p.Contains(expectedSubString));
                 Assert.True(containsExpectedLog);
+            }
+        }
+
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public void Dispose_DelegatesToDurabilityProvider_WhenProviderImplementsIDisposable()
+        {
+            var scaleProvider = (DurableTaskTriggersScaleProvider)RuntimeHelpers.GetUninitializedObject(typeof(DurableTaskTriggersScaleProvider));
+            var disposableDurabilityProvider = new DisposableTestDurabilityProvider();
+            FieldInfo field = typeof(DurableTaskTriggersScaleProvider).GetField("durabilityProvider", BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.NotNull(field);
+            field.SetValue(scaleProvider, disposableDurabilityProvider);
+
+            scaleProvider.Dispose();
+
+            Assert.True(disposableDurabilityProvider.IsDisposed);
+        }
+
+        private sealed class DisposableTestDurabilityProvider : DurabilityProvider, IDisposable
+        {
+            public DisposableTestDurabilityProvider()
+                : base(
+                    "TestProvider",
+                    new Mock<IOrchestrationService>(MockBehavior.Strict).Object,
+                    new Mock<IOrchestrationServiceClient>(MockBehavior.Strict).Object,
+                    "connectionName")
+            {
+            }
+
+            public bool IsDisposed { get; private set; }
+
+            public void Dispose()
+            {
+                this.IsDisposed = true;
             }
         }
     }


### PR DESCRIPTION
This change makes `DurableTaskTriggersScaleProvider` disposable so backend resources are released when scale hosts are rebuilt.

For Azure Managed backends, this ensures `EventSourceListener` instances are disposed , preventing memory/thread growth across repeated scale-controller reinitializations.
