### PR TITLE
Add Function retry when the worker has not been fully initialized

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/OutOfProcMiddleware.cs
+++ b/src/WebJobs.Extensions.DurableTask/OutOfProcMiddleware.cs
@@ -409,9 +409,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
                 if (!functionResult.Succeeded)
                 {
-                    // This exception is thrown when another Function on the worker exceeded the Function timeout.
-                    // In this case we want to make sure to retry this entity's execution rather than marking it as failed.
-                    if (functionResult.Exception is Host.FunctionTimeoutAbortException)
+                    // These exception are thrown when either:
+                    // 1. Another Function on the worker exceeded the Function timeout.
+                    // 2. The worker the Activity was sent to has not yet been fully initialized and is not ready to process the Activity execution.
+                    // In these cases we want to make sure to retry this Activity's execution rather than marking it as failed.
+                    if (functionResult.Exception is Host.FunctionTimeoutAbortException || IsWorkerNotFullyInitializedException(functionResult.Exception))
                     {
                         throw functionResult.Exception;
                     }

--- a/src/WebJobs.Extensions.DurableTask/OutOfProcMiddleware.cs
+++ b/src/WebJobs.Extensions.DurableTask/OutOfProcMiddleware.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using DurableTask.Core;
@@ -21,6 +22,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
     internal class OutOfProcMiddleware
     {
         private const string NoProcessAssociatedMessage = "No process is associated";
+        private const string NoWorkerInitializedMessage = "Did not find any initialized language workers";
+        private const string AssemblyNotLoadedMessage = "Could not load file or assembly";
 
         private readonly DurableTaskExtension extension;
 
@@ -562,9 +565,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     cancellationToken: this.HostLifetimeService.OnStopping);
                 if (!result.Succeeded)
                 {
-                    // This exception is thrown when another Function on the worker exceeded the Function timeout.
-                    // In this case we want to make sure to retry this Activity's execution rather than marking it as failed.
-                    if (result.Exception is Host.FunctionTimeoutAbortException)
+                    // These exception are thrown when either:
+                    // 1. Another Function on the worker exceeded the Function timeout.
+                    // 2. The worker the Activity was sent to has not yet been fully initialized and is not ready to process the Activity execution.
+                    // In these cases we want to make sure to retry this Activity's execution rather than marking it as failed.
+                    if (result.Exception is Host.FunctionTimeoutAbortException || IsWorkerNotFullyInitializedException(result.Exception))
                     {
                         throw result.Exception;
                     }
@@ -666,7 +671,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 || exception?.InnerException is GrpcChannelTemporarilyUnavailableException
                 || (exception?.InnerException?.GetType().ToString().Contains("WorkerProcessExitException", StringComparison.Ordinal) ?? false)
                 || (exception?.InnerException is InvalidOperationException ioe
-                    && ioe.Message.Contains(NoProcessAssociatedMessage, StringComparison.Ordinal));
+                    && ioe.Message.Contains(NoProcessAssociatedMessage, StringComparison.Ordinal))
+                || IsWorkerNotFullyInitializedException(exception);
+        }
+
+        private static bool IsWorkerNotFullyInitializedException(Exception? exception)
+        {
+            return (exception?.InnerException is InvalidOperationException ioe && ioe.Message.Contains(NoWorkerInitializedMessage, StringComparison.Ordinal))
+                || (exception?.InnerException is FileNotFoundException fnfe && fnfe.Message.Contains(AssemblyNotLoadedMessage, StringComparison.Ordinal));
         }
 
         private static FailureDetails GetFailureDetails(Exception e, out bool fromSerializedException)

