### PR TITLE
Fix CVE 2021-24112

### DIFF
--- a/test/e2e/Apps/BasicDotNetIsolated/Directory.Build.props
+++ b/test/e2e/Apps/BasicDotNetIsolated/Directory.Build.props
@@ -1,0 +1,12 @@
+<Project>
+  <!--
+    Pin System.Drawing.Common 4.7.2 for WorkerExtensions to override
+    the vulnerable transitive 4.7.0 from Microsoft.DurableTask.SqlServer (CVE-2021-24112).
+    CPM is disabled for WorkerExtensions via the local Directory.Packages.props.
+    Import-blocking is removed via the _FunctionsExtensionCommonProps override
+    in Directory.Build.targets.
+  -->
+  <ItemGroup Condition="'$(MSBuildProjectFile)' == 'WorkerExtensions.csproj'">
+    <PackageReference Include="System.Drawing.Common" Version="4.7.2" />
+  </ItemGroup>
+</Project>

--- a/test/e2e/Apps/BasicDotNetIsolated/Directory.Build.props
+++ b/test/e2e/Apps/BasicDotNetIsolated/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <!--
-    Pin System.Drawing.Common 4.7.2 for WorkerExtensions to override
+    Pin System.Drawing.Common 4.7.3 for WorkerExtensions to override
     the vulnerable transitive 4.7.0 from Microsoft.DurableTask.SqlServer (CVE-2021-24112).
     CPM is disabled for WorkerExtensions via the local Directory.Packages.props.
     Import-blocking is removed via the _FunctionsExtensionCommonProps override

--- a/test/e2e/Apps/BasicDotNetIsolated/Directory.Build.props
+++ b/test/e2e/Apps/BasicDotNetIsolated/Directory.Build.props
@@ -7,6 +7,6 @@
     in Directory.Build.targets.
   -->
   <ItemGroup Condition="'$(MSBuildProjectFile)' == 'WorkerExtensions.csproj'">
-    <PackageReference Include="System.Drawing.Common" Version="4.7.2" />
+    <PackageReference Include="System.Drawing.Common" Version="4.7.3" />
   </ItemGroup>
 </Project>

--- a/test/e2e/Apps/BasicDotNetIsolated/Directory.Build.targets
+++ b/test/e2e/Apps/BasicDotNetIsolated/Directory.Build.targets
@@ -1,19 +1,12 @@
 <Project>
   <!--
-    The Azure Functions Worker SDK auto-generates a WorkerExtensions.csproj under obj/ with hardcoded
-    PackageReference versions. This conflicts with Central Package Management (CPM), causing NU1008
-    errors and preventing the transitive pin of System.Drawing.Common (in test/Directory.Packages.props)
-    from taking effect. As a result, the vulnerable transitive version 4.7.0 from
-    Microsoft.DurableTask.SqlServer.AzureFunctions remains unpatched (CVE-2021-24112).
-
-    This targets file disables CPM for the generated project and injects a direct PackageReference
-    to override the vulnerable transitive dependency.
+    The Worker SDK sets _FunctionsExtensionCommonProps to block Directory.Build.props/targets
+    and Directory.Packages.props imports for the generated WorkerExtensions.csproj.
+    This prevents our CVE-2021-24112 fix (System.Drawing.Common 4.7.2 pin via
+    Directory.Build.props and Directory.Packages.props) from applying.
+    Override it here (imported after SDK targets) to allow our import files.
   -->
-  <PropertyGroup Condition="'$(AssemblyName)' == 'Microsoft.Azure.Functions.Worker.Extensions'">
-    <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+  <PropertyGroup>
+    <_FunctionsExtensionCommonProps>ImportDirectoryBuildTargets=false</_FunctionsExtensionCommonProps>
   </PropertyGroup>
-
-  <ItemGroup Condition="'$(AssemblyName)' == 'Microsoft.Azure.Functions.Worker.Extensions'">
-    <PackageReference Include="System.Drawing.Common" Version="4.7.3" />
-  </ItemGroup>
 </Project>

--- a/test/e2e/Apps/BasicDotNetIsolated/Directory.Build.targets
+++ b/test/e2e/Apps/BasicDotNetIsolated/Directory.Build.targets
@@ -2,7 +2,7 @@
   <!--
     The Worker SDK sets _FunctionsExtensionCommonProps to block Directory.Build.props/targets
     and Directory.Packages.props imports for the generated WorkerExtensions.csproj.
-    This prevents our CVE-2021-24112 fix (System.Drawing.Common 4.7.2 pin via
+    This prevents our CVE-2021-24112 fix (System.Drawing.Common 4.7.3 pin via
     Directory.Build.props and Directory.Packages.props) from applying.
     Override it here (imported after SDK targets) to allow our import files.
   -->

--- a/test/e2e/Apps/BasicDotNetIsolated/Directory.Packages.props
+++ b/test/e2e/Apps/BasicDotNetIsolated/Directory.Packages.props
@@ -7,7 +7,7 @@
     NuGet walks upward from the project file looking for the nearest Directory.Packages.props.
     This file is found before test/Directory.Packages.props, giving us the chance to:
       - Disable CPM for WorkerExtensions (so its hardcoded versions + our System.Drawing.Common
-        4.7.2 override from Directory.Build.props are accepted).
+        4.7.3 override from Directory.Build.props are accepted).
       - Import the parent Directory.Packages.props for app.csproj and all other normal projects.
   -->
 

