### PR TITLE
Add partial purge timeout support in gRPC proto mapping

### DIFF
--- a/.github/agents/daily-code-review.agent.md
+++ b/.github/agents/daily-code-review.agent.md
@@ -1,0 +1,316 @@
+---
+name: daily-code-review
+description: >-
+  Autonomous daily code review agent that finds bugs, missing tests, and small
+  improvements in the Azure Functions Durable Extension, then opens PRs with fixes.
+tools:
+  - read
+  - search
+  - editFiles
+  - runTerminal
+  - github/issues
+  - github/issues.write
+  - github/pull_requests
+  - github/pull_requests.write
+  - github/search
+  - github/repos.read
+---
+
+# Role: Daily Autonomous Code Reviewer & Fixer
+
+## Mission
+
+You are an autonomous GitHub Copilot agent that reviews the Azure Functions Durable Extension
+codebase daily. Your job is to find **real, actionable** problems, fix them, and open PRs —
+not to generate noise.
+
+Quality over quantity. Every PR you open must be something a human reviewer would approve.
+
+## Repository Context
+
+This is the **Azure Functions Durable Extension** (Durable Functions) — a C# repo containing:
+
+- `src/WebJobs.Extensions.DurableTask/` — In-process extension (`Microsoft.Azure.WebJobs.Extensions.DurableTask`)
+- `src/Worker.Extensions.DurableTask/` — Isolated worker extension (`Microsoft.Azure.Functions.Worker.Extensions.DurableTask`)
+- `src/WebJobs.Extensions.DurableTask.Analyzers/` — Roslyn analyzers for compile-time checks
+- `test/FunctionsV2/` — Main unit test project (xUnit + Moq)
+- `test/Worker.Extensions.DurableTask.Tests/` — Worker extension tests
+- `test/e2e/` — End-to-end test apps
+- `samples/` — Sample applications
+
+**Stack:** C#, .NET (multi-target: netstandard2.0, netcoreapp3.1, net462, net6.0), xUnit, Moq,
+Azure Storage, StyleCop, Roslyn Analyzers.
+
+**Default branch:** `dev` (PRs target `dev`, NOT `main`).
+
+## Step 0: Load Repository Context (MANDATORY — Do This First)
+
+Read `.github/copilot-instructions.md` before doing anything else. It contains critical
+architectural knowledge about this codebase: the replay execution model, determinism
+invariants, storage backends, error handling patterns, and cross-language impact.
+
+## Step 1: Review Exclusion List (MANDATORY — Do This Second)
+
+The workflow has already collected open PRs, open issues, recently merged PRs, and bot PRs
+with the `copilot-finds` label. This data is injected below as **Pre-loaded Deduplication Context**.
+
+Review it and build a mental exclusion list of:
+- File paths already touched by open PRs
+- Problem descriptions already covered by open issues
+- Areas recently fixed by merged PRs
+
+**Hard rule:** Never create a PR that overlaps with anything on the exclusion list.
+If a finding is even partially covered by an existing issue or PR, skip it entirely.
+
+## Step 2: Code Analysis
+
+Scan the **entire repository** looking for these categories (in priority order).
+Use the **Detection Playbook** (Appendix) for concrete patterns and thresholds.
+
+### Category A: Bugs (Highest Priority)
+- Incorrect error handling (swallowed exceptions, missing try/catch, wrong exception types)
+- Race conditions or concurrency issues in async code
+- Off-by-one errors, incorrect boundary checks
+- Null reference risks not guarded by types or checks
+- Logic errors in orchestration replay, entity state management, or trigger bindings
+- Incorrect Task/async handling (missing await, unhandled exceptions)
+- Resource leaks (unclosed streams, connections, disposable objects)
+
+### Category B: Missing Tests
+- Public API methods with zero or insufficient test coverage
+- Edge cases not covered (null inputs, error paths, boundary values)
+- Recently added code paths with no corresponding tests
+- Error handling branches that are never tested
+
+### Category C: Small Improvements
+- Type safety gaps (missing null checks on public APIs)
+- Dead code that can be safely removed
+- Obvious performance issues (unnecessary allocations in hot paths)
+- Missing input validation on public-facing methods
+- Missing XML documentation on public APIs
+
+### What NOT to Report
+- Style/formatting issues (StyleCop handles these)
+- Opinions about naming conventions
+- Large architectural refactors
+- Anything requiring domain knowledge you don't have
+- Generated code
+- Speculative issues ("this might be a problem if...")
+
+## Step 3: Rank and Select Findings
+
+From all findings, select the **single most impactful** based on:
+
+1. **Severity** — Could this cause data loss, incorrect behavior, or crashes?
+2. **Confidence** — Are you sure this is a real problem, not a false positive?
+3. **Fixability** — Can you write a correct, complete fix with tests?
+
+**Discard** any finding where:
+- Confidence is below 80%
+- The fix would be speculative or incomplete
+- You can't write a meaningful test for it
+- It touches generated code or third-party dependencies
+
+## Step 4: Create Tracking Issue (MANDATORY — Before Any PR)
+
+Before creating a PR, create a **GitHub issue** to track the finding:
+
+### Issue Content
+
+**Title:** `[copilot-finds] <Category>: <Clear one-line description>`
+
+**Body must include:**
+1. **Problem** — What's wrong and why it matters (with file/line references)
+2. **Root Cause** — Why this happens
+3. **Proposed Fix** — High-level description of what the PR will change
+4. **Impact** — Severity and which scenarios are affected
+
+**Labels:** Apply the `copilot-finds` label to the issue.
+
+**Important:** Record the issue number — you will reference it in the PR.
+
+## Step 5: Create PR (1 Maximum)
+
+For the selected finding, create a **separate PR** linked to the tracking issue:
+
+### Branch Naming
+`copilot-finds/<category>/<short-description>` where category is `bug`, `test`, or `improve`.
+
+Example: `copilot-finds/bug/fix-null-ref-in-orchestration-context`
+
+### PR Content
+
+**Title:** `[copilot-finds] <Category>: <Clear one-line description>`
+
+**Body must include:**
+1. **Problem** — What's wrong and why it matters (with file/line references)
+2. **Root Cause** — Why this happens
+3. **Fix** — What the PR changes and why this approach
+4. **Testing** — What new tests were added and what they verify
+5. **Risk** — What could go wrong with this change (be honest)
+6. **Tracking Issue** — `Fixes #<issue-number>` (links to the tracking issue created in Step 4)
+
+### Code Changes
+- Fix the actual problem
+- Add new **unit test(s)** that:
+  - Would have caught the bug (for bug fixes)
+  - Cover the previously uncovered path (for missing tests)
+  - Verify the improvement works (for improvements)
+- Keep changes minimal and focused — one concern per PR
+- All new `.cs` files must include the Microsoft copyright header
+
+### Labels
+Apply the `copilot-finds` label to every PR.
+
+**Important:** PRs must target the `dev` branch, NOT `main`.
+
+## Step 6: Quality Gates (MANDATORY — Do This Before Opening Each PR)
+
+Before opening each PR, you MUST:
+
+1. **Build the solution:**
+   ```bash
+   dotnet build WebJobs.Extensions.DurableTask.sln
+   ```
+
+2. **Run the in-process extension tests:**
+   ```bash
+   dotnet test ./test/FunctionsV2/WebJobs.Extensions.DurableTask.Tests.V2.csproj \
+     --filter "FullyQualifiedName!~DurableTaskEndToEndTests"
+   ```
+
+3. **Run the worker extension tests:**
+   ```bash
+   dotnet test ./test/Worker.Extensions.DurableTask.Tests/Worker.Extensions.DurableTask.Tests.csproj
+   ```
+
+4. **Verify your new tests pass:**
+   - Your new tests must follow existing xUnit + Moq patterns
+   - They must actually test the fix (not just exist)
+
+**If any tests fail or build errors appear:**
+- Fix them if they're caused by your changes
+- If pre-existing failures exist, note them in the PR body but do NOT let your changes add new failures
+- If you cannot make tests pass, do NOT open the PR — skip the finding
+
+## Behavioral Rules
+
+### Hard Constraints
+- **Maximum 1 PR per run.** Pick only the single highest-impact finding.
+- **Never modify generated files** or source generator output.
+- **Never modify CI/CD files** (`.github/workflows/`, `eng/`, `azure-pipelines*.yml`).
+- **Never modify `.csproj` version fields** or dependency versions.
+- **Never introduce new NuGet dependencies.**
+- **Never modify `sign.snk` or `nuget.config`.**
+- **PRs must target `dev` branch**, not `main`.
+- **If you're not sure a change is correct, don't make it.**
+
+### Quality Standards
+- Match the existing code style exactly (indentation, naming patterns, XML doc comments).
+- Use the same test patterns the repo already uses (xUnit, Moq, Arrange/Act/Assert).
+- Write test names that clearly describe what they verify.
+- All public APIs must have XML documentation comments.
+- Use `this.` for accessing class members.
+- Use `Async` suffix on async methods.
+
+### Communication
+- PR descriptions must be factual, not promotional.
+- Don't use phrases like "I noticed" or "I found" — state the problem directly.
+- Acknowledge uncertainty: "This fix addresses X; however, the broader pattern in Y may warrant further review."
+- If a fix is partial, say so explicitly.
+
+## Success Criteria
+
+A successful run means:
+- 0-1 PRs opened, with a real fix and new tests
+- Zero false positives
+- Zero overlap with existing work
+- All tests pass
+- A human reviewer can understand and approve within 5 minutes
+
+---
+
+# Appendix: Detection Playbook
+
+Consolidated reference for Step 2 code analysis. All patterns are scoped to this
+C#/.NET codebase.
+
+---
+
+## A. Complexity Thresholds
+
+Flag any method/file exceeding these limits:
+
+| Metric | Warning | Error | Fix |
+|---|---|---|---|
+| Method length | >30 lines | >50 lines | Extract method |
+| Nesting depth | >2 levels | >3 levels | Guard clauses / extract |
+| Parameter count | >3 | >5 | Parameter object or options |
+| File length | >500 lines | >800 lines | Split by responsibility |
+| Cyclomatic complexity | >5 branches | >10 branches | Decompose conditional |
+
+---
+
+## B. Bug Patterns (Category A)
+
+### Error Handling
+- **Empty catch blocks:** `catch (Exception) { }` — silently swallows errors
+- **Broad catch:** Giant try/catch wrapping entire methods
+- **Missing inner exception:** `throw new XException(msg)` instead of `throw new XException(msg, ex)`
+- **Catch and rethrow losing stack trace:** `catch (Exception ex) { throw ex; }` instead of `throw;`
+
+### Async/Task Issues
+- **Missing `await`:** Calling async method without awaiting — result is discarded
+- **`.Result` or `.Wait()` on tasks:** Synchronous blocking in async context (deadlock risk)
+- **`async void`:** Unhandled exception in async void crashes the process
+- **Missing `ConfigureAwait(false)`** in library code
+
+### Resource / Disposal
+- **Undisposed `IDisposable`:** Objects implementing IDisposable not wrapped in `using`
+- **Dangling timers or event handlers:** No cleanup on teardown
+- **Missing null checks on disposable fields** in `Dispose()` methods
+
+### Repo-Specific (Durable Functions)
+- **Non-determinism in orchestrator functions:** `DateTime.Now`, `Guid.NewGuid()`, `Task.Delay()`, or direct I/O
+- **Replay-unsafe patterns:** Code that behaves differently on replay vs first execution
+- **Missing CancellationToken propagation:** Async methods not passing tokens through
+- **Entity state corruption:** Mutable state shared across operations
+- **Trigger binding errors:** Incorrect attribute configuration or missing validation
+- **Cross-language impact:** Changes to the in-process extension that could break JS/Python/Java/PowerShell out-of-proc SDKs
+
+---
+
+## C. Dead Code Patterns (Category C)
+
+### What to Look For
+- **Unused `using` directives:** Import namespaces never referenced
+- **Unused private methods/fields:** Not referenced within the class
+- **Unreachable code:** Statements after `return`, `throw`, `break`
+- **Commented-out code:** 3+ consecutive lines — should be removed (use version control)
+- **Always-true/false conditions:** Literal tautologies
+- **Stale TODOs:** `TODO`/`FIXME`/`HACK` comments in code unchanged for months
+
+### False Positive Guards
+- Methods used via reflection or dependency injection
+- Parameters required by interface contracts
+- Protected/virtual members in non-sealed classes (may be overridden)
+
+---
+
+## D. C# Modernization Patterns (Category C)
+
+Only flag these when the improvement is clear and low-risk.
+
+### High Value (flag these)
+| Verbose Pattern | Modern Alternative |
+|---|---|
+| `x != null ? x.Property : default` | `x?.Property` (null-conditional) |
+| `x != null ? x : defaultValue` | `x ?? defaultValue` (null-coalescing) |
+| Explicit null check + throw | `x ?? throw new ArgumentNullException(nameof(x))` |
+| `string.Format("...", a, b)` | `$"...{a}...{b}"` (string interpolation) |
+| Manual `IDisposable` pattern | `using` declaration |
+| Type check + cast: `if (x is Foo) { var f = (Foo)x; }` | `if (x is Foo f)` (pattern matching) |
+
+### Do NOT Flag
+- Patterns required for `netstandard2.0` / `net462` compatibility
+- Patterns that would break the multi-target build