--- a/src/WebJobs.Extensions.DurableTask/OutOfProcMiddleware.cs
+++ b/src/WebJobs.Extensions.DurableTask/OutOfProcMiddleware.cs
@@ -565,7 +565,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     cancellationToken: this.HostLifetimeService.OnStopping);
                 if (!result.Succeeded)
                 {
-                    // These exception are thrown when either:
+                    // These exceptions are thrown when either:
                     // 1. Another Function on the worker exceeded the Function timeout.
                     // 2. The worker the Activity was sent to has not yet been fully initialized and is not ready to process the Activity execution.
                     // In these cases we want to make sure to retry this Activity's execution rather than marking it as failed.

--- a/test/FunctionsV2/Tests/Unit/OutOfProcMiddlewareTests.cs
+++ b/test/FunctionsV2/Tests/Unit/OutOfProcMiddlewareTests.cs
@@ -23,6 +23,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 {
     public class OutOfProcMiddlewareTests
     {
+        private const string NoWorkerInitializedMessage = "Did not find any initialized language workers";
+        private const string AssemblyNotLoadedMessage = "Could not load file or assembly 'SomeAssembly, Version=1.0.0.0'";
+
         [Fact]
         [Trait("Category", PlatformSpecificHelpers.TestCategory)]
         public async Task CallOrchestratorAsync_DifferentInvalidOperationException_DoesNotThrowSessionAbortedException()
@@ -84,7 +87,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             // indicates the worker is not yet ready and the activity should be retried.
             var exception = new Exception(
                 "Function invocation failed.",
-                new InvalidOperationException("Did not find any initialized language workers"));
+                new InvalidOperationException(NoWorkerInitializedMessage));
 
             (OutOfProcMiddleware middleware, DispatchMiddlewareContext dispatchContext) = this.SetupActivityTest(exception);
 
@@ -100,7 +103,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             // indicates the worker assembly is not yet loaded and the activity should be retried.
             var exception = new Exception(
                 "Function invocation failed.",
-                new FileNotFoundException("Could not load file or assembly 'SomeAssembly, Version=1.0.0.0'"));
+                new FileNotFoundException(AssemblyNotLoadedMessage));
 
             (OutOfProcMiddleware middleware, DispatchMiddlewareContext dispatchContext) = this.SetupActivityTest(exception);
 
@@ -132,10 +135,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             yield return new object[] { new GrpcChannelTemporarilyUnavailableException("The local gRPC endpoint is not available.") };
 
             // InvalidOperationException with "Did not find any initialized language workers" as InnerException (worker not yet initialized)
-            yield return new object[] { new Exception("Function invocation failed.", new InvalidOperationException("Did not find any initialized language workers")) };
+            yield return new object[] { new Exception("Function invocation failed.", new InvalidOperationException(NoWorkerInitializedMessage)) };
 
             // FileNotFoundException with "Could not load file or assembly" as InnerException (assembly not yet loaded during initialization)
-            yield return new object[] { new Exception("Function invocation failed.", new FileNotFoundException("Could not load file or assembly 'SomeAssembly, Version=1.0.0.0'")) };
+            yield return new object[] { new Exception("Function invocation failed.", new FileNotFoundException(AssemblyNotLoadedMessage)) };
         }
 
         private (OutOfProcMiddleware middleware, DispatchMiddlewareContext context) SetupOrchestratorTest(Exception executorException)

--- a/test/FunctionsV2/Tests/Unit/OutOfProcMiddlewareTests.cs
+++ b/test/FunctionsV2/Tests/Unit/OutOfProcMiddlewareTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
@@ -75,6 +76,38 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 () => middleware.CallActivityAsync(dispatchContext, () => Task.CompletedTask));
         }
 
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public async Task CallActivityAsync_WorkerNotInitializedException_ThrowsSessionAbortedException()
+        {
+            // Arrange: an InvalidOperationException with the "Did not find any initialized language workers" message
+            // indicates the worker is not yet ready and the activity should be retried.
+            var exception = new Exception(
+                "Function invocation failed.",
+                new InvalidOperationException("Did not find any initialized language workers"));
+
+            (OutOfProcMiddleware middleware, DispatchMiddlewareContext dispatchContext) = this.SetupActivityTest(exception);
+
+            await Assert.ThrowsAsync<SessionAbortedException>(
+                () => middleware.CallActivityAsync(dispatchContext, () => Task.CompletedTask));
+        }
+
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public async Task CallActivityAsync_AssemblyNotLoadedException_ThrowsSessionAbortedException()
+        {
+            // Arrange: a FileNotFoundException with the "Could not load file or assembly" message
+            // indicates the worker assembly is not yet loaded and the activity should be retried.
+            var exception = new Exception(
+                "Function invocation failed.",
+                new FileNotFoundException("Could not load file or assembly 'SomeAssembly, Version=1.0.0.0'"));
+
+            (OutOfProcMiddleware middleware, DispatchMiddlewareContext dispatchContext) = this.SetupActivityTest(exception);
+
+            await Assert.ThrowsAsync<SessionAbortedException>(
+                () => middleware.CallActivityAsync(dispatchContext, () => Task.CompletedTask));
+        }
+
         public static IEnumerable<object[]> PlatformLevelExceptions()
         {
             // FunctionTimeoutException (top-level)
@@ -97,6 +130,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
             // GrpcChannelTemporarilyUnavailableException as top-level exception (thrown in-process during binding)
             yield return new object[] { new GrpcChannelTemporarilyUnavailableException("The local gRPC endpoint is not available.") };
+
+            // InvalidOperationException with "Did not find any initialized language workers" as InnerException (worker not yet initialized)
+            yield return new object[] { new Exception("Function invocation failed.", new InvalidOperationException("Did not find any initialized language workers")) };
+
+            // FileNotFoundException with "Could not load file or assembly" as InnerException (assembly not yet loaded during initialization)
+            yield return new object[] { new Exception("Function invocation failed.", new FileNotFoundException("Could not load file or assembly 'SomeAssembly, Version=1.0.0.0'")) };
         }
 
         private (OutOfProcMiddleware middleware, DispatchMiddlewareContext context) SetupOrchestratorTest(Exception executorException)

