### PR TITLE
Fix gRPC listener resilience for transient sidecar failures

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/Bindings/BindingHelper.cs
+++ b/src/WebJobs.Extensions.DurableTask/Bindings/BindingHelper.cs
@@ -34,7 +34,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 string? localRpcAddress = this.config.GetLocalRpcAddress();
                 if (localRpcAddress == null)
                 {
-                    throw new InvalidOperationException("The local RPC address has not been configured!");
+                    // Throw a timeout exception rather than InvalidOperationException. This gives the
+                    // Functions host a better signal that this is a transient infrastructure issue,
+                    // not a programming error. For queue-triggered functions, this helps avoid
+                    // rapidly poisoning messages due to an unrecoverable-looking exception type.
+                    throw new TimeoutException(
+                        "The local gRPC endpoint for the Durable Task extension is not available. " +
+                        "The gRPC sidecar may still be starting or may have stopped unexpectedly. " +
+                        "This is typically a transient condition that resolves when the sidecar restarts.");
                 }
 
                 return JsonConvert.SerializeObject(new OrchestrationClientInputData

--- a/src/WebJobs.Extensions.DurableTask/Bindings/BindingHelper.cs
+++ b/src/WebJobs.Extensions.DurableTask/Bindings/BindingHelper.cs
@@ -34,11 +34,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 string? localRpcAddress = this.config.GetLocalRpcAddress();
                 if (localRpcAddress == null)
                 {
-                    // Throw a timeout exception rather than InvalidOperationException. This gives the
-                    // Functions host a better signal that this is a transient infrastructure issue,
-                    // not a programming error. For queue-triggered functions, this helps avoid
-                    // rapidly poisoning messages due to an unrecoverable-looking exception type.
-                    throw new TimeoutException(
+                    // Throw a platform-level exception so the Functions host and the durable
+                    // middleware both recognize this as a transient infrastructure issue rather
+                    // than an application error. This causes orchestrations/activities to be
+                    // safely aborted and retried by the backend, and prevents queue-triggered
+                    // functions from rapidly poisoning messages.
+                    throw new GrpcChannelTemporarilyUnavailableException(
                         "The local gRPC endpoint for the Durable Task extension is not available. " +
                         "The gRPC sidecar may still be starting or may have stopped unexpectedly. " +
                         "This is typically a transient condition that resolves when the sidecar restarts.");

--- a/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
@@ -527,11 +527,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 {
                     try
                     {
-                        this.localGrpcListener.EnsureStartedAsync(default).GetAwaiter().GetResult();
+                        // Use the host stopping token so the wait is canceled promptly during shutdown
+                        // rather than blocking for up to 30 seconds with a default token.
+                        CancellationToken stoppingToken = this.HostLifetimeService.OnStopping;
+
+                        this.localGrpcListener.EnsureStartedAsync(stoppingToken).GetAwaiter().GetResult();
 
                         // Wait up to 30 seconds for the listen address to become available.
                         address = this.localGrpcListener.WaitForListenAddressAsync(
-                            TimeSpan.FromSeconds(30), default).GetAwaiter().GetResult();
+                            TimeSpan.FromSeconds(30), stoppingToken).GetAwaiter().GetResult();
                     }
                     catch (Exception ex)
                     {

--- a/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
@@ -511,7 +511,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         }
 
 #nullable enable
-        internal string GetLocalRpcAddress()
+        internal string? GetLocalRpcAddress()
         {
             if (this.OutOfProcProtocol == OutOfProcOrchestrationProtocol.MiddlewarePassthrough)
             {
@@ -543,7 +543,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     }
                 }
 
-                return address!;
+                return address;
             }
 
             return this.HttpApiHandler.GetBaseUrl();

--- a/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
@@ -510,15 +510,45 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             }
         }
 
+#nullable enable
         internal string GetLocalRpcAddress()
         {
             if (this.OutOfProcProtocol == OutOfProcOrchestrationProtocol.MiddlewarePassthrough)
             {
-                return this.localGrpcListener.ListenAddress;
+                string? address = this.localGrpcListener?.ListenAddress;
+                if (address != null)
+                {
+                    return address;
+                }
+
+                // The address is not yet available. This can happen if the gRPC server failed to start,
+                // stopped unexpectedly, or hasn't finished initializing. Try to (re)start it.
+                if (this.localGrpcListener != null)
+                {
+                    try
+                    {
+                        this.localGrpcListener.EnsureStartedAsync(default).GetAwaiter().GetResult();
+
+                        // Wait up to 30 seconds for the listen address to become available.
+                        address = this.localGrpcListener.WaitForListenAddressAsync(
+                            TimeSpan.FromSeconds(30), default).GetAwaiter().GetResult();
+                    }
+                    catch (Exception ex)
+                    {
+                        this.TraceHelper.ExtensionWarningEvent(
+                            this.Options.HubName,
+                            instanceId: string.Empty,
+                            functionName: string.Empty,
+                            message: $"Failed to start/restart local gRPC listener: {ex.Message}");
+                    }
+                }
+
+                return address!;
             }
 
             return this.HttpApiHandler.GetBaseUrl();
         }
+#nullable restore
 
         internal DurabilityProvider GetDurabilityProvider(DurableClientAttribute attribute)
         {

--- a/src/WebJobs.Extensions.DurableTask/Grpc/AspNetCoreLocalGrpcListener.cs
+++ b/src/WebJobs.Extensions.DurableTask/Grpc/AspNetCoreLocalGrpcListener.cs
@@ -108,22 +108,19 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Grpc
                 return this.ListenAddress;
             }
 
-            // Wait for the TaskCompletionSource to be signaled or timeout
+            // Wait for the TaskCompletionSource to be signaled, with a timeout.
+            // Task.WhenAny does not throw when the delay is canceled, so we check
+            // which task completed to distinguish success from timeout.
             using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
             timeoutCts.CancelAfter(timeout);
 