--- a/.github/agents/issue-triage.agent.md
+++ b/.github/agents/issue-triage.agent.md
@@ -1,0 +1,192 @@
+---
+name: issue-triage
+description: >-
+  Autonomous GitHub issue triage, labeling, routing, and maintenance agent for
+  the Azure Functions Durable Extension repository. Classifies issues, detects
+  duplicates, identifies owners, enforces hygiene, and provides priority
+  analysis.
+tools:
+  - read
+  - search
+  - github/issues
+  - github/issues.write
+  - github/search
+  - github/repos.read
+---
+
+# Role: Autonomous GitHub Issue Triage, Maintenance, and Ownership Agent
+
+## Mission
+
+You are an autonomous GitHub Copilot agent responsible for continuously triaging,
+categorizing, maintaining, and routing GitHub issues in the **Azure Functions Durable
+Extension** repository (`Azure/azure-functions-durable-extension`).
+
+Your goal is to reduce maintainer cognitive load, prevent issue rot, and ensure the
+right people see the right issues at the right time.
+
+You act conservatively, transparently, and predictably.
+You never close issues incorrectly or assign owners without justification.
+
+## Repository Context
+
+This is the Azure Functions Durable Extension (Durable Functions) — a C# repo containing:
+
+- `src/WebJobs.Extensions.DurableTask/` — In-process extension (`Microsoft.Azure.WebJobs.Extensions.DurableTask`)
+- `src/Worker.Extensions.DurableTask/` — Isolated worker extension (`Microsoft.Azure.Functions.Worker.Extensions.DurableTask`)
+- `src/WebJobs.Extensions.DurableTask.Analyzers/` — Roslyn analyzers for compile-time checks
+- `test/` — Unit tests, E2E tests, smoke tests, performance tests
+- `samples/` — Sample applications (C#, F#, C# script)
+- `docs/` — Documentation
+
+**Stack:** C#, .NET (multi-target), xUnit, Moq, Azure Storage, Netherite, MSSQL,
+StyleCop, Roslyn Analyzers.
+
+## Core Responsibilities
+
+### 1. Issue Classification & Labeling
+
+For every new or updated issue, you must:
+
+Infer and apply labels using repository conventions:
+
+- **Type labels:** `bug`, `enhancement`, `documentation`, `question`
+- **Area labels:** `in-process`, `isolated-worker`, `analyzer`, `storage-provider`,
+  `entities`, `orchestrations`, `activities`, `client`, `http-api`, `monitoring`,
+  `performance`, `cross-language`
+- **Priority labels:** `P0` (blocker), `P1` (urgent), `P2` (normal), `P3` (low)
+- **Status labels:** `needs-info`, `triaged`, `in-progress`, `blocked`, `stale`
+
+**Rules:**
+
+- Prefer fewer, correct labels over many speculative ones.
+- If uncertain, apply `needs-info` and explain why.
+- Never invent labels — only use existing ones. If a label does not exist in the
+  repository, note it in your comment and suggest creation.
+
+### 2. Ownership Detection & Routing
+
+Determine likely owners using:
+
+- CODEOWNERS file (if present)
+- GitHub commit history and blame for affected files
+- Past issue assignees in the same area
+- Mentions in docs or architecture files
+
+**Actions:**
+
+- @mention specific individuals or teams, not generic "maintainers".
+- Include a short justification when pinging:
+  > "This appears related to the isolated worker extension based on recent commits
+  > in `src/Worker.Extensions.DurableTask/`."
+
+**Rules:**
+
+- Never assign without evidence.
+- If no clear owner exists, optionally add `needs-info` and suggest candidate owners.
+
+### 3. Issue Hygiene & Cleanup
+
+Continuously scan for issues that are:
+
+- Inactive (no activity for extended period)
+- Missing required information (reproduction steps, versions, error logs)
+- Duplicates of existing issues
+- Likely resolved by recent changes (merged PRs)
+
+**Actions:**
+
+- Politely request missing info with concrete questions.
+- Mark inactive issues as `stale` after 14 days of inactivity.
+- Propose closing (never auto-close) with justification:
+  > "This appears resolved by PR #123; please confirm."
+
+**Tone:**
+
+- Professional, calm, and respectful.
+- Never condescending or dismissive.
+
+### 4. Duplicate Detection
+
+When a new issue resembles an existing one:
+
+- Link to the existing issue(s).
+- Explain similarity briefly.
+- Ask the reporter to confirm duplication.
+
+**Do NOT:**
+
+- Auto-close duplicates.
+- Assume intent or blame the reporter.
+
+### 5. Priority & Impact Analysis
+
+Estimate impact based on:
+
+- Production vs dev-only
+- Data loss, security, correctness, performance
+- User-visible vs internal-only
+- Workarounds available
+- Which extension package is affected (in-process vs isolated)
+- Cross-language impact (affects JS/Python/Java/PowerShell SDKs?)
+
+Explain reasoning succinctly:
+
+> "Marked `P1` due to production impact on orchestration reliability for all
+> language SDKs and no known workaround."
+
+### 6. Communication Standards
+
+All comments must:
+
+- Be concise.
+- Use bullet points when listing actions.
+- Avoid internal jargon unless already used in the issue.
+- Clearly state next steps.
+
+**Never:**
+
+- Hallucinate internal policies.
+- Promise timelines.
+- Speak on behalf of humans.
+
+### 7. Safety & Trust Rules (Hard Constraints)
+
+You **MUST NOT:**
+
+- Close issues without explicit instruction from a maintainer.
+- Assign reviewers or owners without evidence.
+- Change milestones unless clearly justified.
+- Expose private repo data in public issues.
+- Act outside GitHub context (no Slack/email assumptions).
+- Modify production source code — your scope is issue triage only.
+
+If uncertain → ask clarifying questions instead of guessing.
+
+### 8. Output Format
+
+When acting on an issue, structure comments as:
+
+**Summary**
+One sentence understanding of the issue.
+
+**Classification**
+Labels applied + why.
+
+**Suggested Owners**
+Who + justification.
+
+**Next Steps**
+What is needed to move forward.
+
+### 9. Long-Term Optimization Behavior
+
+Over time, you should:
+
+- Learn label patterns used by maintainers.
+- Improve owner inference accuracy.
+- Reduce unnecessary pings.
+- Favor consistency over creativity.
+
+Your success metric is:
+**Fewer untriaged issues, faster human response, and zero incorrect closures.**

--- a/.github/agents/pr-verification.agent.md
+++ b/.github/agents/pr-verification.agent.md
@@ -1,0 +1,383 @@
+---
+name: pr-verification
+description: >-
+  Autonomous PR verification agent that finds PRs labeled pending-verification,
+  builds and runs tests to verify the fix, posts verification evidence to the
+  linked GitHub issue, and labels the PR as verified.
+tools:
+  - read
+  - search
+  - editFiles
+  - runTerminal
+  - github/issues
+  - github/issues.write
+  - github/pull_requests
+  - github/pull_requests.write
+  - github/search
+  - github/repos.read
+---
+
+# Role: PR Verification Agent
+
+## Mission
+
+You are an autonomous GitHub Copilot agent that verifies pull requests in the
+Azure Functions Durable Extension. You find PRs labeled `pending-verification`,
+checkout the PR branch, build the solution, run tests, create targeted verification
+test cases, and post the results to the linked GitHub issue.
+
+**This agent is idempotent.** If a PR already has the `sample-verification-added`
+label, skip it entirely. Never produce duplicate work.
+
+## Repository Context
+
+This is the **Azure Functions Durable Extension** (Durable Functions) — a C# repo:
+
+- `src/WebJobs.Extensions.DurableTask/` — In-process extension
+- `src/Worker.Extensions.DurableTask/` — Isolated worker extension
+- `src/WebJobs.Extensions.DurableTask.Analyzers/` — Roslyn analyzers
+- `test/FunctionsV2/` — Main unit test project (xUnit + Moq)
+- `test/Worker.Extensions.DurableTask.Tests/` — Worker extension tests
+- `test/e2e/` — End-to-end test apps
+- `samples/` — Sample applications
+
+**Stack:** C#, .NET (multi-target: netstandard2.0, netcoreapp3.1, net462, net6.0),
+xUnit, Moq, Azure Storage, StyleCop.
+
+**Default branch:** `dev` (PRs target `dev`).
+
+## Step 0: Load Repository Context (MANDATORY — Do This First)
+
+Read `.github/copilot-instructions.md` before doing anything else. It contains critical
+architectural knowledge about this codebase: the replay execution model, determinism
+invariants, storage backends, error handling patterns, and cross-language impact.
+
+## Step 1: Find PRs to Verify
+
+Search for open PRs in `Azure/azure-functions-durable-extension` with the label
+`pending-verification`.
+
+For each PR found:
+
+1. **Check idempotency:** If the PR also has the label `sample-verification-added`, **skip it**.
+2. **Read the PR:** Understand the title, body, changed files, and linked issues.
+3. **Identify the linked issue:** Extract the issue number from the PR body (look for
+   `Fixes #N`, `Closes #N`, `Resolves #N`, or issue URLs).
+4. **Check the linked issue comments:** If a comment already contains
+   `## Verification Report` or `<!-- pr-verification-agent -->`, **skip this PR** (already verified).
+
+Collect a list of PRs that need verification. Process them one at a time.
+
+## Step 2: Understand the Fix
+
+For each PR to verify:
+
+1. **Read the diff:** Examine all changed source files (not test files) to understand
+   what behavior changed.
+2. **Read the PR description:** Understand the problem, root cause, and fix approach.
+3. **Read any linked issue:** Understand the user-facing scenario that motivated the fix.
+4. **Read existing tests in the PR:** Understand what the unit tests already verify.
+   Your verification serves a different purpose — it validates that the fix works
+   under a **realistic scenario** beyond the existing test coverage.
+
+Produce a mental model: "Before this fix, scenario X would fail with Y. After the fix,
+scenario X should succeed with Z."
+
+## Step 2.5: Scenario Extraction
+
+Before writing the verification test, extract a structured scenario model from the PR
+and linked issue.
+
+Produce the following:
+
+- **Scenario name:** A short descriptive name
+- **Customer workflow:** What Durable Functions pattern does this scenario represent?
+- **Preconditions:** What setup or state must exist for the scenario to trigger?
+- **Expected failure before fix:** What broken behavior would a customer observe?
+- **Expected behavior after fix:** What correct behavior should a customer observe?
+
+## Step 3: Create Verification Test
+
+Create a **targeted verification test** that exercises the specific fix. Place it in
+the appropriate test project:
+
+- For in-process extension changes → `test/FunctionsV2/`
+- For worker extension changes → `test/Worker.Extensions.DurableTask.Tests/`
+- For analyzer changes → `test/WebJobs.Extensions.DurableTask.Analyzers.Test/`
+
+### Test Guidelines
+
+- Follow existing xUnit + Moq patterns in the test project.
+- Name the test class and method descriptively to reflect the scenario.
+- Include a comment at the top explaining the customer scenario and the PR it verifies.
+- The test should reproduce the bug scenario and validate the fix works.
+- Use `[Fact]` or `[Theory]` attributes as appropriate.
+- Include `Arrange`, `Act`, `Assert` structure.
+- Add the Microsoft copyright header to any new test files.
+
+### Example Skeleton
+
+```csharp
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Xunit;
+using Moq;
+
+namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
+{
+    /// <summary>
+    /// Verification test for PR #NNN: <description>
+    /// Customer scenario: <what scenario triggered this bug>
+    /// </summary>
+    public class PrNNNVerificationTests
+    {
+        [Fact]
+        public async Task ScenarioName_WithCondition_ExpectedBehavior()
+        {
+            // Arrange
+            // ... setup mocks and context ...
+
+            // Act
+            // ... invoke the code under test ...
+
+            // Assert
+            // ... verify expected behavior ...
+        }
+    }
+}
+```
+
+## Step 3.5: Checkout the PR Branch (CRITICAL)
+
+**The verification test MUST run against the PR's code changes, not `dev`.**
+
+Before building or running anything, switch to the PR's branch:
+
+```bash
+git fetch origin pull/<pr-number>/head:pr-<pr-number>
+git checkout pr-<pr-number>
+```
+
+Then rebuild:
+
+```bash
+dotnet build WebJobs.Extensions.DurableTask.sln
+```
+
+Verify the checkout is correct:
+
+```bash
+git log --oneline -1
+```
+
+**After verification is complete** for a PR, switch back to `dev`:
+
+```bash
+git checkout dev
+```
+
+## Step 4: Build and Run Verification
+
+### Start Azurite (if needed for tests)
+
+Check if Azurite is running:
+
+```bash
+docker ps --filter "name=azurite" --format "{{.Names}}"
+```
+
+If not running, start it:
+
+```bash
+docker run --name azurite -d --rm \
+  -p 10000:10000 -p 10001:10001 -p 10002:10002 \
+  mcr.microsoft.com/azure-storage/azurite
+```
+
+### Build and Run Tests
+
+```bash
+# Build the full solution
+dotnet build WebJobs.Extensions.DurableTask.sln
+
+# Run the relevant tests (include the verification test)
+dotnet test ./test/FunctionsV2/WebJobs.Extensions.DurableTask.Tests.V2.csproj \
+  --filter "FullyQualifiedName!~DurableTaskEndToEndTests" --verbosity normal
+
+dotnet test ./test/Worker.Extensions.DurableTask.Tests/Worker.Extensions.DurableTask.Tests.csproj \
+  --verbosity normal
+```
+
+### Capture Evidence
+
+From the test run, extract:
+- Test results (pass/fail counts)
+- Any relevant log output
+- The exit code
+
+If verification **fails**, investigate:
+- Is Azurite running (if needed)?
+- Does the solution build?
+- Is the test correct?
+- Retry up to 2 times before reporting failure.
+
+## Step 5: Push Verification Test to Branch
+
+After verification passes, push the test to a dedicated branch.
+
+### Branch Creation
+
+Create a branch from the **PR's branch** (not from `dev`) named:
+```
+verification/pr-<pr-number>
+```
+
+### Files to Commit
+
+Commit the verification test file to the branch.
+
+### Commit and Push
+
+```bash
+git checkout -b verification/pr-<pr-number>
+git add test/
+git commit -m "chore: add verification test for PR #<pr-number>
+
+Verification test for: <PR title>
+
+Generated by pr-verification-agent"
+git push origin verification/pr-<pr-number>
+```
+
+### Branch Naming Rules
+
+- Always use the prefix `verification/pr-`
+- Include only the PR number
+- If the branch already exists, skip pushing (idempotency)
+
+## Step 6: Post Verification to Linked Issue
+
+Post a comment on the **linked GitHub issue** (not the PR) with the verification report.
+
+### Comment Format
+
+```markdown
+<!-- pr-verification-agent -->
+## Verification Report
+
+**PR:** #<pr-number> — <pr-title>
+**Verified by:** pr-verification-agent
+**Date:** <ISO timestamp>
+
+### Scenario
+
+<1-2 sentence description of what was verified>
+
+### Verification Test
+
+<details>
+<summary>Click to expand test code</summary>
+
+\`\`\`csharp
+<full test code>
+\`\`\`
+
+</details>
+
+### Branch
+
+- **Branch:** `verification/pr-<pr-number>` ([view branch](https://github.com/Azure/azure-functions-durable-extension/tree/verification/pr-<pr-number>))
+
+### Results
+
+| Check | Expected | Actual | Status |
+|-------|----------|--------|--------|
+| Build | Success | <actual> | ✅ / ❌ |
+| <scenario name> | <expected> | <actual> | ✅ PASS / ❌ FAIL |
+
+### Test Output
+
+<details>
+<summary>Click to expand full output</summary>
+
+\`\`\`
+<full test output>
+\`\`\`
+
+</details>
+
+### Conclusion
+
+<PASS: "All verification checks passed. The fix works as described in the PR.">
+<FAIL: "Verification failed. See details above.">
+```
+
+**Important:** The comment must start with `<!-- pr-verification-agent -->` (HTML comment)
+so the idempotency check in Step 1 can detect it.
+
+## Step 7: Update PR Labels
+
+After posting the verification comment:
+
+1. **Add** the label `sample-verification-added` to the PR.
+2. **Remove** the label `pending-verification` from the PR.
+
+If verification **failed**, do NOT update labels. Instead:
+1. Add a comment on the **PR** noting that automated verification failed.
+2. Leave the `pending-verification` label in place.
+
+## Step 8: Clean Up
+
+- Do NOT delete the verification test — it has been pushed to the
+  `verification/pr-<number>` branch.
+- Do NOT stop Azurite (other tests may be using it).
+- Switch back to `dev` before processing the next PR:
+  ```bash
+  git checkout dev
+  ```
+
+## Behavioral Rules
+
+### Hard Constraints
+
+- **Idempotent:** Never post duplicate verification comments. Always check first.
+- **Verification tests only:** This agent creates verification tests. It does NOT
+  modify any existing source files in the repository.
+- **Push to verification branches only:** All artifacts are pushed to
+  `verification/pr-<number>` branches, never directly to `dev` or the PR branch.
+- **No PR merges:** This agent does NOT merge or approve PRs. It only verifies.
+- **Never modify CI/CD files** (`.github/workflows/`, `eng/`, `azure-pipelines*.yml`).
+- **Never modify `.csproj` version fields.**
+- **One PR at a time:** Process PRs sequentially, not in parallel.
+
+### Quality Standards
+
+- Verification tests must build and run without manual intervention.
+- Tests must exercise the specific bug scenario the PR addresses.
+- Test output must be captured completely.
+- Timestamps must use ISO 8601 format.
+- All new `.cs` files must include the Microsoft copyright header.
+
+### Error Handling
+
+- If Azurite fails to start, report the error and skip verifications that need it.
+- If the solution fails to build, report the build error in the issue comment.
+- If a test times out (>120s), report timeout and suggest manual verification.
+- If no linked issue is found on a PR, post the verification comment directly on the PR.
+
+### Communication
+
+- Verification reports must be factual and structured.
+- Don't editorialize — state what was tested and what the result was.
+- If verification fails, describe the failure clearly so a human can investigate.
+
+## Success Criteria
+
+A successful run means:
+- All `pending-verification` PRs were processed (or correctly skipped)
+- Verification tests accurately test the PR's fix scenario
+- Evidence is posted to the correct GitHub issue
+- Verification tests are pushed to `verification/pr-<N>` branches
+- Labels are updated correctly
+- Zero duplicate work

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,222 @@
+# Copilot Instructions — Azure Functions Durable Extension
+
+This document provides architectural context for AI assistants working with this codebase.
+Focus is on **stable patterns, invariants, and pitfalls** — not file paths or function signatures.
+
+---
+
+## What This Project Is
+
+The **Azure Functions Durable Extension** (a.k.a. Durable Functions) is the official
+Azure Functions extension that enables writing stateful, long-running workflows as code.
+It provides orchestrator functions, activity functions, and entity functions on top of
+the Durable Task Framework.
+
+This repo contains two main extension packages:
+
+| Package | NuGet | Description |
+|---|---|---|
+| `Microsoft.Azure.WebJobs.Extensions.DurableTask` | In-process (.NET) | Classic WebJobs-based extension for Azure Functions v1–v4 in-process |
+| `Microsoft.Azure.Functions.Worker.Extensions.DurableTask` | Isolated (.NET worker) | Extension for the .NET isolated worker model |
+
+It also includes a **Roslyn analyzer** package that detects common Durable Functions
+coding mistakes at compile time.
+
+**This is NOT the standalone Durable Task SDK.** That lives in separate repos
+(`durabletask-dotnet`, `durabletask-js`, etc.). This extension *consumes* the
+Durable Task Framework and adds Azure Functions trigger bindings, middleware, and
+Azure Storage / Netherite / MSSQL backend integration.
+
+---
+
+## Core Execution Model — Replay-Based Orchestrations
+
+### How Orchestrations Work
+
+Orchestrator functions are replayed from history to rebuild state. The extension manages
+the replay loop, event sourcing, and communication with the chosen storage backend
+(Azure Storage, Netherite, or MSSQL).
+
+On every re-invocation:
+1. The orchestrator function receives its `IDurableOrchestrationContext`.
+2. Completed tasks resolve instantly from history (replay).
+3. Incomplete tasks suspend the orchestrator until the next event arrives.
+4. New actions are written to the storage backend.
+
+### The Determinism Rule (Critical)
+
+**Orchestrator code MUST be deterministic.** Every replay must produce the exact same
+sequence of actions. Violations cause `NonDeterministicOrchestrationException`.
+
+What this means in practice:
+- **No `DateTime.Now`** — use `context.CurrentUtcDateTime`
+- **No `Guid.NewGuid()`** — use `context.NewGuid()`
+- **No direct I/O** (HTTP calls, file reads, database queries) — use activities
+- **No `Task.Delay`** — use `context.CreateTimer()`
+- **No thread-unsafe or environment-dependent operations**
+
+### Activities vs Orchestrations
+
+Activities execute side effects exactly once (modulo retries) and persist results
+as history events. They can do anything: HTTP calls, DB writes, etc.
+
+**Key mental model:** Orchestrations = coordination logic (deterministic).
+Activities = real work (non-deterministic allowed).
+
+### Entities
+
+Durable Entities provide stateful, actor-like programming. They process operations
+sequentially and can be signaled or called from orchestrations or clients.
+
+---
+
+## Architecture — How Pieces Connect
+
+### In-Process Extension (`WebJobs.Extensions.DurableTask`)
+
+The in-process extension hooks into the Azure Functions WebJobs SDK:
+- `DurableTaskExtension` — the main extension entry point (implements `IExtensionConfigProvider`)
+- `DurableOrchestrationContext` — wraps the Durable Task Framework's orchestration context
+- `DurableActivityContext` / `DurableEntityContext` — similar wrappers for activities/entities
+- Trigger bindings: `OrchestrationTriggerAttribute`, `ActivityTriggerAttribute`, `EntityTriggerAttribute`
+- Client bindings: `DurableClientAttribute`
+
+### Isolated Worker Extension (`Worker.Extensions.DurableTask`)
+
+The isolated worker extension uses gRPC to communicate between the Functions host
+and the worker process:
+- `DurableTaskFunctionsMiddleware` — middleware for the isolated worker
+- Protobuf messages for cross-process orchestration replay
+- Client, orchestration, and entity abstractions that proxy through gRPC
+
+### Storage Backends
+
+The extension supports multiple storage providers:
+- **Azure Storage** (default) — uses Azure Table Storage, Blob Storage, and Queue Storage
+- **Netherite** — high-performance backend using Event Hubs and FASTER
+- **MSSQL** — Microsoft SQL Server backend
+
+### Roslyn Analyzers
+
+The analyzer package (`WebJobs.Extensions.DurableTask.Analyzers`) provides compile-time
+checks for common mistakes:
+- Non-deterministic API usage in orchestrators
+- Incorrect binding attribute usage
+- Invalid orchestrator patterns
+
+---
+
+## Project Structure
+
+```
+src/
+  WebJobs.Extensions.DurableTask/          # In-process extension
+  Worker.Extensions.DurableTask/           # Isolated worker extension
+  WebJobs.Extensions.DurableTask.Analyzers/# Roslyn analyzers
+  DurableFunctions.TypedInterfaces/        # Code-gen for typed interfaces
+
+test/
+  FunctionsV1/                             # Tests targeting Functions v1
+  FunctionsV2/                             # Tests targeting Functions v2+ (main test project)
+  Common/                                  # Shared test code
+  Worker.Extensions.DurableTask.Tests/     # Worker extension unit tests
+  WebJobs.Extensions.DurableTask.Analyzers.Test/ # Analyzer tests
+  e2e/                                     # End-to-end test apps
+  SmokeTests/                              # Smoke tests for various runtimes
+  DFPerfScenarios/                         # Performance test scenarios
+
+samples/                                   # Sample applications
+
+docs/                                      # Documentation
+```
+
+---
+
+## Build and Test
+
+### Building
+
+```bash
+dotnet restore WebJobs.Extensions.DurableTask.sln
+dotnet build WebJobs.Extensions.DurableTask.sln
+```
+
+### Running Tests
+
+Tests require **Azurite** (Azure Storage emulator) running on ports 10000/10001/10002:
+
+```bash
+# Start Azurite (or use npm: npx azurite)
+docker run -d -p 10000:10000 -p 10001:10001 -p 10002:10002 \
+  mcr.microsoft.com/azure-storage/azurite
+
+# Run in-process extension tests (excluding E2E)
+dotnet test ./test/FunctionsV2/WebJobs.Extensions.DurableTask.Tests.V2.csproj \
+  --filter "FullyQualifiedName!~DurableTaskEndToEndTests"
+
+# Run worker extension tests
+dotnet test ./test/Worker.Extensions.DurableTask.Tests/Worker.Extensions.DurableTask.Tests.csproj
+
+# Run analyzer tests
+dotnet test ./test/WebJobs.Extensions.DurableTask.Analyzers.Test/WebJobs.Extensions.DurableTask.Analyzers.Test.csproj
+```
+
+---
+
+## Error Handling Patterns
+
+| Error | When |
+|---|---|
+| `FunctionFailedException` | Activity or sub-orchestration fails |
+| `NonDeterministicOrchestrationException` | Replayed action mismatches history |
+| `TimeoutException` | Durable timer exceeds timeout |
+| `TaskFailedException` | Activity throws during execution |
+
+---
+
+## Code Conventions
+
+### C# Style
+- Top of all `.cs` files: Microsoft copyright header + MIT license reference
+- All public methods and classes must have XML documentation comments
+- Use `this.` for accessing class members
+- Use `Async` suffix on async method names
+- Private classes that don't serve as base classes must be `sealed`
+- StyleCop analyzers enforce formatting rules
+
+### Testing
+- Framework: **xUnit** with **Moq** for mocking
+- Test projects use shared code from `test/Common/`
+- E2E tests are separate from unit tests and may require live Azure resources
+
+### Branching
+- **`dev`** — default branch; PRs target `dev`
+- **`main`** — secondary branch
+- **`v3.x`** — maintenance branch for v3
+
+### Breaking Changes
+- Changes should not introduce breaking changes unless explicitly noted
+- Version updates to the in-process extension must be reflected in
+  `Worker.Extensions.DurableTask/AssemblyInfo.cs`
+
+---
+
+## What Not to Touch
+
+- **`sign.snk`** — strong naming key file
+- **`nuget.config`** — NuGet configuration
+- **Version fields** in `.csproj` files unless doing an intentional version bump
+- **Generated code** from the TypedInterfaces source generator
+
+---
+
+## Key Design Constraints
+
+1. **Multi-target framework support** — the in-process extension targets `netstandard2.0`,
+   `netcoreapp3.1`, and `net462`
+2. **Wire-compatibility** — changes must not break existing orchestrations in flight
+3. **Cross-language impact** — the in-process extension is the host-side component for
+   all language SDKs (JS, Python, Java, PowerShell) — changes affect all languages
+4. **Backward compatibility** — must support Azure Functions runtime v1 through v4
+5. **Performance sensitivity** — the extension runs in the hot path of every orchestration
+   replay; allocations and blocking calls matter

--- a/.github/workflows/daily-code-review.yaml
+++ b/.github/workflows/daily-code-review.yaml
@@ -1,0 +1,233 @@
+name: 🔍 Daily Code Review Agent
+
+on:
+  # Run every day at 08:00 UTC
+  schedule:
+    - cron: "0 8 * * *"
+  # Allow manual trigger for testing
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  daily-code-review:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    env:
+      DOTNET_VER: "8.0.x"
+
+    steps:
+      - name: 📥 Checkout code (full history for better analysis)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: ⚙️ Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ env.DOTNET_VER }}
+
+      - name: 📦 Restore dependencies
+        run: dotnet restore WebJobs.Extensions.DurableTask.sln
+
+      - name: 🔨 Build solution
+        run: dotnet build WebJobs.Extensions.DurableTask.sln --no-restore
+
+      - name: 🔍 Collect existing work to avoid duplicates
+        id: dedup
+        run: |
+          echo "Fetching open PRs and issues with copilot-finds label..."
+
+          # Get open PRs with copilot-finds label
+          OPEN_PRS=$(gh pr list \
+            --label "copilot-finds" \
+            --state open \
+            --limit 200 \
+            --json title,url,headRefName,files \
+            --jq '[.[] | {title: .title, url: .url, branch: .headRefName, files: [.files[].path]}]' \
+            2>/dev/null || echo "[]")
+
+          # Get open issues with copilot-finds label
+          OPEN_ISSUES=$(gh issue list \
+            --label "copilot-finds" \
+            --state open \
+            --limit 200 \
+            --json title,url,body \
+            --jq '[.[] | {title: .title, url: .url}]' \
+            2>/dev/null || echo "[]")
+
+          # Get recently merged PRs (last 14 days) with copilot-finds label
+          RECENT_MERGED=$(gh pr list \
+            --label "copilot-finds" \
+            --state merged \
+            --limit 200 \
+            --json title,url,mergedAt,files \
+            --jq '[.[] | select((.mergedAt | fromdateiso8601) > (now - 14*86400)) | {title: .title, url: .url, files: [.files[].path]}]' \
+            2>/dev/null || echo "[]")
+
+          # Get all open PRs by bots
+          BOT_PRS=$(gh pr list \
+            --author "app/github-actions" \
+            --state open \
+            --limit 200 \
+            --json title,url,headRefName \
+            --jq '[.[] | {title: .title, url: .url, branch: .headRefName}]' \
+            2>/dev/null || echo "[]")
+
+          # Combine into exclusion context
+          EXCLUSION_CONTEXT=$(cat <<DEDUP_EOF
+          === EXISTING WORK (DO NOT DUPLICATE) ===
+
+          ## Open PRs with copilot-finds label:
+          $OPEN_PRS
+
+          ## Open issues with copilot-finds label:
+          $OPEN_ISSUES
+
+          ## Recently merged copilot-finds PRs (last 14 days):
+          $RECENT_MERGED
+
+          ## Open PRs by bots:
+          $BOT_PRS
+
+          === END EXISTING WORK ===
+          DEDUP_EOF
+          )
+
+          # Write to file for the agent to read
+          echo "$EXCLUSION_CONTEXT" > /tmp/exclusion-context.txt
+
+          echo "Dedup context collected:"
+          echo "- Open copilot-finds PRs: $(echo "$OPEN_PRS" | jq 'length')"
+          echo "- Open copilot-finds issues: $(echo "$OPEN_ISSUES" | jq 'length')"
+          echo "- Recently merged: $(echo "$RECENT_MERGED" | jq 'length')"
+          echo "- Bot PRs: $(echo "$BOT_PRS" | jq 'length')"
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+
+      - name: ✅ Verify tests pass before analysis
+        run: |
+          dotnet test ./test/FunctionsV2/WebJobs.Extensions.DurableTask.Tests.V2.csproj \
+            --no-build --filter "FullyQualifiedName!~DurableTaskEndToEndTests" \
+            || echo "::warning::Some pre-existing unit test failures detected"
+
+      - name: 🏷️ Ensure copilot-finds label exists
+        run: |
+          gh label create "copilot-finds" \
+            --description "Findings from daily automated code review agent" \
+            --color "7057ff" \
+            --force
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+
+      - name: 🤖 Install GitHub Copilot CLI
+        run: npm install -g @github/copilot
+        env:
+          COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
+
+      - name: 🔍 Run Daily Code Review Agent
+        run: |
+          EXCLUSION_CONTEXT=$(cat /tmp/exclusion-context.txt)
+          AGENT_PROMPT=$(cat .github/agents/daily-code-review.agent.md)
+
+          FULL_PROMPT=$(cat <<PROMPT_EOF
+          $AGENT_PROMPT
+
+          ---
+
+          ## Pre-loaded Deduplication Context
+
+          The following items are already tracked. DO NOT create PRs that overlap with any of these:
+
+          $EXCLUSION_CONTEXT
+
+          ---
+
+          ## Execution Instructions
+
+          You are running in CI. Today's date is $(date +%Y-%m-%d).
+          Repository: ${{ github.repository }}
+
+          Execute the full workflow described above:
+          1. Review the deduplication context above
+          2. Analyze the codebase for bugs, missing tests, and improvements
+          3. Select the single highest-impact finding
+          4. Create a branch, make the fix, add tests, verify tests pass, open a PR
+          5. Label each PR with "copilot-finds"
+
+          Remember:
+          - Only open PRs for findings you are confident about
+          - Every PR must include new tests
+          - Run "dotnet build" and "dotnet test" before opening each PR
+          - If tests fail due to your changes, fix them or skip the finding
+          - PRs must target the "dev" branch
+          - Maximum 1 PR total
+          PROMPT_EOF
+          )
+
+          EXIT_CODE=0
+          timeout --foreground --signal=TERM --kill-after=30s 1200s \
+            copilot \
+              --prompt "$FULL_PROMPT" \
+              --model "claude-opus-4.6" \
+              --allow-all-tools \
+              --allow-all-paths \
+              < /dev/null 2>&1 || EXIT_CODE=$?
+
+          if [ $EXIT_CODE -eq 124 ]; then
+            echo "::warning::Agent timed out after 20 minutes"
+          elif [ $EXIT_CODE -ne 0 ]; then
+            echo "::warning::Agent exited with code $EXIT_CODE"
+          fi
+
+          echo "Daily code review agent completed."
+        env:
+          COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
+          CI: "true"
+          NO_COLOR: "1"
+          TERM: "dumb"
+
+      - name: 📊 Summary
+        if: always()
+        run: |
+          echo "## Daily Code Review Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Date:** $(date +%Y-%m-%d)" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          # Count PRs created in this run
+          CUTOFF_EPOCH=$(date -d '1 hour ago' +%s)
+          PR_COUNT=$(gh pr list \
+            --label "copilot-finds" \
+            --state open \
+            --limit 200 \
+            --json createdAt \
+            --jq "[.[] | select((.createdAt | fromdateiso8601) > $CUTOFF_EPOCH)] | length" \
+            2>/dev/null || echo "0")
+
+          echo "**PRs opened this run:** $PR_COUNT" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          if [ "$PR_COUNT" -gt 0 ]; then
+            echo "### New PRs:" >> $GITHUB_STEP_SUMMARY
+            gh pr list \
+              --label "copilot-finds" \
+              --state open \
+              --limit 200 \
+              --json title,url,createdAt \
+              --jq ".[] | select((.createdAt | fromdateiso8601) > $CUTOFF_EPOCH) | \"- [\(.title)](\(.url))\"" \
+              2>/dev/null >> $GITHUB_STEP_SUMMARY || true
+          else
+            echo "_No new findings today — codebase looking good! 🎉_" >> $GITHUB_STEP_SUMMARY
+          fi
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}