--- a/test/e2e/Apps/BasicDotNetIsolated/Directory.Packages.props
+++ b/test/e2e/Apps/BasicDotNetIsolated/Directory.Packages.props
@@ -1,0 +1,23 @@
+<Project>
+  <!--
+    The Azure Functions Worker SDK auto-generates a WorkerExtensions.csproj under obj/ with
+    hardcoded PackageReference Version attributes. CPM (Central Package Management) forbids
+    Version on PackageReference, so we must disable CPM for that generated project.
+
+    NuGet walks upward from the project file looking for the nearest Directory.Packages.props.
+    This file is found before test/Directory.Packages.props, giving us the chance to:
+      - Disable CPM for WorkerExtensions (so its hardcoded versions + our System.Drawing.Common
+        4.7.2 override from Directory.Build.props are accepted).
+      - Import the parent Directory.Packages.props for app.csproj and all other normal projects.
+  -->
+
+  <!-- For the generated WorkerExtensions project: disable CPM entirely -->
+  <PropertyGroup Condition="'$(MSBuildProjectFile)' == 'WorkerExtensions.csproj'">
+    <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+    <CentralPackageTransitivePinningEnabled>false</CentralPackageTransitivePinningEnabled>
+  </PropertyGroup>
+
+  <!-- For every other project (app.csproj, tests, etc.): delegate to the shared test props -->
+  <Import Condition="'$(MSBuildProjectFile)' != 'WorkerExtensions.csproj'"
+          Project="$([MSBuild]::GetPathOfFileAbove(Directory.Packages.props, $(MSBuildThisFileDirectory)..))" />
+</Project>


### PR DESCRIPTION
# Summary
## What changed?
This pull request updates dependency management for the `BasicDotNetIsolated` test app to ensure the vulnerable transitive version of `System.Drawing.Common` (4.7.0) is properly overridden with a secure version (4.7.3) in the auto-generated `WorkerExtensions.csproj`. The changes address issues with Azure Functions Worker SDK's project generation and Central Package Management (CPM), ensuring that security fixes are reliably applied.

**Dependency management and security fixes:**

* Added a local `Directory.Build.props` to explicitly pin `System.Drawing.Common` to version 4.7.3 for `WorkerExtensions.csproj`, overriding the vulnerable transitive dependency.
* Introduced a local `Directory.Packages.props` to disable CPM and transitive pinning for `WorkerExtensions.csproj`, allowing hardcoded versions and the override to take effect, while delegating package management for other projects to the shared configuration.

**Build system compatibility:**

* Updated `Directory.Build.targets` to override the Worker SDK's import-blocking property (`_FunctionsExtensionCommonProps`), ensuring that custom props and targets files are applied to the generated project and the security fix is effective.

## Why is this change needed?
- Fixing CVE 2021-24112

## Issues / work items
- Resolves #
- Related #

---

# Project checklist
- [ ] Documentation changes are not required
  - [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
- [ ] Release notes are not required for the next release
  - [ ] Otherwise: Notes added to `release_notes.md`
- [ ] Backport is not required
  - [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
- [ ] All required tests have been added/updated (unit tests, E2E tests)
- [ ] No extra work is required to be leveraged by OutOfProc SDKs
  - [ ] Otherwise: Work tracked here: #issue_or_pr_in_each_sdk
- [ ] No change to the version of the `WebJobs.Extensions.DurableTask` package
  - [ ] Otherwise: Major/minor updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
- [ ] No EventIds were added to `EventSource` logs
  - [ ] Otherwise: Ensure EventIds are within the supported range in the existing Windows infrastructure (validate via deployed telemetry). If needed, extend the range via a PR such as https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files
- [ ] This change should be added to the `v2.x` branch
  - [ ] Otherwise: This change applies exclusively to `WebJobs.Extensions.DurableTask` v3.x and will be retained only in the `dev` and `main` branches
- [ ] Breaking change?
  - [ ] If yes:
    - Impact:
    - Migration guidance:
---

# AI-assisted code disclosure (required)
## Was an AI tool used? (select one)
- [ ] No
- [ ] Yes, AI helped write parts of this PR (e.g., GitHub Copilot)
- [ ] Yes, an AI agent generated most of this PR

If AI was used:
- Tool(s):
- AI-assisted areas/files:
- What you changed after AI output:

AI verification (required if AI was used):
- [ ] I understand the code and can explain it
- [ ] I verified referenced APIs/types exist and are correct
- [ ] I reviewed edge cases/failure paths (timeouts, retries, cancellation, exceptions)
- [ ] I reviewed concurrency/async behavior
- [ ] I checked for unintended breaking or behavior changes

---

# Testing
## Automated tests
- Result: Passed / Failed (link logs if failed)

## Manual validation (only if runtime/behavior changed)
- Environment (OS, .NET version, components):
- Steps + observed results:
  1.
  2.
  3.
- Evidence (optional):

---

# Notes for reviewers
- N/A
