### PR TITLE
Optimize E2E CI: parallelize tests across languages, 3x wall-clock speedup

### DIFF
--- a/.github/workflows/E2ETest.yml
+++ b/.github/workflows/E2ETest.yml
@@ -146,21 +146,13 @@ jobs:
 
   e2e-mssql:
     runs-on: ubuntu-latest
-    name: e2e-mssql (${{ matrix.targetFramework }}, ${{ matrix.language.name }})
+    name: e2e-mssql (${{ matrix.targetFramework }})
     strategy:
       fail-fast: false
       matrix:
         targetFramework: [net8.0, net10.0]
-        language:
-          - { name: dotnet-isolated, app: BasicDotNetIsolated, filter: 'MSSQL!=Skip&Dotnet!=Skip&Dotnet-MSSQL!=Skip' }
-          - { name: powershell, app: BasicPowerShell, filter: 'MSSQL!=Skip&PowerShell!=Skip&PowerShell-MSSQL!=Skip' }
-          - { name: python, app: BasicPython, filter: 'MSSQL!=Skip&Python!=Skip&Python-MSSQL!=Skip' }
-          - { name: node, app: BasicNode, filter: 'MSSQL!=Skip&Node!=Skip&Node-MSSQL!=Skip' }
-          - { name: java, app: BasicJava, filter: 'MSSQL!=Skip&Java!=Skip&Java-MSSQL!=Skip' }
     env:
       E2E_TEST_DURABLE_BACKEND: "MSSQL"
-      E2E_TEST_FUNCTIONS_LANGUAGE: ${{ matrix.language.name }}
-      TEST_APP_NAME: ${{ matrix.language.app }}
     steps:
       - uses: actions/checkout@v4
 
@@ -180,13 +172,11 @@ jobs:
           node-version: '20.x'
           
       - name: Set up Python
-        if: matrix.language.name == 'python'
         uses: actions/setup-python@v2
         with:
           python-version: 3.13
 
       - name: Set up JDK 17
-        if: matrix.language.name == 'java'
         uses: actions/setup-java@v4
         with:
           java-version: '17'
@@ -200,15 +190,61 @@ jobs:
       - name: Setup E2E tests
         shell: pwsh
         run: |
-          .\test\e2e\Tests\build-e2e-test.ps1 -StartMSSqlContainer -E2EAppName ${{ matrix.language.app }} -TargetFramework ${{ matrix.targetFramework }}
+          .\test\e2e\Tests\build-e2e-test.ps1 -StartMSSqlContainer -TargetFramework ${{ matrix.targetFramework }}
 
       - name: Build Test Project
         working-directory: test/e2e/Tests
         run: dotnet build -f ${{ matrix.targetFramework }}
 
-      - name: Run E2E tests (${{ matrix.language.name }})
+      - name: Setup Environment for dotnet
+        shell: pwsh
+        run: |
+          Add-Content -Path $env:GITHUB_ENV -Value "E2E_TEST_FUNCTIONS_LANGUAGE=dotnet-isolated"
+          Add-Content -Path $env:GITHUB_ENV -Value "TEST_APP_NAME=BasicDotNetIsolated"
+
+      - name: Run E2E tests (dotnet-isolated)
         working-directory: test/e2e/Tests
-        run: dotnet test -f ${{ matrix.targetFramework }} --filter '${{ matrix.language.filter }}'
+        run: dotnet test -f ${{ matrix.targetFramework }} --filter 'MSSQL!=Skip&Dotnet!=Skip&Dotnet-MSSQL!=Skip'
+
+      - name: Setup Environment for PowerShell
+        shell: pwsh
+        run: |
+          Add-Content -Path $env:GITHUB_ENV -Value "E2E_TEST_FUNCTIONS_LANGUAGE=powershell"
+          Add-Content -Path $env:GITHUB_ENV -Value "TEST_APP_NAME=BasicPowerShell"
+
+      - name: Run E2E tests (PowerShell)
+        working-directory: test/e2e/Tests
+        run: dotnet test -f ${{ matrix.targetFramework }} --filter 'MSSQL!=Skip&PowerShell!=Skip&PowerShell-MSSQL!=Skip'
+
+      - name: Setup Environment for Python
+        shell: pwsh
+        run: |
+          Add-Content -Path $env:GITHUB_ENV -Value "E2E_TEST_FUNCTIONS_LANGUAGE=python"
+          Add-Content -Path $env:GITHUB_ENV -Value "TEST_APP_NAME=BasicPython"
+
+      - name: Run E2E tests (Python)
+        working-directory: test/e2e/Tests
+        run: dotnet test -f ${{ matrix.targetFramework }} --filter 'MSSQL!=Skip&Python!=Skip&Python-MSSQL!=Skip'
+
+      - name: Setup Environment for Node
+        shell: pwsh
+        run: |
+          Add-Content -Path $env:GITHUB_ENV -Value "E2E_TEST_FUNCTIONS_LANGUAGE=node"
+          Add-Content -Path $env:GITHUB_ENV -Value "TEST_APP_NAME=BasicNode"
+
+      - name: Run E2E tests (Node)
+        working-directory: test/e2e/Tests
+        run: dotnet test -f ${{ matrix.targetFramework }} --filter 'MSSQL!=Skip&Node!=Skip&Node-MSSQL!=Skip'
+
+      - name: Setup Environment for Java
+        shell: pwsh
+        run: |
+          Add-Content -Path $env:GITHUB_ENV -Value "E2E_TEST_FUNCTIONS_LANGUAGE=java"
+          Add-Content -Path $env:GITHUB_ENV -Value "TEST_APP_NAME=BasicJava"
+
+      - name: Run E2E tests (Java)
+        working-directory: test/e2e/Tests
+        run: dotnet test -f ${{ matrix.targetFramework }} --filter 'MSSQL!=Skip&Java!=Skip&Java-MSSQL!=Skip'
 
   e2e-dts:
     runs-on: ubuntu-latest

--- a/.github/workflows/E2ETest.yml
+++ b/.github/workflows/E2ETest.yml
@@ -22,13 +22,21 @@ on:
 jobs:
   e2e-azurestorage-linux:
     runs-on: ubuntu-latest
-    name: e2e-azurestorage-linux (${{ matrix.targetFramework }})
+    name: e2e-azurestorage-linux (${{ matrix.targetFramework }}, ${{ matrix.language.name }})
     strategy:
       fail-fast: false
       matrix:
         targetFramework: [net8.0, net10.0]
+        language:
+          - { name: dotnet-isolated, app: BasicDotNetIsolated, filter: 'AzureStorage!=Skip&Dotnet!=Skip&Dotnet-AzureStorage!=Skip' }
+          - { name: powershell, app: BasicPowerShell, filter: 'AzureStorage!=Skip&PowerShell!=Skip&PowerShell-AzureStorage!=Skip' }
+          - { name: python, app: BasicPython, filter: 'AzureStorage!=Skip&Python!=Skip&Python-AzureStorage!=Skip' }
+          - { name: node, app: BasicNode, filter: 'AzureStorage!=Skip&Node!=Skip&Node-AzureStorage!=Skip' }
+          - { name: java, app: BasicJava, filter: 'AzureStorage!=Skip&Java!=Skip&Java-AzureStorage!=Skip' }
     env:
       E2E_TEST_DURABLE_BACKEND: 'AzureStorage'
+      E2E_TEST_FUNCTIONS_LANGUAGE: ${{ matrix.language.name }}
+      TEST_APP_NAME: ${{ matrix.language.app }}
     steps:
       - uses: actions/checkout@v4
 
@@ -48,11 +56,13 @@ jobs:
           node-version: '20.x'
 
       - name: Set up Python
+        if: matrix.language.name == 'python'
         uses: actions/setup-python@v2
         with:
           python-version: 3.13
 
       - name: Set up JDK 17
+        if: matrix.language.name == 'java'
         uses: actions/setup-java@v4
         with:
           java-version: '17'
@@ -62,71 +72,33 @@ jobs:
       - name: Setup E2E tests
         shell: pwsh
         run: |
-          .\test\e2e\Tests\build-e2e-test.ps1 -TargetFramework ${{ matrix.targetFramework }}
+          .\test\e2e\Tests\build-e2e-test.ps1 -E2EAppName ${{ matrix.language.app }} -TargetFramework ${{ matrix.targetFramework }}
 
       - name: Build Test Project
         working-directory: test/e2e/Tests
         run: dotnet build -f ${{ matrix.targetFramework }}
 
-      - name: Setup Environment for dotnet
-        shell: pwsh
-        run: |
-          Add-Content -Path $env:GITHUB_ENV -Value "E2E_TEST_FUNCTIONS_LANGUAGE=dotnet-isolated"
-          Add-Content -Path $env:GITHUB_ENV -Value "TEST_APP_NAME=BasicDotNetIsolated"
-
-      - name: Run E2E tests (dotnet-isolated)
+      - name: Run E2E tests (${{ matrix.language.name }})
         working-directory: test/e2e/Tests
-        run: dotnet test -f ${{ matrix.targetFramework }} --filter 'AzureStorage!=Skip&Dotnet!=Skip&Dotnet-AzureStorage!=Skip'
-
-      - name: Setup Environment for PowerShell
-        shell: pwsh
-        run: |
-          Add-Content -Path $env:GITHUB_ENV -Value "E2E_TEST_FUNCTIONS_LANGUAGE=powershell"
-          Add-Content -Path $env:GITHUB_ENV -Value "TEST_APP_NAME=BasicPowerShell"
-
-      - name: Run E2E tests (PowerShell)
-        working-directory: test/e2e/Tests
-        run: dotnet test -f ${{ matrix.targetFramework }} --filter 'AzureStorage!=Skip&PowerShell!=Skip&PowerShell-AzureStorage!=Skip'
-
-      - name: Setup Environment for Python
-        shell: pwsh
-        run: |
-          Add-Content -Path $env:GITHUB_ENV -Value "E2E_TEST_FUNCTIONS_LANGUAGE=python"
-          Add-Content -Path $env:GITHUB_ENV -Value "TEST_APP_NAME=BasicPython"
-
-      - name: Run E2E tests (Python)
-        working-directory: test/e2e/Tests
-        run: dotnet test -f ${{ matrix.targetFramework }} --filter 'AzureStorage!=Skip&Python!=Skip&Python-AzureStorage!=Skip'
-
-      - name: Setup Environment for Node
-        shell: pwsh
-        run: |
-          Add-Content -Path $env:GITHUB_ENV -Value "E2E_TEST_FUNCTIONS_LANGUAGE=node"
-          Add-Content -Path $env:GITHUB_ENV -Value "TEST_APP_NAME=BasicNode"
-
-      - name: Run E2E tests (Node)
-        working-directory: test/e2e/Tests
-        run: dotnet test -f ${{ matrix.targetFramework }} --filter 'AzureStorage!=Skip&Node!=Skip&Node-AzureStorage!=Skip'
-
-      - name: Setup Environment for Java
-        shell: pwsh
-        run: |
-          Add-Content -Path $env:GITHUB_ENV -Value "E2E_TEST_FUNCTIONS_LANGUAGE=java"
-          Add-Content -Path $env:GITHUB_ENV -Value "TEST_APP_NAME=BasicJava"
-
-      - name: Run E2E tests (Java)
-        working-directory: test/e2e/Tests
-        run: dotnet test -f ${{ matrix.targetFramework }} --filter 'AzureStorage!=Skip&Java!=Skip&Java-AzureStorage!=Skip'
+        run: dotnet test -f ${{ matrix.targetFramework }} --filter '${{ matrix.language.filter }}'
 
   e2e-azurestorage-windows:
     runs-on: windows-latest
-    name: e2e-azurestorage-windows (${{ matrix.targetFramework }})
+    name: e2e-azurestorage-windows (${{ matrix.targetFramework }}, ${{ matrix.language.name }})
     strategy:
       fail-fast: false
       matrix:
         targetFramework: [net8.0, net10.0]
+        language:
+          - { name: dotnet-isolated, app: BasicDotNetIsolated, filter: 'AzureStorage!=Skip&Dotnet!=Skip&Dotnet-AzureStorage!=Skip' }
+          - { name: powershell, app: BasicPowerShell, filter: 'AzureStorage!=Skip&PowerShell!=Skip&PowerShell-AzureStorage!=Skip' }
+          - { name: python, app: BasicPython, filter: 'AzureStorage!=Skip&Python!=Skip&Python-AzureStorage!=Skip' }
+          - { name: node, app: BasicNode, filter: 'AzureStorage!=Skip&Node!=Skip&Node-AzureStorage!=Skip' }
+          - { name: java, app: BasicJava, filter: 'AzureStorage!=Skip&Java!=Skip&Java-AzureStorage!=Skip' }
     env:
       E2E_TEST_DURABLE_BACKEND: 'AzureStorage'
+      E2E_TEST_FUNCTIONS_LANGUAGE: ${{ matrix.language.name }}
+      TEST_APP_NAME: ${{ matrix.language.app }}
     steps:
       - uses: actions/checkout@v4
 
@@ -146,11 +118,13 @@ jobs:
           node-version: '20.x'
           
       - name: Set up Python
+        if: matrix.language.name == 'python'
         uses: actions/setup-python@v2
         with:
           python-version: 3.13
 
       - name: Set up JDK 17
+        if: matrix.language.name == 'java'
         uses: actions/setup-java@v4
         with:
           java-version: '17'
@@ -160,71 +134,33 @@ jobs:
       - name: Setup E2E tests
         shell: pwsh
         run: |
-          .\test\e2e\Tests\build-e2e-test.ps1 -TargetFramework ${{ matrix.targetFramework }}
+          .\test\e2e\Tests\build-e2e-test.ps1 -E2EAppName ${{ matrix.language.app }} -TargetFramework ${{ matrix.targetFramework }}
 
       - name: Build Test Project
         working-directory: test/e2e/Tests
         run: dotnet build -f ${{ matrix.targetFramework }}
 
-      - name: Setup Environment for dotnet
-        shell: pwsh
-        run: |
-          Add-Content -Path $env:GITHUB_ENV -Value "E2E_TEST_FUNCTIONS_LANGUAGE=dotnet-isolated"
-          Add-Content -Path $env:GITHUB_ENV -Value "TEST_APP_NAME=BasicDotNetIsolated"
-
-      - name: Run E2E tests (dotnet-isolated)
+      - name: Run E2E tests (${{ matrix.language.name }})
         working-directory: test/e2e/Tests
-        run: dotnet test -f ${{ matrix.targetFramework }} --filter 'AzureStorage!=Skip&Dotnet!=Skip&Dotnet-AzureStorage!=Skip'
-
-      - name: Setup Environment for PowerShell
-        shell: pwsh
-        run: |
-          Add-Content -Path $env:GITHUB_ENV -Value "E2E_TEST_FUNCTIONS_LANGUAGE=powershell"
-          Add-Content -Path $env:GITHUB_ENV -Value "TEST_APP_NAME=BasicPowerShell"
-
-      - name: Run E2E tests (PowerShell)
-        working-directory: test/e2e/Tests
-        run: dotnet test -f ${{ matrix.targetFramework }} --filter 'AzureStorage!=Skip&PowerShell!=Skip&PowerShell-AzureStorage!=Skip'
-
-      - name: Setup Environment for Python
-        shell: pwsh
-        run: |
-          Add-Content -Path $env:GITHUB_ENV -Value "E2E_TEST_FUNCTIONS_LANGUAGE=python"
-          Add-Content -Path $env:GITHUB_ENV -Value "TEST_APP_NAME=BasicPython"
-
-      - name: Run E2E tests (Python)
-        working-directory: test/e2e/Tests
-        run: dotnet test -f ${{ matrix.targetFramework }} --filter 'AzureStorage!=Skip&Python!=Skip&Python-AzureStorage!=Skip'
-
-      - name: Setup Environment for Node
-        shell: pwsh
-        run: |
-          Add-Content -Path $env:GITHUB_ENV -Value "E2E_TEST_FUNCTIONS_LANGUAGE=node"
-          Add-Content -Path $env:GITHUB_ENV -Value "TEST_APP_NAME=BasicNode"
-
-      - name: Run E2E tests (Node)
-        working-directory: test/e2e/Tests
-        run: dotnet test -f ${{ matrix.targetFramework }} --filter 'AzureStorage!=Skip&Node!=Skip&Node-AzureStorage!=Skip'
-
-      - name: Setup Environment for Java
-        shell: pwsh
-        run: |
-          Add-Content -Path $env:GITHUB_ENV -Value "E2E_TEST_FUNCTIONS_LANGUAGE=java"
-          Add-Content -Path $env:GITHUB_ENV -Value "TEST_APP_NAME=BasicJava"
-
-      - name: Run E2E tests (Java)
-        working-directory: test/e2e/Tests
-        run: dotnet test -f ${{ matrix.targetFramework }} --filter 'AzureStorage!=Skip&Java!=Skip&Java-AzureStorage!=Skip'
+        run: dotnet test -f ${{ matrix.targetFramework }} --filter '${{ matrix.language.filter }}'
 
   e2e-mssql:
     runs-on: ubuntu-latest
