### PR TITLE
Add SetRegisteredFunctions to IDurabilityProviderFactory for work item filter support

### DIFF
--- a/samples/workitem-filters/Functions.cs
+++ b/samples/workitem-filters/Functions.cs
@@ -1,0 +1,225 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Net;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
+using Microsoft.DurableTask;
+using Microsoft.DurableTask.Client;
+using Microsoft.DurableTask.Entities;
+using Microsoft.Extensions.Logging;
+
+namespace WorkItemFiltersSample;
+
+// =============================================================================
+// Orchestrations
+// =============================================================================
+
+/// <summary>
+/// A simple orchestration that calls an activity and returns the result.
+/// With work item filtering enabled, this orchestration will only be dispatched
+/// to workers that have it registered.
+/// </summary>
+public static class GreetingOrchestration
+{
+    [Function(nameof(GreetingOrchestration) + "_Start")]
+    public static async Task<HttpResponseData> Start(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "orchestrators/greeting")] HttpRequestData req,
+        [DurableClient] DurableTaskClient client)
+    {
+        string instanceId = await client.ScheduleNewOrchestrationInstanceAsync(nameof(GreetingOrchestration));
+        return await HttpHelpers.CreateAcceptedResponse(req, instanceId);
+    }
+
+    [Function(nameof(GreetingOrchestration))]
+    public static async Task<string> Run([OrchestrationTrigger] TaskOrchestrationContext ctx)
+    {
+        var logger = ctx.CreateReplaySafeLogger(nameof(GreetingOrchestration));
+        logger.LogInformation("GreetingOrchestration started");
+        string result = await ctx.CallActivityAsync<string>(nameof(SayHello), "World");
+        return result;
+    }
+}
+
+/// <summary>
+/// A fan-out/fan-in orchestration that calls the same activity in parallel with
+/// different inputs. Demonstrates that activity work items are also filtered —
+/// only workers that register the activity will receive the dispatched work.
+/// </summary>
+public static class FanOutOrchestration
+{
+    [Function(nameof(FanOutOrchestration) + "_Start")]
+    public static async Task<HttpResponseData> Start(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "orchestrators/fanout")] HttpRequestData req,
+        [DurableClient] DurableTaskClient client)
+    {
+        string instanceId = await client.ScheduleNewOrchestrationInstanceAsync(nameof(FanOutOrchestration));
+        return await HttpHelpers.CreateAcceptedResponse(req, instanceId);
+    }
+
+    [Function(nameof(FanOutOrchestration))]
+    public static async Task<string[]> Run([OrchestrationTrigger] TaskOrchestrationContext ctx)
+    {
+        var logger = ctx.CreateReplaySafeLogger(nameof(FanOutOrchestration));
+        logger.LogInformation("FanOutOrchestration: fanning out to 3 activities");
+
+        string[] results = await Task.WhenAll(
+            ctx.CallActivityAsync<string>(nameof(SayHello), "Tokyo"),
+            ctx.CallActivityAsync<string>(nameof(SayHello), "London"),
+            ctx.CallActivityAsync<string>(nameof(SayHello), "Seattle"));
+
+        return results;
+    }
+}
+
+/// <summary>
+/// A parent orchestration that calls a child orchestration. Demonstrates that
+/// sub-orchestration dispatch is also governed by work item filters.
+/// </summary>
+public static class ParentOrchestration
+{
+    [Function(nameof(ParentOrchestration) + "_Start")]
+    public static async Task<HttpResponseData> Start(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "orchestrators/parent")] HttpRequestData req,
+        [DurableClient] DurableTaskClient client)
+    {
+        string instanceId = await client.ScheduleNewOrchestrationInstanceAsync(nameof(ParentOrchestration));
+        return await HttpHelpers.CreateAcceptedResponse(req, instanceId);
+    }
+
+    [Function(nameof(ParentOrchestration))]
+    public static async Task<string> Run([OrchestrationTrigger] TaskOrchestrationContext ctx)
+    {
+        var logger = ctx.CreateReplaySafeLogger(nameof(ParentOrchestration));
+        logger.LogInformation("ParentOrchestration: calling sub-orchestration");
+        string result = await ctx.CallSubOrchestratorAsync<string>(nameof(GreetingOrchestration));
+        return $"Parent received: {result}";
+    }
+}
+
+/// <summary>
+/// An orchestration that interacts with a durable entity. Demonstrates that
+/// entity work items are also filtered.
+/// </summary>
+public static class CounterOrchestration
+{
+    [Function(nameof(CounterOrchestration) + "_Start")]
+    public static async Task<HttpResponseData> Start(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "orchestrators/counter")] HttpRequestData req,
+        [DurableClient] DurableTaskClient client)
+    {
+        string instanceId = await client.ScheduleNewOrchestrationInstanceAsync(nameof(CounterOrchestration));
+        return await HttpHelpers.CreateAcceptedResponse(req, instanceId);
+    }
+
+    [Function(nameof(CounterOrchestration))]
+    public static async Task<int> Run([OrchestrationTrigger] TaskOrchestrationContext ctx)
+    {
+        var logger = ctx.CreateReplaySafeLogger(nameof(CounterOrchestration));
+        var entityId = new EntityInstanceId(nameof(CounterEntity), "sample-counter");
+
+        logger.LogInformation("CounterOrchestration: adding 10 then 20 to counter");
+        await ctx.Entities.CallEntityAsync(entityId, "Add", 10);
+        await ctx.Entities.CallEntityAsync(entityId, "Add", 20);
+
+        int value = await ctx.Entities.CallEntityAsync<int>(entityId, "Get");
+        logger.LogInformation("CounterOrchestration: counter value = {Value}", value);
+        return value;
+    }
+}
+
+// =============================================================================
+// Activities
+// =============================================================================
+
+/// <summary>
+/// A simple activity function. With filtering enabled, only workers that have
+/// this activity registered will receive dispatched work items for it.
+/// </summary>
+public static class SayHello
+{
+    [Function(nameof(SayHello))]
+    public static string Run([ActivityTrigger] string name)
+    {
+        return $"Hello, {name}!";
+    }
+}
+
+// =============================================================================
+// Entities
+// =============================================================================
+
+/// <summary>
+/// A simple counter entity. With filtering enabled, only workers that have
+/// this entity registered will receive dispatched work items for it.
+/// </summary>
+public class CounterEntity : TaskEntity<int>
+{
+    public void Add(int amount) => this.State += amount;
+    public void Reset() => this.State = 0;
+    public int Get() => this.State;
+
+    [Function(nameof(CounterEntity))]
+    public static Task Dispatch([EntityTrigger] TaskEntityDispatcher dispatcher)
+        => dispatcher.DispatchAsync<CounterEntity>();
+}
+
+// =============================================================================
+// Utility functions
+// =============================================================================
+
+/// <summary>
+/// Generic starter — can schedule any orchestration by name.
+/// Useful for testing cross-app filter isolation: schedule an orchestration
+/// that this app does NOT have and observe it stays Pending.
+/// </summary>
+public static class GenericStarter
+{
+    [Function("StartOrchestration")]
+    public static async Task<HttpResponseData> Start(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "start/{name}")] HttpRequestData req,
+        [DurableClient] DurableTaskClient client,
+        string name)
+    {
+        string instanceId = await client.ScheduleNewOrchestrationInstanceAsync(name);
+        return await HttpHelpers.CreateAcceptedResponse(req, instanceId);
+    }
+
+    [Function("GetInstanceStatus")]
+    public static async Task<HttpResponseData> GetStatus(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "instances/{instanceId}")] HttpRequestData req,
+        [DurableClient] DurableTaskClient client,
+        string instanceId)
+    {
+        var meta = await client.GetInstanceAsync(instanceId, getInputsAndOutputs: true);
+        var resp = req.CreateResponse(meta == null ? HttpStatusCode.NotFound : HttpStatusCode.OK);
+        resp.Headers.Add("Content-Type", "application/json");
+        if (meta == null)
+        {
+            await resp.WriteStringAsync($"{{\"error\":\"Instance {instanceId} not found\"}}");
+        }
+        else
+        {
+            await resp.WriteStringAsync(
+                $"{{\"name\":\"{meta.Name}\",\"instanceId\":\"{meta.InstanceId}\"," +
+                $"\"status\":\"{meta.RuntimeStatus}\",\"output\":{meta.SerializedOutput ?? "null"}}}");
+        }
+
+        return resp;
+    }
+}
+
+// =============================================================================
+// Shared helper
+// =============================================================================
+
+internal static class HttpHelpers
+{
+    internal static async Task<HttpResponseData> CreateAcceptedResponse(HttpRequestData req, string instanceId)
+    {
+        var resp = req.CreateResponse(HttpStatusCode.Accepted);
+        resp.Headers.Add("Content-Type", "application/json");
+        await resp.WriteStringAsync($"{{\"instanceId\":\"{instanceId}\"}}");
+        return resp;
+    }
+}