-            try
+            Task<string> addressTask = this.addressReady.Task;
+            Task delayTask = Task.Delay(Timeout.Infinite, timeoutCts.Token);
+            Task completedTask = await Task.WhenAny(addressTask, delayTask);
+
+            if (completedTask == addressTask)
             {
-                Task<string> addressTask = this.addressReady.Task;
-                Task completedTask = await Task.WhenAny(addressTask, Task.Delay(Timeout.Infinite, timeoutCts.Token));
-                if (completedTask == addressTask)
-                {
-                    return await addressTask;
-                }
-            }
-            catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
-            {
-                // Timeout expired, not caller cancellation
+                return await addressTask;
             }
 
             return this.ListenAddress;
@@ -195,9 +192,24 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Grpc
             this.host = newHost;
 
             // Signal any waiters that the address is now available.
+            // If ListenAddress is null (e.g. IServerAddressesFeature returned no addresses),
+            // stop the host to avoid a partially-initialized state that would cause
+            // repeated stop/restart loops from the IsHealthy check.
             if (this.ListenAddress != null)
             {
                 this.addressReady.TrySetResult(this.ListenAddress);
+            }
+            else
+            {
+                this.extension.TraceHelper.ExtensionWarningEvent(
+                    this.extension.Options.HubName,
+                    instanceId: string.Empty,
+                    functionName: string.Empty,
+                    message: "gRPC listener started but ListenAddress is null. Stopping to allow retry.");
+
+                // Roll back: stop the host so the next StartAsync call can try again
+                // rather than leaving the listener in a broken state.
+                await this.StopInternalAsync();
             }
         }
 

--- a/src/WebJobs.Extensions.DurableTask/Grpc/AspNetCoreLocalGrpcListener.cs
+++ b/src/WebJobs.Extensions.DurableTask/Grpc/AspNetCoreLocalGrpcListener.cs
@@ -23,6 +23,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Grpc
         private const string HostName = "127.0.0.1";
         private readonly DurableTaskExtension extension;
         private readonly SemaphoreSlim startLock = new SemaphoreSlim(1, 1);
+        private readonly TaskCompletionSource<string> addressReady = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
         private IHost? host;
 
         public AspNetCoreLocalGrpcListener(DurableTaskExtension extension)
@@ -32,10 +33,34 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Grpc
 
         public string? ListenAddress { get; private set; }
 
+        public bool IsHealthy
+        {
+            get
+            {
+                if (this.host is not { } currentHost)
+                {
+                    return false;
+                }
+
+                // Check if the Kestrel server is still accepting connections by verifying
+                // that the IServer is still reporting addresses.
+                try
+                {
+                    IServer? server = currentHost.Services.GetService<IServer>();
+                    IServerAddressesFeature? addressFeature = server?.Features.Get<IServerAddressesFeature>();
+                    return addressFeature?.Addresses.Count > 0;
+                }
+                catch
+                {
+                    return false;
+                }
+            }
+        }
+
         public async Task StartAsync(CancellationToken cancellationToken)
         {
-            // Fast check: if already started, return immediately
-            if (this.host != null)
+            // Fast check: if already started and healthy, return immediately
+            if (this.host != null && this.IsHealthy)
             {
                 return;
             }
@@ -44,8 +69,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Grpc
             try
             {
                 // Double-check after acquiring the lock
-                if (this.host == null)
+                if (this.host == null || !this.IsHealthy)
                 {
+                    await this.StopInternalAsync();
                     await this.StartInternalAsync(cancellationToken);
                 }
             }
@@ -53,6 +79,54 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Grpc
             {
                 this.startLock.Release();
             }
+        }
+
+        public async Task EnsureStartedAsync(CancellationToken cancellationToken)
+        {
+            if (this.host != null && this.IsHealthy && this.ListenAddress != null)
+            {
+                return;
+            }
+
+            this.extension.TraceHelper.ExtensionWarningEvent(
+                this.extension.Options.HubName,
+                instanceId: string.Empty,
+                functionName: string.Empty,
+                message: $"gRPC listener is not healthy (ListenAddress={this.ListenAddress ?? "null"}, " +
+                         $"host={(this.host != null ? "exists" : "null")}, IsHealthy={this.IsHealthy}). " +
+                         $"Attempting restart.");
+
+            // Delegate to StartAsync which handles locking, health check, and restart
+            await this.StartAsync(cancellationToken);
+        }
+
+        public async Task<string?> WaitForListenAddressAsync(TimeSpan timeout, CancellationToken cancellationToken)
+        {
+            // If already available, return immediately
+            if (this.ListenAddress != null)
+            {
+                return this.ListenAddress;
+            }
+
+            // Wait for the TaskCompletionSource to be signaled or timeout
+            using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            timeoutCts.CancelAfter(timeout);
+
+            try
+            {
+                Task<string> addressTask = this.addressReady.Task;
+                Task completedTask = await Task.WhenAny(addressTask, Task.Delay(Timeout.Infinite, timeoutCts.Token));
+                if (completedTask == addressTask)
+                {
+                    return await addressTask;
+                }
+            }
+            catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+            {
+                // Timeout expired, not caller cancellation
+            }
+
+            return this.ListenAddress;
         }
 
         private async Task StartInternalAsync(CancellationToken cancellationToken)
@@ -119,16 +193,48 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Grpc
             // Assign only after fully started so the fast-path check in StartAsync
             // doesn't let concurrent callers return before initialization is complete.
             this.host = newHost;
+
+            // Signal any waiters that the address is now available.
+            if (this.ListenAddress != null)
+            {
+                this.addressReady.TrySetResult(this.ListenAddress);
+            }
         }
 
-        public Task StopAsync(CancellationToken cancellationToken)
+        public async Task StopAsync(CancellationToken cancellationToken)
         {
-            if (this.host is { } host)
+            await this.startLock.WaitAsync(cancellationToken);
+            try
             {
-                return host.StopAsync(cancellationToken);
+                await this.StopInternalAsync();
             }
+            finally
+            {
+                this.startLock.Release();
+            }
+        }
 
