### PR TITLE
Fix CVE-2026-26127

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -59,8 +59,8 @@
     <PackageVersion Include="Microsoft.Azure.DurableTask.Emulator" Version="2.5.4" />
     <PackageVersion Include="Microsoft.Azure.DurableTask.Netherite.AzureFunctions" Version="3.1.0" />
     <PackageVersion Include="Microsoft.Azure.DurableTask.Redis" Version="0.1.9-alpha" />
-    <PackageVersion Include="Microsoft.Azure.Functions.Worker" Version="2.2.0" />
-    <PackageVersion Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="2.0.0" />
+    <PackageVersion Include="Microsoft.Azure.Functions.Worker" Version="2.51.0" />
+    <PackageVersion Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="2.50.0" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask.AzureManaged" Version="1.4.0" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask.SqlServer" Version="1.5.4" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.3.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -19,7 +19,7 @@
     <PackageVersion Include="Microsoft.DurableTask.AzureManagedBackend" Version="1.3.0" />
     <PackageVersion Include="Microsoft.DurableTask.SqlServer" Version="1.5.2" />
     <PackageVersion Include="Microsoft.Azure.DurableTask.Core" Version="3.7.0" />
-    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Core" Version="2.2.0" />
+    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Core" Version="2.51.0" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Abstractions" Version="1.3.0" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Storage.Blobs" Version="6.7.0" />
     <PackageVersion Include="Microsoft.Azure.WebJobs" Version="3.0.45" />


### PR DESCRIPTION
# Summary
## What changed?
This pull request updates a dependency version in the project configuration. The `Microsoft.Azure.Functions.Worker.Core` package has been upgraded from version 2.2.0 to 2.51.0 to fix a security vulnerability in the transitive dependency `Microsoft.Bcl.Memory 9.0.0`.

Dependency update:

* Upgraded `Microsoft.Azure.Functions.Worker.Core` from version 2.2.0 to 2.51.0 in `Directory.Packages.props`. This change updates `Microsoft.Bcl.Memory` to `Microsoft.Bcl.Memory` 10.0.0
* Upgraded `Microsoft.Azure.Functions.Worker` to 2.51.0
* Upgraded `Microsoft.Azure.Functions.Worker.ApplicationInsights` to 2.50.0

## Why is this change needed?
- Fix CVE-2026-26127

## Issues / work items
- Resolves #
- Related #

---

# Project checklist
- [x] Documentation changes are not required
  - [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
- [ ] Release notes are not required for the next release
  - [ ] Otherwise: Notes added to `release_notes.md`
- [x] Backport is not required
  - [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
- [x] All required tests have been added/updated (unit tests, E2E tests)
- [x] No extra work is required to be leveraged by OutOfProc SDKs
  - [ ] Otherwise: Work tracked here: #issue_or_pr_in_each_sdk
- [x] No change to the version of the `WebJobs.Extensions.DurableTask` package
  - [ ] Otherwise: Major/minor updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
- [x] No EventIds were added to `EventSource` logs
  - [ ] Otherwise: Ensure EventIds are within the supported range in the existing Windows infrastructure (validate via deployed telemetry). If needed, extend the range via a PR such as https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files
- [ ] This change should be added to the `v2.x` branch
  - [x] Otherwise: This change applies exclusively to `WebJobs.Extensions.DurableTask` v3.x and will be retained only in the `dev` and `main` branches
- [ ] Breaking change?
  - [ ] If yes:
    - Impact:
    - Migration guidance:
---

# AI-assisted code disclosure (required)
## Was an AI tool used? (select one)
- [ ] No
- [ ] Yes, AI helped write parts of this PR (e.g., GitHub Copilot)
- [x] Yes, an AI agent generated most of this PR

If AI was used:
- Tool(s): VS Code GitHub Copilot
- AI-assisted areas/files:
- What you changed after AI output:

AI verification (required if AI was used):
- [x] I understand the code and can explain it
- [x] I verified referenced APIs/types exist and are correct
- [x] I reviewed edge cases/failure paths (timeouts, retries, cancellation, exceptions)
- [x] I reviewed concurrency/async behavior
- [x] I checked for unintended breaking or behavior changes

---

# Testing
## Automated tests
- Result: Passed / Failed (link logs if failed)

## Manual validation (only if runtime/behavior changed)
- Environment (OS, .NET version, components):
- Steps + observed results:
  1.
  2.
  3.
- Evidence (optional):

---

# Notes for reviewers
- N/A