--- a/samples/workitem-filters/Program.cs
+++ b/samples/workitem-filters/Program.cs
@@ -1,0 +1,5 @@
+using Microsoft.Azure.Functions.Worker.Builder;
+using Microsoft.Extensions.Hosting;
+
+FunctionsApplicationBuilder builder = FunctionsApplication.CreateBuilder(args);
+builder.Build().Run();

--- a/samples/workitem-filters/README.md
+++ b/samples/workitem-filters/README.md
@@ -1,0 +1,147 @@
+# Work Item Filters Sample
+
+This sample demonstrates the **work item filtering** feature for Durable Functions with the [Durable Task Scheduler](https://learn.microsoft.com/azure/azure-functions/durable/durable-functions-task-hubs?tabs=csharp#durable-task-scheduler) (DTS) backend.
+
+## What are work item filters?
+
+When multiple Function apps share the same DTS task hub, the backend dispatches work items (orchestrations, activities, entities) to any connected worker. This can cause failures when a worker receives a function it doesn't have:
+
+> *"The function 'X' doesn't exist, is disabled, or is not an orchestrator function."*
+
+Work item filters solve this by having each app automatically advertise which functions it handles. DTS then only dispatches matching work to each app.
+
+## How it works
+
+1. The Durable Functions extension discovers registered orchestrators, activities, and entities during function indexing
+2. These names are sent to the DTS backend as `WorkItemFilters` on the `GetWorkItems` gRPC stream
+3. DTS only dispatches work items that match the worker's registered functions
+4. Unmatched work items stay in the queue until a worker with the right filter connects
+
+No code changes are required — just enable the feature in `host.json`.
+
+## Prerequisites
+
+- [.NET 8 SDK](https://dotnet.microsoft.com/download/dotnet/8.0) or later
+- [Azure Functions Core Tools v4](https://learn.microsoft.com/azure/azure-functions/functions-run-local)
+- [Docker Desktop](https://www.docker.com/products/docker-desktop/) (for Azurite and optionally the DTS emulator)
+- A running Durable Task Scheduler instance (see [Setup DTS](#setup-dts) below)
+
+## Setup DTS
+
+### Option A: Docker emulator (recommended for local dev)
+
+```bash
+docker run -d --name dts-emulator -p 8080:8080 mcr.microsoft.com/dts/emulator:latest
+```
+
+### Option B: Build from source
+
+If you have the DTS backend source code:
+
+```bash
+dotnet run --project src/Backend/Microsoft.DTMB.BackendAPI \
+  -p:DefineConstants=EMULATOR_BUILD \
+  -- --Database:UseDatabase=false \
+     --ClientAuth:DisableAuthentication=true \
+     --Database:TaskHubNames=default \
+     --urls="http://localhost:8080;http://localhost:8081"
+```
+
+## Setup Azurite (storage emulator)
+
+```bash
+docker run -d --name azurite -p 10000:10000 -p 10001:10001 -p 10002:10002 \
+  mcr.microsoft.com/azure-storage/azurite
+```
+
+## Configuration
+
+The sample's [`host.json`](host.json) enables work item filtering:
+
+```json
+{
+  "extensions": {
+    "durableTask": {
+      "storageProvider": {
+        "type": "azureManaged",
+        "connectionStringName": "DURABLE_TASK_SCHEDULER_CONNECTION_STRING",
+        "workItemFilteringEnabled": true
+      }
+    }
+  }
+}
+```
+
+The [`local.settings.json`](local.settings.json) points to the local DTS emulator:
+
+```json
+{
+  "Values": {
+    "DURABLE_TASK_SCHEDULER_CONNECTION_STRING": "Endpoint=http://localhost:8080;Authentication=None"
+  }
+}
+```
+
+## Run the sample
+
+```bash
+cd samples/workitem-filters
+func start --port 7071
+```
+
+You should see log output like:
+
+```
+Work item filtering enabled. Registered 4 orchestrators, 1 activities, 1 entities.
+```
+
+## Test the sample
+
+Open [`demo.http`](demo.http) in VS Code with the [REST Client extension](https://marketplace.visualstudio.com/items?itemName=humao.REST-Client) and step through the requests in order.
+
+Alternatively, use curl:
+
+```bash
+# 1. Start an orchestration (should complete)
+curl -X POST http://localhost:7071/api/orchestrators/greeting
+
+# 2. Check status (copy instanceId from response)
+curl http://localhost:7071/api/instances/<instanceId>
+
+# 3. Schedule an unknown orchestration (should stay Pending with filters)
+curl -X POST http://localhost:7071/api/start/SomeOtherOrchestration
+
+# 4. Check status — should be Pending, proving filter isolation
+curl http://localhost:7071/api/instances/<instanceId>
+```
+
+## What this sample registers
+
+| Type          | Function Name           | Description                             |
+|---------------|-------------------------|-----------------------------------------|
+| Orchestration | `GreetingOrchestration` | Simple activity call                    |
+| Orchestration | `FanOutOrchestration`   | Parallel fan-out to 3 activity calls    |
+| Orchestration | `ParentOrchestration`   | Calls `GreetingOrchestration` as a sub-orchestration |
+| Orchestration | `CounterOrchestration`  | Interacts with `CounterEntity`          |
+| Activity      | `SayHello`              | Returns a greeting string               |
+| Entity        | `CounterEntity`         | Simple counter with Add/Reset/Get       |
+
+With filtering enabled, DTS will **only** dispatch these types to this worker. Scheduling any other orchestration name (e.g., `SomeOtherOrchestration`) via the generic starter will result in it staying `Pending` — proving that DTS is correctly holding unmatched work items.
+
+## Multi-app scenario
+
+To demonstrate filter isolation across two apps:
+
+1. Create a second Function app with **different** orchestrations/activities/entities
+2. Point both apps to the **same** DTS task hub (same connection string and hub name)
+3. Enable `workItemFilteringEnabled: true` in both apps' `host.json`
+4. Schedule orchestrations from either app — each will only process its own functions
+
+## Key behaviors
+
+| Scenario | Behavior |
+|----------|----------|
+| Work item matches a registered function | Dispatched to this worker |
+| Work item does NOT match any registered function | Held in DTS queue (not dispatched) |
+| `workItemFilteringEnabled` is `false` or not set | All work items dispatched to all workers (default, no filtering) |
+| Worker disconnects | Filter channel stays active briefly; items drain back to the general queue after a timeout |

--- a/samples/workitem-filters/WorkItemFiltersSample.csproj
+++ b/samples/workitem-filters/WorkItemFiltersSample.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+    <AzureFunctionsVersion>v4</AzureFunctionsVersion>
+    <OutputType>Exe</OutputType>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Azure.Functions.Worker" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" />
+    <ProjectReference Include="../../src/Worker.Extensions.DurableTask/Worker.Extensions.DurableTask.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Update="host.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="local.settings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>Never</CopyToPublishDirectory>
+    </None>
+  </ItemGroup>
+</Project>

--- a/samples/workitem-filters/demo.http
+++ b/samples/workitem-filters/demo.http
@@ -1,0 +1,136 @@
+# =============================================================================
+# Work Item Filters Sample — Demo Workflow
+# =============================================================================
+#
+# This file walks through the work item filter feature step by step.
+# Use the VS Code REST Client extension to send requests (click "Send Request"
+# above each ### block).
+#
+# Prerequisites:
+#   1. Durable Task Scheduler running locally (see README.md for setup)
+#   2. Azurite running (storage emulator for AzureWebJobsStorage)
+#   3. This sample app running: func start --port 7071
+#
+# This app registers:
+#   Orchestrations: GreetingOrchestration, FanOutOrchestration,
+#                   ParentOrchestration, CounterOrchestration
+#   Activities:     SayHello
+#   Entities:       CounterEntity
+#
+# With workItemFilteringEnabled: true, DTS will ONLY dispatch these
+# function types to this worker. Any other orchestration/activity/entity
+# names will be held in the DTS queue until a matching worker connects.
+# =============================================================================
+
+@baseUrl = http://localhost:7071/api
+
+
+# =============================================================================
+# 1. BASIC ORCHESTRATION — simple activity call
+#    Expected: Completed with "Hello, World!"
+# =============================================================================
+
+### 1a. Start GreetingOrchestration
+# @name greeting
+POST {{baseUrl}}/orchestrators/greeting
+
+### 1b. Check status (wait a few seconds)
+GET {{baseUrl}}/instances/{{greeting.response.body.instanceId}}
+
+
+# =============================================================================
+# 2. FAN-OUT/FAN-IN — parallel activity calls
+#    Expected: Completed with ["Hello, Tokyo!", "Hello, London!", "Hello, Seattle!"]
+# =============================================================================
+
+### 2a. Start FanOutOrchestration
+# @name fanout
+POST {{baseUrl}}/orchestrators/fanout
+
+### 2b. Check status
+GET {{baseUrl}}/instances/{{fanout.response.body.instanceId}}
+
+
+# =============================================================================
+# 3. SUB-ORCHESTRATION — parent calls child orchestration
+#    Expected: Completed with "Parent received: Hello, World!"
+# =============================================================================
+
+### 3a. Start ParentOrchestration
+# @name parent
+POST {{baseUrl}}/orchestrators/parent
+
+### 3b. Check status
+GET {{baseUrl}}/instances/{{parent.response.body.instanceId}}
+
+
+# =============================================================================
+# 4. ENTITY — orchestration interacts with a durable entity
+#    Expected: Completed with 30 (10 + 20)
+# =============================================================================
+
+### 4a. Start CounterOrchestration
+# @name counter
+POST {{baseUrl}}/orchestrators/counter
+
+### 4b. Check status (entities may take a few extra seconds)
+GET {{baseUrl}}/instances/{{counter.response.body.instanceId}}
+
+
+# =============================================================================
+# 5. FILTER ISOLATION — schedule an orchestration this app does NOT have
+#    Expected: Stays Pending (DTS holds it because no worker has a matching filter)
+# =============================================================================
+
+### 5a. Schedule a non-existent orchestration via the generic starter
+# @name unknown
+POST {{baseUrl}}/start/SomeOtherOrchestration
+
+### 5b. Check status immediately — should be Pending
+GET {{baseUrl}}/instances/{{unknown.response.body.instanceId}}
+
+### 5c. Check again after 15 seconds — should STILL be Pending
+#      This proves DTS is correctly holding unmatched work items instead of
+#      dispatching them to this worker.
+#      Without filters, this would show Failed: "function doesn't exist"
+GET {{baseUrl}}/instances/{{unknown.response.body.instanceId}}
+
+
+# =============================================================================
+# 6. POSITIVE CONTROL — schedule a known orchestration via the generic starter
+#    Expected: Completed (confirms the generic starter works and filters allow it)
+# =============================================================================
+
+### 6a. Schedule GreetingOrchestration via generic starter
+# @name genericGreeting
+POST {{baseUrl}}/start/GreetingOrchestration
+
+### 6b. Check status
+GET {{baseUrl}}/instances/{{genericGreeting.response.body.instanceId}}
+
+
+# =============================================================================
+# 7. VIEW ALL INSTANCES — shows a summary of all orchestrations in the task hub
+# =============================================================================
+
+### 7a. List all instances via the Durable Functions management API
+GET http://localhost:7071/runtime/webhooks/durabletask/instances
+
+
+# =============================================================================
+# EXPECTED RESULTS SUMMARY
+# =============================================================================
+#
+# | Test | Orchestration            | Expected Status | Why                           |
+# |------|--------------------------|-----------------|-------------------------------|
+# | 1    | GreetingOrchestration    | Completed       | Matches filter → dispatched   |
+# | 2    | FanOutOrchestration      | Completed       | Activities also filtered      |
+# | 3    | ParentOrchestration      | Completed       | Sub-orch also filtered        |
+# | 4    | CounterOrchestration     | Completed       | Entity also filtered          |
+# | 5    | SomeOtherOrchestration   | Pending         | No matching filter → held     |
+# | 6    | GreetingOrchestration    | Completed       | Generic starter + filter OK   |
+#
+# The key proof is Test 5: without filters, "SomeOtherOrchestration" would be
+# dispatched to this worker and fail with "function doesn't exist". With filters,
+# DTS correctly holds it in the queue, waiting for a worker that has it registered.
+#

--- a/samples/workitem-filters/host.json
+++ b/samples/workitem-filters/host.json
@@ -1,0 +1,19 @@
+{
+  "version": "2.0",
+  "logging": {
+    "logLevel": {
+      "DurableTask.AzureStorage": "Warning",
+      "DurableTask.Core": "Warning"
+    }
+  },
+  "extensions": {
+    "durableTask": {
+      "hubName": "default",
+      "storageProvider": {
+        "type": "azureManaged",
+        "connectionStringName": "DURABLE_TASK_SCHEDULER_CONNECTION_STRING",
+        "workItemFilteringEnabled": true
+      }
+    }
+  }
+}

--- a/samples/workitem-filters/local.settings.json
+++ b/samples/workitem-filters/local.settings.json
@@ -1,0 +1,8 @@
+{
+  "IsEncrypted": false,
+  "Values": {
+    "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+    "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",
+    "DURABLE_TASK_SCHEDULER_CONNECTION_STRING": "Endpoint=http://localhost:8080;Authentication=None"
+  }
+}

--- a/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
@@ -1171,6 +1171,26 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             return info;
         }
 
+        internal (
+            IReadOnlyCollection<string> orchestratorNames,
+            IReadOnlyCollection<string> activityNames,
+            IReadOnlyCollection<string> entityNames) GetActiveRegisteredFunctionNames()
+        {
+            return (
+                orchestratorNames: this.knownOrchestrators
+                    .Where(kvp => !kvp.Value.IsDeregistered)
+                    .Select(kvp => kvp.Key.Name)
+                    .ToList(),
+                activityNames: this.knownActivities
+                    .Where(kvp => !kvp.Value.IsDeregistered)
+                    .Select(kvp => kvp.Key.Name)
+                    .ToList(),
+                entityNames: this.knownEntities
+                    .Where(kvp => !kvp.Value.IsDeregistered)
+                    .Select(kvp => kvp.Key.Name)
+                    .ToList());
+        }
+
         // This is temporary until script loading
         private static void ConfigureLoaderHooks()
         {
@@ -1431,10 +1451,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                         // Pass registered function names to the factory so backends that support
                         // work-item filtering (e.g., DTS/AzureManaged) can build WorkItemFilters
                         // before the task hub worker opens its GetWorkItems stream.
+                        var activeFunctions = this.GetActiveRegisteredFunctionNames();
                         this.durabilityProviderFactory.SetRegisteredFunctions(
-                            orchestratorNames: this.knownOrchestrators.Keys.Select(fn => fn.Name).ToList(),
-                            activityNames: this.knownActivities.Keys.Select(fn => fn.Name).ToList(),
-                            entityNames: this.knownEntities.Keys.Select(fn => fn.Name).ToList());
+                            orchestratorNames: activeFunctions.orchestratorNames,
+                            activityNames: activeFunctions.activityNames,
+                            entityNames: activeFunctions.entityNames);
 
                         await this.EnsureTaskHubWorker().StartAsync();
 

--- a/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
@@ -1427,6 +1427,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
                         Stopwatch sw = Stopwatch.StartNew();
                         await this.defaultDurabilityProvider.CreateIfNotExistsAsync();
+
+                        // Pass registered function names to the factory so backends that support
+                        // work-item filtering (e.g., DTS/AzureManaged) can build WorkItemFilters
+                        // before the task hub worker opens its GetWorkItems stream.
+                        this.durabilityProviderFactory.SetRegisteredFunctions(
+                            orchestratorNames: this.knownOrchestrators.Keys.Select(fn => fn.Name).ToList(),
+                            activityNames: this.knownActivities.Keys.Select(fn => fn.Name).ToList(),
+                            entityNames: this.knownEntities.Keys.Select(fn => fn.Name).ToList());
+
                         await this.EnsureTaskHubWorker().StartAsync();
 
                         this.GetTaskHubWorkerOrThrow().TaskOrchestrationDispatcher.EntitiesEnabled = true;

--- a/src/WebJobs.Extensions.DurableTask/IDurabilityProviderFactory.cs
+++ b/src/WebJobs.Extensions.DurableTask/IDurabilityProviderFactory.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 using System;
+using System.Collections.Generic;
 using Microsoft.Azure.WebJobs.Host.Scale;
 
 namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
@@ -49,6 +50,23 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         void SetUseSeparateQueueForEntityWorkItems(bool newValue)
         {
             throw new NotImplementedException($"The {this.Name} provider does not support SetUseSeparateQueueForEntityWorkItems.");
+        }
+
+        /// <summary>
+        /// Passes the names of registered orchestrators, activities, and entities to the factory
+        /// so that it can build work-item filters for backends that support selective dispatch (e.g., DTS).
+        /// Called after function indexing completes but before the task hub worker starts.
+        /// The default implementation is a no-op.
+        /// </summary>
+        /// <param name="orchestratorNames">The names of registered orchestrator functions.</param>
+        /// <param name="activityNames">The names of registered activity functions.</param>
+        /// <param name="entityNames">The names of registered entity functions.</param>
+        void SetRegisteredFunctions(
+            IReadOnlyCollection<string> orchestratorNames,
+            IReadOnlyCollection<string> activityNames,
+            IReadOnlyCollection<string> entityNames)
+        {
+            // No-op by default. Only backends that support work-item filtering need to override this.
         }
     }
 }

--- a/test/FunctionsV2/Tests/Unit/SetRegisteredFunctionsTests.cs
+++ b/test/FunctionsV2/Tests/Unit/SetRegisteredFunctionsTests.cs
@@ -3,7 +3,11 @@
 
 #nullable enable
 
+using System;
 using System.Collections.Generic;
+using DurableTask.AzureStorage;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
@@ -27,6 +31,74 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 new[] { "Entity1" });
 
             // No exception = pass. The default method body is empty.
+        }
+
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public void DeregisteredFunctions_AreExcludedFromFilterList()
+        {
+            // Arrange: register some functions, then deregister a subset
+            var extension = CreateExtension();
+
+            var orch1 = new FunctionName("Orch1");
+            var orch2 = new FunctionName("Orch2");
+            var act1 = new FunctionName("Activity1");
+            var act2 = new FunctionName("Activity2");
+            var ent1 = new FunctionName("Entity1");
+            var ent2 = new FunctionName("Entity2");
+
+            extension.RegisterOrchestrator(orch1, new RegisteredFunctionInfo(executor: null!, isOutOfProc: true));
+            extension.RegisterOrchestrator(orch2, new RegisteredFunctionInfo(executor: null!, isOutOfProc: true));
+            extension.RegisterActivity(act1, executor: null!);
+            extension.RegisterActivity(act2, executor: null!);
+            extension.RegisterEntity(ent1, new RegisteredFunctionInfo(executor: null!, isOutOfProc: true));
+            extension.RegisterEntity(ent2, new RegisteredFunctionInfo(executor: null!, isOutOfProc: true));
+
+            // Deregister one of each type
+            extension.DeregisterOrchestrator(orch2);
+            extension.DeregisterActivity(act2);
+            extension.DeregisterEntity(ent1);
+
+            // Assert: only active (not deregistered) functions are included in
+            // the names passed to SetRegisteredFunctions.
+            var activeFunctions = extension.GetActiveRegisteredFunctionNames();
+
+            Assert.Single(activeFunctions.orchestratorNames);
+            Assert.Contains("Orch1", activeFunctions.orchestratorNames);
+            Assert.DoesNotContain("Orch2", activeFunctions.orchestratorNames);
+
+            Assert.Single(activeFunctions.activityNames);
+            Assert.Contains("Activity1", activeFunctions.activityNames);
+            Assert.DoesNotContain("Activity2", activeFunctions.activityNames);
+
+            Assert.Single(activeFunctions.entityNames);
+            Assert.Contains("Entity2", activeFunctions.entityNames);
+            Assert.DoesNotContain("Entity1", activeFunctions.entityNames);
+        }
+
+        private static DurableTaskExtension CreateExtension()
+        {
+            var options = new DurableTaskOptions
+            {
+                HubName = "TestHub",
+                WebhookUriProviderOverride = () => new Uri("https://localhost"),
+            };
+
+            return new DurableTaskExtension(
+                new OptionsWrapper<DurableTaskOptions>(options),
+                NullLoggerFactory.Instance,
+                TestHelpers.GetTestNameResolver(),
+                [
+                    new AzureStorageDurabilityProviderFactory(
+                        new OptionsWrapper<DurableTaskOptions>(options),
+                        new TestStorageServiceClientProviderFactory(),
+                        TestHelpers.GetTestNameResolver(),
+                        NullLoggerFactory.Instance,
+                        TestHelpers.GetMockPlatformInformationService()),
+                ],
+                new TestHostShutdownNotificationService(),
+                new DurableHttpMessageHandlerFactory(),
+                platformInformationService: TestHelpers.GetMockPlatformInformationService());
         }
 
         /// <summary>

--- a/test/FunctionsV2/Tests/Unit/SetRegisteredFunctionsTests.cs
+++ b/test/FunctionsV2/Tests/Unit/SetRegisteredFunctionsTests.cs
@@ -1,0 +1,47 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#nullable enable
+
+using System.Collections.Generic;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
+{
+    /// <summary>
+    /// Tests for <see cref="IDurabilityProviderFactory.SetRegisteredFunctions"/>.
+    /// </summary>
+    public class SetRegisteredFunctionsTests
+    {
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public void DefaultInterfaceMethod_IsNoOp()
+        {
+            // A factory that does NOT override SetRegisteredFunctions should use
+            // the default no-op implementation without throwing.
+            IDurabilityProviderFactory factory = new NoOpDurabilityProviderFactory();
+
+            factory.SetRegisteredFunctions(
+                new[] { "Orch1", "Orch2" },
+                new[] { "Activity1" },
+                new[] { "Entity1" });
+
+            // No exception = pass. The default method body is empty.
+        }
+
+        /// <summary>
+        /// A minimal factory that does NOT override SetRegisteredFunctions,
+        /// exercising the default interface method.
+        /// </summary>
+        private class NoOpDurabilityProviderFactory : IDurabilityProviderFactory
+        {
+            public string Name => "NoOpProvider";
+
+            public DurabilityProvider GetDurabilityProvider()
+                => throw new System.NotImplementedException();
+
+            public DurabilityProvider GetDurabilityProvider(DurableClientAttribute attribute)
+                => throw new System.NotImplementedException();
+        }
+    }
+}

--- a/test/e2e/Tests/Fixtures/FixtureHelpers.cs
+++ b/test/e2e/Tests/Fixtures/FixtureHelpers.cs
@@ -141,7 +141,6 @@ public static class FixtureHelpers
                 funcProcess.StartInfo.EnvironmentVariables["AzureFunctionsJobHost__extensions__durableTask__hubName"] = "default";
                 funcProcess.StartInfo.EnvironmentVariables["AzureFunctionsJobHost__extensions__durableTask__storageProvider__type"] = "azureManaged";
                 funcProcess.StartInfo.EnvironmentVariables["AzureFunctionsJobHost__extensions__durableTask__storageProvider__connectionStringName"] = "DURABLE_TASK_SCHEDULER_CONNECTION_STRING";
-                funcProcess.StartInfo.EnvironmentVariables["AzureFunctionsJobHost__extensions__durableTask__storageProvider__workItemFilteringEnabled"] = "true";
                 funcProcess.StartInfo.EnvironmentVariables["DURABLE_TASK_SCHEDULER_CONNECTION_STRING"] = $"Endpoint=http://localhost:8080;Authentication=None";
                 funcProcess.StartInfo.EnvironmentVariables["AzureFunctionsJobHost__extensions__durableTask__ThrowStatusExceptionsOnRaiseEvent"] = "true";
                 return;

--- a/test/e2e/Tests/Fixtures/FixtureHelpers.cs
+++ b/test/e2e/Tests/Fixtures/FixtureHelpers.cs
@@ -141,6 +141,7 @@ public static class FixtureHelpers
                 funcProcess.StartInfo.EnvironmentVariables["AzureFunctionsJobHost__extensions__durableTask__hubName"] = "default";
                 funcProcess.StartInfo.EnvironmentVariables["AzureFunctionsJobHost__extensions__durableTask__storageProvider__type"] = "azureManaged";
                 funcProcess.StartInfo.EnvironmentVariables["AzureFunctionsJobHost__extensions__durableTask__storageProvider__connectionStringName"] = "DURABLE_TASK_SCHEDULER_CONNECTION_STRING";
+                funcProcess.StartInfo.EnvironmentVariables["AzureFunctionsJobHost__extensions__durableTask__storageProvider__workItemFilteringEnabled"] = "true";
                 funcProcess.StartInfo.EnvironmentVariables["DURABLE_TASK_SCHEDULER_CONNECTION_STRING"] = $"Endpoint=http://localhost:8080;Authentication=None";
                 funcProcess.StartInfo.EnvironmentVariables["AzureFunctionsJobHost__extensions__durableTask__ThrowStatusExceptionsOnRaiseEvent"] = "true";
                 return;

--- a/test/e2e/Tests/Fixtures/FunctionAppProcess.cs
+++ b/test/e2e/Tests/Fixtures/FunctionAppProcess.cs
@@ -21,6 +21,12 @@ internal class FunctionAppProcess
     private ILogger logger;
     private TestLoggerProvider TestLogs;
 
+    /// <summary>
+    /// Additional environment variables to set on the function host process
+    /// before it starts. Set by fixture subclasses to scope settings to specific test collections.
+    /// </summary>
+    internal Dictionary<string, string>? AdditionalEnvironmentVariables { get; set; }
+
     public FunctionAppProcess(ILogger logger, TestLoggerProvider TestLogs, LanguageType testLanguage)
     {
         this.logger = logger;
@@ -91,6 +97,15 @@ internal class FunctionAppProcess
             this.logger.LogInformation($"  File name:   '${fileName}' Exists: '{File.Exists(fileName)}'");
 
             FixtureHelpers.AddDurableBackendEnvironmentVariables(this.funcProcess, this.logger);
+
+            if (this.AdditionalEnvironmentVariables != null)
+            {
+                foreach (var kvp in this.AdditionalEnvironmentVariables)
+                {
+                    this.logger.LogInformation($"  Additional env var: {kvp.Key}");
+                    this.funcProcess.StartInfo.EnvironmentVariables[kvp.Key] = kvp.Value;
+                }
+            }
 
             FixtureHelpers.StartProcessWithLogging(this.funcProcess, this.logger);
 

--- a/test/e2e/Tests/Fixtures/WorkItemFilterFixture.cs
+++ b/test/e2e/Tests/Fixtures/WorkItemFilterFixture.cs
@@ -1,0 +1,23 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Xunit.Abstractions;
+
+namespace Microsoft.Azure.Durable.Tests.DotnetIsolatedE2E;
+
+/// <summary>
+/// Fixture that starts the function host with work-item filtering enabled.
+/// Used by <see cref="WorkItemFilterTests"/> to scope the
+/// <c>workItemFilteringEnabled</c> setting to only those tests.
+/// </summary>
+public class WorkItemFilterFixture : FunctionAppFixture
+{
+    public WorkItemFilterFixture(IMessageSink messageSink)
+        : base(messageSink)
+    {
+        this.functionAppProcess.AdditionalEnvironmentVariables = new Dictionary<string, string>
+        {
+            ["AzureFunctionsJobHost__extensions__durableTask__storageProvider__workItemFilteringEnabled"] = "true",
+        };
+    }
+}

--- a/test/e2e/Tests/TestCollections/WorkItemFilterCollection.cs
+++ b/test/e2e/Tests/TestCollections/WorkItemFilterCollection.cs
@@ -1,0 +1,12 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Xunit;
+
+namespace Microsoft.Azure.Durable.Tests.DotnetIsolatedE2E;
+
+[CollectionDefinition(Name, DisableParallelization = true)]
+public class WorkItemFilterCollection : ICollectionFixture<WorkItemFilterFixture>
+{
+    public const string Name = "WorkItemFilterTests";
+}

--- a/test/e2e/Tests/Tests/WorkItemFilterTests.cs
+++ b/test/e2e/Tests/Tests/WorkItemFilterTests.cs
@@ -13,16 +13,16 @@ namespace Microsoft.Azure.Durable.Tests.DotnetIsolatedE2E;
 /// the DTS backend only dispatches work items for functions registered in this app.
 /// Orchestrations for unknown function names should stay Pending instead of failing.
 /// </summary>
-[Collection(Constants.FunctionAppCollectionName)]
+[Collection(WorkItemFilterCollection.Name)]
 [Trait("AzureStorage", "Skip")] // Work item filtering is a DTS-only feature
 [Trait("MSSQL", "Skip")] // Work item filtering is a DTS-only feature
 [Trait("DTS", "Skip")] // TODO: Remove once AzureManaged backend package with work item filter support is available
 public class WorkItemFilterTests
 {
-    private readonly FunctionAppFixture fixture;
+    private readonly WorkItemFilterFixture fixture;
     private readonly ITestOutputHelper output;
 
-    public WorkItemFilterTests(FunctionAppFixture fixture, ITestOutputHelper testOutputHelper)
+    public WorkItemFilterTests(WorkItemFilterFixture fixture, ITestOutputHelper testOutputHelper)
     {
         this.fixture = fixture;
         this.fixture.TestLogs.UseTestLogger(testOutputHelper);
@@ -63,21 +63,32 @@ public class WorkItemFilterTests
     {
         string unknownName = $"NonExistentOrchestration_{Guid.NewGuid():N}";
 
-        using HttpResponseMessage response = await HttpHelpers.InvokeHttpTrigger(
+        // Start a known orchestration alongside the unknown one so we can use
+        // its completion as a synchronization signal — proving the worker is
+        // actively dispatching work items — before asserting the unknown one
+        // is still Pending.
+        using HttpResponseMessage knownResponse = await HttpHelpers.InvokeHttpTrigger(
+            "StartOrchestration",
+            "?orchestrationName=HelloCities");
+
+        using HttpResponseMessage unknownResponse = await HttpHelpers.InvokeHttpTrigger(
             "StartOrchestration",
             $"?orchestrationName={unknownName}");
 
-        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
+        Assert.Equal(HttpStatusCode.Accepted, knownResponse.StatusCode);
+        Assert.Equal(HttpStatusCode.Accepted, unknownResponse.StatusCode);
 
-        string statusQueryGetUri = await DurableHelpers.ParseStatusQueryGetUriAsync(response);
+        string knownStatusUri = await DurableHelpers.ParseStatusQueryGetUriAsync(knownResponse);
+        string unknownStatusUri = await DurableHelpers.ParseStatusQueryGetUriAsync(unknownResponse);
 
-        // Wait a few seconds and verify it stays Pending (not Failed)
-        await Task.Delay(TimeSpan.FromSeconds(10));
+        // Wait for the known orchestration to complete — this proves the worker
+        // is running and dispatching work items.
+        await DurableHelpers.WaitForOrchestrationStateAsync(knownStatusUri, "Completed", 30);
 
-        var details = await DurableHelpers.GetRunningOrchestrationDetailsAsync(statusQueryGetUri);
-
+        // Now assert the unknown orchestration is still Pending.
         // With filtering enabled: Pending (DTS holds it — no matching worker)
         // Without filtering: would be Failed ("function doesn't exist")
+        var details = await DurableHelpers.GetRunningOrchestrationDetailsAsync(unknownStatusUri);
         Assert.Equal("Pending", details.RuntimeStatus);
 
         this.output.WriteLine(

--- a/test/e2e/Tests/Tests/WorkItemFilterTests.cs
+++ b/test/e2e/Tests/Tests/WorkItemFilterTests.cs
@@ -1,0 +1,124 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Net;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.Azure.Durable.Tests.DotnetIsolatedE2E;
+
+/// <summary>
+/// E2E tests for work item filtering with the AzureManaged (DTS) backend.
+/// These tests verify that when workItemFilteringEnabled is true in host.json,
+/// the DTS backend only dispatches work items for functions registered in this app.
+/// Orchestrations for unknown function names should stay Pending instead of failing.
+/// </summary>
+[Collection(Constants.FunctionAppCollectionName)]
+[Trait("AzureStorage", "Skip")] // Work item filtering is a DTS-only feature
+[Trait("MSSQL", "Skip")] // Work item filtering is a DTS-only feature
+[Trait("DTS", "Skip")] // TODO: Remove once AzureManaged backend package with work item filter support is available
+public class WorkItemFilterTests
+{
+    private readonly FunctionAppFixture fixture;
+    private readonly ITestOutputHelper output;
+
+    public WorkItemFilterTests(FunctionAppFixture fixture, ITestOutputHelper testOutputHelper)
+    {
+        this.fixture = fixture;
+        this.fixture.TestLogs.UseTestLogger(testOutputHelper);
+        this.output = testOutputHelper;
+    }
+
+    /// <summary>
+    /// Verifies that a known orchestration (registered in this app) completes normally
+    /// when work item filtering is enabled. This is the positive control — filters
+    /// should not prevent dispatching matching work items.
+    /// </summary>
+    [Fact]
+    public async Task KnownOrchestration_CompletesWithFiltering()
+    {
+        using HttpResponseMessage response = await HttpHelpers.InvokeHttpTrigger(
+            "StartOrchestration",
+            "?orchestrationName=HelloCities");
+
+        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
+
+        string statusQueryGetUri = await DurableHelpers.ParseStatusQueryGetUriAsync(response);
+
+        await DurableHelpers.WaitForOrchestrationStateAsync(statusQueryGetUri, "Completed", 30);
+
+        var details = await DurableHelpers.GetRunningOrchestrationDetailsAsync(statusQueryGetUri);
+        Assert.Equal("Completed", details.RuntimeStatus);
+        Assert.Contains("Hello Tokyo!", details.Output);
+    }
+
+    /// <summary>
+    /// Verifies that an unknown orchestration (NOT registered in this app) stays in
+    /// Pending state when work item filtering is enabled. Without filtering, this would
+    /// fail with "The function 'X' doesn't exist". With filtering, DTS holds the work
+    /// item in the queue because no connected worker has it in its filter list.
+    /// </summary>
+    [Fact]
+    public async Task UnknownOrchestration_StaysPendingWithFiltering()
+    {
+        string unknownName = $"NonExistentOrchestration_{Guid.NewGuid():N}";
+
+        using HttpResponseMessage response = await HttpHelpers.InvokeHttpTrigger(
+            "StartOrchestration",
+            $"?orchestrationName={unknownName}");
+
+        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
+
+        string statusQueryGetUri = await DurableHelpers.ParseStatusQueryGetUriAsync(response);
+
+        // Wait a few seconds and verify it stays Pending (not Failed)
+        await Task.Delay(TimeSpan.FromSeconds(10));
+
+        var details = await DurableHelpers.GetRunningOrchestrationDetailsAsync(statusQueryGetUri);
+
+        // With filtering enabled: Pending (DTS holds it — no matching worker)
+        // Without filtering: would be Failed ("function doesn't exist")
+        Assert.Equal("Pending", details.RuntimeStatus);
+
+        this.output.WriteLine(
+            $"Unknown orchestration '{unknownName}' stayed Pending as expected (filter isolation working)");
+    }
+
+    /// <summary>
+    /// Verifies that two different registered orchestration types both complete when filtering
+    /// is enabled. This proves filters correctly include all registered functions, not just one.
+    /// HelloCities calls SayHello activity; GetMainActivityInfoOrchestration calls a different
+    /// activity — proving both orchestrator and activity filters work across function types.
+    /// </summary>
+    [Fact]
+    public async Task DifferentKnownOrchestrations_BothCompleteWithFiltering()
+    {
+        // Start two different orchestration types
+        using HttpResponseMessage response1 = await HttpHelpers.InvokeHttpTrigger(
+            "StartOrchestration",
+            "?orchestrationName=HelloCities");
+
+        using HttpResponseMessage response2 = await HttpHelpers.InvokeHttpTrigger(
+            "StartOrchestration",
+            "?orchestrationName=GetMainActivityInfoOrchestration");
+
+        Assert.Equal(HttpStatusCode.Accepted, response1.StatusCode);
+        Assert.Equal(HttpStatusCode.Accepted, response2.StatusCode);
+
+        string uri1 = await DurableHelpers.ParseStatusQueryGetUriAsync(response1);
+        string uri2 = await DurableHelpers.ParseStatusQueryGetUriAsync(response2);
+
+        // Both should complete — filters include all registered functions
+        await DurableHelpers.WaitForOrchestrationStateAsync(uri1, "Completed", 30);
+        await DurableHelpers.WaitForOrchestrationStateAsync(uri2, "Completed", 30);
+
+        var details1 = await DurableHelpers.GetRunningOrchestrationDetailsAsync(uri1);
+        var details2 = await DurableHelpers.GetRunningOrchestrationDetailsAsync(uri2);
+
+        Assert.Equal("Completed", details1.RuntimeStatus);
+        Assert.Equal("Completed", details2.RuntimeStatus);
+
+        this.output.WriteLine($"Orchestration 1 output: {details1.Output}");
+        this.output.WriteLine($"Orchestration 2 output: {details2.Output}");
+    }
+}


### PR DESCRIPTION
# Summary
## What changed?
- Added `SetRegisteredFunctions(IReadOnlyCollection<string>, IReadOnlyCollection<string>, IReadOnlyCollection<string>)` default interface method to `IDurabilityProviderFactory` with a no-op default implementation
- Added a call to `SetRegisteredFunctions` in `DurableTaskExtension.StartTaskHubWorkerIfNotStartedAsync()`, before `EnsureTaskHubWorker().StartAsync()`, passing orchestrator/activity/entity names from `knownOrchestrators`/`knownActivities`/`knownEntities` (projected via `FunctionName.Name`). The durability provider is created before function indexing runs, so it doesn't know what orchestrators, activities, and entities the app has registered. SetRegisteredFunctions is called after indexing but before the worker starts, giving the provider the function names it needs to build work item filters for selective dispatch.
- Added a sample under samples/workitem-filters

## Why is this change needed?
- When multiple Function apps share the same Durable Task Scheduler (DTS) task hub, work items are dispatched to any connected worker causing failures when a worker receives a function it doesn't have (e.g., "The function 'X' doesn't exist")
- The DTS backend already supports `WorkItemFilters` on the `GetWorkItems` gRPC stream (from https://github.com/microsoft/durabletask-dotnet/pull/616). The AzureManaged durability provider needs the registered function names to build these filters. This PR provides the hook, the AzureManaged provider overrides `SetRegisteredFunctions` to build and send the proto filters.
- Non-AzureManaged backends are unaffected (the default implementation is a no-op)

## Issues / work items
- Related: https://github.com/microsoft/durabletask-dotnet/pull/616

---

# Project checklist
- [ ] Documentation changes are not required
  - [x] Documentation will be needed when the full feature ships (host.json `workItemFilteringEnabled` setting), tracked separately
- [x] Release notes are not required for the next release
- [x] Backport is not required
- [x] All required tests have been added/updated (unit tests, E2E tests)
- [x] No extra work is required to be leveraged by OutOfProc SDKs
- [x] No change to the version of the `WebJobs.Extensions.DurableTask` package
- [x] No EventIds were added to `EventSource` logs
- [ ] This change should be added to the `v2.x` branch
  - [x] This change applies exclusively to v3.x (default interface methods require C# 8+)
- [x] Not a breaking change — adds a new default interface method with no-op implementation

---

# AI-assisted code disclosure (required)
## Was an AI tool used? (select one)
- [ ] No
- [ ] Yes, AI helped write parts of this PR (e.g., GitHub Copilot)
- [x] Yes, an AI agent generated most of this PR

If AI was used:
- Tool(s): GitHub Copilot (Claude Opus 4.6)
- AI-assisted areas/files:
  - `IDurabilityProviderFactory.cs` (new `SetRegisteredFunctions` method)
  - `DurableTaskExtension.cs` (call site in `StartTaskHubWorkerIfNotStartedAsync`)
- What you changed after AI output: Reviewed code, verified lifecycle timing, validated against live DTS emulator E2E

AI verification (required if AI was used):
- [x] I understand the code and can explain it
- [x] I verified referenced APIs/types exist and are correct
- [x] I reviewed edge cases/failure paths (timeouts, retries, cancellation, exceptions)
- [x] I reviewed concurrency/async behavior
- [x] I checked for unintended breaking or behavior changes

---

# Testing
## Automated tests
- Result: Passed
- - Added `DefaultInterfaceMethod_IsNoOp` test

## Manual validation (only if runtime/behavior changed)
- Environment: Windows 11, .NET 8/10, DTS emulator (in-memory), Azurite (Docker), func 4.9.0
- Steps + observed results:
  1. Built local NuGet packages with this change + companion AzureManaged provider changes
  2. Ran .NET isolated Function app with `workItemFilteringEnabled: true` against DTS emulator
  3. Host log confirmed: `Work item filtering enabled. Registered N orchestrators, N activities, N entities.`
  4. Ran 8 E2E tests: matching orchestrations completed; non-matching stayed Pending (filter isolation confirmed)

---

# Notes for reviewers
- This is the extension-side half of work item filter support. The AzureManaged durability provider (separate package) implements the `SetRegisteredFunctions` override.
- `SetRegisteredFunctions` is called from `StartTaskHubWorkerIfNotStartedAsync` — guaranteed to run after function indexing but before `TaskHubWorker.StartAsync()`. This is a new call point; no existing factory method is called here today.
- The no-op default means all non-AzureManaged backends (Azure Storage, MSSQL, Netherite) are completely unaffected.