-            return Task.CompletedTask;
+        private async Task StopInternalAsync()
+        {
+            if (this.host is { } previousHost)
+            {
+                try
+                {
+                    await previousHost.StopAsync(default);
+                }
+                catch (Exception ex)
+                {
+                    this.extension.TraceHelper.ExtensionWarningEvent(
+                        this.extension.Options.HubName,
+                        instanceId: string.Empty,
+                        functionName: string.Empty,
+                        message: $"Error stopping local gRPC endpoint: {ex.Message}");
+                }
+
+                // Reset state so StartAsync can re-initialize
+                this.host = null;
+                this.ListenAddress = null;
+            }
         }
 
         private static int GetFreeTcpPort()

--- a/src/WebJobs.Extensions.DurableTask/Grpc/AspNetCoreLocalGrpcListener.cs
+++ b/src/WebJobs.Extensions.DurableTask/Grpc/AspNetCoreLocalGrpcListener.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Grpc
         private const string HostName = "127.0.0.1";
         private readonly DurableTaskExtension extension;
         private readonly SemaphoreSlim startLock = new SemaphoreSlim(1, 1);
-        private readonly TaskCompletionSource<string> addressReady = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+        private TaskCompletionSource<string> addressReady = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
         private IHost? host;
 
         public AspNetCoreLocalGrpcListener(DurableTaskExtension extension)
@@ -71,7 +71,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Grpc
                 // Double-check after acquiring the lock
                 if (this.host == null || !this.IsHealthy)
                 {
-                    await this.StopInternalAsync();
+                    await this.StopInternalAsync(cancellationToken);
                     await this.StartInternalAsync(cancellationToken);
                 }
             }
@@ -206,7 +206,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Grpc
             await this.startLock.WaitAsync(cancellationToken);
             try
             {
-                await this.StopInternalAsync();
+                await this.StopInternalAsync(cancellationToken);
             }
             finally
             {
@@ -214,13 +214,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Grpc
             }
         }
 
-        private async Task StopInternalAsync()
+        private async Task StopInternalAsync(CancellationToken cancellationToken = default)
         {
             if (this.host is { } previousHost)
             {
                 try
                 {
-                    await previousHost.StopAsync(default);
+                    await previousHost.StopAsync(cancellationToken);
                 }
                 catch (Exception ex)
                 {
@@ -231,9 +231,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Grpc
                         message: $"Error stopping local gRPC endpoint: {ex.Message}");
                 }
 
-                // Reset state so StartAsync can re-initialize
+                // Reset state so StartAsync can re-initialize.
+                // Re-create the TCS so that WaitForListenAddressAsync callers
+                // don't receive a stale address from a previous start cycle.
                 this.host = null;
                 this.ListenAddress = null;
+                this.addressReady = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
             }
         }
 

--- a/src/WebJobs.Extensions.DurableTask/Grpc/AspNetCoreLocalGrpcListener.cs
+++ b/src/WebJobs.Extensions.DurableTask/Grpc/AspNetCoreLocalGrpcListener.cs
@@ -123,7 +123,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Grpc
                 return await addressTask;
             }
 
-            return this.ListenAddress;
+            // Timeout or cancellation — return null rather than reading ListenAddress,
+            // which could be set concurrently and produce unpredictable results.
+            return null;
         }
 
         private async Task StartInternalAsync(CancellationToken cancellationToken)
@@ -241,6 +243,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Grpc
                         instanceId: string.Empty,
                         functionName: string.Empty,
                         message: $"Error stopping local gRPC endpoint: {ex.Message}");
+                }
+                finally
+                {
+                    // Dispose the host to release server, sockets, and DI container resources.
+                    // This prevents resource leaks during repeated stop/start cycles.
+                    if (previousHost is IDisposable disposable)
+                    {
+                        disposable.Dispose();
+                    }
                 }
 
                 // Reset state so StartAsync can re-initialize.

--- a/src/WebJobs.Extensions.DurableTask/Grpc/ILocalGrpcListener.cs
+++ b/src/WebJobs.Extensions.DurableTask/Grpc/ILocalGrpcListener.cs
@@ -2,6 +2,9 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 #nullable enable
+using System;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Hosting;
 
 namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Grpc
@@ -22,6 +25,22 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Grpc
         /// Gets the address this listener is listening to.
         /// </summary>
         string? ListenAddress { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether the gRPC listener is healthy (started and responsive).
+        /// </summary>
+        bool IsHealthy { get; }
+
+        /// <summary>
+        /// Ensures the gRPC listener is started and healthy, restarting it if necessary.
+        /// </summary>
+        Task EnsureStartedAsync(CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Waits for the <see cref="ListenAddress"/> to become available, with a timeout.
+        /// Returns the listen address, or null if the timeout expires.
+        /// </summary>
+        Task<string?> WaitForListenAddressAsync(TimeSpan timeout, CancellationToken cancellationToken);
     }
 
     internal static class LocalGrpcListener

--- a/src/WebJobs.Extensions.DurableTask/GrpcChannelTemporarilyUnavailableException.cs
+++ b/src/WebJobs.Extensions.DurableTask/GrpcChannelTemporarilyUnavailableException.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
+using System.Runtime.Serialization;
 
 namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 {
@@ -43,5 +44,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             : base(message, innerException)
         {
         }
+
+#pragma warning disable SYSLIB0051 // Type or member is obsolete
+        protected GrpcChannelTemporarilyUnavailableException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+        }
+#pragma warning restore SYSLIB0051
     }
 }