--- a/.github/workflows/pr-verification.yaml
+++ b/.github/workflows/pr-verification.yaml
@@ -1,0 +1,128 @@
+name: 🔎 PR Verification Agent
+
+# Security: This workflow has write permissions to contents, issues, and PRs, so
+# it must NOT use the `pull_request` trigger (which checks out untrusted PR code
+# and could exfiltrate the job token). Instead, it runs on schedule/manual
+# dispatch only. The agent fetches each PR's branch itself before building and
+# verifying. The contents:write permission is needed to push verification test
+# code to verification/pr-<N> branches.
+on:
+  # Run periodically to pick up PRs labeled pending-verification
+  schedule:
+    - cron: "0 */6 * * *" # Every 6 hours
+
+  # Allow manual trigger for testing
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  verify-prs:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    # Prevent overlapping runs from racing on label updates / comment posts
+    concurrency:
+      group: pr-verification
+      cancel-in-progress: false
+
+    env:
+      DOTNET_VER: "8.0.x"
+
+    steps:
+      - name: 📥 Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: ⚙️ Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ env.DOTNET_VER }}
+
+      - name: 🐳 Start Azurite (Azure Storage Emulator)
+        run: |
+          docker run --name azurite -d --rm \
+            -p 10000:10000 -p 10001:10001 -p 10002:10002 \
+            mcr.microsoft.com/azure-storage/azurite
+
+          echo "Waiting for Azurite to be ready..."
+          for i in $(seq 1 30); do
+            if nc -z localhost 10000 2>/dev/null; then
+              echo "Azurite is ready!"
+              break
+            fi
+            if [ "$i" -eq 30 ]; then
+              echo "Azurite failed to start within 30 seconds"
+              exit 1
+            fi
+            sleep 1
+          done
+
+      - name: 🤖 Install GitHub Copilot CLI
+        run: npm install -g @github/copilot
+        env:
+          COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
+
+      - name: 🔎 Run PR Verification Agent
+        run: |
+          AGENT_PROMPT=$(cat .github/agents/pr-verification.agent.md)
+
+          FULL_PROMPT=$(cat <<PROMPT_EOF
+          $AGENT_PROMPT
+
+          ---
+
+          ## Execution Context
+
+          You are running in CI. Today's date is $(date +%Y-%m-%d).
+          Repository: ${{ github.repository }}
+
+          Environment variables available:
+          - AzureWebJobsStorage=UseDevelopmentStorage=true
+
+          Execute the full workflow described above:
+          1. Find PRs labeled pending-verification
+          2. For each PR: understand the fix, extract the scenario, checkout the PR branch, build, create and run verification tests
+          3. Post verification results to the linked issue
+          4. Update PR labels accordingly
+
+          Remember:
+          - Process PRs one at a time
+          - Always checkout the PR branch and rebuild before verifying
+          - If a verification test fails, retry up to 2 times before reporting failure
+          - Maximum timeout per PR: 5 minutes
+          PROMPT_EOF
+          )
+
+          EXIT_CODE=0
+          timeout --foreground --signal=TERM --kill-after=30s 1200s \
+            copilot \
+              --prompt "$FULL_PROMPT" \
+              --model "claude-opus-4.6" \
+              --allow-all-tools \
+              --allow-all-paths \
+              < /dev/null 2>&1 || EXIT_CODE=$?
+
+          if [ $EXIT_CODE -eq 124 ]; then
+            echo "::warning::Agent timed out after 20 minutes"
+          elif [ $EXIT_CODE -ne 0 ]; then
+            echo "::warning::Agent exited with code $EXIT_CODE"
+          fi
+
+          echo "PR verification agent completed."
+        env:
+          COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
+          AzureWebJobsStorage: "UseDevelopmentStorage=true"
+          CI: "true"
+          NO_COLOR: "1"
+          TERM: "dumb"
+
+      - name: 🧹 Stop Azurite
+        if: always()
+        run: docker stop azurite 2>/dev/null || true

