### PR TITLE
Fix null reference exception handling for disabled functions

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
@@ -1176,17 +1176,22 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             IReadOnlyCollection<string> activityNames,
             IReadOnlyCollection<string> entityNames) GetActiveRegisteredFunctionNames()
         {
+            // Note: dictionary values can be null for functions disabled via attribute or
+            // app setting. The binding provider registers the name with a null
+            // RegisteredFunctionInfo during indexing; for disabled functions the listener
+            // factory never replaces it. Treat null entries as inactive, matching the
+            // existing pattern in StopTaskHubWorkerIfIdleAsync.
             return (
                 orchestratorNames: this.knownOrchestrators
-                    .Where(kvp => !kvp.Value.IsDeregistered)
+                    .Where(kvp => kvp.Value != null && !kvp.Value.IsDeregistered)
                     .Select(kvp => kvp.Key.Name)
                     .ToList(),
                 activityNames: this.knownActivities
-                    .Where(kvp => !kvp.Value.IsDeregistered)
+                    .Where(kvp => kvp.Value != null && !kvp.Value.IsDeregistered)
                     .Select(kvp => kvp.Key.Name)
                     .ToList(),
                 entityNames: this.knownEntities
-                    .Where(kvp => !kvp.Value.IsDeregistered)
+                    .Where(kvp => kvp.Value != null && !kvp.Value.IsDeregistered)
                     .Select(kvp => kvp.Key.Name)
                     .ToList());
         }