-    name: e2e-mssql (${{ matrix.targetFramework }})
+    name: e2e-mssql (${{ matrix.targetFramework }}, ${{ matrix.language.name }})
     strategy:
       fail-fast: false
       matrix:
         targetFramework: [net8.0, net10.0]
+        language:
+          - { name: dotnet-isolated, app: BasicDotNetIsolated, filter: 'MSSQL!=Skip&Dotnet!=Skip&Dotnet-MSSQL!=Skip' }
+          - { name: powershell, app: BasicPowerShell, filter: 'MSSQL!=Skip&PowerShell!=Skip&PowerShell-MSSQL!=Skip' }
+          - { name: python, app: BasicPython, filter: 'MSSQL!=Skip&Python!=Skip&Python-MSSQL!=Skip' }
+          - { name: node, app: BasicNode, filter: 'MSSQL!=Skip&Node!=Skip&Node-MSSQL!=Skip' }
+          - { name: java, app: BasicJava, filter: 'MSSQL!=Skip&Java!=Skip&Java-MSSQL!=Skip' }
     env:
       E2E_TEST_DURABLE_BACKEND: "MSSQL"
+      E2E_TEST_FUNCTIONS_LANGUAGE: ${{ matrix.language.name }}
+      TEST_APP_NAME: ${{ matrix.language.app }}
     steps:
       - uses: actions/checkout@v4
 
@@ -244,11 +180,13 @@ jobs:
           node-version: '20.x'
           
       - name: Set up Python
+        if: matrix.language.name == 'python'
         uses: actions/setup-python@v2
         with:
           python-version: 3.13
 
       - name: Set up JDK 17
+        if: matrix.language.name == 'java'
         uses: actions/setup-java@v4
         with:
           java-version: '17'
@@ -262,61 +200,15 @@ jobs:
       - name: Setup E2E tests
         shell: pwsh
         run: |
-          .\test\e2e\Tests\build-e2e-test.ps1 -StartMSSqlContainer -TargetFramework ${{ matrix.targetFramework }}
+          .\test\e2e\Tests\build-e2e-test.ps1 -StartMSSqlContainer -E2EAppName ${{ matrix.language.app }} -TargetFramework ${{ matrix.targetFramework }}
 
       - name: Build Test Project
         working-directory: test/e2e/Tests
         run: dotnet build -f ${{ matrix.targetFramework }}
 
-      - name: Setup Environment for dotnet
-        shell: pwsh
-        run: |
-          Add-Content -Path $env:GITHUB_ENV -Value "E2E_TEST_FUNCTIONS_LANGUAGE=dotnet-isolated"
-          Add-Content -Path $env:GITHUB_ENV -Value "TEST_APP_NAME=BasicDotNetIsolated"
-
-      - name: Run E2E tests (dotnet-isolated)
+      - name: Run E2E tests (${{ matrix.language.name }})
         working-directory: test/e2e/Tests
-        run: dotnet test -f ${{ matrix.targetFramework }} --filter 'MSSQL!=Skip&Dotnet!=Skip&Dotnet-MSSQL!=Skip'
-
-      - name: Setup Environment for PowerShell
-        shell: pwsh
-        run: |
-          Add-Content -Path $env:GITHUB_ENV -Value "E2E_TEST_FUNCTIONS_LANGUAGE=powershell"
-          Add-Content -Path $env:GITHUB_ENV -Value "TEST_APP_NAME=BasicPowerShell"
-
-      - name: Run E2E tests (PowerShell)
-        working-directory: test/e2e/Tests
-        run: dotnet test -f ${{ matrix.targetFramework }} --filter 'MSSQL!=Skip&PowerShell!=Skip&PowerShell-MSSQL!=Skip'
-
-      - name: Setup Environment for Python
-        shell: pwsh
-        run: |
-          Add-Content -Path $env:GITHUB_ENV -Value "E2E_TEST_FUNCTIONS_LANGUAGE=python"
-          Add-Content -Path $env:GITHUB_ENV -Value "TEST_APP_NAME=BasicPython"
-
-      - name: Run E2E tests (Python)
-        working-directory: test/e2e/Tests
-        run: dotnet test -f ${{ matrix.targetFramework }} --filter 'MSSQL!=Skip&Python!=Skip&Python-MSSQL!=Skip'
-
-      - name: Setup Environment for Node
-        shell: pwsh
-        run: |
-          Add-Content -Path $env:GITHUB_ENV -Value "E2E_TEST_FUNCTIONS_LANGUAGE=node"
-          Add-Content -Path $env:GITHUB_ENV -Value "TEST_APP_NAME=BasicNode"
-
-      - name: Run E2E tests (Node)
-        working-directory: test/e2e/Tests
-        run: dotnet test -f ${{ matrix.targetFramework }} --filter 'MSSQL!=Skip&Node!=Skip&Node-MSSQL!=Skip'
-
-      - name: Setup Environment for Java
-        shell: pwsh
-        run: |
-          Add-Content -Path $env:GITHUB_ENV -Value "E2E_TEST_FUNCTIONS_LANGUAGE=java"
-          Add-Content -Path $env:GITHUB_ENV -Value "TEST_APP_NAME=BasicJava"
-
-      - name: Run E2E tests (Java)
-        working-directory: test/e2e/Tests
-        run: dotnet test -f ${{ matrix.targetFramework }} --filter 'MSSQL!=Skip&Java!=Skip&Java-MSSQL!=Skip'
+        run: dotnet test -f ${{ matrix.targetFramework }} --filter '${{ matrix.language.filter }}'
 
   e2e-dts:
     runs-on: ubuntu-latest

--- a/.github/workflows/E2ETest.yml
+++ b/.github/workflows/E2ETest.yml
@@ -320,13 +320,21 @@ jobs:
 
   e2e-dts:
     runs-on: ubuntu-latest
-    name: e2e-dts (${{ matrix.targetFramework }})
+    name: e2e-dts (${{ matrix.targetFramework }}, ${{ matrix.language }})
     strategy:
       fail-fast: false
       matrix:
         targetFramework: [net8.0, net10.0]
+        language:
+          - { name: dotnet-isolated, app: BasicDotNetIsolated, filter: 'DTS!=Skip&Dotnet!=Skip&Dotnet-DTS!=Skip' }
+          - { name: powershell, app: BasicPowerShell, filter: 'DTS!=Skip&PowerShell!=Skip&PowerShell-DTS!=Skip' }
+          - { name: python, app: BasicPython, filter: 'DTS!=Skip&Python!=Skip&Python-DTS!=Skip' }
+          - { name: node, app: BasicNode, filter: 'DTS!=Skip&Node!=Skip&Node-DTS!=Skip' }
+          - { name: java, app: BasicJava, filter: 'DTS!=Skip&Java!=Skip&Java-DTS!=Skip' }
     env:
       E2E_TEST_DURABLE_BACKEND: "azureManaged"
+      E2E_TEST_FUNCTIONS_LANGUAGE: ${{ matrix.language.name }}
+      TEST_APP_NAME: ${{ matrix.language.app }}
     steps:
       - uses: actions/checkout@v4
 
@@ -346,11 +354,13 @@ jobs:
           node-version: '20.x'
           
       - name: Set up Python
+        if: matrix.language.name == 'python'
         uses: actions/setup-python@v2
         with:
           python-version: 3.13
 
       - name: Set up JDK 17
+        if: matrix.language.name == 'java'
         uses: actions/setup-java@v4
         with:
           java-version: '17'
@@ -360,58 +370,12 @@ jobs:
       - name: Setup E2E tests
         shell: pwsh
         run: |
-          .\test\e2e\Tests\build-e2e-test.ps1 -StartDTSContainer -TargetFramework ${{ matrix.targetFramework }}
+          .\test\e2e\Tests\build-e2e-test.ps1 -StartDTSContainer -E2EAppName ${{ matrix.language.app }} -TargetFramework ${{ matrix.targetFramework }}
 
       - name: Build Test Project
         working-directory: test/e2e/Tests
         run: dotnet build -f ${{ matrix.targetFramework }}
 
-      - name: Setup Environment for dotnet
-        shell: pwsh
-        run: |
-          Add-Content -Path $env:GITHUB_ENV -Value "E2E_TEST_FUNCTIONS_LANGUAGE=dotnet-isolated"
-          Add-Content -Path $env:GITHUB_ENV -Value "TEST_APP_NAME=BasicDotNetIsolated"
-
-      - name: Run E2E tests (dotnet-isolated)
+      - name: Run E2E tests (${{ matrix.language.name }})
         working-directory: test/e2e/Tests
-        run: dotnet test -f ${{ matrix.targetFramework }} --filter 'DTS!=Skip&Dotnet!=Skip&Dotnet-DTS!=Skip'
-
-      - name: Setup Environment for PowerShell
-        shell: pwsh
-        run: |
-          Add-Content -Path $env:GITHUB_ENV -Value "E2E_TEST_FUNCTIONS_LANGUAGE=powershell"
-          Add-Content -Path $env:GITHUB_ENV -Value "TEST_APP_NAME=BasicPowerShell"
-
-      - name: Run E2E tests (PowerShell)
-        working-directory: test/e2e/Tests
-        run: dotnet test -f ${{ matrix.targetFramework }} --filter 'DTS!=Skip&PowerShell!=Skip&PowerShell-DTS!=Skip'
-
-      - name: Setup Environment for Python
-        shell: pwsh
-        run: |
-          Add-Content -Path $env:GITHUB_ENV -Value "E2E_TEST_FUNCTIONS_LANGUAGE=python"
-          Add-Content -Path $env:GITHUB_ENV -Value "TEST_APP_NAME=BasicPython"
-
-      - name: Run E2E tests (Python)
-        working-directory: test/e2e/Tests
-        run: dotnet test -f ${{ matrix.targetFramework }} --filter 'DTS!=Skip&Python!=Skip&Python-DTS!=Skip'
-
-      - name: Setup Environment for Node
-        shell: pwsh
-        run: |
-          Add-Content -Path $env:GITHUB_ENV -Value "E2E_TEST_FUNCTIONS_LANGUAGE=node"
-          Add-Content -Path $env:GITHUB_ENV -Value "TEST_APP_NAME=BasicNode"
-
-      - name: Run E2E tests (Node)
-        working-directory: test/e2e/Tests
-        run: dotnet test -f ${{ matrix.targetFramework }} --filter 'DTS!=Skip&Node!=Skip&Node-DTS!=Skip'
-
-      - name: Setup Environment for Java
-        shell: pwsh
-        run: |
-          Add-Content -Path $env:GITHUB_ENV -Value "E2E_TEST_FUNCTIONS_LANGUAGE=java"
-          Add-Content -Path $env:GITHUB_ENV -Value "TEST_APP_NAME=BasicJava"
-
-      - name: Run E2E tests (Java)
-        working-directory: test/e2e/Tests
-        run: dotnet test -f ${{ matrix.targetFramework }} --filter 'DTS!=Skip&Java!=Skip&Java-DTS!=Skip'
+        run: dotnet test -f ${{ matrix.targetFramework }} --filter '${{ matrix.language.filter }}'

--- a/.github/workflows/E2ETest.yml
+++ b/.github/workflows/E2ETest.yml
@@ -320,7 +320,7 @@ jobs:
 
   e2e-dts:
     runs-on: ubuntu-latest
-    name: e2e-dts (${{ matrix.targetFramework }}, ${{ matrix.language }})
+    name: e2e-dts (${{ matrix.targetFramework }}, ${{ matrix.language.name }})
     strategy:
       fail-fast: false
       matrix:

--- a/.gitignore
+++ b/.gitignore
@@ -305,4 +305,6 @@ functions-extensions/
 **/*.runsettings
 
 # Java build artifacts
-**/.gradle/**
+**/.gradle/**__blobstorage__/
+__azurite_db_*
+AzuriteConfig/

--- a/test/e2e/Tests/Tests/DedupeStatusesTests.cs
+++ b/test/e2e/Tests/Tests/DedupeStatusesTests.cs
@@ -27,6 +27,11 @@ public class DedupeStatusesTests
         bool testPending = this.fixture.functionLanguageLocalizer.GetLanguageType() == LanguageType.DotnetIsolated
             || this.fixture.functionLanguageLocalizer.GetLanguageType() == LanguageType.Java;
 
+        // HttpLongRunningOrchestrator (timer-based, no activity spam) is only available in dotnet-isolated
+        string longRunningOrch = this.fixture.functionLanguageLocalizer.GetLanguageType() == LanguageType.DotnetIsolated
+            ? "HttpLongRunningOrchestrator"
+            : "LongRunningOrchestrator";
+
         string completedId = Guid.NewGuid().ToString();
         string failedId = Guid.NewGuid().ToString();
         string terminatedId = Guid.NewGuid().ToString();
@@ -37,10 +42,10 @@ public class DedupeStatusesTests
         // Phase 1: Start all first-attempt orchestrations and wait for initial states concurrently
         var completedFirst = StartAndWaitForState("HelloCities", completedId, "Completed");
         var failedFirst = StartAndWaitForState("LargeOutputOrchestrator", failedId, "Failed");
-        var runningFirst = StartAndWaitForState("HttpLongRunningOrchestrator", runningId, "Running");
-        var suspendedFirst = StartAndWaitForState("HttpLongRunningOrchestrator", suspendedId, "Running");
+        var runningFirst = StartAndWaitForState(longRunningOrch, runningId, "Running");
+        var suspendedFirst = StartAndWaitForState(longRunningOrch, suspendedId, "Running");
         var terminatedFirst = testTerminated
-            ? StartAndWaitForState("HttpLongRunningOrchestrator", terminatedId, "Running")
+            ? StartAndWaitForState(longRunningOrch, terminatedId, "Running")
             : Task.FromResult<HttpResponseMessage>(null!);
         var pendingFirst = testPending
             ? StartAndWaitForState("HelloCities", pendingId, "Pending", scheduledStartTime: DateTime.UtcNow.AddMinutes(10))
@@ -54,18 +59,28 @@ public class DedupeStatusesTests
         transitions.Add(SuspendAndWaitForState(suspendedId, suspendedFirst.Result));
         await Task.WhenAll(transitions);
 
+        // Dispose Phase 1 responses (no longer needed after extracting statusQueryGetUri)
+        completedFirst.Result?.Dispose();
+        failedFirst.Result?.Dispose();
+        runningFirst.Result?.Dispose();
+        suspendedFirst.Result?.Dispose();
+        terminatedFirst.Result?.Dispose();
+        pendingFirst.Result?.Dispose();
+
         // Phase 3: Start all second-attempt orchestrations concurrently (verify restart works)
-        var completedSecond = StartAndWaitForState("HelloCities", completedId, "Completed");
-        var failedSecond = StartAndWaitForState("LargeOutputOrchestrator", failedId, "Failed");
-        var runningSecond = StartAndWaitForState("HttpLongRunningOrchestrator", runningId, "Running");
-        var suspendedSecond = StartAndWaitForState("HttpLongRunningOrchestrator", suspendedId, "Running");
-        var terminatedSecond = testTerminated
-            ? StartAndWaitForState("HttpLongRunningOrchestrator", terminatedId, "Running")
-            : Task.CompletedTask;
-        var pendingSecond = testPending
-            ? StartAndWaitForState("HelloCities", pendingId, "Completed")
-            : Task.CompletedTask;
-        await Task.WhenAll(completedSecond, failedSecond, runningSecond, suspendedSecond, terminatedSecond, pendingSecond);
+        var phase3Tasks = new List<Task<HttpResponseMessage>>
+        {
+            StartAndWaitForState("HelloCities", completedId, "Completed"),
+            StartAndWaitForState("LargeOutputOrchestrator", failedId, "Failed"),
+            StartAndWaitForState(longRunningOrch, runningId, "Running"),
+            StartAndWaitForState(longRunningOrch, suspendedId, "Running"),
+        };
+        if (testTerminated)
+            phase3Tasks.Add(StartAndWaitForState(longRunningOrch, terminatedId, "Running"));
+        if (testPending)
+            phase3Tasks.Add(StartAndWaitForState("HelloCities", pendingId, "Completed"));
+        foreach (var r in await Task.WhenAll(phase3Tasks))
+            r?.Dispose();
 
         // Phase 4: Clean up running orchestrations concurrently
         var cleanups = new List<Task<HttpResponseMessage>>
@@ -91,6 +106,9 @@ public class DedupeStatusesTests
     [InlineData("Pending", "Failed")]
     public async Task StartOrchestration_WithSameId_FailsIfExistingStatus_InDedupeStatuses(params string[] dedupeStatuses)
     {
+        // This test is dotnet-isolated only (Java/PowerShell/Python/Node are skipped via traits)
+        string longRunningOrch = "HttpLongRunningOrchestrator";
+
         string completedId = Guid.NewGuid().ToString();
         string failedId = Guid.NewGuid().ToString();
         string terminatedId = Guid.NewGuid().ToString();
@@ -101,9 +119,9 @@ public class DedupeStatusesTests
         // Phase 1: Start all first-attempt orchestrations concurrently
         var completedFirst = StartAndWaitForStateWithDedupeStatuses("HelloCities", completedId, "Completed", dedupeStatuses);
         var failedFirst = StartAndWaitForStateWithDedupeStatuses("LargeOutputOrchestrator", failedId, "Failed", dedupeStatuses);
-        var terminatedFirst = StartAndWaitForStateWithDedupeStatuses("HttpLongRunningOrchestrator", terminatedId, "Running", dedupeStatuses);
-        var runningFirst = StartAndWaitForStateWithDedupeStatuses("HttpLongRunningOrchestrator", runningId, "Running", dedupeStatuses);
-        var suspendedFirst = StartAndWaitForStateWithDedupeStatuses("HttpLongRunningOrchestrator", suspendedId, "Running", dedupeStatuses);
+        var terminatedFirst = StartAndWaitForStateWithDedupeStatuses(longRunningOrch, terminatedId, "Running", dedupeStatuses);
+        var runningFirst = StartAndWaitForStateWithDedupeStatuses(longRunningOrch, runningId, "Running", dedupeStatuses);
+        var suspendedFirst = StartAndWaitForStateWithDedupeStatuses(longRunningOrch, suspendedId, "Running", dedupeStatuses);
         var pendingFirst = StartAndWaitForStateWithDedupeStatuses(
             "HelloCities", pendingId, "Pending", dedupeStatuses, scheduledStartTime: DateTime.UtcNow.AddMinutes(10));
         await Task.WhenAll(completedFirst, failedFirst, terminatedFirst, runningFirst, suspendedFirst, pendingFirst);
@@ -113,20 +131,26 @@ public class DedupeStatusesTests
             TerminateAndWaitForState(terminatedId, terminatedFirst.Result),
             SuspendAndWaitForState(suspendedId, suspendedFirst.Result));
 
+        // Dispose Phase 1 responses
+        foreach (var t in new Task<HttpResponseMessage>[] { completedFirst, failedFirst, terminatedFirst, runningFirst, suspendedFirst, pendingFirst })
+            (await t)?.Dispose();
+
         // Phase 3: Start all second-attempt orchestrations concurrently (check dedupe behavior)
-        await Task.WhenAll(
+        var phase3 = await Task.WhenAll(
             StartAndWaitForStateWithDedupeStatuses("HelloCities", completedId, "Completed", dedupeStatuses,
                 expectedCode: dedupeStatuses.Contains("Completed") ? HttpStatusCode.Conflict : HttpStatusCode.Accepted),
             StartAndWaitForStateWithDedupeStatuses("LargeOutputOrchestrator", failedId, "Failed", dedupeStatuses,
                 expectedCode: dedupeStatuses.Contains("Failed") ? HttpStatusCode.Conflict : HttpStatusCode.Accepted),
-            StartAndWaitForStateWithDedupeStatuses("HttpLongRunningOrchestrator", terminatedId, "Running", dedupeStatuses,
+            StartAndWaitForStateWithDedupeStatuses(longRunningOrch, terminatedId, "Running", dedupeStatuses,
                 expectedCode: dedupeStatuses.Contains("Terminated") ? HttpStatusCode.Conflict : HttpStatusCode.Accepted),
-            StartAndWaitForStateWithDedupeStatuses("HttpLongRunningOrchestrator", runningId, "Running", dedupeStatuses,
+            StartAndWaitForStateWithDedupeStatuses(longRunningOrch, runningId, "Running", dedupeStatuses,
                 expectedCode: dedupeStatuses.Contains("Running") ? HttpStatusCode.Conflict : HttpStatusCode.Accepted),
-            StartAndWaitForStateWithDedupeStatuses("HttpLongRunningOrchestrator", suspendedId, "Running", dedupeStatuses,
+            StartAndWaitForStateWithDedupeStatuses(longRunningOrch, suspendedId, "Running", dedupeStatuses,
                 expectedCode: dedupeStatuses.Contains("Suspended") ? HttpStatusCode.Conflict : HttpStatusCode.Accepted),
             StartAndWaitForStateWithDedupeStatuses("HelloCities", pendingId, "Completed", dedupeStatuses,
                 expectedCode: dedupeStatuses.Contains("Pending") ? HttpStatusCode.Conflict : HttpStatusCode.Accepted));
+        foreach (var r in phase3)
+            r?.Dispose();
 
         // Phase 4: Clean up running orchestrations concurrently
         var cleanups = new List<Task<HttpResponseMessage>>
@@ -136,7 +160,11 @@ public class DedupeStatusesTests
         };
         if (!dedupeStatuses.Contains("Terminated"))
             cleanups.Add(HttpHelpers.InvokeHttpTrigger("TerminateInstance", $"?instanceId={terminatedId}"));
-        await Task.WhenAll(cleanups);
+        foreach (var r in await Task.WhenAll(cleanups))
+        {
+            Assert.Equal(HttpStatusCode.OK, r.StatusCode);
+            r.Dispose();
+        }
     }
 
     [Theory]

--- a/test/e2e/Tests/Tests/DedupeStatusesTests.cs
+++ b/test/e2e/Tests/Tests/DedupeStatusesTests.cs
@@ -57,17 +57,17 @@ public class DedupeStatusesTests
         // Phase 2: Apply state transitions concurrently
         var transitions = new List<Task>();
         if (testTerminated)
-            transitions.Add(TerminateAndWaitForState(terminatedId, terminatedFirst.Result));
-        transitions.Add(SuspendAndWaitForState(suspendedId, suspendedFirst.Result));
+            transitions.Add(TerminateAndWaitForState(terminatedId, await terminatedFirst));
+        transitions.Add(SuspendAndWaitForState(suspendedId, await suspendedFirst));
         await Task.WhenAll(transitions);
 
         // Dispose Phase 1 responses (no longer needed after extracting statusQueryGetUri)
-        completedFirst.Result?.Dispose();
-        failedFirst.Result?.Dispose();
-        runningFirst.Result?.Dispose();
-        suspendedFirst.Result?.Dispose();
-        terminatedFirst.Result?.Dispose();
-        pendingFirst.Result?.Dispose();
+        (await completedFirst)?.Dispose();
+        (await failedFirst)?.Dispose();
+        (await runningFirst)?.Dispose();
+        (await suspendedFirst)?.Dispose();
+        (await terminatedFirst)?.Dispose();
+        (await pendingFirst)?.Dispose();
 
         // Phase 3: Start all second-attempt orchestrations concurrently (verify restart works)
         var phase3Tasks = new List<Task<HttpResponseMessage>>
@@ -131,8 +131,8 @@ public class DedupeStatusesTests
 
         // Phase 2: Apply state transitions concurrently
         await Task.WhenAll(
-            TerminateAndWaitForState(terminatedId, terminatedFirst.Result),
-            SuspendAndWaitForState(suspendedId, suspendedFirst.Result));
+            TerminateAndWaitForState(terminatedId, await terminatedFirst),
+            SuspendAndWaitForState(suspendedId, await suspendedFirst));
 
         // Dispose Phase 1 responses
         foreach (var t in new Task<HttpResponseMessage>[] { completedFirst, failedFirst, terminatedFirst, runningFirst, suspendedFirst, pendingFirst })

--- a/test/e2e/Tests/Tests/DedupeStatusesTests.cs
+++ b/test/e2e/Tests/Tests/DedupeStatusesTests.cs
@@ -34,10 +34,6 @@ public class DedupeStatusesTests
             ? "HttpLongRunningOrchestrator"
             : "LongRunningOrchestrator";
 
-        // Only parallelize long-running orchestration starts for dotnet-isolated (uses lightweight timer).
-        // Non-dotnet languages use LongRunningOrchestrator (100K activities) which overwhelms the host if parallelized.
-        bool canParallelize = this.fixture.functionLanguageLocalizer.GetLanguageType() == LanguageType.DotnetIsolated;
-
         string completedId = Guid.NewGuid().ToString();
         string failedId = Guid.NewGuid().ToString();
         string terminatedId = Guid.NewGuid().ToString();
@@ -45,73 +41,48 @@ public class DedupeStatusesTests
         string suspendedId = Guid.NewGuid().ToString();
         string pendingId = Guid.NewGuid().ToString();
 
-        // Phase 1: Start first-attempt orchestrations
-        // Fast orchestrations (HelloCities, LargeOutputOrchestrator) always run concurrently.
-        // Long-running orchestrations are parallelized only for dotnet-isolated.
-        using var completedFirst = await StartAndWaitForState("HelloCities", completedId, "Completed");
-        using var failedFirst = await StartAndWaitForState("LargeOutputOrchestrator", failedId, "Failed");
-
-        HttpResponseMessage? runningFirst, suspendedFirst, terminatedFirst, pendingFirst;
-        if (canParallelize)
-        {
-            var longTasks = new List<Task<HttpResponseMessage>>
-            {
-                StartAndWaitForState(longRunningOrch, runningId, "Running"),
-                StartAndWaitForState(longRunningOrch, suspendedId, "Running"),
-            };
-            if (testTerminated) longTasks.Add(StartAndWaitForState(longRunningOrch, terminatedId, "Running"));
-            var longResults = await Task.WhenAll(longTasks);
-            runningFirst = longResults[0];
-            suspendedFirst = longResults[1];
-            terminatedFirst = testTerminated ? longResults[2] : null;
-        }
-        else
-        {
-            runningFirst = await StartAndWaitForState(longRunningOrch, runningId, "Running");
-            suspendedFirst = await StartAndWaitForState(longRunningOrch, suspendedId, "Running");
-            terminatedFirst = testTerminated ? await StartAndWaitForState(longRunningOrch, terminatedId, "Running") : null;
-        }
-        pendingFirst = testPending
-            ? await StartAndWaitForState("HelloCities", pendingId, "Pending", scheduledStartTime: DateTime.UtcNow.AddMinutes(10))
-            : null;
+        // Phase 1: Start all first-attempt orchestrations and wait for initial states concurrently
+        var completedFirst = StartAndWaitForState("HelloCities", completedId, "Completed");
+        var failedFirst = StartAndWaitForState("LargeOutputOrchestrator", failedId, "Failed");
+        var runningFirst = StartAndWaitForState(longRunningOrch, runningId, "Running");
+        var suspendedFirst = StartAndWaitForState(longRunningOrch, suspendedId, "Running");
+        var terminatedFirst = testTerminated
+            ? StartAndWaitForState(longRunningOrch, terminatedId, "Running")
+            : Task.FromResult<HttpResponseMessage>(null!);
+        var pendingFirst = testPending
+            ? StartAndWaitForState("HelloCities", pendingId, "Pending", scheduledStartTime: DateTime.UtcNow.AddMinutes(10))
+            : Task.FromResult<HttpResponseMessage>(null!);
+        await Task.WhenAll(completedFirst, failedFirst, runningFirst, suspendedFirst, terminatedFirst, pendingFirst);
 
         // Phase 2: Apply state transitions concurrently
         var transitions = new List<Task>();
         if (testTerminated)
-            transitions.Add(TerminateAndWaitForState(terminatedId, terminatedFirst!));
-        transitions.Add(SuspendAndWaitForState(suspendedId, suspendedFirst));
+            transitions.Add(TerminateAndWaitForState(terminatedId, terminatedFirst.Result));
+        transitions.Add(SuspendAndWaitForState(suspendedId, suspendedFirst.Result));
         await Task.WhenAll(transitions);
 
-        // Dispose Phase 1 responses
-        runningFirst?.Dispose();
-        suspendedFirst?.Dispose();
-        terminatedFirst?.Dispose();
-        pendingFirst?.Dispose();
+        // Dispose Phase 1 responses (no longer needed after extracting statusQueryGetUri)
+        completedFirst.Result?.Dispose();
+        failedFirst.Result?.Dispose();
+        runningFirst.Result?.Dispose();
+        suspendedFirst.Result?.Dispose();
+        terminatedFirst.Result?.Dispose();
+        pendingFirst.Result?.Dispose();
 
-        // Phase 3: Start second-attempt orchestrations
-        if (canParallelize)
+        // Phase 3: Start all second-attempt orchestrations concurrently (verify restart works)
+        var phase3Tasks = new List<Task<HttpResponseMessage>>
         {
-            var phase3Tasks = new List<Task<HttpResponseMessage>>
-            {
-                StartAndWaitForState("HelloCities", completedId, "Completed"),
-                StartAndWaitForState("LargeOutputOrchestrator", failedId, "Failed"),
-                StartAndWaitForState(longRunningOrch, runningId, "Running"),
-                StartAndWaitForState(longRunningOrch, suspendedId, "Running"),
-            };
-            if (testTerminated) phase3Tasks.Add(StartAndWaitForState(longRunningOrch, terminatedId, "Running"));
-            if (testPending) phase3Tasks.Add(StartAndWaitForState("HelloCities", pendingId, "Completed"));
-            foreach (var r in await Task.WhenAll(phase3Tasks))
-                r?.Dispose();
-        }
-        else
-        {
-            using var _ = await StartAndWaitForState("HelloCities", completedId, "Completed");
-            using var __ = await StartAndWaitForState("LargeOutputOrchestrator", failedId, "Failed");
-            using var ___ = await StartAndWaitForState(longRunningOrch, runningId, "Running");
-            using var ____ = await StartAndWaitForState(longRunningOrch, suspendedId, "Running");
-            if (testTerminated) (await StartAndWaitForState(longRunningOrch, terminatedId, "Running")).Dispose();
-            if (testPending) (await StartAndWaitForState("HelloCities", pendingId, "Completed")).Dispose();
-        }
+            StartAndWaitForState("HelloCities", completedId, "Completed"),
+            StartAndWaitForState("LargeOutputOrchestrator", failedId, "Failed"),
+            StartAndWaitForState(longRunningOrch, runningId, "Running"),
+            StartAndWaitForState(longRunningOrch, suspendedId, "Running"),
+        };
+        if (testTerminated)
+            phase3Tasks.Add(StartAndWaitForState(longRunningOrch, terminatedId, "Running"));
+        if (testPending)
+            phase3Tasks.Add(StartAndWaitForState("HelloCities", pendingId, "Completed"));
+        foreach (var r in await Task.WhenAll(phase3Tasks))
+            r?.Dispose();
 
         // Phase 4: Clean up running orchestrations concurrently
         var cleanups = new List<Task<HttpResponseMessage>>

--- a/test/e2e/Tests/Tests/DedupeStatusesTests.cs
+++ b/test/e2e/Tests/Tests/DedupeStatusesTests.cs
@@ -34,6 +34,10 @@ public class DedupeStatusesTests
             ? "HttpLongRunningOrchestrator"
             : "LongRunningOrchestrator";
 
+        // Only parallelize long-running orchestration starts for dotnet-isolated (uses lightweight timer).
+        // Non-dotnet languages use LongRunningOrchestrator (100K activities) which overwhelms the host if parallelized.
+        bool canParallelize = this.fixture.functionLanguageLocalizer.GetLanguageType() == LanguageType.DotnetIsolated;
+
         string completedId = Guid.NewGuid().ToString();
         string failedId = Guid.NewGuid().ToString();
         string terminatedId = Guid.NewGuid().ToString();
@@ -41,48 +45,73 @@ public class DedupeStatusesTests
         string suspendedId = Guid.NewGuid().ToString();
         string pendingId = Guid.NewGuid().ToString();
 
-        // Phase 1: Start all first-attempt orchestrations and wait for initial states concurrently
-        var completedFirst = StartAndWaitForState("HelloCities", completedId, "Completed");
-        var failedFirst = StartAndWaitForState("LargeOutputOrchestrator", failedId, "Failed");
-        var runningFirst = StartAndWaitForState(longRunningOrch, runningId, "Running");
-        var suspendedFirst = StartAndWaitForState(longRunningOrch, suspendedId, "Running");
-        var terminatedFirst = testTerminated
-            ? StartAndWaitForState(longRunningOrch, terminatedId, "Running")
-            : Task.FromResult<HttpResponseMessage>(null!);
-        var pendingFirst = testPending
-            ? StartAndWaitForState("HelloCities", pendingId, "Pending", scheduledStartTime: DateTime.UtcNow.AddMinutes(10))
-            : Task.FromResult<HttpResponseMessage>(null!);
-        await Task.WhenAll(completedFirst, failedFirst, runningFirst, suspendedFirst, terminatedFirst, pendingFirst);
+        // Phase 1: Start first-attempt orchestrations
+        // Fast orchestrations (HelloCities, LargeOutputOrchestrator) always run concurrently.
+        // Long-running orchestrations are parallelized only for dotnet-isolated.
+        using var completedFirst = await StartAndWaitForState("HelloCities", completedId, "Completed");
+        using var failedFirst = await StartAndWaitForState("LargeOutputOrchestrator", failedId, "Failed");
+
+        HttpResponseMessage? runningFirst, suspendedFirst, terminatedFirst, pendingFirst;
+        if (canParallelize)
+        {
+            var longTasks = new List<Task<HttpResponseMessage>>
+            {
+                StartAndWaitForState(longRunningOrch, runningId, "Running"),
+                StartAndWaitForState(longRunningOrch, suspendedId, "Running"),
+            };
+            if (testTerminated) longTasks.Add(StartAndWaitForState(longRunningOrch, terminatedId, "Running"));
+            var longResults = await Task.WhenAll(longTasks);
+            runningFirst = longResults[0];
+            suspendedFirst = longResults[1];
+            terminatedFirst = testTerminated ? longResults[2] : null;
+        }
+        else
+        {
+            runningFirst = await StartAndWaitForState(longRunningOrch, runningId, "Running");
+            suspendedFirst = await StartAndWaitForState(longRunningOrch, suspendedId, "Running");
+            terminatedFirst = testTerminated ? await StartAndWaitForState(longRunningOrch, terminatedId, "Running") : null;
+        }
+        pendingFirst = testPending
+            ? await StartAndWaitForState("HelloCities", pendingId, "Pending", scheduledStartTime: DateTime.UtcNow.AddMinutes(10))
+            : null;
 
         // Phase 2: Apply state transitions concurrently
         var transitions = new List<Task>();
         if (testTerminated)
-            transitions.Add(TerminateAndWaitForState(terminatedId, terminatedFirst.Result));
-        transitions.Add(SuspendAndWaitForState(suspendedId, suspendedFirst.Result));
+            transitions.Add(TerminateAndWaitForState(terminatedId, terminatedFirst!));
+        transitions.Add(SuspendAndWaitForState(suspendedId, suspendedFirst));
         await Task.WhenAll(transitions);
 
-        // Dispose Phase 1 responses (no longer needed after extracting statusQueryGetUri)
-        completedFirst.Result?.Dispose();
-        failedFirst.Result?.Dispose();
-        runningFirst.Result?.Dispose();
-        suspendedFirst.Result?.Dispose();
-        terminatedFirst.Result?.Dispose();
-        pendingFirst.Result?.Dispose();
+        // Dispose Phase 1 responses
+        runningFirst?.Dispose();
+        suspendedFirst?.Dispose();
+        terminatedFirst?.Dispose();
+        pendingFirst?.Dispose();
 
-        // Phase 3: Start all second-attempt orchestrations concurrently (verify restart works)
-        var phase3Tasks = new List<Task<HttpResponseMessage>>
+        // Phase 3: Start second-attempt orchestrations
+        if (canParallelize)
         {
-            StartAndWaitForState("HelloCities", completedId, "Completed"),
-            StartAndWaitForState("LargeOutputOrchestrator", failedId, "Failed"),
-            StartAndWaitForState(longRunningOrch, runningId, "Running"),
-            StartAndWaitForState(longRunningOrch, suspendedId, "Running"),
-        };
-        if (testTerminated)
-            phase3Tasks.Add(StartAndWaitForState(longRunningOrch, terminatedId, "Running"));
-        if (testPending)
-            phase3Tasks.Add(StartAndWaitForState("HelloCities", pendingId, "Completed"));
-        foreach (var r in await Task.WhenAll(phase3Tasks))
-            r?.Dispose();
+            var phase3Tasks = new List<Task<HttpResponseMessage>>
+            {
+                StartAndWaitForState("HelloCities", completedId, "Completed"),
+                StartAndWaitForState("LargeOutputOrchestrator", failedId, "Failed"),
+                StartAndWaitForState(longRunningOrch, runningId, "Running"),
+                StartAndWaitForState(longRunningOrch, suspendedId, "Running"),
+            };
+            if (testTerminated) phase3Tasks.Add(StartAndWaitForState(longRunningOrch, terminatedId, "Running"));
+            if (testPending) phase3Tasks.Add(StartAndWaitForState("HelloCities", pendingId, "Completed"));
+            foreach (var r in await Task.WhenAll(phase3Tasks))
+                r?.Dispose();
+        }
+        else
+        {
+            using var _ = await StartAndWaitForState("HelloCities", completedId, "Completed");
+            using var __ = await StartAndWaitForState("LargeOutputOrchestrator", failedId, "Failed");
+            using var ___ = await StartAndWaitForState(longRunningOrch, runningId, "Running");
+            using var ____ = await StartAndWaitForState(longRunningOrch, suspendedId, "Running");
+            if (testTerminated) (await StartAndWaitForState(longRunningOrch, terminatedId, "Running")).Dispose();
+            if (testPending) (await StartAndWaitForState("HelloCities", pendingId, "Completed")).Dispose();
+        }
 
         // Phase 4: Clean up running orchestrations concurrently
         var cleanups = new List<Task<HttpResponseMessage>>

--- a/test/e2e/Tests/Tests/DedupeStatusesTests.cs
+++ b/test/e2e/Tests/Tests/DedupeStatusesTests.cs
@@ -22,75 +22,64 @@ public class DedupeStatusesTests
     [Fact]
     public async Task CanStartOrchestration_WithSameId_ForAllStatuses_ForEmptyDedupeStatuses()
     {
-        HttpResponseMessage terminateResponse;
+        bool testTerminated = this.fixture.functionLanguageLocalizer.GetLanguageType() != LanguageType.Java
+            || this.fixture.GetDurabilityProvider() != FunctionAppFixture.ConfiguredDurabilityProviderType.MSSQL;
+        bool testPending = this.fixture.functionLanguageLocalizer.GetLanguageType() == LanguageType.DotnetIsolated
+            || this.fixture.functionLanguageLocalizer.GetLanguageType() == LanguageType.Java;
 
-        // Completed
-        string completedInstanceId = Guid.NewGuid().ToString();
-        using HttpResponseMessage startCompletedResponseFirstAttempt = await StartAndWaitForState(
-            "HelloCities", completedInstanceId, "Completed");
-        using HttpResponseMessage startCompletedResponseSecondAttempt = await StartAndWaitForState(
-            "HelloCities", completedInstanceId, "Completed");
+        string completedId = Guid.NewGuid().ToString();
+        string failedId = Guid.NewGuid().ToString();
+        string terminatedId = Guid.NewGuid().ToString();
+        string runningId = Guid.NewGuid().ToString();
+        string suspendedId = Guid.NewGuid().ToString();
+        string pendingId = Guid.NewGuid().ToString();
 
-        // Failed
-        // This invocation will fail because the "LargeOutputOrchestrator" expects a non-zero input, but we provide none
-        string failedInstanceId = Guid.NewGuid().ToString();
-        using HttpResponseMessage startFailedResponseFirstAttempt = await StartAndWaitForState(
-            "LargeOutputOrchestrator", failedInstanceId, "Failed");
-        using HttpResponseMessage startFailedResponseSecondAttempt = await StartAndWaitForState(
-            "LargeOutputOrchestrator", failedInstanceId, "Failed");
+        // Phase 1: Start all first-attempt orchestrations and wait for initial states concurrently
+        var completedFirst = StartAndWaitForState("HelloCities", completedId, "Completed");
+        var failedFirst = StartAndWaitForState("LargeOutputOrchestrator", failedId, "Failed");
+        var runningFirst = StartAndWaitForState("HttpLongRunningOrchestrator", runningId, "Running");
+        var suspendedFirst = StartAndWaitForState("HttpLongRunningOrchestrator", suspendedId, "Running");
+        var terminatedFirst = testTerminated
+            ? StartAndWaitForState("HttpLongRunningOrchestrator", terminatedId, "Running")
+            : Task.FromResult<HttpResponseMessage>(null!);
+        var pendingFirst = testPending
+            ? StartAndWaitForState("HelloCities", pendingId, "Pending", scheduledStartTime: DateTime.UtcNow.AddMinutes(10))
+            : Task.FromResult<HttpResponseMessage>(null!);
+        await Task.WhenAll(completedFirst, failedFirst, runningFirst, suspendedFirst, terminatedFirst, pendingFirst);
 
-        // Terminated
-        if (this.fixture.functionLanguageLocalizer.GetLanguageType() != LanguageType.Java
-            || this.fixture.GetDurabilityProvider() != FunctionAppFixture.ConfiguredDurabilityProviderType.MSSQL) // Bug: https://github.com/microsoft/durabletask-java/issues/237
+        // Phase 2: Apply state transitions concurrently
+        var transitions = new List<Task>();
+        if (testTerminated)
+            transitions.Add(TerminateAndWaitForState(terminatedId, terminatedFirst.Result));
+        transitions.Add(SuspendAndWaitForState(suspendedId, suspendedFirst.Result));
+        await Task.WhenAll(transitions);
+
+        // Phase 3: Start all second-attempt orchestrations concurrently (verify restart works)
+        var completedSecond = StartAndWaitForState("HelloCities", completedId, "Completed");
+        var failedSecond = StartAndWaitForState("LargeOutputOrchestrator", failedId, "Failed");
+        var runningSecond = StartAndWaitForState("HttpLongRunningOrchestrator", runningId, "Running");
+        var suspendedSecond = StartAndWaitForState("HttpLongRunningOrchestrator", suspendedId, "Running");
+        var terminatedSecond = testTerminated
+            ? StartAndWaitForState("HttpLongRunningOrchestrator", terminatedId, "Running")
+            : Task.CompletedTask;
+        var pendingSecond = testPending
+            ? StartAndWaitForState("HelloCities", pendingId, "Completed")
+            : Task.CompletedTask;
+        await Task.WhenAll(completedSecond, failedSecond, runningSecond, suspendedSecond, terminatedSecond, pendingSecond);
+
+        // Phase 4: Clean up running orchestrations concurrently
+        var cleanups = new List<Task<HttpResponseMessage>>
         {
-            string terminatedInstanceId = Guid.NewGuid().ToString();
-            using HttpResponseMessage startTerminatedResponseFirstAttempt = await StartAndWaitForState(
-                "LongRunningOrchestrator", terminatedInstanceId, "Running");
-            await TerminateAndWaitForState(terminatedInstanceId, startTerminatedResponseFirstAttempt);
-            using HttpResponseMessage startTerminatedResponseSecondAttempt = await StartAndWaitForState(
-                "LongRunningOrchestrator", terminatedInstanceId, "Running");
-            // Clean-up
-            terminateResponse = await HttpHelpers.InvokeHttpTrigger("TerminateInstance", $"?instanceId={terminatedInstanceId}");
-            Assert.Equal(HttpStatusCode.OK, terminateResponse.StatusCode);
-            terminateResponse.Dispose();
-        }
-
-        // Pending
-        // Scheduled start times are currently only implemented in Java and .NET isolated, which is the only true way
-        // to get an orchestration in a "Pending" state
-        if (this.fixture.functionLanguageLocalizer.GetLanguageType() == LanguageType.DotnetIsolated
-            || this.fixture.functionLanguageLocalizer.GetLanguageType() == LanguageType.Java)
+            HttpHelpers.InvokeHttpTrigger("TerminateInstance", $"?instanceId={runningId}"),
+            HttpHelpers.InvokeHttpTrigger("TerminateInstance", $"?instanceId={suspendedId}"),
+        };
+        if (testTerminated)
+            cleanups.Add(HttpHelpers.InvokeHttpTrigger("TerminateInstance", $"?instanceId={terminatedId}"));
+        foreach (var r in await Task.WhenAll(cleanups))
         {
-            string pendingInstanceId = Guid.NewGuid().ToString();
-            DateTime scheduledStartTime = DateTime.UtcNow.AddMinutes(10);
-            using HttpResponseMessage startPendingResponseFirstAttempt = await StartAndWaitForState(
-                "HelloCities", pendingInstanceId, "Pending", scheduledStartTime: scheduledStartTime);
-            using HttpResponseMessage startPendingResponseSecondAttempt = await StartAndWaitForState(
-                "HelloCities", pendingInstanceId, "Completed");
+            Assert.Equal(HttpStatusCode.OK, r.StatusCode);
+            r.Dispose();
         }
-
-        // Running
-        string runningInstanceId = Guid.NewGuid().ToString();
-        using HttpResponseMessage startRunningResponseFirstAttempt = await StartAndWaitForState(
-            "LongRunningOrchestrator", runningInstanceId, "Running");
-        using HttpResponseMessage startRunningResponseSecondAttempt = await StartAndWaitForState(
-            "LongRunningOrchestrator", runningInstanceId, "Running");
-        // Clean-up
-        terminateResponse = await HttpHelpers.InvokeHttpTrigger("TerminateInstance", $"?instanceId={runningInstanceId}");
-        Assert.Equal(HttpStatusCode.OK, terminateResponse.StatusCode);
-        terminateResponse.Dispose();
-
-        // Suspended
-        string suspendedInstanceId = Guid.NewGuid().ToString();
-        using HttpResponseMessage startSuspendedResponseFirstAttempt = await StartAndWaitForState(
-            "LongRunningOrchestrator", suspendedInstanceId, "Running");
-        await SuspendAndWaitForState(suspendedInstanceId, startSuspendedResponseFirstAttempt);
-        using HttpResponseMessage startSuspendedResponseSecondAttempt = await StartAndWaitForState(
-            "LongRunningOrchestrator", suspendedInstanceId, "Running");
-        // Clean-up
-        terminateResponse = await HttpHelpers.InvokeHttpTrigger("TerminateInstance", $"?instanceId={suspendedInstanceId}");
-        Assert.Equal(HttpStatusCode.OK, terminateResponse.StatusCode);
-        terminateResponse.Dispose();
     }
 
     [Theory]
@@ -102,99 +91,59 @@ public class DedupeStatusesTests
     [InlineData("Pending", "Failed")]
     public async Task StartOrchestration_WithSameId_FailsIfExistingStatus_InDedupeStatuses(params string[] dedupeStatuses)
     {
-        HttpResponseMessage terminateResponse;
+        string completedId = Guid.NewGuid().ToString();
+        string failedId = Guid.NewGuid().ToString();
+        string terminatedId = Guid.NewGuid().ToString();
+        string runningId = Guid.NewGuid().ToString();
+        string suspendedId = Guid.NewGuid().ToString();
+        string pendingId = Guid.NewGuid().ToString();
 
-        // Completed
-        string completedInstanceId = Guid.NewGuid().ToString();
-        using HttpResponseMessage startCompletedResponseFirstAttempt = await StartAndWaitForStateWithDedupeStatuses(
-            "HelloCities", completedInstanceId, "Completed", dedupeStatuses);
-        using HttpResponseMessage startCompletedResponseSecondAttempt = await StartAndWaitForStateWithDedupeStatuses(
-            "HelloCities",
-            completedInstanceId,
-            "Completed",
-            dedupeStatuses,
-            expectedCode: dedupeStatuses.Contains("Completed") ? HttpStatusCode.Conflict : HttpStatusCode.Accepted);
+        // Phase 1: Start all first-attempt orchestrations concurrently
+        var completedFirst = StartAndWaitForStateWithDedupeStatuses("HelloCities", completedId, "Completed", dedupeStatuses);
+        var failedFirst = StartAndWaitForStateWithDedupeStatuses("LargeOutputOrchestrator", failedId, "Failed", dedupeStatuses);
+        var terminatedFirst = StartAndWaitForStateWithDedupeStatuses("HttpLongRunningOrchestrator", terminatedId, "Running", dedupeStatuses);
+        var runningFirst = StartAndWaitForStateWithDedupeStatuses("HttpLongRunningOrchestrator", runningId, "Running", dedupeStatuses);
+        var suspendedFirst = StartAndWaitForStateWithDedupeStatuses("HttpLongRunningOrchestrator", suspendedId, "Running", dedupeStatuses);
+        var pendingFirst = StartAndWaitForStateWithDedupeStatuses(
+            "HelloCities", pendingId, "Pending", dedupeStatuses, scheduledStartTime: DateTime.UtcNow.AddMinutes(10));
+        await Task.WhenAll(completedFirst, failedFirst, terminatedFirst, runningFirst, suspendedFirst, pendingFirst);
 
-        // Terminated
-        string terminatedInstanceId = Guid.NewGuid().ToString();
-        using HttpResponseMessage startTerminatedResponseFirstAttempt = await StartAndWaitForStateWithDedupeStatuses(
-            "LongRunningOrchestrator", terminatedInstanceId, "Running", dedupeStatuses);
-        await TerminateAndWaitForState(terminatedInstanceId, startTerminatedResponseFirstAttempt);
-        using HttpResponseMessage startTerminatedResponseSecondAttempt = await StartAndWaitForStateWithDedupeStatuses(
-            "LongRunningOrchestrator",
-            terminatedInstanceId,
-            "Running",
-            dedupeStatuses,
-            expectedCode: dedupeStatuses.Contains("Terminated") ? HttpStatusCode.Conflict : HttpStatusCode.Accepted);
-        // Clean-up
-        if (!dedupeStatuses.Contains("Terminated"))
+        // Phase 2: Apply state transitions concurrently
+        await Task.WhenAll(
+            TerminateAndWaitForState(terminatedId, terminatedFirst.Result),
+            SuspendAndWaitForState(suspendedId, suspendedFirst.Result));
+
+        // Phase 3: Start all second-attempt orchestrations concurrently (check dedupe behavior)
+        await Task.WhenAll(
+            StartAndWaitForStateWithDedupeStatuses("HelloCities", completedId, "Completed", dedupeStatuses,
+                expectedCode: dedupeStatuses.Contains("Completed") ? HttpStatusCode.Conflict : HttpStatusCode.Accepted),
+            StartAndWaitForStateWithDedupeStatuses("LargeOutputOrchestrator", failedId, "Failed", dedupeStatuses,
+                expectedCode: dedupeStatuses.Contains("Failed") ? HttpStatusCode.Conflict : HttpStatusCode.Accepted),
+            StartAndWaitForStateWithDedupeStatuses("HttpLongRunningOrchestrator", terminatedId, "Running", dedupeStatuses,
+                expectedCode: dedupeStatuses.Contains("Terminated") ? HttpStatusCode.Conflict : HttpStatusCode.Accepted),
+            StartAndWaitForStateWithDedupeStatuses("HttpLongRunningOrchestrator", runningId, "Running", dedupeStatuses,
+                expectedCode: dedupeStatuses.Contains("Running") ? HttpStatusCode.Conflict : HttpStatusCode.Accepted),
+            StartAndWaitForStateWithDedupeStatuses("HttpLongRunningOrchestrator", suspendedId, "Running", dedupeStatuses,
+                expectedCode: dedupeStatuses.Contains("Suspended") ? HttpStatusCode.Conflict : HttpStatusCode.Accepted),
+            StartAndWaitForStateWithDedupeStatuses("HelloCities", pendingId, "Completed", dedupeStatuses,
+                expectedCode: dedupeStatuses.Contains("Pending") ? HttpStatusCode.Conflict : HttpStatusCode.Accepted));
+
+        // Phase 4: Clean up running orchestrations concurrently
+        var cleanups = new List<Task<HttpResponseMessage>>
         {
-            terminateResponse = await HttpHelpers.InvokeHttpTrigger("TerminateInstance", $"?instanceId={terminatedInstanceId}");
-            Assert.Equal(HttpStatusCode.OK, terminateResponse.StatusCode);
-            terminateResponse.Dispose();
-        }
-
-        // Failed
-        // This invocation will fail because the "LargeOutputOrchestrator" expects a non-zero input, but we provide none
-        string failedInstanceId = Guid.NewGuid().ToString();
-        using HttpResponseMessage startFailedResponseFirstAttempt = await StartAndWaitForStateWithDedupeStatuses(
-            "LargeOutputOrchestrator", failedInstanceId, "Failed", dedupeStatuses);
-        using HttpResponseMessage startFailedResponseSecondAttempt = await StartAndWaitForStateWithDedupeStatuses(
-            "LargeOutputOrchestrator",
-            failedInstanceId,
-            "Failed",
-            dedupeStatuses,
-            expectedCode: dedupeStatuses.Contains("Failed") ? HttpStatusCode.Conflict : HttpStatusCode.Accepted);
-
-        // Pending
-        string pendingInstanceId = Guid.NewGuid().ToString();
-        DateTime scheduledStartTime = DateTime.UtcNow.AddMinutes(10);
-        using HttpResponseMessage startPendingResponseFirstAttempt = await StartAndWaitForStateWithDedupeStatuses(
-            "HelloCities", pendingInstanceId, "Pending", dedupeStatuses, scheduledStartTime: scheduledStartTime);
-        using HttpResponseMessage startPendingResponseSecondAttempt = await StartAndWaitForStateWithDedupeStatuses(
-            "HelloCities",
-            pendingInstanceId,
-            "Completed",
-            dedupeStatuses,
-            expectedCode: dedupeStatuses.Contains("Pending") ? HttpStatusCode.Conflict : HttpStatusCode.Accepted);
-
-        // Running
-        string runningInstanceId = Guid.NewGuid().ToString();
-        using HttpResponseMessage startRunningResponseFirstAttempt = await StartAndWaitForStateWithDedupeStatuses(
-            "LongRunningOrchestrator", runningInstanceId, "Running", dedupeStatuses);
-        using HttpResponseMessage startRunningResponseSecondAttempt = await StartAndWaitForStateWithDedupeStatuses(
-            "LongRunningOrchestrator",
-            runningInstanceId,
-            expectedState: "Running",
-            dedupeStatuses,
-            expectedCode: dedupeStatuses.Contains("Running") ? HttpStatusCode.Conflict : HttpStatusCode.Accepted);
-        // Clean-up
-        terminateResponse = await HttpHelpers.InvokeHttpTrigger("TerminateInstance", $"?instanceId={runningInstanceId}");
-        Assert.Equal(HttpStatusCode.OK, terminateResponse.StatusCode);
-        terminateResponse.Dispose();
-
-        // Suspended
-        string suspendedInstanceId = Guid.NewGuid().ToString();
-        using HttpResponseMessage startSuspendedResponseFirstAttempt = await StartAndWaitForStateWithDedupeStatuses(
-            "LongRunningOrchestrator", suspendedInstanceId, "Running", dedupeStatuses);
-        await SuspendAndWaitForState(suspendedInstanceId, startSuspendedResponseFirstAttempt);
-        using HttpResponseMessage startSuspendedResponseSecondAttempt = await StartAndWaitForStateWithDedupeStatuses(
-            "LongRunningOrchestrator",
-            suspendedInstanceId,
-            "Running",
-            dedupeStatuses,
-            expectedCode: dedupeStatuses.Contains("Suspended") ? HttpStatusCode.Conflict : HttpStatusCode.Accepted);
-        // Clean-up
-        terminateResponse = await HttpHelpers.InvokeHttpTrigger("TerminateInstance", $"?instanceId={suspendedInstanceId}");
-        Assert.Equal(HttpStatusCode.OK, terminateResponse.StatusCode);
-        terminateResponse.Dispose();
+            HttpHelpers.InvokeHttpTrigger("TerminateInstance", $"?instanceId={runningId}"),
+            HttpHelpers.InvokeHttpTrigger("TerminateInstance", $"?instanceId={suspendedId}"),
+        };
+        if (!dedupeStatuses.Contains("Terminated"))
+            cleanups.Add(HttpHelpers.InvokeHttpTrigger("TerminateInstance", $"?instanceId={terminatedId}"));
+        await Task.WhenAll(cleanups);
     }
 
     [Theory]
-    [Trait("PowerShell", "Skip")] // Dedupe statuses not implemented in PowerShell
-    [Trait("Python", "Skip")] // Dedupe statuses not implemented in Python
-    [Trait("Node", "Skip")] // Dedupe statuses not implemented in Node
-    [Trait("Java", "Skip")] // Dedupe statuses not implemented in Java
+    [Trait("PowerShell", "Skip")]
+    [Trait("Python", "Skip")]
+    [Trait("Node", "Skip")]
+    [Trait("Java", "Skip")]
     [InlineData("Pending", "Failed", "Terminated")]
     [InlineData("Running", "Failed", "Terminated")]
     [InlineData("Suspended", "Failed", "Terminated")]

--- a/test/e2e/Tests/Tests/DedupeStatusesTests.cs
+++ b/test/e2e/Tests/Tests/DedupeStatusesTests.cs
@@ -28,8 +28,7 @@ public class DedupeStatusesTests
             || this.fixture.functionLanguageLocalizer.GetLanguageType() == LanguageType.Java;
 
         // HttpLongRunningOrchestrator (timer-based, no activity spam) is only available in dotnet-isolated.
-        // For other languages, LongRunningOrchestrator is used. Its activity load is isolated because
-        // each language runs in its own CI job with a dedicated emulator instance.
+        // For other languages, LongRunningOrchestrator is used for this test scenario.
         string longRunningOrch = this.fixture.functionLanguageLocalizer.GetLanguageType() == LanguageType.DotnetIsolated
             ? "HttpLongRunningOrchestrator"
             : "LongRunningOrchestrator";
@@ -42,13 +41,20 @@ public class DedupeStatusesTests
         string pendingId = Guid.NewGuid().ToString();
 
         // Phase 1: Start all first-attempt orchestrations and wait for initial states concurrently
+        // Completed
         var completedFirst = StartAndWaitForState("HelloCities", completedId, "Completed");
+        // Failed — "LargeOutputOrchestrator" expects a non-zero input, but we provide none
         var failedFirst = StartAndWaitForState("LargeOutputOrchestrator", failedId, "Failed");
+        // Running
         var runningFirst = StartAndWaitForState(longRunningOrch, runningId, "Running");
+        // Suspended (starts as Running, transitioned in Phase 2)
         var suspendedFirst = StartAndWaitForState(longRunningOrch, suspendedId, "Running");
+        // Terminated (starts as Running, transitioned in Phase 2)
         var terminatedFirst = testTerminated
             ? StartAndWaitForState(longRunningOrch, terminatedId, "Running")
             : Task.FromResult<HttpResponseMessage>(null!);
+        // Pending — scheduled start times are currently only implemented in Java and .NET isolated,
+        // which is the only true way to get an orchestration in a "Pending" state
         var pendingFirst = testPending
             ? StartAndWaitForState("HelloCities", pendingId, "Pending", scheduledStartTime: DateTime.UtcNow.AddMinutes(10))
             : Task.FromResult<HttpResponseMessage>(null!);
@@ -72,13 +78,19 @@ public class DedupeStatusesTests
         // Phase 3: Start all second-attempt orchestrations concurrently (verify restart works)
         var phase3Tasks = new List<Task<HttpResponseMessage>>
         {
+            // Completed
             StartAndWaitForState("HelloCities", completedId, "Completed"),
+            // Failed — "LargeOutputOrchestrator" expects a non-zero input, but we provide none
             StartAndWaitForState("LargeOutputOrchestrator", failedId, "Failed"),
+            // Running
             StartAndWaitForState(longRunningOrch, runningId, "Running"),
+            // Suspended
             StartAndWaitForState(longRunningOrch, suspendedId, "Running"),
         };
+        // Terminated
         if (testTerminated)
             phase3Tasks.Add(StartAndWaitForState(longRunningOrch, terminatedId, "Running"));
+        // Pending
         if (testPending)
             phase3Tasks.Add(StartAndWaitForState("HelloCities", pendingId, "Completed"));
         foreach (var r in await Task.WhenAll(phase3Tasks))
@@ -96,7 +108,14 @@ public class DedupeStatusesTests
             cleanups.Add(HttpHelpers.InvokeHttpTrigger("TerminateInstance", $"?instanceId={pendingId}"));
         foreach (var r in await Task.WhenAll(cleanups))
         {
-            r.Dispose();
+            using (r)
+            {
+                if (r.StatusCode != HttpStatusCode.OK)
+                {
+                    this.output.WriteLine(
+                        $"TerminateInstance cleanup returned status code {r.StatusCode} for request {r.RequestMessage?.RequestUri}");
+                }
+            }
         }
     }
 
@@ -120,11 +139,17 @@ public class DedupeStatusesTests
         string pendingId = Guid.NewGuid().ToString();
 
         // Phase 1: Start all first-attempt orchestrations concurrently
+        // Completed
         var completedFirst = StartAndWaitForStateWithDedupeStatuses("HelloCities", completedId, "Completed", dedupeStatuses);
+        // Failed — "LargeOutputOrchestrator" expects a non-zero input, but we provide none
         var failedFirst = StartAndWaitForStateWithDedupeStatuses("LargeOutputOrchestrator", failedId, "Failed", dedupeStatuses);
+        // Terminated (starts as Running, transitioned in Phase 2)
         var terminatedFirst = StartAndWaitForStateWithDedupeStatuses(longRunningOrch, terminatedId, "Running", dedupeStatuses);
+        // Running
         var runningFirst = StartAndWaitForStateWithDedupeStatuses(longRunningOrch, runningId, "Running", dedupeStatuses);
+        // Suspended (starts as Running, transitioned in Phase 2)
         var suspendedFirst = StartAndWaitForStateWithDedupeStatuses(longRunningOrch, suspendedId, "Running", dedupeStatuses);
+        // Pending
         var pendingFirst = StartAndWaitForStateWithDedupeStatuses(
             "HelloCities", pendingId, "Pending", dedupeStatuses, scheduledStartTime: DateTime.UtcNow.AddMinutes(10));
         await Task.WhenAll(completedFirst, failedFirst, terminatedFirst, runningFirst, suspendedFirst, pendingFirst);
@@ -140,16 +165,22 @@ public class DedupeStatusesTests
 
         // Phase 3: Start all second-attempt orchestrations concurrently (check dedupe behavior)
         var phase3 = await Task.WhenAll(
+            // Completed
             StartAndWaitForStateWithDedupeStatuses("HelloCities", completedId, "Completed", dedupeStatuses,
                 expectedCode: dedupeStatuses.Contains("Completed") ? HttpStatusCode.Conflict : HttpStatusCode.Accepted),
+            // Failed — "LargeOutputOrchestrator" expects a non-zero input, but we provide none
             StartAndWaitForStateWithDedupeStatuses("LargeOutputOrchestrator", failedId, "Failed", dedupeStatuses,
                 expectedCode: dedupeStatuses.Contains("Failed") ? HttpStatusCode.Conflict : HttpStatusCode.Accepted),
+            // Terminated
             StartAndWaitForStateWithDedupeStatuses(longRunningOrch, terminatedId, "Running", dedupeStatuses,
                 expectedCode: dedupeStatuses.Contains("Terminated") ? HttpStatusCode.Conflict : HttpStatusCode.Accepted),
+            // Running
             StartAndWaitForStateWithDedupeStatuses(longRunningOrch, runningId, "Running", dedupeStatuses,
                 expectedCode: dedupeStatuses.Contains("Running") ? HttpStatusCode.Conflict : HttpStatusCode.Accepted),
+            // Suspended
             StartAndWaitForStateWithDedupeStatuses(longRunningOrch, suspendedId, "Running", dedupeStatuses,
                 expectedCode: dedupeStatuses.Contains("Suspended") ? HttpStatusCode.Conflict : HttpStatusCode.Accepted),
+            // Pending
             StartAndWaitForStateWithDedupeStatuses("HelloCities", pendingId, "Completed", dedupeStatuses,
                 expectedCode: dedupeStatuses.Contains("Pending") ? HttpStatusCode.Conflict : HttpStatusCode.Accepted));
         foreach (var r in phase3)
@@ -166,7 +197,14 @@ public class DedupeStatusesTests
             cleanups.Add(HttpHelpers.InvokeHttpTrigger("TerminateInstance", $"?instanceId={terminatedId}"));
         foreach (var r in await Task.WhenAll(cleanups))
         {
-            r.Dispose();
+            using (r)
+            {
+                if (r.StatusCode != HttpStatusCode.OK)
+                {
+                    this.output.WriteLine(
+                        $"TerminateInstance cleanup returned status code {r.StatusCode} for request {r.RequestMessage?.RequestUri}");
+                }
+            }
         }
     }
 

--- a/test/e2e/Tests/Tests/DedupeStatusesTests.cs
+++ b/test/e2e/Tests/Tests/DedupeStatusesTests.cs
@@ -171,10 +171,10 @@ public class DedupeStatusesTests
     }
 
     [Theory]
-    [Trait("PowerShell", "Skip")]
-    [Trait("Python", "Skip")]
-    [Trait("Node", "Skip")]
-    [Trait("Java", "Skip")]
+    [Trait("PowerShell", "Skip")] // Dedupe statuses not implemented in PowerShell
+    [Trait("Python", "Skip")] // Dedupe statuses not implemented in Python
+    [Trait("Node", "Skip")] // Dedupe statuses not implemented in Node
+    [Trait("Java", "Skip")] // Dedupe statuses not implemented in Java
     [InlineData("Pending", "Failed", "Terminated")]
     [InlineData("Running", "Failed", "Terminated")]
     [InlineData("Suspended", "Failed", "Terminated")]

--- a/test/e2e/Tests/Tests/DedupeStatusesTests.cs
+++ b/test/e2e/Tests/Tests/DedupeStatusesTests.cs
@@ -27,7 +27,9 @@ public class DedupeStatusesTests
         bool testPending = this.fixture.functionLanguageLocalizer.GetLanguageType() == LanguageType.DotnetIsolated
             || this.fixture.functionLanguageLocalizer.GetLanguageType() == LanguageType.Java;
 
-        // HttpLongRunningOrchestrator (timer-based, no activity spam) is only available in dotnet-isolated
+        // HttpLongRunningOrchestrator (timer-based, no activity spam) is only available in dotnet-isolated.
+        // For other languages, LongRunningOrchestrator is used. Its activity load is isolated because
+        // each language runs in its own CI job with a dedicated emulator instance.
         string longRunningOrch = this.fixture.functionLanguageLocalizer.GetLanguageType() == LanguageType.DotnetIsolated
             ? "HttpLongRunningOrchestrator"
             : "LongRunningOrchestrator";

--- a/test/e2e/Tests/Tests/DedupeStatusesTests.cs
+++ b/test/e2e/Tests/Tests/DedupeStatusesTests.cs
@@ -157,12 +157,12 @@ public class DedupeStatusesTests
         {
             HttpHelpers.InvokeHttpTrigger("TerminateInstance", $"?instanceId={runningId}"),
             HttpHelpers.InvokeHttpTrigger("TerminateInstance", $"?instanceId={suspendedId}"),
+            HttpHelpers.InvokeHttpTrigger("TerminateInstance", $"?instanceId={pendingId}"),
         };
         if (!dedupeStatuses.Contains("Terminated"))
             cleanups.Add(HttpHelpers.InvokeHttpTrigger("TerminateInstance", $"?instanceId={terminatedId}"));
         foreach (var r in await Task.WhenAll(cleanups))
         {
-            Assert.Equal(HttpStatusCode.OK, r.StatusCode);
             r.Dispose();
         }
     }

--- a/test/e2e/Tests/Tests/DedupeStatusesTests.cs
+++ b/test/e2e/Tests/Tests/DedupeStatusesTests.cs
@@ -84,7 +84,7 @@ public class DedupeStatusesTests
         foreach (var r in await Task.WhenAll(phase3Tasks))
             r?.Dispose();
 
-        // Phase 4: Clean up running orchestrations concurrently
+        // Phase 4: Clean up non-terminal orchestrations concurrently
         var cleanups = new List<Task<HttpResponseMessage>>
         {
             HttpHelpers.InvokeHttpTrigger("TerminateInstance", $"?instanceId={runningId}"),
@@ -92,9 +92,10 @@ public class DedupeStatusesTests
         };
         if (testTerminated)
             cleanups.Add(HttpHelpers.InvokeHttpTrigger("TerminateInstance", $"?instanceId={terminatedId}"));
+        if (testPending)
+            cleanups.Add(HttpHelpers.InvokeHttpTrigger("TerminateInstance", $"?instanceId={pendingId}"));
         foreach (var r in await Task.WhenAll(cleanups))
         {
-            Assert.Equal(HttpStatusCode.OK, r.StatusCode);
             r.Dispose();
         }
     }

--- a/test/e2e/Tests/Tests/PurgeInstancesTests.cs
+++ b/test/e2e/Tests/Tests/PurgeInstancesTests.cs
@@ -149,7 +149,9 @@ public class PurgeInstancesTests
         bool testPending = this.fixture.functionLanguageLocalizer.GetLanguageType() == LanguageType.DotnetIsolated
             || this.fixture.functionLanguageLocalizer.GetLanguageType() == LanguageType.Java;
 
-        // HttpLongRunningOrchestrator (timer-based, no activity spam) is only available in dotnet-isolated
+        // HttpLongRunningOrchestrator (timer-based, no activity spam) is only available in dotnet-isolated.
+        // For other languages, LongRunningOrchestrator is used. Its activity load is isolated because
+        // each language runs in its own CI job with a dedicated emulator instance.
         string longRunningOrch = this.fixture.functionLanguageLocalizer.GetLanguageType() == LanguageType.DotnetIsolated
             ? "HttpLongRunningOrchestrator"
             : "LongRunningOrchestrator";
@@ -227,7 +229,8 @@ public class PurgeInstancesTests
             completedId,
             this.fixture.functionLanguageLocalizer.GetLanguageType());
 
-        // Clean up non-terminal instances to avoid background load on subsequent tests
+        // Clean up non-terminal instances to avoid background load on subsequent tests.
+        // Terminate may fail for some instances (e.g., already completed), so just log and dispose.
         var cleanups = new List<Task<HttpResponseMessage>>
         {
             HttpHelpers.InvokeHttpTrigger("TerminateInstance", $"?instanceId={runningId}"),
@@ -236,7 +239,11 @@ public class PurgeInstancesTests
         if (testPending)
             cleanups.Add(HttpHelpers.InvokeHttpTrigger("TerminateInstance", $"?instanceId={(await pendingStart!).instanceId}"));
         foreach (var r in await Task.WhenAll(cleanups))
+        {
+            // Best-effort cleanup: log status but don't fail the test if terminate returns non-OK
+            // (instance may have already completed or been purged)
             r.Dispose();
+        }
     }
 
     private async Task<(string instanceId, string statusUri)> StartOrchAndWaitForStatus(

--- a/test/e2e/Tests/Tests/PurgeInstancesTests.cs
+++ b/test/e2e/Tests/Tests/PurgeInstancesTests.cs
@@ -132,9 +132,6 @@ public class PurgeInstancesTests
     [Trait("PowerShell", "Skip")] // Instance purging not supported in PowerShell
     public async Task PurgeOnlyPurgesTerminalOrchestrations()
     {
-        // For all of the following tests, since non-.NET languages throw a generic error in the case of a failure to purge there is no great way 
-        // to return specific status codes, whereas .NET isolated returns specific error types which can be used to return specific status codes.
-        // So, in the non-.NET case, we simply check for the InternalServerError status code.
         void AssertFailedPurgeResponseStatusCode(HttpResponseMessage purgeHttpResponse)
         {
             if (this.fixture.functionLanguageLocalizer.GetLanguageType() == LanguageType.DotnetIsolated)
@@ -147,107 +144,117 @@ public class PurgeInstancesTests
             }
         }
 
-        // Completed orchestration, should succeed
-        using HttpResponseMessage startCompletedOrchestrationResponse = await HttpHelpers.InvokeHttpTrigger(
-            "StartOrchestration",
-            "?orchestrationName=HelloCities");
-        Assert.Equal(HttpStatusCode.Accepted, startCompletedOrchestrationResponse.StatusCode);
-        string completedInstanceId = await DurableHelpers.ParseInstanceIdAsync(startCompletedOrchestrationResponse);
-        string completedStatusQueryGetUri = await DurableHelpers.ParseStatusQueryGetUriAsync(startCompletedOrchestrationResponse);
-        await DurableHelpers.WaitForOrchestrationStateAsync(completedStatusQueryGetUri, "Completed", 30);
-        HttpResponseMessage purgeCompleted = await HttpHelpers.InvokeHttpTrigger("PurgeOrchestrationHistory", $"?instanceId={completedInstanceId}");
-        Assert.Equal(HttpStatusCode.OK, purgeCompleted.StatusCode);
-        await AssertPurgeCount(purgeCompleted, 1);
+        bool testTerminated = this.fixture.functionLanguageLocalizer.GetLanguageType() != LanguageType.Java
+            || this.fixture.GetDurabilityProvider() != FunctionAppFixture.ConfiguredDurabilityProviderType.MSSQL;
+        bool testPending = this.fixture.functionLanguageLocalizer.GetLanguageType() == LanguageType.DotnetIsolated
+            || this.fixture.functionLanguageLocalizer.GetLanguageType() == LanguageType.Java;
 
-        // Verify that the ClientOperationReceived logs were emitted with a FunctionInvocationId
-        ClientOperationLogHelpers.AssertClientOperationLogExists(
-            () => this.fixture.TestLogs.CoreToolsLogs,
-            "StartOrchestration",
-            completedInstanceId,
-            this.fixture.functionLanguageLocalizer.GetLanguageType());
-        ClientOperationLogHelpers.AssertClientOperationLogExists(
-            () => this.fixture.TestLogs.CoreToolsLogs,
-            "PurgeInstances",
-            completedInstanceId,
-            this.fixture.functionLanguageLocalizer.GetLanguageType());
+        // Phase 1: Start all orchestrations and wait for initial states concurrently
+        var completedStart = StartOrchAndWaitForStatus("HelloCities", "Completed");
+        var failedStart = StartOrchAndWaitForStatus("HelloActivityDIFailure", "Failed");
+        var terminatedStart = testTerminated ? StartOrchAndWaitForStatus("HttpLongRunningOrchestrator", "Running") : null;
+        var runningStart = StartOrchAndWaitForStatus("HttpLongRunningOrchestrator", "Running");
+        var suspendedStart = StartOrchAndWaitForStatus("HttpLongRunningOrchestrator", "Running");
+        Task<(string instanceId, string statusUri)>? pendingStart = testPending
+            ? StartOrchAndWaitForStatus("HelloCities", "Pending", scheduledStartTime: DateTime.UtcNow + TimeSpan.FromMinutes(1))
+            : null;
 
-        // Terminated orchestration, should succeed
-        if (this.fixture.functionLanguageLocalizer.GetLanguageType() != LanguageType.Java
-            || this.fixture.GetDurabilityProvider() != FunctionAppFixture.ConfiguredDurabilityProviderType.MSSQL) // Bug: https://github.com/microsoft/durabletask-java/issues/237
+        var phase1Tasks = new List<Task> { completedStart, failedStart, runningStart, suspendedStart };
+        if (terminatedStart != null) phase1Tasks.Add(terminatedStart);
+        if (pendingStart != null) phase1Tasks.Add(pendingStart);
+        await Task.WhenAll(phase1Tasks);
+
+        // Phase 2: Apply transitions concurrently (terminate, suspend)
+        var transitions = new List<Task>();
+        if (testTerminated)
         {
-            using HttpResponseMessage startTerminatedOrchestrationResponse = await HttpHelpers.InvokeHttpTrigger(
-                "StartOrchestration",
-                "?orchestrationName=LongRunningOrchestrator");
-            Assert.Equal(HttpStatusCode.Accepted, startTerminatedOrchestrationResponse.StatusCode);
-            string terminatedInstanceId = await DurableHelpers.ParseInstanceIdAsync(startTerminatedOrchestrationResponse);
-            string terminatedStatusQueryGetUri = await DurableHelpers.ParseStatusQueryGetUriAsync(startTerminatedOrchestrationResponse);
-            await DurableHelpers.WaitForOrchestrationStateAsync(terminatedStatusQueryGetUri, "Running", 30);
-            using HttpResponseMessage terminateResponse = await HttpHelpers.InvokeHttpTrigger("TerminateInstance", $"?instanceId={terminatedInstanceId}");
-            Assert.Equal(HttpStatusCode.OK, terminateResponse.StatusCode);
-            await DurableHelpers.WaitForOrchestrationStateAsync(terminatedStatusQueryGetUri, "Terminated", 30);
-            using HttpResponseMessage purgeTerminated = await HttpHelpers.InvokeHttpTrigger("PurgeOrchestrationHistory", $"?instanceId={terminatedInstanceId}");
-            Assert.Equal(HttpStatusCode.OK, purgeTerminated.StatusCode);
-            await AssertPurgeCount(purgeTerminated, 1);
+            var (termId, termUri) = await terminatedStart!;
+            transitions.Add(TerminateAndWaitForStatus(termId, termUri));
         }
+        var (suspId, suspUri) = await suspendedStart;
+        transitions.Add(SuspendAndWaitForStatus(suspId, suspUri));
+        await Task.WhenAll(transitions);
 
-        // Failed orchestration, should succeed
-        using HttpResponseMessage startFailedOrchestrationResponse = await HttpHelpers.InvokeHttpTrigger(
-            "StartOrchestration",
-            "?orchestrationName=HelloActivityDIFailure");
-        Assert.Equal(HttpStatusCode.Accepted, startFailedOrchestrationResponse.StatusCode);
-        string failedInstanceId = await DurableHelpers.ParseInstanceIdAsync(startFailedOrchestrationResponse);
-        string failedStatusQueryGetUri = await DurableHelpers.ParseStatusQueryGetUriAsync(startFailedOrchestrationResponse);
-        await DurableHelpers.WaitForOrchestrationStateAsync(failedStatusQueryGetUri, "Failed", 30);
-        using HttpResponseMessage purgeFailed = await HttpHelpers.InvokeHttpTrigger("PurgeOrchestrationHistory", $"?instanceId={failedInstanceId}");
-        Assert.Equal(HttpStatusCode.OK, purgeFailed.StatusCode);
-        await AssertPurgeCount(purgeFailed, 1);
+        // Phase 3: Test purge behavior — terminal states should succeed, non-terminal should fail
+        var (completedId, _) = await completedStart;
+        var (failedId, _) = await failedStart;
+        var (runningId, _) = await runningStart;
 
-        // Non-existent orchestration, should succeed and have purge count of 0
+        // Terminal state purges (can run concurrently)
+        var terminalPurgeTasks = new List<Task>();
+        terminalPurgeTasks.Add(AssertPurgeSucceeds(completedId));
+        if (testTerminated)
+            terminalPurgeTasks.Add(AssertPurgeSucceeds((await terminatedStart!).instanceId));
+        terminalPurgeTasks.Add(AssertPurgeSucceeds(failedId));
+        await Task.WhenAll(terminalPurgeTasks);
+
+        // Non-existent orchestration
         using HttpResponseMessage purgeNonExistent = await HttpHelpers.InvokeHttpTrigger("PurgeOrchestrationHistory", $"?instanceId={Guid.NewGuid()}");
         Assert.Equal(HttpStatusCode.OK, purgeNonExistent.StatusCode);
         await AssertPurgeCount(purgeNonExistent, 0);
 
-        // Running orchestration, should fail
-        using HttpResponseMessage startRunningOrchestrationResponse = await HttpHelpers.InvokeHttpTrigger(
-            "StartOrchestration",
-            "?orchestrationName=LongRunningOrchestrator");
-        Assert.Equal(HttpStatusCode.Accepted, startRunningOrchestrationResponse.StatusCode);
-        string runningInstanceId = await DurableHelpers.ParseInstanceIdAsync(startRunningOrchestrationResponse);
-        string runningStatusQueryGetUri = await DurableHelpers.ParseStatusQueryGetUriAsync(startRunningOrchestrationResponse);
-        await DurableHelpers.WaitForOrchestrationStateAsync(runningStatusQueryGetUri, "Running", 30);
-        using HttpResponseMessage purgeRunning = await HttpHelpers.InvokeHttpTrigger("PurgeOrchestrationHistory", $"?instanceId={runningInstanceId}");
-        AssertFailedPurgeResponseStatusCode(purgeRunning);
-
-        // Pending orchestration, should fail
-        // Scheduled start times are currently only implemented in Java and .NET isolated, which is the only true way to get an orchestration in a "Pending" state
-        if (this.fixture.functionLanguageLocalizer.GetLanguageType() == LanguageType.DotnetIsolated
-            || this.fixture.functionLanguageLocalizer.GetLanguageType() == LanguageType.Java)
+        // Non-terminal state purges should fail (can run concurrently)
+        var nonTerminalPurgeTasks = new List<Task<HttpResponseMessage>>
         {
-            DateTime scheduledStartTime = DateTime.UtcNow + TimeSpan.FromMinutes(1);
-            using HttpResponseMessage startPendingOrchestrationResponse = await HttpHelpers.InvokeHttpTrigger(
-                "HelloCities_HttpStart_Scheduled",
-                $"?ScheduledStartTime={scheduledStartTime:o}");
-            Assert.Equal(HttpStatusCode.Accepted, startPendingOrchestrationResponse.StatusCode);
-            string pendingInstanceId = await DurableHelpers.ParseInstanceIdAsync(startPendingOrchestrationResponse);
-            string pendingStatusQueryGetUri = await DurableHelpers.ParseStatusQueryGetUriAsync(startPendingOrchestrationResponse);
-            await DurableHelpers.WaitForOrchestrationStateAsync(pendingStatusQueryGetUri, "Pending", 30);
-            using HttpResponseMessage purgePending = await HttpHelpers.InvokeHttpTrigger("PurgeOrchestrationHistory", $"?instanceId={pendingInstanceId}");
-            AssertFailedPurgeResponseStatusCode(purgePending);
+            HttpHelpers.InvokeHttpTrigger("PurgeOrchestrationHistory", $"?instanceId={runningId}"),
+            HttpHelpers.InvokeHttpTrigger("PurgeOrchestrationHistory", $"?instanceId={suspId}"),
+        };
+        if (testPending)
+            nonTerminalPurgeTasks.Add(HttpHelpers.InvokeHttpTrigger("PurgeOrchestrationHistory", $"?instanceId={(await pendingStart!).instanceId}"));
+        foreach (var response in await Task.WhenAll(nonTerminalPurgeTasks))
+            AssertFailedPurgeResponseStatusCode(response);
+
+        // Verify log assertions for the completed instance
+        ClientOperationLogHelpers.AssertClientOperationLogExists(
+            () => this.fixture.TestLogs.CoreToolsLogs,
+            "StartOrchestration",
+            completedId,
+            this.fixture.functionLanguageLocalizer.GetLanguageType());
+        ClientOperationLogHelpers.AssertClientOperationLogExists(
+            () => this.fixture.TestLogs.CoreToolsLogs,
+            "PurgeInstances",
+            completedId,
+            this.fixture.functionLanguageLocalizer.GetLanguageType());
+    }
+
+    private async Task<(string instanceId, string statusUri)> StartOrchAndWaitForStatus(
+        string orchestrationName, string targetStatus, DateTime? scheduledStartTime = null)
+    {
+        string functionName = "StartOrchestration";
+        string queryParams = $"?orchestrationName={orchestrationName}";
+        if (scheduledStartTime is not null)
+        {
+            functionName = "HelloCities_HttpStart_Scheduled";
+            queryParams = $"?ScheduledStartTime={scheduledStartTime:o}";
         }
 
-        // Suspended orchestration, should fail
-        using HttpResponseMessage startSuspendedOrchestrationResponse = await HttpHelpers.InvokeHttpTrigger(
-            "StartOrchestration",
-            "?orchestrationName=LongRunningOrchestrator");
-        Assert.Equal(HttpStatusCode.Accepted, startSuspendedOrchestrationResponse.StatusCode);
-        string suspendedInstanceId = await DurableHelpers.ParseInstanceIdAsync(startSuspendedOrchestrationResponse);
-        string suspendedStatusQueryGetUri = await DurableHelpers.ParseStatusQueryGetUriAsync(startSuspendedOrchestrationResponse);
-        await DurableHelpers.WaitForOrchestrationStateAsync(suspendedStatusQueryGetUri, "Running", 30);
-        using HttpResponseMessage suspendResponse = await HttpHelpers.InvokeHttpTrigger("SuspendInstance", $"?instanceId={suspendedInstanceId}");
+        using var response = await HttpHelpers.InvokeHttpTrigger(functionName, queryParams);
+        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
+        string instanceId = await DurableHelpers.ParseInstanceIdAsync(response);
+        string statusUri = await DurableHelpers.ParseStatusQueryGetUriAsync(response);
+        await DurableHelpers.WaitForOrchestrationStateAsync(statusUri, targetStatus, 30);
+        return (instanceId, statusUri);
+    }
+
+    private async Task TerminateAndWaitForStatus(string instanceId, string statusUri)
+    {
+        using var terminateResponse = await HttpHelpers.InvokeHttpTrigger("TerminateInstance", $"?instanceId={instanceId}");
+        Assert.Equal(HttpStatusCode.OK, terminateResponse.StatusCode);
+        await DurableHelpers.WaitForOrchestrationStateAsync(statusUri, "Terminated", 30);
+    }
+
+    private async Task SuspendAndWaitForStatus(string instanceId, string statusUri)
+    {
+        using var suspendResponse = await HttpHelpers.InvokeHttpTrigger("SuspendInstance", $"?instanceId={instanceId}");
         Assert.Equal(HttpStatusCode.OK, suspendResponse.StatusCode);
-        await DurableHelpers.WaitForOrchestrationStateAsync(suspendedStatusQueryGetUri, "Suspended", 30);
-        using HttpResponseMessage purgeSuspended = await HttpHelpers.InvokeHttpTrigger("PurgeOrchestrationHistory", $"?instanceId={suspendedInstanceId}");
-        AssertFailedPurgeResponseStatusCode(purgeSuspended);
+        await DurableHelpers.WaitForOrchestrationStateAsync(statusUri, "Suspended", 30);
+    }
+
+    private async Task AssertPurgeSucceeds(string instanceId)
+    {
+        using var response = await HttpHelpers.InvokeHttpTrigger("PurgeOrchestrationHistory", $"?instanceId={instanceId}");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        await AssertPurgeCount(response, 1);
     }
 
     [Fact]

--- a/test/e2e/Tests/Tests/PurgeInstancesTests.cs
+++ b/test/e2e/Tests/Tests/PurgeInstancesTests.cs
@@ -149,12 +149,17 @@ public class PurgeInstancesTests
         bool testPending = this.fixture.functionLanguageLocalizer.GetLanguageType() == LanguageType.DotnetIsolated
             || this.fixture.functionLanguageLocalizer.GetLanguageType() == LanguageType.Java;
 
+        // HttpLongRunningOrchestrator (timer-based, no activity spam) is only available in dotnet-isolated
+        string longRunningOrch = this.fixture.functionLanguageLocalizer.GetLanguageType() == LanguageType.DotnetIsolated
+            ? "HttpLongRunningOrchestrator"
+            : "LongRunningOrchestrator";
+
         // Phase 1: Start all orchestrations and wait for initial states concurrently
         var completedStart = StartOrchAndWaitForStatus("HelloCities", "Completed");
         var failedStart = StartOrchAndWaitForStatus("HelloActivityDIFailure", "Failed");
-        var terminatedStart = testTerminated ? StartOrchAndWaitForStatus("HttpLongRunningOrchestrator", "Running") : null;
-        var runningStart = StartOrchAndWaitForStatus("HttpLongRunningOrchestrator", "Running");
-        var suspendedStart = StartOrchAndWaitForStatus("HttpLongRunningOrchestrator", "Running");
+        var terminatedStart = testTerminated ? StartOrchAndWaitForStatus(longRunningOrch, "Running") : null;
+        var runningStart = StartOrchAndWaitForStatus(longRunningOrch, "Running");
+        var suspendedStart = StartOrchAndWaitForStatus(longRunningOrch, "Running");
         Task<(string instanceId, string statusUri)>? pendingStart = testPending
             ? StartOrchAndWaitForStatus("HelloCities", "Pending", scheduledStartTime: DateTime.UtcNow + TimeSpan.FromMinutes(1))
             : null;
@@ -201,8 +206,14 @@ public class PurgeInstancesTests
         };
         if (testPending)
             nonTerminalPurgeTasks.Add(HttpHelpers.InvokeHttpTrigger("PurgeOrchestrationHistory", $"?instanceId={(await pendingStart!).instanceId}"));
-        foreach (var response in await Task.WhenAll(nonTerminalPurgeTasks))
-            AssertFailedPurgeResponseStatusCode(response);
+        var nonTerminalResponses = await Task.WhenAll(nonTerminalPurgeTasks);
+        foreach (var response in nonTerminalResponses)
+        {
+            using (response)
+            {
+                AssertFailedPurgeResponseStatusCode(response);
+            }
+        }
 
         // Verify log assertions for the completed instance
         ClientOperationLogHelpers.AssertClientOperationLogExists(
@@ -225,7 +236,7 @@ public class PurgeInstancesTests
         if (scheduledStartTime is not null)
         {
             functionName = "HelloCities_HttpStart_Scheduled";
-            queryParams = $"?ScheduledStartTime={scheduledStartTime:o}";
+            queryParams = $"?orchestrationName={orchestrationName}&ScheduledStartTime={scheduledStartTime:o}";
         }
 
         using var response = await HttpHelpers.InvokeHttpTrigger(functionName, queryParams);

--- a/test/e2e/Tests/Tests/PurgeInstancesTests.cs
+++ b/test/e2e/Tests/Tests/PurgeInstancesTests.cs
@@ -229,8 +229,8 @@ public class PurgeInstancesTests
             completedId,
             this.fixture.functionLanguageLocalizer.GetLanguageType());
 
-        // Clean up non-terminal instances to avoid background load on subsequent tests.
-        // Terminate may fail for some instances (e.g., already completed), so just log and dispose.
+        // Best-effort cleanup of non-terminal instances to avoid background load on subsequent tests.
+        // Terminate may return non-OK for already-completed or purged instances; just dispose.
         var cleanups = new List<Task<HttpResponseMessage>>
         {
             HttpHelpers.InvokeHttpTrigger("TerminateInstance", $"?instanceId={runningId}"),
@@ -239,11 +239,7 @@ public class PurgeInstancesTests
         if (testPending)
             cleanups.Add(HttpHelpers.InvokeHttpTrigger("TerminateInstance", $"?instanceId={(await pendingStart!).instanceId}"));
         foreach (var r in await Task.WhenAll(cleanups))
-        {
-            // Best-effort cleanup: log status but don't fail the test if terminate returns non-OK
-            // (instance may have already completed or been purged)
             r.Dispose();
-        }
     }
 
     private async Task<(string instanceId, string statusUri)> StartOrchAndWaitForStatus(

--- a/test/e2e/Tests/Tests/PurgeInstancesTests.cs
+++ b/test/e2e/Tests/Tests/PurgeInstancesTests.cs
@@ -226,6 +226,17 @@ public class PurgeInstancesTests
             "PurgeInstances",
             completedId,
             this.fixture.functionLanguageLocalizer.GetLanguageType());
+
+        // Clean up non-terminal instances to avoid background load on subsequent tests
+        var cleanups = new List<Task<HttpResponseMessage>>
+        {
+            HttpHelpers.InvokeHttpTrigger("TerminateInstance", $"?instanceId={runningId}"),
+            HttpHelpers.InvokeHttpTrigger("TerminateInstance", $"?instanceId={suspId}"),
+        };
+        if (testPending)
+            cleanups.Add(HttpHelpers.InvokeHttpTrigger("TerminateInstance", $"?instanceId={(await pendingStart!).instanceId}"));
+        foreach (var r in await Task.WhenAll(cleanups))
+            r.Dispose();
     }
 
     private async Task<(string instanceId, string statusUri)> StartOrchAndWaitForStatus(

--- a/test/e2e/Tests/Tests/PurgeInstancesTests.cs
+++ b/test/e2e/Tests/Tests/PurgeInstancesTests.cs
@@ -155,43 +155,21 @@ public class PurgeInstancesTests
         string longRunningOrch = this.fixture.functionLanguageLocalizer.GetLanguageType() == LanguageType.DotnetIsolated
             ? "HttpLongRunningOrchestrator"
             : "LongRunningOrchestrator";
-        bool canParallelize = this.fixture.functionLanguageLocalizer.GetLanguageType() == LanguageType.DotnetIsolated;
 
-        // Phase 1: Start orchestrations and wait for initial states.
-        // Fast orchestrations always run concurrently. Long-running ones are sequential for non-dotnet
-        // to avoid overwhelming the function host with 100K-activity LongRunningOrchestrator instances.
+        // Phase 1: Start all orchestrations and wait for initial states concurrently
         var completedStart = StartOrchAndWaitForStatus("HelloCities", "Completed");
         var failedStart = StartOrchAndWaitForStatus("HelloActivityDIFailure", "Failed");
-
-        Task<(string instanceId, string statusUri)>? terminatedStart, pendingStart;
-        (string instanceId, string statusUri) runningResult, suspendedResult;
-
-        if (canParallelize)
-        {
-            var longTasks = new List<Task<(string, string)>>
-            {
-                StartOrchAndWaitForStatus(longRunningOrch, "Running"),
-                StartOrchAndWaitForStatus(longRunningOrch, "Running"),
-            };
-            terminatedStart = testTerminated ? StartOrchAndWaitForStatus(longRunningOrch, "Running") : null;
-            if (terminatedStart != null) longTasks.Add(terminatedStart);
-            var longResults = await Task.WhenAll(longTasks);
-            runningResult = longResults[0];
-            suspendedResult = longResults[1];
-        }
-        else
-        {
-            runningResult = await StartOrchAndWaitForStatus(longRunningOrch, "Running");
-            suspendedResult = await StartOrchAndWaitForStatus(longRunningOrch, "Running");
-            terminatedStart = testTerminated ? StartOrchAndWaitForStatus(longRunningOrch, "Running") : null;
-            if (terminatedStart != null) await terminatedStart;
-        }
-        pendingStart = testPending
+        var terminatedStart = testTerminated ? StartOrchAndWaitForStatus(longRunningOrch, "Running") : null;
+        var runningStart = StartOrchAndWaitForStatus(longRunningOrch, "Running");
+        var suspendedStart = StartOrchAndWaitForStatus(longRunningOrch, "Running");
+        Task<(string instanceId, string statusUri)>? pendingStart = testPending
             ? StartOrchAndWaitForStatus("HelloCities", "Pending", scheduledStartTime: DateTime.UtcNow + TimeSpan.FromMinutes(1))
             : null;
 
-        // Ensure fast orchestrations are done
-        await Task.WhenAll(new[] { completedStart, failedStart, pendingStart! }.Where(t => t != null));
+        var phase1Tasks = new List<Task> { completedStart, failedStart, runningStart, suspendedStart };
+        if (terminatedStart != null) phase1Tasks.Add(terminatedStart);
+        if (pendingStart != null) phase1Tasks.Add(pendingStart);
+        await Task.WhenAll(phase1Tasks);
 
         // Phase 2: Apply transitions concurrently (terminate, suspend)
         var transitions = new List<Task>();
@@ -200,14 +178,14 @@ public class PurgeInstancesTests
             var (termId, termUri) = await terminatedStart!;
             transitions.Add(TerminateAndWaitForStatus(termId, termUri));
         }
-        var (suspId, suspUri) = suspendedResult;
+        var (suspId, suspUri) = await suspendedStart;
         transitions.Add(SuspendAndWaitForStatus(suspId, suspUri));
         await Task.WhenAll(transitions);
 
         // Phase 3: Test purge behavior — terminal states should succeed, non-terminal should fail
         var (completedId, _) = await completedStart;
         var (failedId, _) = await failedStart;
-        var (runningId, _) = runningResult;
+        var (runningId, _) = await runningStart;
 
         // Terminal state purges (can run concurrently)
         var terminalPurgeTasks = new List<Task>();

--- a/test/e2e/Tests/Tests/PurgeInstancesTests.cs
+++ b/test/e2e/Tests/Tests/PurgeInstancesTests.cs
@@ -155,21 +155,43 @@ public class PurgeInstancesTests
         string longRunningOrch = this.fixture.functionLanguageLocalizer.GetLanguageType() == LanguageType.DotnetIsolated
             ? "HttpLongRunningOrchestrator"
             : "LongRunningOrchestrator";
+        bool canParallelize = this.fixture.functionLanguageLocalizer.GetLanguageType() == LanguageType.DotnetIsolated;
 
-        // Phase 1: Start all orchestrations and wait for initial states concurrently
+        // Phase 1: Start orchestrations and wait for initial states.
+        // Fast orchestrations always run concurrently. Long-running ones are sequential for non-dotnet
+        // to avoid overwhelming the function host with 100K-activity LongRunningOrchestrator instances.
         var completedStart = StartOrchAndWaitForStatus("HelloCities", "Completed");
         var failedStart = StartOrchAndWaitForStatus("HelloActivityDIFailure", "Failed");
-        var terminatedStart = testTerminated ? StartOrchAndWaitForStatus(longRunningOrch, "Running") : null;
-        var runningStart = StartOrchAndWaitForStatus(longRunningOrch, "Running");
-        var suspendedStart = StartOrchAndWaitForStatus(longRunningOrch, "Running");
-        Task<(string instanceId, string statusUri)>? pendingStart = testPending
+
+        Task<(string instanceId, string statusUri)>? terminatedStart, pendingStart;
+        (string instanceId, string statusUri) runningResult, suspendedResult;
+
+        if (canParallelize)
+        {
+            var longTasks = new List<Task<(string, string)>>
+            {
+                StartOrchAndWaitForStatus(longRunningOrch, "Running"),
+                StartOrchAndWaitForStatus(longRunningOrch, "Running"),
+            };
+            terminatedStart = testTerminated ? StartOrchAndWaitForStatus(longRunningOrch, "Running") : null;
+            if (terminatedStart != null) longTasks.Add(terminatedStart);
+            var longResults = await Task.WhenAll(longTasks);
+            runningResult = longResults[0];
+            suspendedResult = longResults[1];
+        }
+        else
+        {
+            runningResult = await StartOrchAndWaitForStatus(longRunningOrch, "Running");
+            suspendedResult = await StartOrchAndWaitForStatus(longRunningOrch, "Running");
+            terminatedStart = testTerminated ? StartOrchAndWaitForStatus(longRunningOrch, "Running") : null;
+            if (terminatedStart != null) await terminatedStart;
+        }
+        pendingStart = testPending
             ? StartOrchAndWaitForStatus("HelloCities", "Pending", scheduledStartTime: DateTime.UtcNow + TimeSpan.FromMinutes(1))
             : null;
 
-        var phase1Tasks = new List<Task> { completedStart, failedStart, runningStart, suspendedStart };
-        if (terminatedStart != null) phase1Tasks.Add(terminatedStart);
-        if (pendingStart != null) phase1Tasks.Add(pendingStart);
-        await Task.WhenAll(phase1Tasks);
+        // Ensure fast orchestrations are done
+        await Task.WhenAll(new[] { completedStart, failedStart, pendingStart! }.Where(t => t != null));
 
         // Phase 2: Apply transitions concurrently (terminate, suspend)
         var transitions = new List<Task>();
@@ -178,14 +200,14 @@ public class PurgeInstancesTests
             var (termId, termUri) = await terminatedStart!;
             transitions.Add(TerminateAndWaitForStatus(termId, termUri));
         }
-        var (suspId, suspUri) = await suspendedStart;
+        var (suspId, suspUri) = suspendedResult;
         transitions.Add(SuspendAndWaitForStatus(suspId, suspUri));
         await Task.WhenAll(transitions);
 
         // Phase 3: Test purge behavior — terminal states should succeed, non-terminal should fail
         var (completedId, _) = await completedStart;
         var (failedId, _) = await failedStart;
-        var (runningId, _) = await runningStart;
+        var (runningId, _) = runningResult;
 
         // Terminal state purges (can run concurrently)
         var terminalPurgeTasks = new List<Task>();

--- a/test/e2e/Tests/Tests/PurgeInstancesTests.cs
+++ b/test/e2e/Tests/Tests/PurgeInstancesTests.cs
@@ -132,6 +132,9 @@ public class PurgeInstancesTests
     [Trait("PowerShell", "Skip")] // Instance purging not supported in PowerShell
     public async Task PurgeOnlyPurgesTerminalOrchestrations()
     {
+        // For all of the following tests, since non-.NET languages throw a generic error in the case of a failure to purge there is no great way
+        // to return specific status codes, whereas .NET isolated returns specific error types which can be used to return specific status codes.
+        // So, in the non-.NET case, we simply check for the InternalServerError status code.
         void AssertFailedPurgeResponseStatusCode(HttpResponseMessage purgeHttpResponse)
         {
             if (this.fixture.functionLanguageLocalizer.GetLanguageType() == LanguageType.DotnetIsolated)
@@ -150,18 +153,26 @@ public class PurgeInstancesTests
             || this.fixture.functionLanguageLocalizer.GetLanguageType() == LanguageType.Java;
 
         // HttpLongRunningOrchestrator (timer-based, no activity spam) is only available in dotnet-isolated.
-        // For other languages, LongRunningOrchestrator is used. Its activity load is isolated because
-        // each language runs in its own CI job with a dedicated emulator instance.
+        // For other languages, LongRunningOrchestrator is used, which generates activity load against the
+        // configured durability provider.
         string longRunningOrch = this.fixture.functionLanguageLocalizer.GetLanguageType() == LanguageType.DotnetIsolated
             ? "HttpLongRunningOrchestrator"
             : "LongRunningOrchestrator";
 
         // Phase 1: Start all orchestrations and wait for initial states concurrently
+        // Completed orchestration, should succeed purge
         var completedStart = StartOrchAndWaitForStatus("HelloCities", "Completed");
+        // Failed orchestration, should succeed purge
         var failedStart = StartOrchAndWaitForStatus("HelloActivityDIFailure", "Failed");
+        // Terminated orchestration, should succeed purge
         var terminatedStart = testTerminated ? StartOrchAndWaitForStatus(longRunningOrch, "Running") : null;
+        // Running orchestration, should fail purge
         var runningStart = StartOrchAndWaitForStatus(longRunningOrch, "Running");
+        // Suspended orchestration, should fail purge
         var suspendedStart = StartOrchAndWaitForStatus(longRunningOrch, "Running");
+        // Pending orchestration, should fail purge
+        // Scheduled start times are currently only implemented in Java and .NET isolated,
+        // which is the only true way to get an orchestration in a "Pending" state
         Task<(string instanceId, string statusUri)>? pendingStart = testPending
             ? StartOrchAndWaitForStatus("HelloCities", "Pending", scheduledStartTime: DateTime.UtcNow + TimeSpan.FromMinutes(1))
             : null;
@@ -195,7 +206,7 @@ public class PurgeInstancesTests
         terminalPurgeTasks.Add(AssertPurgeSucceeds(failedId));
         await Task.WhenAll(terminalPurgeTasks);
 
-        // Non-existent orchestration
+        // Non-existent orchestration, should succeed and have purge count of 0
         using HttpResponseMessage purgeNonExistent = await HttpHelpers.InvokeHttpTrigger("PurgeOrchestrationHistory", $"?instanceId={Guid.NewGuid()}");
         Assert.Equal(HttpStatusCode.OK, purgeNonExistent.StatusCode);
         await AssertPurgeCount(purgeNonExistent, 0);
@@ -217,7 +228,7 @@ public class PurgeInstancesTests
             }
         }
 
-        // Verify log assertions for the completed instance
+        // Verify that the ClientOperationReceived logs were emitted with a FunctionInvocationId
         ClientOperationLogHelpers.AssertClientOperationLogExists(
             () => this.fixture.TestLogs.CoreToolsLogs,
             "StartOrchestration",
@@ -230,7 +241,7 @@ public class PurgeInstancesTests
             this.fixture.functionLanguageLocalizer.GetLanguageType());
 
         // Best-effort cleanup of non-terminal instances to avoid background load on subsequent tests.
-        // Terminate may return non-OK for already-completed or purged instances; just dispose.
+        // Terminate may return non-OK for already-completed or purged instances; log and dispose.
         var cleanups = new List<Task<HttpResponseMessage>>
         {
             HttpHelpers.InvokeHttpTrigger("TerminateInstance", $"?instanceId={runningId}"),
@@ -239,7 +250,16 @@ public class PurgeInstancesTests
         if (testPending)
             cleanups.Add(HttpHelpers.InvokeHttpTrigger("TerminateInstance", $"?instanceId={(await pendingStart!).instanceId}"));
         foreach (var r in await Task.WhenAll(cleanups))
-            r.Dispose();
+        {
+            using (r)
+            {
+                if (!r.IsSuccessStatusCode)
+                {
+                    this.output.WriteLine(
+                        $"TerminateInstance cleanup returned status {r.StatusCode} for request {r.RequestMessage?.RequestUri}");
+                }
+            }
+        }
     }
 
     private async Task<(string instanceId, string statusUri)> StartOrchAndWaitForStatus(

--- a/test/e2e/Tests/build-e2e-test.ps1
+++ b/test/e2e/Tests/build-e2e-test.ps1
@@ -287,9 +287,22 @@ function StartDTSContainer() {
       exit $LASTEXITCODE
   }
 
-  # The container needs a bit more time before it can start accepting commands
-  Write-Host "Sleeping for 30 seconds to let the container finish initializing..." -ForegroundColor Yellow
-  Start-Sleep -Seconds 30
+  # Poll the health endpoint instead of a fixed sleep
+  Write-Host "Waiting for DTS emulator to become ready..." -ForegroundColor Yellow
+  $maxAttempts = 30
+  for ($i = 1; $i -le $maxAttempts; $i++) {
+      try {
+          $response = Invoke-WebRequest -Uri "http://localhost:8081" -TimeoutSec 2 -ErrorAction SilentlyContinue
+          if ($response.StatusCode -eq 200) {
+              Write-Host "DTS emulator is ready after $i seconds." -ForegroundColor Green
+              break
+          }
+      } catch { }
+      if ($i -eq $maxAttempts) {
+          Write-Warning "DTS emulator did not become ready within $maxAttempts seconds. Proceeding anyway."
+      }
+      Start-Sleep -Seconds 1
+  }
 
   # Check to see what containers are running
   docker ps

--- a/test/e2e/Tests/build-e2e-test.ps1
+++ b/test/e2e/Tests/build-e2e-test.ps1
@@ -284,16 +284,6 @@ function StartMSSQLContainer($mssqlPwd) {
       Start-Sleep -Seconds 1
   }
 
-  # Pre-create the DurableDB database so all language runtimes can use it independently.
-  # Without this, non-dotnet languages may fail if they can't auto-create the database.
-  Write-Host "Creating DurableDB database..." -ForegroundColor Yellow
-  docker exec mssql-server /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "$mssqlPwd" -Q "IF NOT EXISTS (SELECT name FROM sys.databases WHERE name = 'DurableDB') CREATE DATABASE DurableDB" -C -b
-  if ($LASTEXITCODE -ne 0) {
-      Write-Error "Failed to create DurableDB database."
-      exit 1
-  }
-  Write-Host "DurableDB database created successfully." -ForegroundColor Green
-
   # Check to see what containers are running
   docker ps
 }

--- a/test/e2e/Tests/build-e2e-test.ps1
+++ b/test/e2e/Tests/build-e2e-test.ps1
@@ -294,7 +294,7 @@ function StartDTSContainer() {
 
   # Start the DTS Server docker container with the specified edition
   Write-Host "Starting DTS docker container on port 8080" -ForegroundColor DarkYellow
-  docker run -i -p 8080:8080 -p 8081:8081 -p 8082:8082 -d mcr.microsoft.com/dts/dts-emulator:latest
+  docker run -i --name dts-emulator --rm -p 8080:8080 -p 8081:8081 -p 8082:8082 -d mcr.microsoft.com/dts/dts-emulator:latest
 
   if ($LASTEXITCODE -ne 0) {
       exit $LASTEXITCODE
@@ -316,7 +316,7 @@ function StartDTSContainer() {
       } catch { }
       if ($i -eq $maxAttempts) {
           Write-Error "DTS emulator did not become ready within $maxAttempts seconds."
-          docker logs $(docker ps -q --filter "ancestor=mcr.microsoft.com/dts/dts-emulator:latest") 2>&1 | Select-Object -Last 20
+          docker logs dts-emulator 2>&1 | Select-Object -Last 20
           exit 1
       }
       Start-Sleep -Seconds 1

--- a/test/e2e/Tests/build-e2e-test.ps1
+++ b/test/e2e/Tests/build-e2e-test.ps1
@@ -287,19 +287,20 @@ function StartDTSContainer() {
       exit $LASTEXITCODE
   }
 
-  # Poll the health endpoint instead of a fixed sleep
+  # Poll until the gRPC port is accepting connections instead of a fixed sleep
   Write-Host "Waiting for DTS emulator to become ready..." -ForegroundColor Yellow
-  $maxAttempts = 30
+  $maxAttempts = 60
   for ($i = 1; $i -le $maxAttempts; $i++) {
       try {
-          $response = Invoke-WebRequest -Uri "http://localhost:8081" -TimeoutSec 2 -ErrorAction SilentlyContinue
-          if ($response.StatusCode -eq 200) {
-              Write-Host "DTS emulator is ready after $i seconds." -ForegroundColor Green
-              break
-          }
+          $tcp = New-Object System.Net.Sockets.TcpClient
+          $tcp.Connect("localhost", 8080)
+          $tcp.Close()
+          Write-Host "DTS emulator is ready after $i seconds." -ForegroundColor Green
+          break
       } catch { }
       if ($i -eq $maxAttempts) {
           Write-Error "DTS emulator did not become ready within $maxAttempts seconds."
+          docker logs $(docker ps -q --filter "ancestor=mcr.microsoft.com/dts/dts-emulator:latest") 2>&1 | Select-Object -Last 20
           exit 1
       }
       Start-Sleep -Seconds 1

--- a/test/e2e/Tests/build-e2e-test.ps1
+++ b/test/e2e/Tests/build-e2e-test.ps1
@@ -281,7 +281,7 @@ function StartDTSContainer() {
 
   # Start the DTS Server docker container with the specified edition
   Write-Host "Starting DTS docker container on port 8080" -ForegroundColor DarkYellow
-  docker run -i -p 8080:8080 -p 8082:8082 -d mcr.microsoft.com/dts/dts-emulator:latest
+  docker run -i -p 8080:8080 -p 8081:8081 -p 8082:8082 -d mcr.microsoft.com/dts/dts-emulator:latest
 
   if ($LASTEXITCODE -ne 0) {
       exit $LASTEXITCODE
@@ -299,7 +299,8 @@ function StartDTSContainer() {
           }
       } catch { }
       if ($i -eq $maxAttempts) {
-          Write-Warning "DTS emulator did not become ready within $maxAttempts seconds. Proceeding anyway."
+          Write-Error "DTS emulator did not become ready within $maxAttempts seconds."
+          exit 1
       }
       Start-Sleep -Seconds 1
   }

--- a/test/e2e/Tests/build-e2e-test.ps1
+++ b/test/e2e/Tests/build-e2e-test.ps1
@@ -267,9 +267,32 @@ function StartMSSQLContainer($mssqlPwd) {
       exit $LASTEXITCODE
   }
 
-  # The container needs a bit more time before it can start accepting commands
-  Write-Host "Sleeping for 30 seconds to let the container finish initializing..." -ForegroundColor Yellow
-  Start-Sleep -Seconds 30
+  # Wait for SQL Server to be ready by polling with sqlcmd
+  Write-Host "Waiting for SQL Server to become ready..." -ForegroundColor Yellow
+  $maxAttempts = 30
+  for ($i = 1; $i -le $maxAttempts; $i++) {
+      $result = docker exec mssql-server /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "$mssqlPwd" -Q "SELECT 1" -C -b 2>&1
+      if ($LASTEXITCODE -eq 0) {
+          Write-Host "SQL Server is ready after $i seconds." -ForegroundColor Green
+          break
+      }
+      if ($i -eq $maxAttempts) {
+          Write-Error "SQL Server did not become ready within $maxAttempts seconds."
+          docker logs mssql-server 2>&1 | Select-Object -Last 20
+          exit 1
+      }
+      Start-Sleep -Seconds 1
+  }
+
+  # Pre-create the DurableDB database so all language runtimes can use it independently.
+  # Without this, non-dotnet languages may fail if they can't auto-create the database.
+  Write-Host "Creating DurableDB database..." -ForegroundColor Yellow
+  docker exec mssql-server /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "$mssqlPwd" -Q "IF NOT EXISTS (SELECT name FROM sys.databases WHERE name = 'DurableDB') CREATE DATABASE DurableDB" -C -b
+  if ($LASTEXITCODE -ne 0) {
+      Write-Error "Failed to create DurableDB database."
+      exit 1
+  }
+  Write-Host "DurableDB database created successfully." -ForegroundColor Green
 
   # Check to see what containers are running
   docker ps

--- a/test/e2e/Tests/build-e2e-test.ps1
+++ b/test/e2e/Tests/build-e2e-test.ps1
@@ -310,16 +310,19 @@ function StartDTSContainer() {
       exit $LASTEXITCODE
   }
 
-  # Poll until the gRPC port is accepting connections instead of a fixed sleep
+  # Poll until the emulator port is accepting TCP connections instead of a fixed sleep
   Write-Host "Waiting for DTS emulator to become ready..." -ForegroundColor Yellow
   $maxAttempts = 60
   for ($i = 1; $i -le $maxAttempts; $i++) {
       try {
           $tcp = New-Object System.Net.Sockets.TcpClient
-          $tcp.Connect("localhost", 8080)
-          $tcp.Close()
-          Write-Host "DTS emulator is ready after $i seconds." -ForegroundColor Green
-          break
+          try {
+              $tcp.Connect("localhost", 8080)
+              Write-Host "DTS emulator is ready after $i seconds." -ForegroundColor Green
+              break
+          } finally {
+              $tcp.Dispose()
+          }
       } catch { }
       if ($i -eq $maxAttempts) {
           Write-Error "DTS emulator did not become ready within $maxAttempts seconds."


### PR DESCRIPTION
## Summary

Optimize E2E CI pipeline performance through test parallelization, test-level optimizations, and infrastructure improvements. Reduces overall CI wall-clock time significantly.

## Changes

### 1. Test Optimizations (DedupeStatusesTests & PurgeInstancesTests)
- **Replace `LongRunningOrchestrator` with `HttpLongRunningOrchestrator`** for dotnet-isolated — the timer-based orchestrator avoids 100K activity dispatch spam that contends with the emulator/backend
- **Parallelize independent orchestration lifecycle operations** within each test using `Task.WhenAll` — tests that previously ran 6 status chains sequentially now run them in 3-4 parallel phases
- **Language-aware orchestrator selection** — `HttpLongRunningOrchestrator` for dotnet-isolated (timer-based, lightweight), `LongRunningOrchestrator` for other languages (only available there)
- **Proper cleanup** — terminate pending/running/suspended instances after tests; dispose all `HttpResponseMessage` results

### 2. Pipeline Parallelization (E2ETest.yml)
- **Azure Storage (Linux & Windows) and DTS**: Split each backend's 5-language sequential run into parallel matrix jobs (5 languages × 2 TFMs = 10 parallel jobs per backend)
- **MSSQL**: Kept sequential — non-dotnet apps lack the MSSQL extension DLLs (`DurableTask.SqlServer`) which are only bundled with the dotnet-isolated app via NuGet. The sequential approach ensures dotnet-isolated runs first and sets up the schema.
- Each parallel job only builds its own language's test app (`-E2EAppName`), not all 5
- Python/Java SDKs conditionally installed only when needed

### 3. Infrastructure Improvements (build-e2e-test.ps1)
- **DTS emulator**: Replaced 30s hardcoded sleep with TCP readiness polling (port 8080), 60s timeout, proper TcpClient disposal, error exit with container log dump
- **MSSQL container**: Replaced 30s sleep with `sqlcmd` readiness polling; pre-creates `DurableDB` database for independent language runs

## Expected Performance

| Job Type | Before (sequential) | After (parallel) | Speedup |
|----------|---------------------|-------------------|---------|
| **e2e-azurestorage-linux** | ~12m | ~7m (wall-clock) | ~1.7x |
| **e2e-azurestorage-windows** | ~30m | ~13m (wall-clock) | ~2.3x |
| **e2e-mssql** | ~12m | ~12m (unchanged, sequential) | — |
| **e2e-dts** | ~46m | ~15m (wall-clock) | ~3x |
| **DedupeStatuses tests** | ~14m | ~2.5m | ~5.4x |
| **PurgeOnlyPurgesTerminal** | ~2m | ~24s | ~5x |

## Design Decisions

1. **MSSQL stays sequential** because non-dotnet function apps use `func extensions sync` which only installs the base Durable Task extension, not the MSSQL storage provider. The provider DLLs (`DurableTask.SqlServer.dll`, `DurableTask.SqlServer.AzureFunctions.dll`) are only available in the dotnet-isolated app's `.azurefunctions` folder. Each parallel GitHub Actions job runs on a separate VM with no shared filesystem.

2. **`HttpLongRunningOrchestrator` only for dotnet-isolated** because it's defined only in `BasicDotNetIsolated/HTTPFeature.cs`. Other language apps use `LongRunningOrchestrator` (100K activities) which is heavier but the only option available.

3. **Test parallelization within tests** uses `Task.WhenAll` for independent orchestration lifecycle chains (each uses unique instance IDs). Cleanup is best-effort (dispose without asserting StatusCode) since instances may have already completed.