--- a/test/FunctionsV2/Tests/Unit/OutOfProcMiddlewareTests.cs
+++ b/test/FunctionsV2/Tests/Unit/OutOfProcMiddlewareTests.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
     public class OutOfProcMiddlewareTests
     {
         private const string NoWorkerInitializedMessage = "Did not find any initialized language workers";
-        private const string AssemblyNotLoadedMessage = "Could not load file or assembly 'SomeAssembly, Version=1.0.0.0'";
+        private const string AssemblyNotLoadedMessage = "Could not load file or assembly";
 
         [Fact]
         [Trait("Category", PlatformSpecificHelpers.TestCategory)]

--- a/test/FunctionsV2/Tests/Unit/OutOfProcMiddlewareTests.cs
+++ b/test/FunctionsV2/Tests/Unit/OutOfProcMiddlewareTests.cs
@@ -69,6 +69,38 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
         [Fact]
         [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public async Task CallEntityAsync_WorkerNotInitializedException_ThrowsSessionAbortedException()
+        {
+            // Arrange: an InvalidOperationException with the "Did not find any initialized language workers" message
+            // indicates the worker is not yet ready and the entity should be retried.
+            var exception = new Exception(
+                "Function invocation failed.",
+                new InvalidOperationException(NoWorkerInitializedMessage));
+
+            (OutOfProcMiddleware middleware, DispatchMiddlewareContext dispatchContext) = this.SetupEntityTest(exception);
+
+            await Assert.ThrowsAsync<SessionAbortedException>(
+                () => middleware.CallEntityAsync(dispatchContext, () => Task.CompletedTask));
+        }
+
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public async Task CallEntityAsync_AssemblyNotLoadedException_ThrowsSessionAbortedException()
+        {
+            // Arrange: a FileNotFoundException with the "Could not load file or assembly" message
+            // indicates the worker assembly is not yet loaded and the entity should be retried.
+            var exception = new Exception(
+                "Function invocation failed.",
+                new FileNotFoundException(AssemblyNotLoadedMessage));
+
+            (OutOfProcMiddleware middleware, DispatchMiddlewareContext dispatchContext) = this.SetupEntityTest(exception);
+
+            await Assert.ThrowsAsync<SessionAbortedException>(
+                () => middleware.CallEntityAsync(dispatchContext, () => Task.CompletedTask));
+        }
+
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
         public async Task CallActivityAsync_FunctionTimeoutAbortException_ThrowsSessionAbortedException()
         {
             var exception = new FunctionTimeoutAbortException("Activity A timed out! Worker channel closing");


### PR DESCRIPTION
# Summary
## What changed?
This PR adds a new case for Activity/orchestration/entity execution failures that detects errors related to a worker not being fully initialized, and throws a `SessionAbortedException` in these cases which will ensure the Function execution is retried rather than failed.

## Why is this change needed?
Previously these Function invocations were marked as failed, but they should be retried for platform-related errors.

## Issues / work items
- Resolves #3438 

---

# Project checklist
- [ ] Documentation changes are not required
  - [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
- [ ] Release notes are not required for the next release
  - [ ] Otherwise: Notes added to `release_notes.md`
- [ ] Backport is not required
  - [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
- [ ] All required tests have been added/updated (unit tests, E2E tests)
- [ ] No extra work is required to be leveraged by OutOfProc SDKs
  - [ ] Otherwise: Work tracked here: #issue_or_pr_in_each_sdk
- [ ] No change to the version of the `WebJobs.Extensions.DurableTask` package
  - [ ] Otherwise: Major/minor updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
- [ ] No EventIds were added to `EventSource` logs
  - [ ] Otherwise: Ensure EventIds are within the supported range in the existing Windows infrastructure (validate via deployed telemetry). If needed, extend the range via a PR such as https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files
- [ ] This change should be added to the `v2.x` branch
  - [ ] Otherwise: This change applies exclusively to `WebJobs.Extensions.DurableTask` v3.x and will be retained only in the `dev` and `main` branches
- [ ] Breaking change?
  - [ ] If yes:
    - Impact:
    - Migration guidance:
---

# AI-assisted code disclosure (required)
## Was an AI tool used? (select one)
- [ ] No
- [ ] Yes, AI helped write parts of this PR (e.g., GitHub Copilot)
- [ ] Yes, an AI agent generated most of this PR

If AI was used:
- Tool(s):
- AI-assisted areas/files:
- What you changed after AI output:

AI verification (required if AI was used):
- [ ] I understand the code and can explain it
- [ ] I verified referenced APIs/types exist and are correct
- [ ] I reviewed edge cases/failure paths (timeouts, retries, cancellation, exceptions)
- [ ] I reviewed concurrency/async behavior
- [ ] I checked for unintended breaking or behavior changes

---

# Testing
## Automated tests
- Result: Passed / Failed (link logs if failed)

## Manual validation (only if runtime/behavior changed)
- Environment (OS, .NET version, components):
- Steps + observed results:
  1.
  2.
  3.
- Evidence (optional):

---

# Notes for reviewers
- N/A