--- a/src/WebJobs.Extensions.DurableTask/GrpcChannelTemporarilyUnavailableException.cs
+++ b/src/WebJobs.Extensions.DurableTask/GrpcChannelTemporarilyUnavailableException.cs
@@ -1,0 +1,47 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+
+namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
+{
+    /// <summary>
+    /// Exception thrown when the local gRPC channel used for communication between the
+    /// Durable Task extension host and the out-of-process worker is temporarily unavailable.
+    /// </summary>
+    /// <remarks>
+    /// This is a transient, platform-level error: the gRPC sidecar may still be starting or
+    /// may have stopped unexpectedly. The extension treats this as retriable so that
+    /// orchestrations and activities are safely aborted and retried by the durable backend
+    /// rather than being marked as permanently failed.
+    /// </remarks>
+    [Serializable]
+    public class GrpcChannelTemporarilyUnavailableException : Exception
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GrpcChannelTemporarilyUnavailableException"/> class.
+        /// </summary>
+        public GrpcChannelTemporarilyUnavailableException()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GrpcChannelTemporarilyUnavailableException"/> class.
+        /// </summary>
+        /// <param name="message">A message describing the unavailability condition.</param>
+        public GrpcChannelTemporarilyUnavailableException(string message)
+            : base(message)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GrpcChannelTemporarilyUnavailableException"/> class.
+        /// </summary>
+        /// <param name="message">A message describing the unavailability condition.</param>
+        /// <param name="innerException">The inner exception that caused this error.</param>
+        public GrpcChannelTemporarilyUnavailableException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+    }
+}

--- a/src/WebJobs.Extensions.DurableTask/OutOfProcMiddleware.cs
+++ b/src/WebJobs.Extensions.DurableTask/OutOfProcMiddleware.cs
@@ -662,6 +662,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             return exception is Host.FunctionTimeoutException
                 || exception is Host.FunctionTimeoutAbortException
                 || exception?.InnerException is SessionAbortedException // see RemoteOrchestrationContext.TrySetResultInternal for details on OOM-handling
+                || exception?.InnerException is GrpcChannelTemporarilyUnavailableException
                 || (exception?.InnerException?.GetType().ToString().Contains("WorkerProcessExitException", StringComparison.Ordinal) ?? false)
                 || (exception?.InnerException is InvalidOperationException ioe
                     && ioe.Message.Contains(NoProcessAssociatedMessage, StringComparison.Ordinal));

