### PR TITLE
Add critical sections support for OOProc SDKs (schema V4)

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/Bindings/OrchestrationTriggerAttributeBindingProvider.cs
+++ b/src/WebJobs.Extensions.DurableTask/Bindings/OrchestrationTriggerAttributeBindingProvider.cs
@@ -251,7 +251,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     new JProperty("isReplaying", arg.IsReplaying),
                     new JProperty("parentInstanceId", arg.ParentInstanceId),
                     new JProperty("upperSchemaVersion", SchemaVersion.V2),
-                    new JProperty("upperSchemaVersionNew", SchemaVersion.V3),
+                    new JProperty("upperSchemaVersionNew", SchemaVersion.V4),
                     new JProperty("longRunningTimerIntervalDuration", arg.LongRunningTimerIntervalLength),
                     new JProperty("maximumShortTimerDuration", arg.MaximumShortTimerDuration),
                     new JProperty("defaultHttpAsyncRequestSleepTimeMillseconds", arg.DefaultHttpAsyncRequestSleepTimeMillseconds));

--- a/src/WebJobs.Extensions.DurableTask/Listener/OutOfProcOrchestrationShim.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/OutOfProcOrchestrationShim.cs
@@ -193,6 +193,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                             throw new ArgumentException("LockEntities action requires a non-empty LockSet.");
                         }
 
+                        if (action.LockSet.Any(e => e == null || string.IsNullOrEmpty(e.Name) || e.Key == null))
+                        {
+                            throw new ArgumentException("LockEntities action requires each LockSet entry to have a non-empty name and a non-null key.");
+                        }
+
                         var ctxForLock = this.context as DurableOrchestrationContext;
                         if (ctxForLock == null)
                         {

--- a/src/WebJobs.Extensions.DurableTask/Listener/OutOfProcOrchestrationShim.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/OutOfProcOrchestrationShim.cs
@@ -39,6 +39,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             Original = 0,
             V2 = 1,
             V3 = 2,
+            V4 = 3,
         }
 
         private enum AsyncActionType
@@ -56,6 +57,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             ScheduledSignalEntity = 10,
             WhenAny = 11,
             WhenAll = 12,
+            LockEntities = 13,
+            ReleaseEntities = 14,
         }
 
         // Handles replaying the Durable Task APIs that the out-of-proc function scheduled
@@ -183,6 +186,44 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 case AsyncActionType.WhenAny:
                     task = Task.WhenAny(action.CompoundActions.Select(x => this.InvokeAPIFromAction(x, schema)));
                     break;
+                case AsyncActionType.LockEntities:
+                    {
+                        if (action.LockSet == null || action.LockSet.Length == 0)
+                        {
+                            throw new ArgumentException("LockEntities action requires a non-empty LockSet.");
+                        }
+
+                        var ctxForLock = this.context as DurableOrchestrationContext;
+                        if (ctxForLock == null)
+                        {
+                            throw new InvalidOperationException("LockEntities action requires a DurableOrchestrationContext.");
+                        }
+
+                        var entityIds = action.LockSet
+                            .Select(e => new EntityId(e.Name, e.Key))
+                            .ToArray();
+
+                        // We intentionally do NOT hold onto the returned IDisposable here:
+                        // the worker emits an explicit ReleaseEntities action when the
+                        // user releases the lock (or when the orchestration completes).
+                        // ReleaseLocks() reads ContextLocks from the context.
+                        task = ((IDurableOrchestrationContext)ctxForLock).LockAsync(entityIds);
+                        break;
+                    }
+
+                case AsyncActionType.ReleaseEntities:
+                    {
+                        var ctxForRelease = this.context as DurableOrchestrationContext;
+                        if (ctxForRelease == null)
+                        {
+                            throw new InvalidOperationException("ReleaseEntities action requires a DurableOrchestrationContext.");
+                        }
+
+                        ctxForRelease.ReleaseLocks();
+                        task = fireAndForgetTask;
+                        break;
+                    }
+
                 default:
                     throw new Exception($"Received an unexpected action type from the out-of-proc function: '${action.ActionType}'.");
             }
