### PR TITLE
Update publish pipeline

### DIFF
--- a/eng/ci/publish.yml
+++ b/eng/ci/publish.yml
@@ -5,19 +5,11 @@
 trigger: none # only trigger is manual
 pr: none # only trigger is manual
 
-# We include to this variable group to be able to access the NuGet API key
-variables:
-- group: durabletask_config
-
 resources:
     repositories:
         - repository: 1es
           type: git
           name: 1ESPipelineTemplates/1ESPipelineTemplates
-          ref: refs/tags/release
-        - repository: eng
-          type: git
-          name: engineering
           ref: refs/tags/release
 
     pipelines:
@@ -37,32 +29,30 @@ extends:
       jobs:
 
       # ADO release
-      - job: adoRelease
+      - job: AdoRelease
         displayName: ADO Release
         templateContext:
+          type: releaseJob
+          isProduction: true
           inputs:
           - input: pipelineArtifact
             pipeline: officialPipeline  # Pipeline reference, as defined in the resources section
             artifactName: drop
             targetPath: $(System.DefaultWorkingDirectory)/drop
-
-          # The preferred method of release on 1ES is by populating the 'output' section of a 1ES template.
-          # We use this method to release to ADO, but not to release to NuGet; this is explained in the 'nugetRelease' job.
-          # To read more about the 'output syntax', see: 
-          # - https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/1es-pipeline-templates/features/outputs
-          # - https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/1es-pipeline-templates/features/outputs/nuget-packages
-          outputs:
-          - output: nuget # 'nuget' is an output "type" for pushing to NuGet
-            displayName: 'Push to durabletask ADO feed'
+        steps:
+        - task: 1ES.PublishNuget@1
+          displayName: 'Push to durabletask ADO feed'
+          inputs:
+            command: push
             packageParentPath: $(System.DefaultWorkingDirectory) # This needs to be set to some prefix of the `packagesToPush` parameter. Apparently it helps with SDL tooling
             packagesToPush: '$(System.DefaultWorkingDirectory)/**/*.nupkg;!$(System.DefaultWorkingDirectory)/**/*.symbols.nupkg'
-            publishVstsFeed: '3f99e810-c336-441f-8892-84983093ad7f/c895696b-ce37-4fe7-b7ce-74333a04f8bf'
+            publishVstsFeed: 'internal/durabletask-internal'
             allowPackageConflicts: true
 
       # NuGet approval gate
       - job: nugetApproval
         displayName: NuGetApproval
-        pool: server # This task only works when executed on serverl pools, so this needs to be specified
+        pool: server # This task only works when executed on server pools, so this needs to be specified
         steps:
           # Wait for manual approval. 
           - task: ManualValidation@1
@@ -70,30 +60,59 @@ extends:
               instructions: Confirm you want to push to NuGet
               onTimeout: 'reject'
 
-      # NuGet release
-      - job: nugetRelease
-        displayName: NuGet Release
-        dependsOn:
-        - nugetApproval
-        - adoRelease
-        condition: succeeded('nugetApproval', 'adoRelease')
+      #================== NuGet publishing section ==================
+      # We publish each nupkg to NuGet in a separate job so that a duplicate version failure
+      # for one package does not block the other packages from being published.
+      # The 1ES.PublishNuget@1 task will fail the ADO job if we attempt to push any package
+      # versions that were already uploaded to NuGet. By splitting each package into its own
+      # job, the other packages can still be published independently.
+
+      # NuGet release (Microsoft.Azure.WebJobs.Extensions.DurableTask)
+      - job: nugetRelease_WebJobs_Extensions_DurableTask
+        displayName: NuGet Release (Microsoft.Azure.WebJobs.Extensions.DurableTask)
+        dependsOn: nugetApproval
+        condition: succeeded('nugetApproval')
         templateContext:
+          type: releaseJob
+          isProduction: true
           inputs:
           - input: pipelineArtifact
             pipeline: officialPipeline  # Pipeline reference as defined in the resources section
             artifactName: drop
             targetPath: $(System.DefaultWorkingDirectory)/drop
-        # Ideally, we would push to NuGet using the 1ES "template output" syntax, like we do for ADO.
-        # Unfortunately, that syntax does not allow for skipping duplicates when pushing to NuGet feeds
-        # (i.e; not failing the job when trying to push a package version that already exists on NuGet).
-        # This is a problem for us because our pipelines often produce multiple packages, and we want to be able to
-        # perform a 'nuget push *.nupkg' that skips packages already on NuGet while pushing the rest.
-        # Therefore, we use a regular .NET Core ADO Task to publish the packages until that usability gap is addressed.
         steps:
-        - task: DotNetCoreCLI@2
-          displayName: 'Push to nuget.org'
+        - task: 1ES.PublishNuget@1
+          displayName: 'NuGet push (Microsoft.Azure.WebJobs.Extensions.DurableTask)'
           inputs:
-            command: custom
-            custom: nuget
-            arguments: 'push "*.nupkg" --api-key $(nuget_api_key) --skip-duplicate --source https://api.nuget.org/v3/index.json'
-            workingDirectory: '$(System.DefaultWorkingDirectory)/drop'
+            command: push
+            nuGetFeedType: external
+            publishFeedCredentials: 'DurableTask org NuGet API Key'
+            # the packages to push pattern explicitly excludes:
+            # - 'Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers'
+            # - 'Microsoft.Azure.WebJobs.Extensions.DurableTask.FunctionsScale'
+            # which could match the same prefix
+            packagesToPush: '$(System.DefaultWorkingDirectory)/drop/Microsoft.Azure.WebJobs.Extensions.DurableTask.*.nupkg;!$(System.DefaultWorkingDirectory)/drop/Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers.*.nupkg;!$(System.DefaultWorkingDirectory)/drop/Microsoft.Azure.WebJobs.Extensions.DurableTask.FunctionsScale.*.nupkg;!$(System.DefaultWorkingDirectory)/**/*.symbols.nupkg'
+            packageParentPath: $(System.DefaultWorkingDirectory) # This needs to be set to some prefix of the `packagesToPush` parameter. Apparently it helps with SDL tooling
+
+      # NuGet release (Microsoft.Azure.Functions.Worker.Extensions.DurableTask)
+      - job: nugetRelease_Worker_Extensions_DurableTask
+        displayName: NuGet Release (Microsoft.Azure.Functions.Worker.Extensions.DurableTask)
+        dependsOn: nugetApproval
+        condition: succeeded('nugetApproval')
+        templateContext:
+          type: releaseJob
+          isProduction: true
+          inputs:
+          - input: pipelineArtifact
+            pipeline: officialPipeline  # Pipeline reference as defined in the resources section
+            artifactName: drop
+            targetPath: $(System.DefaultWorkingDirectory)/drop
+        steps:
+        - task: 1ES.PublishNuget@1
+          displayName: 'NuGet push (Microsoft.Azure.Functions.Worker.Extensions.DurableTask)'
+          inputs:
+            command: push
+            nuGetFeedType: external
+            publishFeedCredentials: 'DurableTask org NuGet API Key'
+            packagesToPush: '$(System.DefaultWorkingDirectory)/drop/Microsoft.Azure.Functions.Worker.Extensions.DurableTask.*.nupkg;!$(System.DefaultWorkingDirectory)/**/*.symbols.nupkg'
+            packageParentPath: $(System.DefaultWorkingDirectory) # This needs to be set to some prefix of the `packagesToPush` parameter.


### PR DESCRIPTION
# Summary
## What changed?
Updates the publish pipeline ([publish.yml](vscode-file://vscode-app/c:/Users/vabachu/AppData/Local/Programs/Microsoft%20VS%20Code/07ff9d6178/resources/app/out/vs/code/electron-browser/workbench/workbench.html)) to follow 1ES best practices, modeled after the [durabletask-dotnet publish pipeline](https://github.com/microsoft/durabletask-dotnet/blob/main/eng/publish/publish.yml).

Changes
* ADO release: Replaced outputs syntax with 1ES.PublishNuget@1 step and added releaseJob template context with isProduction: true for proper 1ES release tracking and SDL compliance.
* NuGet release: Replaced single DotNetCoreCLI@2 job (using raw API key variable) with per-package 1ES.PublishNuget@1 jobs using the 'DurableTask org NuGet API Key' service connection. Each package is published in its own job so a duplicate version failure for one doesn't block the other.
* Package safety: Added exclusions for Analyzers and FunctionsScale packages in the WebJobs push pattern to prevent unintended prefix matches.
* Readable feed reference: Replaced hardcoded ADO feed GUIDs with friendly 'internal/durabletask-internal' name.
* Cleanup: Removed unused [eng](vscode-file://vscode-app/c:/Users/vabachu/AppData/Local/Programs/Microsoft%20VS%20Code/07ff9d6178/resources/app/out/vs/code/electron-browser/workbench/workbench.html) repository resource and durabletask_config variable group (no longer needed with service connection auth).

---

# Project checklist
- [x] Documentation changes are not required
  - [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
- [x] Release notes are not required for the next release
  - [ ] Otherwise: Notes added to `release_notes.md`
- [x] Backport is not required
  - [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
- [x] All required tests have been added/updated (unit tests, E2E tests)
- [x] No extra work is required to be leveraged by OutOfProc SDKs
  - [ ] Otherwise: Work tracked here: #issue_or_pr_in_each_sdk
- [x] No change to the version of the `WebJobs.Extensions.DurableTask` package
  - [ ] Otherwise: Major/minor updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
- [x] No EventIds were added to `EventSource` logs
  - [ ] Otherwise: Ensure EventIds are within the supported range in the existing Windows infrastructure (validate via deployed telemetry). If needed, extend the range via a PR such as https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files
- [ ] This change should be added to the `v2.x` branch
  - [x] Otherwise: This change applies exclusively to `WebJobs.Extensions.DurableTask` v3.x and will be retained only in the `dev` and `main` branches
- [ ] Breaking change?
  - [ ] If yes:
    - Impact:
    - Migration guidance:
---

# AI-assisted code disclosure (required)
## Was an AI tool used? (select one)
- [ ] No
- [ ] Yes, AI helped write parts of this PR (e.g., GitHub Copilot)
- [x] Yes, an AI agent generated most of this PR

If AI was used:
- Tool(s): VS Code GitHub CoPilot (Claude Opus 4.6)
- AI-assisted areas/files: publish.yml
- What you changed after AI output: a few comments

AI verification (required if AI was used):
- [x] I understand the code and can explain it
- [x] I verified referenced APIs/types exist and are correct
- [x] I reviewed edge cases/failure paths (timeouts, retries, cancellation, exceptions)
- [x] I reviewed concurrency/async behavior
- [x] I checked for unintended breaking or behavior changes

---

# Testing
## Automated tests
- Result: Passed / Failed (link logs if failed)

## Manual validation (only if runtime/behavior changed)
- Environment (OS, .NET version, components):
- Steps + observed results:
  1.
  2.
  3.
- Evidence (optional):

---

# Notes for reviewers
- N/A