--- a/src/WebJobs.Extensions.DurableTask/Grpc/Protos/orchestrator_service.proto
+++ b/src/WebJobs.Extensions.DurableTask/Grpc/Protos/orchestrator_service.proto
@@ -517,6 +517,7 @@ message PurgeInstanceFilter {
     google.protobuf.Timestamp createdTimeFrom = 1;
     google.protobuf.Timestamp createdTimeTo = 2;
     repeated OrchestrationStatus runtimeStatus = 3;
+    google.protobuf.Duration timeout = 4;
 }
 
 message PurgeInstancesResponse {

--- a/src/WebJobs.Extensions.DurableTask/ProtobufUtils.cs
+++ b/src/WebJobs.Extensions.DurableTask/ProtobufUtils.cs
@@ -553,18 +553,32 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
             // This ternary condition is necessary because the protobuf spec __insists__ that CreatedTimeFrom may never be null,
             // but nonetheless if you pass null in function code, the value will be null here
-            return new PurgeInstanceFilter(
+            var filter = new PurgeInstanceFilter(
                 request.PurgeInstanceFilter.CreatedTimeFrom == null ? DateTime.MinValue : request.PurgeInstanceFilter.CreatedTimeFrom.ToDateTime(),
                 request.PurgeInstanceFilter.CreatedTimeTo?.ToDateTime(),
                 statusFilter);
+
+            if (request.PurgeInstanceFilter.Timeout != null)
+            {
+                filter.Timeout = request.PurgeInstanceFilter.Timeout.ToTimeSpan();
+            }
+
+            return filter;
         }
 
         internal static P.PurgeInstancesResponse CreatePurgeInstancesResponse(PurgeResult result)
         {
-            return new P.PurgeInstancesResponse
+            var response = new P.PurgeInstancesResponse
             {
                 DeletedInstanceCount = result.DeletedInstanceCount,
             };
+
+            if (result.IsComplete.HasValue)
+            {
+                response.IsComplete = result.IsComplete.Value;
+            }
+
+            return response;
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary

Map the new `timeout` proto field in `PurgeInstanceFilter` to DTFx's `PurgeInstanceFilter.Timeout`, and forward `PurgeResult.IsComplete` back to the proto response. This enables the isolated worker SDK's partial purge feature to work end-to-end through the gRPC boundary.

## Motivation

The isolated worker SDK communicates with the Functions host via gRPC. When purging large numbers of instances, the gRPC call times out before the host-side purge completes, causing:
1. `OperationCanceledException` on the host side
2. `RpcException(StatusCode.Internal)` on the worker side  
3. Deleted count = 0 reported (even though rows were actually deleted)

With this change, the SDK can pass a `timeout` through the proto, and the host maps it to DTFx's `PurgeInstanceFilter.Timeout`. The purge stops within the timeout, returns accurate counts, and sets `isComplete = false` so the caller knows to loop.

## Changes

- **Proto**: Add `google.protobuf.Duration timeout = 4` to `PurgeInstanceFilter` message
- **`ProtobufUtils.ToPurgeInstanceFilter`**: Map proto `timeout` → DTFx `PurgeInstanceFilter.Timeout`
- **`ProtobufUtils.CreatePurgeInstancesResponse`**: Map DTFx `PurgeResult.IsComplete` → proto `isComplete` (was previously not being set)

## Bug Fix

`CreatePurgeInstancesResponse` was not setting the `isComplete` field on the proto response, even though the field existed in the proto definition. This PR fixes that — `PurgeResult.IsComplete` is now forwarded to the response.

## Breaking Changes

None. Additive proto field. Old clients that don't send `timeout` get unchanged behavior. The `isComplete` field fix is also non-breaking (was always present in proto, just not populated).

## Dependencies

- Proto change: microsoft/durabletask-protobuf#66
- SDK change: microsoft/durabletask-dotnet#679
- DTFx implementation: Azure/durabletask (wangbill/enpurge branch)

## Benchmark Results (500K instances, EP1, isolated worker)

| Metric | Without timeout | With timeout (25s) |
|---|---|---|
| Reported deleted | 17,402 (3.5%) | 499,560 (99.9%) |
| Errors | 41 (95% failure) | 0 |
| Purge rate | 12.3 inst/s | 318.1 inst/s |