@@ -229,6 +270,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         {
             switch (schema)
             {
+                case SchemaVersion.V4:
                 case SchemaVersion.V3:
                 case SchemaVersion.V2:
                     // In this schema, action arrays should be 1 dimensional (1 action per yield), but due to legacy behavior they're nested within a 2-dimensional array.
@@ -340,6 +382,18 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
             [JsonProperty("operation")]
             internal string EntityOperation { get; set; }
+
+            [JsonProperty("lockSet")]
+            internal LockSetEntry[] LockSet { get; set; }
+        }
+
+        private class LockSetEntry
+        {
+            [JsonProperty("name")]
+            internal string Name { get; set; }
+
+            [JsonProperty("key")]
+            internal string Key { get; set; }
         }
     }
 }

--- a/test/FunctionsV2/Tests/E2E/OutOfProcTests.cs
+++ b/test/FunctionsV2/Tests/E2E/OutOfProcTests.cs
@@ -505,5 +505,102 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 Assert.Equal(3, capturedRetryOptions.MaxNumberOfAttempts);
             }
         }
+
+        // --- LockEntities action validation (V4 schema) ---
+        //
+        // These tests exercise the input-validation guards in InvokeAPIFromAction's
+        // LockEntities branch. The guards run before the context cast, so we can
+        // assert ArgumentException using a plain IDurableOrchestrationContext mock.
+
+        [Theory]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        [InlineData(@"""lockSet"": []", "non-empty LockSet")]
+        [InlineData("", "non-empty LockSet")]
+        [InlineData(@"""lockSet"": [null]", "non-empty name and a non-null key")]
+        [InlineData(@"""lockSet"": [{""name"": """", ""key"": ""a""}]", "non-empty name and a non-null key")]
+        [InlineData(@"""lockSet"": [{""name"": ""Counter"", ""key"": null}]", "non-empty name and a non-null key")]
+        [InlineData(@"""lockSet"": [{""name"": ""Counter"", ""key"": ""ok""}, {""name"": """", ""key"": ""a""}]", "non-empty name and a non-null key")]
+        public async Task LockEntitiesAction_RejectsInvalidLockSet(string lockSetField, string expectedMessageFragment)
+        {
+            var contextMock = new Mock<IDurableOrchestrationContext>();
+            var shim = new OutOfProcOrchestrationShim(contextMock.Object);
+
+            var executionJson = $@"
+{{
+    ""isDone"": false,
+    ""schemaVersion"": ""V4"",
+    ""actions"": [
+        [{{
+            ""actionType"": ""LockEntities""{(string.IsNullOrEmpty(lockSetField) ? string.Empty : "," + lockSetField)}
+        }}]
+    ]
+}}";
+
+            var jsonObject = JObject.Parse(executionJson);
+            var result = new OrchestrationInvocationResult(jsonObject);
+
+            var ex = await Assert.ThrowsAsync<ArgumentException>(() => shim.ScheduleDurableTaskEvents(result));
+            Assert.Contains(expectedMessageFragment, ex.Message);
+        }
+
+        // Verifies that a well-formed LockEntities payload passes validation and entity-ID
+        // parsing, then fails at the concrete-context cast when the context is a plain
+        // IDurableOrchestrationContext mock. This is the deepest path reachable in a unit
+        // test; happy-path replay (LockAsync actually awaited) is covered by E2E tests
+        // built on top of the real DurableOrchestrationContext.
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public async Task LockEntitiesAction_ThrowsWhenContextIsNotDurableOrchestrationContext()
+        {
+            var contextMock = new Mock<IDurableOrchestrationContext>();
+            var shim = new OutOfProcOrchestrationShim(contextMock.Object);
+
+            var executionJson = @"
+{
+    ""isDone"": false,
+    ""schemaVersion"": ""V4"",
+    ""actions"": [
+        [{
+            ""actionType"": ""LockEntities"",
+            ""lockSet"": [
+                { ""name"": ""Counter"", ""key"": ""a"" },
+                { ""name"": ""Counter"", ""key"": ""b"" }
+            ]
+        }]
+    ]
+}";
+
+            var jsonObject = JObject.Parse(executionJson);
+            var result = new OrchestrationInvocationResult(jsonObject);
+
+            var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => shim.ScheduleDurableTaskEvents(result));
+            Assert.Contains("DurableOrchestrationContext", ex.Message);
+        }
+
+        // Same shape as the LockEntities cast-guard test, for the ReleaseEntities branch.
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public async Task ReleaseEntitiesAction_ThrowsWhenContextIsNotDurableOrchestrationContext()
+        {
+            var contextMock = new Mock<IDurableOrchestrationContext>();
+            var shim = new OutOfProcOrchestrationShim(contextMock.Object);
+
+            var executionJson = @"
+{
+    ""isDone"": false,
+    ""schemaVersion"": ""V4"",
+    ""actions"": [
+        [{
+            ""actionType"": ""ReleaseEntities""
+        }]
+    ]
+}";
+
+            var jsonObject = JObject.Parse(executionJson);
+            var result = new OrchestrationInvocationResult(jsonObject);
+
+            var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => shim.ScheduleDurableTaskEvents(result));
+            Assert.Contains("DurableOrchestrationContext", ex.Message);
+        }
     }
 }

--- a/test/FunctionsV2/Tests/E2E/OutOfProcTests.cs
+++ b/test/FunctionsV2/Tests/E2E/OutOfProcTests.cs
@@ -543,8 +543,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             Assert.Contains(expectedMessageFragment, ex.Message);
         }
 
-        // Verifies that a well-formed LockEntities payload passes validation and entity-ID
-        // parsing, then fails at the concrete-context cast when the context is a plain
+        // Verifies that a well-formed LockEntities payload passes LockSet validation,
+        // then fails at the concrete-context cast when the context is a plain
         // IDurableOrchestrationContext mock. This is the deepest path reachable in a unit
         // test; happy-path replay (LockAsync actually awaited) is covered by E2E tests
         // built on top of the real DurableOrchestrationContext.

--- a/test/e2e/Apps/BasicNode/src/functions/CriticalSections.ts
+++ b/test/e2e/Apps/BasicNode/src/functions/CriticalSections.ts
@@ -112,3 +112,29 @@ const nestedLockViolation: OrchestrationHandler = function* (context: Orchestrat
     }
 };
 df.app.orchestration("CriticalSectionNestedLockViolation", nestedLockViolation);
+
+// ----------------------------------------------------------------------------
+// CriticalSectionTimedLockHold
+//
+// Acquires a lock on a single hardcoded entity, holds it for ~5 seconds via
+// createTimer, then releases. Used by the mutual-exclusion test that starts
+// two instances simultaneously: the winner takes ~5 s end-to-end, while the
+// loser is blocked at `lock(...)` for ~5 s and then runs its own 5 s hold —
+// roughly ~10 s end-to-end. The C# test asserts the loser's elapsed time is
+// >= 2 × holdSec - slack.
+// ----------------------------------------------------------------------------
+const HOLD_LOCK_SECONDS = 5;
+const timedLockHold: OrchestrationHandler = function* (context: OrchestrationContext) {
+    const e = new df.EntityId(accountEntityName, "TimedHoldShared");
+
+    // @ts-expect-error context.df.lock ships in the next durable-functions release.
+    const lock = yield context.df.lock(e);
+    try {
+        const wakeAt = new Date(context.df.currentUtcDateTime.getTime() + HOLD_LOCK_SECONDS * 1000);
+        yield context.df.createTimer(wakeAt);
+        return "held";
+    } finally {
+        lock.release();
+    }
+};
+df.app.orchestration("CriticalSectionTimedLockHold", timedLockHold);

--- a/test/e2e/Apps/BasicNode/src/functions/CriticalSections.ts
+++ b/test/e2e/Apps/BasicNode/src/functions/CriticalSections.ts
@@ -1,0 +1,114 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+// Critical-section E2E coverage for the Node worker.
+//
+// These orchestrations exercise `context.df.lock(...)` and the locking-rule
+// enforcement that the durable-functions JS worker layers on top of OOProc
+// schema V4 (added in the JS worker PR that pairs with this extension change).
+//
+// All paired tests in CriticalSectionsTests.cs are currently skipped because
+// the JS worker change has not been released. The `@ts-expect-error` markers
+// below silence compile errors against the published `durable-functions`
+// package — they will start erroring once the package exposes `lock` /
+// `DurableLock`, forcing a cleanup pass alongside the dependency bump.
+
+import * as df from "durable-functions";
+import {
+    EntityContext,
+    EntityHandler,
+    OrchestrationContext,
+    OrchestrationHandler,
+} from "durable-functions";
+
+const accountEntityName = "CriticalSectionsAccount";
+
+// ----------------------------------------------------------------------------
+// Account entity: int balance, supports get / set / add.
+// ----------------------------------------------------------------------------
+const accountEntity: EntityHandler<number> = function (context: EntityContext<number>): void {
+    let balance: number = context.df.getState(() => 0);
+
+    switch (context.df.operationName) {
+        case "set":
+            balance = context.df.getInput<number>();
+            break;
+        case "add":
+            balance += context.df.getInput<number>();
+            break;
+        case "get":
+            context.df.return(balance);
+            break;
+    }
+
+    context.df.setState(balance);
+};
+df.app.entity(accountEntityName, accountEntity);
+
+// ----------------------------------------------------------------------------
+// CriticalSectionLockedTransfer
+//
+// Seeds two accounts via signals, acquires both locks, debits one, credits
+// the other, releases the locks, and returns the final balances as
+// "from=<n>;to=<n>". Tests assert the exact output string.
+//
+// Hardcoded keys (no input) so the existing StartOrchestration handler
+// (which doesn't forward query input to the orchestration) can drive it.
+// ----------------------------------------------------------------------------
+const lockedTransfer: OrchestrationHandler = function* (context: OrchestrationContext) {
+    const fromKey = "A";
+    const toKey = "B";
+    const amount = 30;
+
+    const src = new df.EntityId(accountEntityName, fromKey);
+    const dst = new df.EntityId(accountEntityName, toKey);
+
+    // Seed balances. Signals do not need to be inside the critical section.
+    context.df.signalEntity(src, "set", 100);
+    context.df.signalEntity(dst, "set", 0);
+
+    // @ts-expect-error context.df.lock ships in the next durable-functions release.
+    const lock = yield context.df.lock(src, dst);
+    try {
+        const fromBalance: number = yield context.df.callEntity(src, "get");
+        if (fromBalance < amount) {
+            return `insufficient:${fromBalance}`;
+        }
+        yield context.df.callEntity(src, "add", -amount);
+        yield context.df.callEntity(dst, "add", amount);
+    } finally {
+        lock.release();
+    }
+
+    // Re-read the balances *outside* the section so the assertion reflects
+    // the committed state visible after release.
+    const finalFrom: number = yield context.df.callEntity(src, "get");
+    const finalTo: number = yield context.df.callEntity(dst, "get");
+    return `from=${finalFrom};to=${finalTo}`;
+};
+df.app.orchestration("CriticalSectionLockedTransfer", lockedTransfer);
+
+// ----------------------------------------------------------------------------
+// CriticalSectionNestedLockViolation
+//
+// Acquires a lock and then attempts to acquire a second one. The JS worker
+// must throw LockingRulesViolationError on the inner `lock` call. The
+// orchestration is expected to FAIL (we let the exception propagate so the
+// test can assert RuntimeStatus == "Failed").
+// ----------------------------------------------------------------------------
+const nestedLockViolation: OrchestrationHandler = function* (context: OrchestrationContext) {
+    const eA = new df.EntityId(accountEntityName, "A");
+    const eB = new df.EntityId(accountEntityName, "B");
+
+    // @ts-expect-error context.df.lock ships in the next durable-functions release.
+    const lock = yield context.df.lock(eA);
+    try {
+        // This call must throw LockingRulesViolationError synchronously.
+        // @ts-expect-error context.df.lock ships in the next durable-functions release.
+        yield context.df.lock(eB);
+        return "reached-after-inner-lock"; // should not be returned
+    } finally {
+        lock.release();
+    }
+};
+df.app.orchestration("CriticalSectionNestedLockViolation", nestedLockViolation);

--- a/test/e2e/Tests/Tests/CriticalSectionsTests.cs
+++ b/test/e2e/Tests/Tests/CriticalSectionsTests.cs
@@ -97,4 +97,86 @@ public class CriticalSectionsTests
         // on a stable substring; the full message is worker-defined and may change.
         Assert.Contains("critical section", orchestrationDetails.Output, StringComparison.OrdinalIgnoreCase);
     }
+
+    /// <summary>
+    /// Mutual exclusion: two instances of <c>CriticalSectionTimedLockHold</c> start
+    /// concurrently and contend for the same single-entity lock. The winner acquires
+    /// the lock, holds it for ~<see cref="HoldLockSeconds"/> seconds via a durable
+    /// timer, then releases. The loser blocks at <c>lock(...)</c> until the winner
+    /// releases, then runs its own ~<see cref="HoldLockSeconds"/>-second hold.
+    ///
+    /// If the locks really serialize the two instances, the slower (loser)
+    /// orchestration's end-to-end elapsed time must be at least <c>2 × hold</c>.
+    /// If the locks did NOT serialize (a regression), both instances would finish
+    /// in ~<c>hold</c>. We assert <c>slowest &gt;= 2 × hold − slack</c>; the slack
+    /// absorbs scheduling jitter and timer granularity in the DTS emulator.
+    /// </summary>
+    [Fact]
+    [Trait("Node", "Skip")] // TODO: remove once durable-functions ships context.df.lock
+    [Trait("Dotnet", "Skip")] // CriticalSection* orchestrations are only registered in the BasicNode app
+    [Trait("Python", "Skip")] // context.df.lock is not implemented in Python
+    [Trait("PowerShell", "Skip")] // Durable Entities are not implemented in PowerShell
+    [Trait("Java", "Skip")] // Durable Entities are not implemented in Java
+    [Trait("MSSQL", "Skip")] // Durable Entities are not supported in MSSQL for out-of-proc
+    public async Task CriticalSection_ConcurrentLockedTransfers_Serialize()
+    {
+        // Must match HOLD_LOCK_SECONDS in BasicNode/src/functions/CriticalSections.ts.
+        const int HoldLockSeconds = 5;
+        const int SlackSeconds = 1;
+        const int WaitTimeoutSeconds = 60;
+
+        // Fire two starts in parallel so neither has a head start beyond the
+        // HTTP round trip.
+        Task<HttpResponseMessage> start1 = HttpHelpers.InvokeHttpTrigger(
+            functionName: "StartOrchestration",
+            queryString: "?orchestrationName=CriticalSectionTimedLockHold");
+        Task<HttpResponseMessage> start2 = HttpHelpers.InvokeHttpTrigger(
+            functionName: "StartOrchestration",
+            queryString: "?orchestrationName=CriticalSectionTimedLockHold");
+
+        HttpResponseMessage[] startResponses = await Task.WhenAll(start1, start2);
+        try
+        {
+            Assert.Equal(HttpStatusCode.Accepted, startResponses[0].StatusCode);
+            Assert.Equal(HttpStatusCode.Accepted, startResponses[1].StatusCode);
+
+            string statusUri1 = await DurableHelpers.ParseStatusQueryGetUriAsync(startResponses[0]);
+            string statusUri2 = await DurableHelpers.ParseStatusQueryGetUriAsync(startResponses[1]);
+
+            // Wait for both to complete in parallel.
+            await Task.WhenAll(
+                DurableHelpers.WaitForOrchestrationStateAsync(statusUri1, "Completed", WaitTimeoutSeconds),
+                DurableHelpers.WaitForOrchestrationStateAsync(statusUri2, "Completed", WaitTimeoutSeconds));
+
+            DurableHelpers.OrchestrationStatusDetails details1 =
+                await DurableHelpers.GetRunningOrchestrationDetailsAsync(statusUri1);
+            DurableHelpers.OrchestrationStatusDetails details2 =
+                await DurableHelpers.GetRunningOrchestrationDetailsAsync(statusUri2);
+
+            Assert.NotEqual(details1.InstanceId, details2.InstanceId);
+            Assert.Equal("\"held\"", details1.Output);
+            Assert.Equal("\"held\"", details2.Output);
+
+            TimeSpan elapsed1 = details1.LastUpdatedTime - details1.CreatedTime;
+            TimeSpan elapsed2 = details2.LastUpdatedTime - details2.CreatedTime;
+            TimeSpan slowest = elapsed1 > elapsed2 ? elapsed1 : elapsed2;
+
+            this.output.WriteLine(
+                $"Instance 1: elapsed={elapsed1.TotalSeconds:F2}s; Instance 2: elapsed={elapsed2.TotalSeconds:F2}s; slowest={slowest.TotalSeconds:F2}s");
+
+            // If the locks serialize the two instances, the loser cannot finish in
+            // less than ~2 × hold seconds. Without lock serialization, both would
+            // finish in ~hold seconds and this assertion would fail.
+            double minSlowestSeconds = (2 * HoldLockSeconds) - SlackSeconds;
+            Assert.True(
+                slowest.TotalSeconds >= minSlowestSeconds,
+                $"Expected slower instance to take >= {minSlowestSeconds}s (mutual exclusion), but it took {slowest.TotalSeconds:F2}s. " +
+                $"Instance 1: {elapsed1.TotalSeconds:F2}s, Instance 2: {elapsed2.TotalSeconds:F2}s.");
+        }
+        finally
+        {
+            startResponses[0].Dispose();
+            startResponses[1].Dispose();
+        }
+    }
 }

--- a/test/e2e/Tests/Tests/CriticalSectionsTests.cs
+++ b/test/e2e/Tests/Tests/CriticalSectionsTests.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Azure.Durable.Tests.DotnetIsolatedE2E;
 ///
 /// Today every test is skipped for every language. Reason matrix:
 ///   - Node: the extension half is in this repo, but the JS worker change
-///     (durable-functions PR `vabachu/critical-sections-js-2`) has not been
+///     (durable-functions PR) has not been
 ///     released. Remove <c>[Trait("Node", "Skip")]</c> once `durable-functions`
 ///     ships the <c>context.df.lock</c> API.
 ///   - Dotnet: the test orchestrations (CriticalSectionLockedTransfer,

--- a/test/e2e/Tests/Tests/CriticalSectionsTests.cs
+++ b/test/e2e/Tests/Tests/CriticalSectionsTests.cs
@@ -1,0 +1,100 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Net;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.Azure.Durable.Tests.DotnetIsolatedE2E;
+
+/// <summary>
+/// E2E coverage for OOProc critical sections (entity locks).
+///
+/// These tests exercise the new <c>LockEntities</c> / <c>ReleaseEntities</c>
+/// action types and OOProc schema V4 that this extension change adds.
+///
+/// Today every test is skipped for every language. Reason matrix:
+///   - Node: the extension half is in this repo, but the JS worker change
+///     (durable-functions PR `vabachu/critical-sections-js-2`) has not been
+///     released. Remove <c>[Trait("Node", "Skip")]</c> once `durable-functions`
+///     ships the <c>context.df.lock</c> API.
+///   - Dotnet: the test orchestrations (CriticalSectionLockedTransfer,
+///     CriticalSectionNestedLockViolation) are only registered in the
+///     BasicNode app — running them against BasicDotNetIsolated would 404.
+///   - Python, PowerShell, Java: <c>context.df.lock</c> / equivalent is not
+///     implemented in those OOProc workers yet.
+///   - MSSQL backend: entities are not supported in MSSQL for out-of-proc
+///     (https://github.com/microsoft/durabletask-mssql/issues/205).
+/// </summary>
+[Collection(Constants.FunctionAppCollectionName)]
+public class CriticalSectionsTests
+{
+    private readonly FunctionAppFixture fixture;
+    private readonly ITestOutputHelper output;
+
+    public CriticalSectionsTests(FunctionAppFixture fixture, ITestOutputHelper testOutputHelper)
+    {
+        this.fixture = fixture;
+        this.fixture.TestLogs.UseTestLogger(testOutputHelper);
+        this.output = testOutputHelper;
+    }
+
+    /// <summary>
+    /// Happy-path: orchestration acquires both locks, transfers 30 from A (seeded 100)
+    /// to B (seeded 0), releases, and reports the post-commit balances.
+    /// </summary>
+    [Fact]
+    [Trait("Node", "Skip")] // TODO: remove once durable-functions ships context.df.lock
+    [Trait("Dotnet", "Skip")] // CriticalSection* orchestrations are only registered in the BasicNode app
+    [Trait("Python", "Skip")] // context.df.lock is not implemented in Python
+    [Trait("PowerShell", "Skip")] // Durable Entities are not implemented in PowerShell
+    [Trait("Java", "Skip")] // Durable Entities are not implemented in Java
+    [Trait("MSSQL", "Skip")] // Durable Entities are not supported in MSSQL for out-of-proc (see https://github.com/microsoft/durabletask-mssql/issues/205)
+    public async Task CriticalSection_LockedTransfer_Succeeds()
+    {
+        using HttpResponseMessage response = await HttpHelpers.InvokeHttpTrigger(
+            functionName: "StartOrchestration",
+            queryString: "?orchestrationName=CriticalSectionLockedTransfer");
+        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
+
+        string statusQueryGetUri = await DurableHelpers.ParseStatusQueryGetUriAsync(response);
+        await DurableHelpers.WaitForOrchestrationStateAsync(statusQueryGetUri, "Completed", 60);
+
+        DurableHelpers.OrchestrationStatusDetails orchestrationDetails =
+            await DurableHelpers.GetRunningOrchestrationDetailsAsync(statusQueryGetUri);
+
+        // The orchestration seeds A=100, B=0 and transfers 30, so the post-commit balances
+        // must be exactly A=70, B=30. Quoted because the JSON output is a string.
+        Assert.Equal("\"from=70;to=30\"", orchestrationDetails.Output);
+    }
+
+    /// <summary>
+    /// Rule enforcement: a nested <c>lock</c> call inside an active critical
+    /// section must throw <c>LockingRulesViolationError</c> and fail the
+    /// orchestration.
+    /// </summary>
+    [Fact]
+    [Trait("Node", "Skip")] // TODO: remove once durable-functions ships context.df.lock
+    [Trait("Dotnet", "Skip")] // CriticalSection* orchestrations are only registered in the BasicNode app
+    [Trait("Python", "Skip")] // context.df.lock is not implemented in Python
+    [Trait("PowerShell", "Skip")] // Durable Entities are not implemented in PowerShell
+    [Trait("Java", "Skip")] // Durable Entities are not implemented in Java
+    [Trait("MSSQL", "Skip")] // Durable Entities are not supported in MSSQL for out-of-proc
+    public async Task CriticalSection_NestedLock_FailsOrchestration()
+    {
+        using HttpResponseMessage response = await HttpHelpers.InvokeHttpTrigger(
+            functionName: "StartOrchestration",
+            queryString: "?orchestrationName=CriticalSectionNestedLockViolation");
+        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
+
+        string statusQueryGetUri = await DurableHelpers.ParseStatusQueryGetUriAsync(response);
+        await DurableHelpers.WaitForOrchestrationStateAsync(statusQueryGetUri, "Failed", 60);
+
+        DurableHelpers.OrchestrationStatusDetails orchestrationDetails =
+            await DurableHelpers.GetRunningOrchestrationDetailsAsync(statusQueryGetUri);
+
+        // The failure payload must mention the locking-rule violation. We assert
+        // on a stable substring; the full message is worker-defined and may change.
+        Assert.Contains("critical section", orchestrationDetails.Output, StringComparison.OrdinalIgnoreCase);
+    }
+}


### PR DESCRIPTION
# Summary
## What changed?
- Bumped advertised OOProc schema from V3 to V4 in `OrchestrationTriggerAttributeBindingProvider` so SDKs can opt in to critical-section semantics.
- Added two new async action types in `OutOfProcOrchestrationShim`: `LockEntities` (13) and `ReleaseEntities` (14), plus the corresponding `LockSet` / `LockSetEntry` JSON shape.
- `LockEntities` handler resolves the `EntityId[]` from the lock set and calls `IDurableOrchestrationContext.LockAsync(...)`. `ReleaseEntities` calls `DurableOrchestrationContext.ReleaseLocks()` and completes as fire-and-forget.
- Extended the `SchemaVersion` enum and `InvokeAPIFromAction` switch to recognize V4.

## Why is this change needed?
- The JS Durable Functions SDK is adding `context.df.lock(...)` / `isLocked()` (critical sections) and needs an extension that understands the new action types. This is the extension half of that change.
- Reuses the existing `callEntity` replay shape (`RequestMessage` keyed by lock-request GUID, matched by `EventRaised`) — no new history event type is introduced. Only the action surface and the schema-version handshake change.

## Issues / work items
- Resolves #
- Related https://github.com/Azure/azure-functions-durable-js/pull/704

---

# Project checklist
- [ ] Documentation changes are not required
  - [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
- [ ] Release notes are not required for the next release
  - [ ] Otherwise: Notes added to `release_notes.md`
- [x] Backport is not required
  - [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
- [ ] All required tests have been added/updated (unit tests, E2E tests)
- [ ] No extra work is required to be leveraged by OutOfProc SDKs
  - [x] Otherwise: Work tracked here: JS worker PR `vabachu/critical-sections-js-2` (Python/Java/PowerShell follow-ups TBD)
- [ ] No change to the version of the `WebJobs.Extensions.DurableTask` package
  - [ ] Otherwise: Major/minor updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
- [x] No EventIds were added to `EventSource` logs
- [ ] This change should be added to the `v2.x` branch
  - [x] Otherwise: Applies exclusively to v3.x — retained in `dev` and `main` only.
- [ ] Breaking change?
  - [ ] If yes:
    - Impact:
    - Migration guidance:

---

# AI-assisted code disclosure (required)
## Was an AI tool used? (select one)
- [ ] No
- [x] Yes, AI helped write parts of this PR (e.g., GitHub Copilot)
- [ ] Yes, an AI agent generated most of this PR

If AI was used:
- Tool(s): GitHub Copilot
- AI-assisted areas/files:
- What you changed after AI output:

AI verification (required if AI was used):
- [x] I understand the code and can explain it
- [x] I verified referenced APIs/types exist and are correct
- [x] I reviewed edge cases/failure paths (timeouts, retries, cancellation, exceptions)
- [x] I reviewed concurrency/async behavior
- [x] I checked for unintended breaking or behavior changes