### PR TITLE
Remove e2e build from official pipeline

### DIFF
--- a/eng/templates/build.yml
+++ b/eng/templates/build.yml
@@ -67,7 +67,7 @@ jobs:
         displayName: 'Build E2E test apps'
         inputs:
           filePath: 'test/e2e/tests/build-e2e-test.ps1'
-          arguments: '-SkipStorageEmulator -SkipCoreTools'
+          arguments: '-TargetFramework net8.0 -SkipStorageEmulator -SkipCoreTools'
           pwsh: true
 
       # Build durable-extension

--- a/eng/templates/build.yml
+++ b/eng/templates/build.yml
@@ -56,19 +56,6 @@ jobs:
             projects: '**/**/*.csproj'
             feedsToUse: config
             nugetConfigPath: 'nuget.config'
-            
-      - task: UsePythonVersion@0
-        inputs:
-          versionSpec: '3.11.x'
-          addToPath: true
-          architecture: 'x64'
-
-      - task: PowerShell@2
-        displayName: 'Build E2E test apps'
-        inputs:
-          filePath: 'test/e2e/tests/build-e2e-test.ps1'
-          arguments: '-TargetFramework net8.0 -SkipStorageEmulator -SkipCoreTools'
-          pwsh: true
 
       # Build durable-extension
       - task: VSBuild@1

--- a/test/e2e/Tests/build-e2e-test.ps1
+++ b/test/e2e/Tests/build-e2e-test.ps1
@@ -219,8 +219,11 @@ if (!$SkipBuild)
   
   # Do NOT use --output with multi-targeted projects to avoid race conditions
   # when multiple TFMs try to write to the same output directory (MSB4018).
+  # Disable GeneratePackageOnBuild to prevent parallel TFM builds from racing
+  # to write the same .nuspec file. The E2E test apps produce their own local
+  # .nupkg via MSBuild PreBuild targets, so the package is not needed here.
 
-  dotnet build -c Debug "$WebJobsExtensionProjectDirectory\WebJobs.Extensions.DurableTask.csproj"
+  dotnet build -c Debug /p:GeneratePackageOnBuild=false "$WebJobsExtensionProjectDirectory\WebJobs.Extensions.DurableTask.csproj"
 
   if ($LASTEXITCODE -ne 0) { Set-Location $PSScriptRoot; throw "WebJobs Extension build failed" }
 


### PR DESCRIPTION
# Summary
## What changed?
- Removes the step that attempts to build e2e projects from the official pipeline. 

## Why is this change needed?
- Previously, we ran this script to ensure all code in the project gets built for CodeQL / SDL purposes. However, this was never actually working in practice: 
  - Building Java apps with extensions.csproj using mvn requires Core Tools, which cannot be installed on runners for official CI
  - The Java step was always failing, but recent changes to build-e2e-test.ps1 causes this to fail the whole pipeline
  - Now that the extensions.csproj for e2e apps are self-contained, CodeQL/SDL should be satisfied without running the build script

## Issues / work items
- Resolves #
- Related #

---

# Project checklist
- [x] Documentation changes are not required
  - [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
- [x] Release notes are not required for the next release
  - [ ] Otherwise: Notes added to `release_notes.md`
- [x] Backport is not required
  - [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
- [x] All required tests have been added/updated (unit tests, E2E tests)
- [x] No extra work is required to be leveraged by OutOfProc SDKs
  - [ ] Otherwise: Work tracked here: #issue_or_pr_in_each_sdk
- [x] No change to the version of the `WebJobs.Extensions.DurableTask` package
  - [ ] Otherwise: Major/minor updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
- [x] No EventIds were added to `EventSource` logs
  - [ ] Otherwise: Ensure EventIds are within the supported range in the existing Windows infrastructure (validate via deployed telemetry). If needed, extend the range via a PR such as https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files
- [ ] This change should be added to the `v2.x` branch
  - [x] Otherwise: This change applies exclusively to `WebJobs.Extensions.DurableTask` v3.x and will be retained only in the `dev` and `main` branches
- [ ] Breaking change?
  - [ ] If yes:
    - Impact:
    - Migration guidance:
---

# AI-assisted code disclosure (required)
## Was an AI tool used? (select one)
- [ ] No
- [x] Yes, AI helped write parts of this PR (e.g., GitHub Copilot)
- [ ] Yes, an AI agent generated most of this PR

If AI was used:
- Tool(s): VS Copilot
- AI-assisted areas/files:
- What you changed after AI output:

AI verification (required if AI was used):
- [x] I understand the code and can explain it
- [x] I verified referenced APIs/types exist and are correct
- [x] I reviewed edge cases/failure paths (timeouts, retries, cancellation, exceptions)
- [x] I reviewed concurrency/async behavior
- [x] I checked for unintended breaking or behavior changes