--- a/test/FunctionsV2/Tests/Unit/SetRegisteredFunctionsTests.cs
+++ b/test/FunctionsV2/Tests/Unit/SetRegisteredFunctionsTests.cs
@@ -76,6 +76,45 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             Assert.DoesNotContain("Entity1", activeFunctions.entityNames);
         }
 
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public void DisabledFunctions_AreExcludedFromFilterList()
+        {
+            // Reproduces https://github.com/Azure/azure-functions-durable-extension/issues/3448.
+            // Binding providers register orchestrators/entities with a null RegisteredFunctionInfo
+            // during indexing (see OrchestrationTriggerAttributeBindingProvider /
+            // EntityTriggerAttributeBindingProvider). For functions disabled via attribute or
+            // the AzureWebJobs.<Name>.Disabled app setting, the listener factory never runs,
+            // so the null is never replaced. GetActiveRegisteredFunctionNames must (1) not
+            // throw NullReferenceException on those entries, and (2) treat them as inactive,
+            // matching the null-tolerant pattern used in StopTaskHubWorkerIfIdleAsync.
+            var extension = CreateExtension();
+
+            extension.RegisterOrchestrator(new FunctionName("DisabledOrch"), orchestratorInfo: null);
+            extension.RegisterOrchestrator(new FunctionName("ActiveOrch"), new RegisteredFunctionInfo(executor: null!, isOutOfProc: true));
+
+            // No "DisabledActivity" case: unlike RegisterOrchestrator / RegisterEntity (which
+            // accept and store a possibly-null RegisteredFunctionInfo), RegisterActivity always
+            // wraps its executor in a non-null RegisteredFunctionInfo, so knownActivities never
+            // holds a null value through any legitimate code path. The production null-check on
+            // activities exists for symmetry / defense-in-depth only and can't be exercised here
+            // without reflection.
+            extension.RegisterActivity(new FunctionName("ActiveActivity"), executor: null!);
+
+            extension.RegisterEntity(new FunctionName("DisabledEntity"), entityInfo: null);
+            extension.RegisterEntity(new FunctionName("ActiveEntity"), new RegisteredFunctionInfo(executor: null!, isOutOfProc: true));
+
+            var activeFunctions = extension.GetActiveRegisteredFunctionNames();
+
+            Assert.Contains("ActiveOrch", activeFunctions.orchestratorNames);
+            Assert.DoesNotContain("DisabledOrch", activeFunctions.orchestratorNames);
+
+            Assert.Contains("ActiveActivity", activeFunctions.activityNames);
+
+            Assert.Contains("ActiveEntity", activeFunctions.entityNames);
+            Assert.DoesNotContain("DisabledEntity", activeFunctions.entityNames);
+        }
+
         private static DurableTaskExtension CreateExtension()
         {
             var options = new DurableTaskOptions

--- a/test/e2e/Apps/BasicDotNetIsolated/DisabledActivity.cs
+++ b/test/e2e/Apps/BasicDotNetIsolated/DisabledActivity.cs
@@ -1,0 +1,15 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Microsoft.Azure.Functions.Worker;
+
+namespace Microsoft.Azure.Durable.Tests.E2E;
+
+// Disabled at runtime via the AzureWebJobs.DisabledActivity.Disabled app setting
+// in local.settings.json. Used by DisabledOrchestrationTests to validate that the app
+// keeps working when a disabled activity is registered.
+public static class DisabledActivity
+{
+    [Function(nameof(DisabledActivity))]
+    public static string Run([ActivityTrigger] string input) => input;
+}

--- a/test/e2e/Apps/BasicDotNetIsolated/DisabledEntity.cs
+++ b/test/e2e/Apps/BasicDotNetIsolated/DisabledEntity.cs
@@ -1,0 +1,17 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.DurableTask.Entities;
+
+namespace Microsoft.Azure.Durable.Tests.E2E;
+
+// Disabled at runtime via the AzureWebJobs.DisabledEntity.Disabled app setting
+// in local.settings.json. Used by DisabledOrchestrationTests to validate that the app
+// keeps working when a disabled entity is registered.
+public static class DisabledEntity
+{
+    [Function(nameof(DisabledEntity))]
+    public static Task Run([EntityTrigger] TaskEntityDispatcher dispatcher)
+        => dispatcher.DispatchAsync<object>();
+}

--- a/test/e2e/Apps/BasicDotNetIsolated/DisabledOrchestration.cs
+++ b/test/e2e/Apps/BasicDotNetIsolated/DisabledOrchestration.cs
@@ -1,0 +1,19 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.DurableTask;
+
+namespace Microsoft.Azure.Durable.Tests.E2E;
+
+// Disabled at runtime via the AzureWebJobs.DisabledOrchestration.Disabled app setting
+// in local.settings.json. Used by DisabledOrchestrationTests to validate that the app
+// keeps working when a disabled orchestration is registered.
+public static class DisabledOrchestration
+{
+    [Function(nameof(DisabledOrchestration))]
+    public static Task RunOrchestrator([OrchestrationTrigger] TaskOrchestrationContext context)
+    {
+        return Task.CompletedTask;
+    }
+}

--- a/test/e2e/Apps/BasicDotNetIsolated/local.settings.json
+++ b/test/e2e/Apps/BasicDotNetIsolated/local.settings.json
@@ -4,6 +4,9 @@
     "FUNCTIONS_INPROC_NET8_ENABLED": "1",
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",
-    "APPLICATIONINSIGHTS_CONNECTION_STRING": "InstrumentationKey=xxxx;IngestionEndpoint =https://xxxx.applicationinsights.azure.com/;LiveEndpoint=https://xxxx.livediagnostics.monitor.azure.com/"
+    "APPLICATIONINSIGHTS_CONNECTION_STRING": "InstrumentationKey=xxxx;IngestionEndpoint =https://xxxx.applicationinsights.azure.com/;LiveEndpoint=https://xxxx.livediagnostics.monitor.azure.com/",
+    "AzureWebJobs.DisabledOrchestration.Disabled": "true",
+    "AzureWebJobs.DisabledActivity.Disabled": "true",
+    "AzureWebJobs.DisabledEntity.Disabled": "true"
   }
 }

--- a/test/e2e/Tests/Tests/DisabledOrchestrationTests.cs
+++ b/test/e2e/Tests/Tests/DisabledOrchestrationTests.cs
@@ -1,0 +1,40 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Net;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.Azure.Durable.Tests.DotnetIsolatedE2E;
+
+// Validates that the app starts and active orchestrations run normally when
+// disabled durable functions (DisabledOrchestration, DisabledActivity,
+// DisabledEntity) are also registered.
+[Collection(Constants.FunctionAppCollectionName)]
+public class DisabledOrchestrationTests
+{
+    private readonly FunctionAppFixture fixture;
+
+    public DisabledOrchestrationTests(FunctionAppFixture fixture, ITestOutputHelper testOutputHelper)
+    {
+        this.fixture = fixture;
+        this.fixture.TestLogs.UseTestLogger(testOutputHelper);
+    }
+
+    [Fact]
+    public async Task ActiveOrchestration_StartsWhenDisabledFunctionsAreRegistered()
+    {
+        using HttpResponseMessage response = await HttpHelpers.InvokeHttpTrigger(
+            "StartOrchestration",
+            "?orchestrationName=HelloCities");
+
+        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
+
+        string statusQueryGetUri = await DurableHelpers.ParseStatusQueryGetUriAsync(response);
+        await DurableHelpers.WaitForOrchestrationStateAsync(statusQueryGetUri, "Completed", 30);
+
+        var details = await DurableHelpers.GetRunningOrchestrationDetailsAsync(statusQueryGetUri);
+        Assert.Equal("Completed", details.RuntimeStatus);
+        Assert.Contains("Hello Tokyo!", details.Output);
+    }
+}


