### PR TITLE
Upgrade Java 8 smoke test: setup-java v4, Gradle 6.9.4, setup-gradle v4

### DIFF
--- a/.github/workflows/smoketest-java8-v4.yml
+++ b/.github/workflows/smoketest-java8-v4.yml
@@ -22,15 +22,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK 8
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           java-version: '8'
           distribution: 'temurin'
-      - name: Build azure functions sample
-        uses: gradle/gradle-build-action@v2.4.2
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
         with:
-          gradle-version: 6.5
-          arguments: azureFunctionsPackage -p test/SmokeTests/OOProcSmokeTests/durableJava/
+          gradle-version: 6.9.4
+      - name: Build azure functions sample
+        run: gradle azureFunctionsPackage -p test/SmokeTests/OOProcSmokeTests/durableJava/
         continue-on-error: true
       - name: Download azure functions java library # TODO: Remove this step once gradle plugin is updated
         run: |


### PR DESCRIPTION
## Summary

Upgrades the Java 8 smoke test workflow (`smoketest-java8-v4.yml`) to fix persistent CI failures caused by deprecated GitHub Actions and Gradle cache incompatibilities.

## Changes

| Component | Before | After | Reason |
|-----------|--------|-------|--------|
| `actions/setup-java` | v2 | **v4** | v2 uses deprecated Node.js 16 |
| `gradle/gradle-build-action` | v2.4.2 | **`gradle/actions/setup-gradle@v4`** | Old action is deprecated; its cache API causes HTTP 400 errors on current GitHub runners |
| Gradle | 6.5 (June 2020) | **6.9.4** (latest 6.x) | Avoids cache restore failures while staying within the 6.x line |

## Context

The Java 8 smoke test has been intermittently failing with:
```
Restore Gradle distribution 6.5 failed: Error: Cache service responded with 400
Gradle build failed: see console output for details
```

The root cause is that `gradle/gradle-build-action@v2.4.2` uses an outdated cache API that is incompatible with current GitHub Actions infrastructure. The action has been replaced by `gradle/actions/setup-gradle` starting at v3.