--- a/src/WebJobs.Extensions.DurableTask/OutOfProcMiddleware.cs
+++ b/src/WebJobs.Extensions.DurableTask/OutOfProcMiddleware.cs
@@ -564,7 +564,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 {
                     // This exception is thrown when another Function on the worker exceeded the Function timeout.
                     // In this case we want to make sure to retry this Activity's execution rather than marking it as failed.
-                    if (result.Exception is Host.FunctionTimeoutAbortException)
+                    if (IsPlatformLevelException(result.Exception))
                     {
                         throw result.Exception;
                     }
@@ -661,6 +661,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             // Should we add that dependency or should it be exposed in WebJobs.Host?
             return exception is Host.FunctionTimeoutException
                 || exception is Host.FunctionTimeoutAbortException
+                || exception is GrpcChannelTemporarilyUnavailableException
                 || exception?.InnerException is SessionAbortedException // see RemoteOrchestrationContext.TrySetResultInternal for details on OOM-handling
                 || exception?.InnerException is GrpcChannelTemporarilyUnavailableException
                 || (exception?.InnerException?.GetType().ToString().Contains("WorkerProcessExitException", StringComparison.Ordinal) ?? false)

--- a/src/WebJobs.Extensions.DurableTask/OutOfProcMiddleware.cs
+++ b/src/WebJobs.Extensions.DurableTask/OutOfProcMiddleware.cs
@@ -564,7 +564,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 {
                     // This exception is thrown when another Function on the worker exceeded the Function timeout.
                     // In this case we want to make sure to retry this Activity's execution rather than marking it as failed.
-                    if (IsPlatformLevelException(result.Exception))
+                    if (result.Exception is Host.FunctionTimeoutAbortException)
                     {
                         throw result.Exception;
                     }

--- a/test/FunctionsV2/LocalGrpcListenerTests.cs
+++ b/test/FunctionsV2/LocalGrpcListenerTests.cs
@@ -472,13 +472,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
         /// <summary>
         /// Verifies that BindingHelper.DurableOrchestrationClientToString throws
-        /// TimeoutException (not InvalidOperationException) when the gRPC address is unavailable.
-        /// This is critical for queue-triggered functions: TimeoutException signals a transient
-        /// issue, preventing rapid poison-queue escalation.
+        /// GrpcChannelTemporarilyUnavailableException (not InvalidOperationException)
+        /// when the gRPC address is unavailable.
+        /// This is critical for queue-triggered functions: the platform-level exception
+        /// signals a transient issue, preventing rapid poison-queue escalation.
         /// </summary>
         [Fact]
         [Trait("Category", PlatformSpecificHelpers.TestCategory)]
-        public void TestBindingHelper_ThrowsTimeoutException_WhenGrpcAddressUnavailable()
+        public void TestBindingHelper_ThrowsGrpcChannelUnavailableException_WhenGrpcAddressUnavailable()
         {
             // Create an extension configured for gRPC but with no localGrpcListener instance.
             // Because localGrpcListener is null, GetLocalRpcAddress() skips the

--- a/test/FunctionsV2/LocalGrpcListenerTests.cs
+++ b/test/FunctionsV2/LocalGrpcListenerTests.cs
@@ -4,12 +4,14 @@
 using System;
 using System.Net;
 using System.Net.Sockets;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Extensions.DurableTask.Grpc;
 using Microsoft.Azure.WebJobs.Host.TestCommon;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
+using Moq;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -159,6 +161,344 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             }
         }
 
+        /// <summary>
+        /// Verifies that IsHealthy returns false before the listener is started.
+        /// </summary>
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public void TestGrpcListener_IsHealthy_FalseBeforeStart()
+        {
+            using DurableTaskExtension extension = this.CreateExtension("IsHealthyBeforeStart");
+            ILocalGrpcListener listener = LocalGrpcListener.Create(extension, LocalGrpcListenerMode.AspNetCore);
+
+            Assert.False(listener.IsHealthy);
+            Assert.Null(listener.ListenAddress);
+        }
+
+        /// <summary>
+        /// Verifies that IsHealthy returns true after the listener is started
+        /// and false again after it is stopped.
+        /// </summary>
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public async Task TestGrpcListener_IsHealthy_TrueAfterStart_FalseAfterStop()
+        {
+            using DurableTaskExtension extension = this.CreateExtension("IsHealthyLifecycle");
+            ILocalGrpcListener listener = LocalGrpcListener.Create(extension, LocalGrpcListenerMode.AspNetCore);
+
+            try
+            {
+                await listener.StartAsync(default);
+
+                Assert.True(listener.IsHealthy);
+                Assert.NotNull(listener.ListenAddress);
+
+                await listener.StopAsync(default);
+
+                Assert.False(listener.IsHealthy);
+                Assert.Null(listener.ListenAddress);
+            }
+            catch
+            {
+                await listener.StopAsync(default);
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// Verifies that StopAsync resets the listener state, allowing StartAsync
+        /// to restart it on a (potentially different) port.
+        /// </summary>
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public async Task TestGrpcListener_CanRestartAfterStop()
+        {
+            using DurableTaskExtension extension = this.CreateExtension("RestartAfterStop");
+            ILocalGrpcListener listener = LocalGrpcListener.Create(extension, LocalGrpcListenerMode.AspNetCore);
+
+            try
+            {
+                // First start
+                await listener.StartAsync(default);
+                string firstAddress = listener.ListenAddress;
+                Assert.NotNull(firstAddress);
+                Assert.True(listener.IsHealthy);
+
+                // Stop — should reset state
+                await listener.StopAsync(default);
+                Assert.Null(listener.ListenAddress);
+                Assert.False(listener.IsHealthy);
+
+                // Restart — should get a new address
+                await listener.StartAsync(default);
+                Assert.NotNull(listener.ListenAddress);
+                Assert.True(listener.IsHealthy);
+            }
+            finally
+            {
+                await listener.StopAsync(default);
+            }
+        }
+
+        /// <summary>
+        /// Verifies that EnsureStartedAsync is a no-op when the listener is already healthy.
+        /// </summary>
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public async Task TestGrpcListener_EnsureStarted_NoOpWhenHealthy()
+        {
+            using DurableTaskExtension extension = this.CreateExtension("EnsureStartedNoOp");
+            ILocalGrpcListener listener = LocalGrpcListener.Create(extension, LocalGrpcListenerMode.AspNetCore);
+
+            try
+            {
+                await listener.StartAsync(default);
+                string originalAddress = listener.ListenAddress;
+
+                // Calling EnsureStartedAsync when healthy should not change the address
+                await listener.EnsureStartedAsync(default);
+                Assert.Equal(originalAddress, listener.ListenAddress);
+                Assert.True(listener.IsHealthy);
+            }
+            finally
+            {
+                await listener.StopAsync(default);
+            }
+        }
+
+        /// <summary>
+        /// Verifies that EnsureStartedAsync restarts the listener when it is not healthy
+        /// (e.g. after being stopped).
+        /// </summary>
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public async Task TestGrpcListener_EnsureStarted_RestartsWhenUnhealthy()
+        {
+            using DurableTaskExtension extension = this.CreateExtension("EnsureStartedRestart");
+            ILocalGrpcListener listener = LocalGrpcListener.Create(extension, LocalGrpcListenerMode.AspNetCore);
+
+            try
+            {
+                await listener.StartAsync(default);
+                Assert.True(listener.IsHealthy);
+
+                // Simulate unhealthy state by stopping
+                await listener.StopAsync(default);
+                Assert.False(listener.IsHealthy);
+                Assert.Null(listener.ListenAddress);
+
+                // EnsureStartedAsync should restart
+                await listener.EnsureStartedAsync(default);
+                Assert.True(listener.IsHealthy);
+                Assert.NotNull(listener.ListenAddress);
+            }
+            finally
+            {
+                await listener.StopAsync(default);
+            }
+        }
+
+        /// <summary>
+        /// Verifies that WaitForListenAddressAsync returns the address immediately
+        /// when the listener is already started.
+        /// </summary>
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public async Task TestGrpcListener_WaitForAddress_ReturnsImmediatelyWhenReady()
+        {
+            using DurableTaskExtension extension = this.CreateExtension("WaitForAddressReady");
+            ILocalGrpcListener listener = LocalGrpcListener.Create(extension, LocalGrpcListenerMode.AspNetCore);
+
+            try
+            {
+                await listener.StartAsync(default);
+                string expected = listener.ListenAddress;
+                Assert.NotNull(expected);
+
+                // Should return immediately since address is already set
+                string result = await listener.WaitForListenAddressAsync(TimeSpan.FromSeconds(5), default);
+                Assert.Equal(expected, result);
+            }
+            finally
+            {
+                await listener.StopAsync(default);
+            }
+        }
+
+        /// <summary>
+        /// Verifies that WaitForListenAddressAsync returns the address when another
+        /// task starts the listener concurrently.
+        /// </summary>
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public async Task TestGrpcListener_WaitForAddress_ReturnsWhenStartedConcurrently()
+        {
+            using DurableTaskExtension extension = this.CreateExtension("WaitForAddressConcurrent");
+            ILocalGrpcListener listener = LocalGrpcListener.Create(extension, LocalGrpcListenerMode.AspNetCore);
+
+            try
+            {
+                // Start waiting before the listener is started
+                Task<string> waitTask = listener.WaitForListenAddressAsync(TimeSpan.FromSeconds(10), default);
+
+                // Give a small delay then start the listener
+                await Task.Delay(100);
+                await listener.StartAsync(default);
+
+                // The wait task should complete with the address
+                string result = await waitTask;
+                Assert.NotNull(result);
+                Assert.Equal(listener.ListenAddress, result);
+            }
+            finally
+            {
+                await listener.StopAsync(default);
+            }
+        }
+
+        /// <summary>
+        /// Verifies that WaitForListenAddressAsync returns null when the timeout expires
+        /// and the listener was never started.
+        /// </summary>
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public async Task TestGrpcListener_WaitForAddress_ReturnsNullOnTimeout()
+        {
+            using DurableTaskExtension extension = this.CreateExtension("WaitForAddressTimeout");
+            ILocalGrpcListener listener = LocalGrpcListener.Create(extension, LocalGrpcListenerMode.AspNetCore);
+
+            // Wait with a very short timeout — listener is never started, so it should time out
+            string result = await listener.WaitForListenAddressAsync(TimeSpan.FromMilliseconds(100), default);
+            Assert.Null(result);
+        }
+
+        /// <summary>
+        /// Verifies that WaitForListenAddressAsync returns null promptly when
+        /// the caller's cancellation token fires.
+        /// </summary>
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public async Task TestGrpcListener_WaitForAddress_ReturnsNullOnCancellation()
+        {
+            using DurableTaskExtension extension = this.CreateExtension("WaitForAddressCancel");
+            ILocalGrpcListener listener = LocalGrpcListener.Create(extension, LocalGrpcListenerMode.AspNetCore);
+
+            using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(100));
+
+            // Should return null when the cancellation token fires, not wait the full timeout
+            string result = await listener.WaitForListenAddressAsync(TimeSpan.FromSeconds(30), cts.Token);
+            Assert.Null(result);
+        }
+
+        /// <summary>
+        /// Verifies that concurrent calls to StartAsync are safe and only one
+        /// initialization occurs.
+        /// </summary>
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public async Task TestGrpcListener_ConcurrentStartAsync_IsSafe()
+        {
+            using DurableTaskExtension extension = this.CreateExtension("ConcurrentStart");
+            ILocalGrpcListener listener = LocalGrpcListener.Create(extension, LocalGrpcListenerMode.AspNetCore);
+
+            try
+            {
+                // Start multiple times concurrently
+                var tasks = new Task[5];
+                for (int i = 0; i < tasks.Length; i++)
+                {
+                    tasks[i] = listener.StartAsync(default);
+                }
+
+                await Task.WhenAll(tasks);
+
+                // All should succeed, and we should have a valid address
+                Assert.NotNull(listener.ListenAddress);
+                Assert.True(listener.IsHealthy);
+            }
+            finally
+            {
+                await listener.StopAsync(default);
+            }
+        }
+
+        /// <summary>
+        /// Verifies that calling StartAsync again (idempotent) when already started
+        /// doesn't change the address.
+        /// </summary>
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public async Task TestGrpcListener_StartAsync_IdempotentWhenHealthy()
+        {
+            using DurableTaskExtension extension = this.CreateExtension("IdempotentStart");
+            ILocalGrpcListener listener = LocalGrpcListener.Create(extension, LocalGrpcListenerMode.AspNetCore);
+
+            try
+            {
+                await listener.StartAsync(default);
+                string firstAddress = listener.ListenAddress;
+
+                // Start again — should be idempotent
+                await listener.StartAsync(default);
+                Assert.Equal(firstAddress, listener.ListenAddress);
+            }
+            finally
+            {
+                await listener.StopAsync(default);
+            }
+        }
+
+        /// <summary>
+        /// Verifies that GetLocalRpcAddress returns the address after the gRPC listener
+        /// is properly started through the extension's EnsureTaskHubWorker path.
+        /// </summary>
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public void TestGetLocalRpcAddress_ReturnsAddressWhenGrpcListenerStarted()
+        {
+            using DurableTaskExtension extension = this.CreateExtension("GetLocalRpcAddress");
+
+            // The extension is configured for DotNetIsolated (gRPC protocol).
+            Assert.Equal(OutOfProcOrchestrationProtocol.MiddlewarePassthrough, extension.OutOfProcProtocol);
+
+            // EnsureTaskHubWorker triggers InitializeTaskHubWorker which starts the gRPC listener
+            extension.EnsureTaskHubWorker();
+
+            string address = extension.GetLocalRpcAddress();
+            Assert.NotNull(address);
+            Assert.True(Uri.TryCreate(address, UriKind.Absolute, out Uri uri));
+            Assert.True(uri.IsLoopback);
+        }
+
+        /// <summary>
+        /// Verifies that BindingHelper.DurableOrchestrationClientToString throws
+        /// TimeoutException (not InvalidOperationException) when the gRPC address is unavailable.
+        /// This is critical for queue-triggered functions: TimeoutException signals a transient
+        /// issue, preventing rapid poison-queue escalation.
+        /// </summary>
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public void TestBindingHelper_ThrowsTimeoutException_WhenGrpcAddressUnavailable()
+        {
+            // Create an extension configured for gRPC but WITHOUT starting the gRPC listener.
+            // We use a very short timeout to avoid waiting 30s in a test.
+            using DurableTaskExtension extension = this.CreateExtensionWithNullGrpcListener("BindingHelperTimeout");
+
+            var bindingHelper = new BindingHelper(extension);
+
+            // Mock a minimal client
+            var attr = new DurableClientAttribute();
+            var client = new Moq.Mock<IDurableOrchestrationClient>();
+            client.Setup(c => c.TaskHubName).Returns("TestHub");
+
+            // The exception should be TimeoutException, NOT InvalidOperationException
+            var ex = Assert.Throws<TimeoutException>(
+                () => bindingHelper.DurableOrchestrationClientToString(client.Object, attr));
+
+            Assert.Contains("gRPC endpoint", ex.Message);
+            Assert.Contains("transient", ex.Message);
+        }
+
         private DurableTaskExtension CreateExtension(string hubName)
         {
             var options = new DurableTaskOptions { HubName = hubName };
@@ -179,6 +519,40 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 new TestHostShutdownNotificationService(),
                 new DurableHttpMessageHandlerFactory(),
                 platformInformationService: TestHelpers.GetMockPlatformInformationService(language: WorkerRuntimeType.DotNetIsolated));
+        }
+
+        /// <summary>
+        /// Creates an extension configured for gRPC protocol (MiddlewarePassthrough)
+        /// but WITHOUT a gRPC listener, simulating a state where the listener was never
+        /// created or has been lost. This is used to test error handling paths.
+        /// </summary>
+        private DurableTaskExtension CreateExtensionWithNullGrpcListener(string hubName)
+        {
+            var options = new DurableTaskOptions { HubName = hubName };
+            var wrappedOptions = new OptionsWrapper<DurableTaskOptions>(options);
+            var nameResolver = TestHelpers.GetTestNameResolver();
+            var serviceFactory = new AzureStorageDurabilityProviderFactory(
+                wrappedOptions,
+                new TestStorageServiceClientProviderFactory(),
+                nameResolver,
+                NullLoggerFactory.Instance,
+                TestHelpers.GetMockPlatformInformationService(language: WorkerRuntimeType.DotNet));
+
+            // Create extension with DotNet (in-process) runtime so it doesn't auto-configure gRPC,
+            // then manually set the protocol to MiddlewarePassthrough with no listener.
+            var extension = new DurableTaskExtension(
+                wrappedOptions,
+                new LoggerFactory(),
+                nameResolver,
+                new[] { serviceFactory },
+                new TestHostShutdownNotificationService(),
+                new DurableHttpMessageHandlerFactory(),
+                platformInformationService: TestHelpers.GetMockPlatformInformationService(language: WorkerRuntimeType.DotNet));
+
+            // Force gRPC protocol mode without a listener to simulate broken state
+            extension.OutOfProcProtocol = OutOfProcOrchestrationProtocol.MiddlewarePassthrough;
+
+            return extension;
         }
 
         private static bool IsPortInUse(int port)

--- a/test/FunctionsV2/LocalGrpcListenerTests.cs
+++ b/test/FunctionsV2/LocalGrpcListenerTests.cs
@@ -493,8 +493,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             var client = new Moq.Mock<IDurableOrchestrationClient>();
             client.Setup(c => c.TaskHubName).Returns("TestHub");
 
-            // The exception should be TimeoutException, NOT InvalidOperationException
-            var ex = Assert.Throws<TimeoutException>(
+            // The exception should be GrpcChannelTemporarilyUnavailableException, NOT InvalidOperationException
+            var ex = Assert.Throws<GrpcChannelTemporarilyUnavailableException>(
                 () => bindingHelper.DurableOrchestrationClientToString(client.Object, attr));
 
             Assert.Contains("gRPC endpoint", ex.Message);

--- a/test/FunctionsV2/LocalGrpcListenerTests.cs
+++ b/test/FunctionsV2/LocalGrpcListenerTests.cs
@@ -480,8 +480,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         [Trait("Category", PlatformSpecificHelpers.TestCategory)]
         public void TestBindingHelper_ThrowsTimeoutException_WhenGrpcAddressUnavailable()
         {
-            // Create an extension configured for gRPC but WITHOUT starting the gRPC listener.
-            // We use a very short timeout to avoid waiting 30s in a test.
+            // Create an extension configured for gRPC but with no localGrpcListener instance.
+            // Because localGrpcListener is null, GetLocalRpcAddress() skips the
+            // EnsureStartedAsync/WaitForListenAddressAsync path entirely and returns null
+            // immediately, so this test completes without any 30s wait.
             using DurableTaskExtension extension = this.CreateExtensionWithNullGrpcListener("BindingHelperTimeout");
 
             var bindingHelper = new BindingHelper(extension);

--- a/test/FunctionsV2/OutOfProcMiddlewareTests.cs
+++ b/test/FunctionsV2/OutOfProcMiddlewareTests.cs
@@ -91,6 +91,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
             // InvalidOperationException with "No process is associated" as InnerException
             yield return new object[] { new Exception("Function invocation failed.", new InvalidOperationException("No process is associated with this object.")) };
+
+            // GrpcChannelTemporarilyUnavailableException as InnerException (gRPC sidecar unavailable)
+            yield return new object[] { new Exception("Function invocation failed.", new GrpcChannelTemporarilyUnavailableException("The local gRPC endpoint is not available.")) };
         }
 
         private (OutOfProcMiddleware middleware, DispatchMiddlewareContext context) SetupOrchestratorTest(Exception executorException)

--- a/test/FunctionsV2/OutOfProcMiddlewareTests.cs
+++ b/test/FunctionsV2/OutOfProcMiddlewareTests.cs
@@ -92,8 +92,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             // InvalidOperationException with "No process is associated" as InnerException
             yield return new object[] { new Exception("Function invocation failed.", new InvalidOperationException("No process is associated with this object.")) };
 
-            // GrpcChannelTemporarilyUnavailableException as InnerException (gRPC sidecar unavailable)
+            // GrpcChannelTemporarilyUnavailableException as InnerException (gRPC sidecar unavailable, wrapped by host)
             yield return new object[] { new Exception("Function invocation failed.", new GrpcChannelTemporarilyUnavailableException("The local gRPC endpoint is not available.")) };
+
+            // GrpcChannelTemporarilyUnavailableException as top-level exception (thrown in-process during binding)
+            yield return new object[] { new GrpcChannelTemporarilyUnavailableException("The local gRPC endpoint is not available.") };
         }
 
         private (OutOfProcMiddleware middleware, DispatchMiddlewareContext context) SetupOrchestratorTest(Exception executorException)


### PR DESCRIPTION
## Summary

When the local gRPC sidecar is temporarily unavailable, `BindingHelper.DurableOrchestrationClientToString` threw `InvalidOperationException("The local RPC address has not been configured!")`. The Azure Functions host treats this as a **non-retryable application error**, which is incorrect for what is fundamentally a transient infrastructure condition.

For **queue-triggered functions** with `[DurableClient]` input bindings, this is especially damaging: the rapid, non-retryable failures cause messages to exhaust their dequeue count (default: 5) within seconds and move to **poison queues**, resulting in data loss that requires manual reprocessing.

The failure occurs in the host-side input binding pipeline — **before user function code executes** — so no application-level retry strategy (e.g., Polly) can work around it.

### Related issue
- Azure/durabletask#1306

## Root Cause Analysis

The error is thrown at [`BindingHelper.cs:37`](src/WebJobs.Extensions.DurableTask/Bindings/BindingHelper.cs) when `GetLocalRpcAddress()` returns `null`. Through investigation, I identified the following contributing scenarios:

1. **gRPC server fails to start** (e.g., port conflict in `GetFreeTcpPort` TOCTOU race) — `ListenAddress` is never set
2. **gRPC server stops unexpectedly** — `StopAsync()` did not reset `host` or `ListenAddress`, so `StartAsync()` fast-path would skip re-initialization, permanently leaving a dead server
3. **`ListenAddress` set to `null` after Kestrel starts** — if `IServerAddressesFeature` returns empty addresses, the server appears "started" but `ListenAddress` is `null`, and subsequent calls hit the fast-path and never retry

In all cases, the `InvalidOperationException` exception type made recovery impossible at every layer.

## Changes

### Fix 1: Platform-level exception + wait-with-timeout

**`GrpcChannelTemporarilyUnavailableException.cs`** (new) — A dedicated `[Serializable]` exception type for transient gRPC sidecar unavailability. This is recognized as a platform-level error by the durable middleware, causing orchestrations/activities to be safely aborted and retried by the backend rather than permanently failed.

**`BindingHelper.cs`** — Replaced `InvalidOperationException` with `GrpcChannelTemporarilyUnavailableException`. The message clearly describes the transient sidecar unavailability condition.

**`OutOfProcMiddleware.cs`** — Added `GrpcChannelTemporarilyUnavailableException` to `IsPlatformLevelException()`, following the same pattern as PR #3355. When this exception is the `InnerException` of a function invocation failure, the middleware aborts the dispatch and triggers a durable retry instead of marking the orchestration as failed.

**`DurableTaskExtension.cs` → `GetLocalRpcAddress()`** — Instead of returning `null` immediately when `ListenAddress` is not set, the method now:
1. Returns immediately if the address is already available (fast path)
2. Attempts to restart the gRPC listener via `EnsureStartedAsync()`
3. Waits up to 30 seconds for the listen address to become available via `WaitForListenAddressAsync()`
4. Only returns `null` (triggering the exception) after exhausting the timeout

### Fix 2: Health checking + self-healing restart for the gRPC listener

**`ILocalGrpcListener.cs`** — Added three new interface members:
- `bool IsHealthy` — checks if the gRPC server is alive and responsive
- `Task EnsureStartedAsync()` — verifies health and restarts if needed
- `Task<string?> WaitForListenAddressAsync()` — waits with timeout for the address to become available

**`AspNetCoreLocalGrpcListener.cs`** — Major resilience improvements:
- **`IsHealthy` property**: Checks if the Kestrel `IServer` is still reporting addresses
- **`StartAsync()` now checks health**: If the host exists but is unhealthy, it stops and restarts (previously skipped via fast-path)
- **`StopAsync()` resets state**: Sets `host = null` and `ListenAddress = null`, and re-creates the `TaskCompletionSource` so subsequent `StartAsync()` calls properly reinitialize and waiters don't receive stale addresses
- **`StopInternalAsync()` threads `CancellationToken`**: The cancellation token is forwarded to the inner `host.StopAsync()` to avoid shutdown hangs
- **`EnsureStartedAsync()`**: Logs a warning and delegates to `StartAsync()` for health-aware restart
- **`WaitForListenAddressAsync()`**: Uses a `TaskCompletionSource<string>` to efficiently wait for the address without polling; the TCS is signaled upon successful startup
- **Error-resilient `StopInternalAsync()`**: Gracefully handles errors during stop so cleanup always completes

### Behavior comparison

| Scenario | Before | After |
|---|---|---|
| gRPC server not started | `InvalidOperationException` (instant, non-retryable) | Attempts restart, waits up to 30s, then `GrpcChannelTemporarilyUnavailableException` (platform-level, retriable) |
| gRPC server crashed | Fast-path skip (stale host ref), `ListenAddress` null forever | Health check detects dead server, restarts it |
| `StopAsync()` then `StartAsync()` | Skipped (host ref was non-null) | Properly resets state, allows clean restart |
| Queue-triggered function binding failure | Poison queue after ~5 rapid failures | Wait-with-retry gives server time to recover; platform-level exception triggers durable retry |
| Orchestration during gRPC unavailability | Orchestration marked as permanently failed | `IsPlatformLevelException` aborts dispatch → durable backend retries safely |

## Tests

Added 13 new tests to `LocalGrpcListenerTests.cs` and 1 to `OutOfProcMiddlewareTests.cs` (all pass on both net8.0 and net10.0):

**gRPC Listener tests:**
| Test | What it verifies |
|---|---|
| `IsHealthy_FalseBeforeStart` | `IsHealthy` is false before `StartAsync` |
| `IsHealthy_TrueAfterStart_FalseAfterStop` | `IsHealthy` tracks lifecycle correctly |
| `CanRestartAfterStop` | `StartAsync` works after `StopAsync` (new behavior) |
| `EnsureStarted_NoOpWhenHealthy` | No-op when already healthy |
| `EnsureStarted_RestartsWhenUnhealthy` | Restarts after stopped state |
| `WaitForAddress_ReturnsImmediatelyWhenReady` | Instant return when address available |
| `WaitForAddress_ReturnsWhenStartedConcurrently` | Waiter unblocks on concurrent start |
| `WaitForAddress_ReturnsNullOnTimeout` | Returns null on timeout (doesn't hang) |
| `WaitForAddress_ReturnsNullOnCancellation` | Respects cancellation token |
| `ConcurrentStartAsync_IsSafe` | 5 concurrent starts succeed safely |
| `StartAsync_IdempotentWhenHealthy` | Repeated starts return same address |
| `GetLocalRpcAddress_ReturnsAddressWhenStarted` | End-to-end via `DurableTaskExtension` |
| `BindingHelper_ThrowsGrpcChannelTemporarilyUnavailableException` | Confirms correct exception type when gRPC address unavailable |

**OutOfProcMiddleware test:**
| Test | What it verifies |
|---|---|
| `PlatformLevelExceptions` (new theory case) | `GrpcChannelTemporarilyUnavailableException` as InnerException triggers `SessionAbortedException` (safe abort + retry) |