### PR DESCRIPTION
Resolves #3448

# Summary

## What changed?

- Null-guarded the new `GetActiveRegisteredFunctionNames` in `DurableTaskExtension.cs` so that a `null` `RegisteredFunctionInfo` (left behind for functions disabled via attribute or `AzureWebJobs.<Name>.Disabled`) is treated as inactive instead of throwing `NullReferenceException`.
- Added a unit test (`SetRegisteredFunctionsTests.DisabledFunctions_AreExcludedFromFilterList`) covering null entries from disabled orchestrators and entities.
- Added three disabled durable functions to `BasicDotNetIsolated` (`DisabledOrchestration`, `DisabledActivity`, `DisabledEntity`) and an E2E test (`DisabledOrchestrationTests.ActiveOrchestration_StartsWhenDisabledFunctionsAreRegistered`) asserting that active durable functions still start when disabled ones are registered alongside them.

## Why is this change needed?

PR #3430 (shipped in `WebJobs.Extensions.DurableTask` 3.12.5 / `Worker.Extensions.DurableTask` 1.16.5) added `GetActiveRegisteredFunctionNames`, called from `StartTaskHubWorkerIfNotStartedAsync` before the task hub worker starts. It enumerates `knownOrchestrators`/`knownActivities`/`knownEntities` and reads `kvp.Value.IsDeregistered` without a null check.

The binding providers for orchestration and entity triggers call `RegisterOrchestrator(name, null)` / `RegisterEntity(name, null)` during indexing, storing a null in the dictionary. For functions disabled via `[Disable]` or `AzureWebJobs.<Name>.Disabled`, the listener factory never replaces that null. When any other listener tries to start, `GetActiveRegisteredFunctionNames` throws `NullReferenceException`, and every durable listener in the app fails with the symptom from #3448:

> `The listener for function '<name>' was unable to start. Microsoft.Azure.WebJobs.Extensions.DurableTask: Object reference not set to an instance of an object.`

The fix mirrors the convention already used in `StopTaskHubWorkerIfIdleAsync` (`info?.HasActiveListener ?? false`, with the inline comment "info can be null if function is disabled via attribute"), so a disabled function is treated as inactive and excluded from the work-item filter list.

## Issues / work items

- Resolves #3448

---

# Project checklist
- [x] Documentation changes are not required
- [ ] Release notes are not required for the next release
  - [ ] Otherwise: Notes added to `release_notes.md`
- [x] Backport is not required
- [x] All required tests have been added/updated (unit tests, E2E tests)
- [x] No extra work is required to be leveraged by OutOfProc SDKs
- [x] No change to the version of the `WebJobs.Extensions.DurableTask` package
- [x] No EventIds were added to `EventSource` logs
- [ ] This change should be added to the `v2.x` branch
  - [x] Otherwise: This change applies exclusively to `WebJobs.Extensions.DurableTask` v3.x
- [x] Not a breaking change

---

# AI-assisted code disclosure (required)
## Was an AI tool used?
- [x] Yes, an AI agent generated most of this PR

If AI was used:
- Tool(s): Claude Code
- AI-assisted areas/files: investigation of the regressing PR, the `GetActiveRegisteredFunctionNames` fix, `SetRegisteredFunctionsTests.DisabledFunctions_AreExcludedFromFilterList`, `BasicDotNetIsolated` disabled-function additions, `DisabledOrchestrationTests`.
- What you changed after AI output: Nothing

AI verification (required if AI was used):
- [x] I understand the code and can explain it
- [x] I verified referenced APIs/types exist and are correct
- [x] I reviewed edge cases/failure paths (timeouts, retries, cancellation, exceptions)
- [x] I reviewed concurrency/async behavior
- [x] I checked for unintended breaking or behavior changes

---

# Testing
## Automated tests
- Result: Passed (unit + E2E, locally on net10.0 against Azurite).

---

# Notes for reviewers
- N/A
