### PR TITLE
Add worker drain signal

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/OutOfProcMiddleware.cs
+++ b/src/WebJobs.Extensions.DurableTask/OutOfProcMiddleware.cs
@@ -24,6 +24,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         private const string NoProcessAssociatedMessage = "No process is associated";
         private const string NoWorkerInitializedMessage = "Did not find any initialized language workers";
         private const string AssemblyNotLoadedMessage = "Could not load file or assembly";
+        private const string WorkerDrainingMessageMarker = "[DurableTask:WorkerDraining]";
 
         private readonly DurableTaskExtension extension;
 
@@ -124,6 +125,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 workItemMetadata.IncludeState);
 
             bool workerRequiresHistory = false;
+            bool isWorkerDraining = false;
 
             var input = new TriggeredFunctionData
             {
@@ -153,6 +155,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     P.OrchestratorResponse response = P.OrchestratorResponse.Parser.ParseFrom(triggerReturnValueBytes);
 
                     workerRequiresHistory = response.RequiresHistory;
+                    isWorkerDraining = response.IsWorkerDraining;
 
                     // TrySetResult may throw if a platform-level error is encountered (like an out of memory exception).
                     context.SetResult(
@@ -178,6 +181,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     // Shutdown can surface as a completed invocation in a failed state.
                     // Re-throw so we can abort this invocation.
                     this.HostLifetimeService.OnStopping.ThrowIfCancellationRequested();
+
+                    // The Function may have failed because the worker is draining, so we want to retry its execution in this case
+                    if (isWorkerDraining)
+                    {
+                        throw new Exception("Worker is shutting down. The orchestration execution will be aborted and retried.");
+                    }
                 }
 
                 // we abort the invocation on "platform level errors" such as:
@@ -193,7 +202,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             {
                 string reason = this.HostLifetimeService.OnStopping.IsCancellationRequested ?
                     "The Functions/WebJobs runtime is shutting down!" :
-                    $"Unhandled exception in the Functions/WebJobs runtime: {hostRuntimeException}";
+                        isWorkerDraining ?
+                             "The worker is shutting down. The orchestration execution will be aborted and retried." :
+                                $"Unhandled exception in the Functions/WebJobs runtime: {hostRuntimeException}";
 
                 this.TraceHelper.FunctionAborted(
                     this.Options.HubName,
@@ -365,6 +376,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 workItemMetadata.IncludeState);
 
             bool workerRequiresEntityState = false;
+            bool isWorkerDraining = false;
 
             var input = new TriggeredFunctionData
             {
@@ -393,6 +405,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     byte[] triggerReturnValueBytes = Convert.FromBase64String(triggerReturnValue);
                     P.EntityBatchResult response = P.EntityBatchResult.Parser.ParseFrom(triggerReturnValueBytes);
                     workerRequiresEntityState = response.RequiresState;
+                    isWorkerDraining = response.IsWorkerDraining;
                     context.Result = response.ToEntityBatchResult(this.Options.DefaultVersion);
 
                     context.ThrowIfFailed();
@@ -418,6 +431,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                         throw functionResult.Exception;
                     }
 
+                    // The Function may have failed because the worker is draining, so we want to retry its execution in this case
+                    if (isWorkerDraining)
+                    {
+                        throw new Exception("Worker is shutting down. The entity execution will be aborted and retried.");
+                    }
+
                     // Shutdown can surface as a completed invocation in a failed state.
                     // Re-throw so we can abort this invocation.
                     this.HostLifetimeService.OnStopping.ThrowIfCancellationRequested();
@@ -427,7 +446,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             {
                 string reason = this.HostLifetimeService.OnStopping.IsCancellationRequested ?
                     "The Functions/WebJobs runtime is shutting down!" :
-                    $"Unhandled exception in the Functions/WebJobs runtime: {hostRuntimeException}";
+                        isWorkerDraining ?
+                             "The worker is shutting down. The entity execution will be aborted and retried." :
+                                $"Unhandled exception in the Functions/WebJobs runtime: {hostRuntimeException}";
 
                 this.TraceHelper.FunctionAborted(
                     this.Options.HubName,
@@ -598,6 +619,19 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 throw new SessionAbortedException(reason);
             }
 
+            // The Function may have failed because the worker is draining, so we want to retry its execution in this case
+            if (!result.Succeeded && IsWorkerDrainingException(result.Exception))
+            {
+                this.TraceHelper.FunctionAborted(
+                    this.Options.HubName,
+                    functionName.Name,
+                    instance.InstanceId,
+                    "The worker is shutting down. The activity execution will be aborted and retried.",
+                    functionType: FunctionType.Activity);
+
+                throw new SessionAbortedException("The worker is shutting down. The activity execution will be aborted and retried.");
+            }
+
             ActivityExecutionResult activityResult;
             if (result.Succeeded)
             {
@@ -681,6 +715,19 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         {
             return (exception?.InnerException is InvalidOperationException ioe && ioe.Message.Contains(NoWorkerInitializedMessage, StringComparison.Ordinal))
                 || (exception?.InnerException is FileNotFoundException fnfe && fnfe.Message.Contains(AssemblyNotLoadedMessage, StringComparison.Ordinal));
+        }
+
+        private static bool IsWorkerDrainingException(Exception? exception)
+        {
+            for (Exception? current = exception; current != null; current = current.InnerException)
+            {
+                if (current.Message != null && current.Message.Contains(WorkerDrainingMessageMarker, StringComparison.Ordinal))
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         private static FailureDetails GetFailureDetails(Exception e, out bool fromSerializedException)

--- a/src/Worker.Extensions.DurableTask/Exceptions/WorkerDrainingException.cs
+++ b/src/Worker.Extensions.DurableTask/Exceptions/WorkerDrainingException.cs
@@ -1,0 +1,23 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.Azure.Functions.Worker.Extensions.DurableTask.Exceptions;
+
+/// <summary>
+/// Thrown by the worker when a Function completes while the worker is draining (shutting down).
+/// </summary>
+internal sealed class WorkerDrainingException : Exception
+{
+    /// <summary>
+    /// Stable marker the host matches on to detect this exception after it crosses the gRPC boundary
+    /// as a serialized string. The host keeps an identical copy of this literal; keep them in sync.
+    /// </summary>
+    internal const string Sentinel = "[DurableTask:WorkerDraining]";
+
+    public WorkerDrainingException()
+        : base($"The worker is shutting down and will not commit this result; the work item should be retried on another worker. {Sentinel}")
+    {
+    }
+}

--- a/src/Worker.Extensions.DurableTask/Exceptions/WorkerDrainingException.cs
+++ b/src/Worker.Extensions.DurableTask/Exceptions/WorkerDrainingException.cs
@@ -3,6 +3,7 @@
 
 using System;
 
+#nullable enable
 namespace Microsoft.Azure.Functions.Worker.Extensions.DurableTask.Exceptions;
 
 /// <summary>

--- a/src/Worker.Extensions.DurableTask/Execution/DurableFunctionExecutor.Activity.cs
+++ b/src/Worker.Extensions.DurableTask/Execution/DurableFunctionExecutor.Activity.cs
@@ -28,11 +28,16 @@ internal partial class DurableFunctionExecutor
             if (context.FunctionDefinition.EntryPoint == ActivityEntryPoint)
             {
                 await this.RunDirectActivityAsync(context, triggerBinding);
-                return;
+            }
+            else
+            {
+                await inner.ExecuteAsync(context);
             }
 
-            await inner.ExecuteAsync(context);
-            return;
+            if (this.IsWorkerDraining)
+            {
+                throw new WorkerDrainingException();
+            }
         }
         catch (Exception ex)
         {

--- a/src/Worker.Extensions.DurableTask/Execution/DurableFunctionExecutor.Entity.cs
+++ b/src/Worker.Extensions.DurableTask/Execution/DurableFunctionExecutor.Entity.cs
@@ -3,9 +3,11 @@
 
 using System;
 using System.Threading.Tasks;
+using Google.Protobuf;
 using Microsoft.DurableTask.Entities;
 using Microsoft.DurableTask.Worker;
 using Microsoft.DurableTask.Worker.Grpc;
+using P = Microsoft.DurableTask.Protobuf;
 
 namespace Microsoft.Azure.Functions.Worker.Extensions.DurableTask.Execution;
 
@@ -40,7 +42,15 @@ internal partial class DurableFunctionExecutor
         TaskEntityDispatcher dispatcher = new(encodedEntityBatch, context.InstanceServices, extendedSessionsCache);
         triggerInputData.Value = dispatcher;
         await inner.ExecuteAsync(context);
-        context.GetInvocationResult().Value = dispatcher.Result;
+
+        string entityResult = dispatcher.Result;
+
+        if (this.IsWorkerDraining)
+        {
+            entityResult = FlagEntityDraining(entityResult);
+        }
+
+        context.GetInvocationResult().Value = entityResult;
     }
 
     private async Task RunDirectEntityAsync(
@@ -61,6 +71,20 @@ internal partial class DurableFunctionExecutor
 
         string result = await GrpcEntityRunner.LoadAndRunAsync(
             encodedEntityBatch, entity, context.InstanceServices);
+
+        if (this.IsWorkerDraining)
+        {
+            result = FlagEntityDraining(result);
+        }
+
         context.GetInvocationResult().Value = result;
+    }
+
+    private static string FlagEntityDraining(string encodedEntityBatchResult)
+    {
+        byte[] resultBytes = Convert.FromBase64String(encodedEntityBatchResult);
+        P.EntityBatchResult result = P.EntityBatchResult.Parser.ParseFrom(resultBytes);
+        result.IsWorkerDraining = true;
+        return Convert.ToBase64String(result.ToByteArray());
     }
 }

--- a/src/Worker.Extensions.DurableTask/Execution/DurableFunctionExecutor.Orchestration.cs
+++ b/src/Worker.Extensions.DurableTask/Execution/DurableFunctionExecutor.Orchestration.cs
@@ -3,8 +3,10 @@
 
 using System;
 using System.Threading.Tasks;
+using Google.Protobuf;
 using Microsoft.DurableTask;
 using Microsoft.DurableTask.Worker.Grpc;
+using P = Microsoft.DurableTask.Protobuf;
 
 namespace Microsoft.Azure.Functions.Worker.Extensions.DurableTask.Execution;
 
@@ -34,8 +36,21 @@ internal partial class DurableFunctionExecutor
         string orchestratorOutput = GrpcOrchestrationRunner.LoadAndRun(
             encodedOrchestratorState, orchestrator, extendedSessionsCache, context.InstanceServices);
 
+        if (this.IsWorkerDraining)
+        {
+            orchestratorOutput = FlagOrchestratorDraining(orchestratorOutput);
+        }
+
         // Send the encoded orchestrator output as the return value seen by the functions host extension
         context.GetInvocationResult().Value = orchestratorOutput;
+    }
+
+    private static string FlagOrchestratorDraining(string encodedOrchestratorOutput)
+    {
+        byte[] responseBytes = Convert.FromBase64String(encodedOrchestratorOutput);
+        P.OrchestratorResponse response = P.OrchestratorResponse.Parser.ParseFrom(responseBytes);
+        response.IsWorkerDraining = true;
+        return Convert.ToBase64String(response.ToByteArray());
     }
 
     private IDisposableOrchestrator CreateOrchestrator(

--- a/src/Worker.Extensions.DurableTask/Execution/DurableFunctionExecutor.cs
+++ b/src/Worker.Extensions.DurableTask/Execution/DurableFunctionExecutor.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Microsoft.Azure.Functions.Worker.Invocation;
 using Microsoft.DurableTask;
 using Microsoft.DurableTask.Worker;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 
 namespace Microsoft.Azure.Functions.Worker.Extensions.DurableTask.Execution;
@@ -15,10 +16,14 @@ internal partial class DurableFunctionExecutor(
     ExtendedSessionsCache extendedSessionsCache,
     IDurableTaskFactory factory,
     IOptions<DurableTaskWorkerOptions> options,
+    IHostApplicationLifetime? hostApplicationLifetime = null,
     IExceptionPropertiesProvider? exceptionPropertiesProvider = null)
     : IFunctionExecutor
 {
     private DataConverter Converter => options.Value.DataConverter;
+
+    private bool IsWorkerDraining =>
+        hostApplicationLifetime?.ApplicationStopping.IsCancellationRequested ?? false;
 
     public virtual ValueTask ExecuteAsync(FunctionContext context)
     {

--- a/test/FunctionsV2/Tests/Unit/OutOfProcMiddlewareTests.cs
+++ b/test/FunctionsV2/Tests/Unit/OutOfProcMiddlewareTests.cs
@@ -12,12 +12,14 @@ using DurableTask.Core.Entities.OperationFormat;
 using DurableTask.Core.Exceptions;
 using DurableTask.Core.History;
 using DurableTask.Core.Middleware;
+using Google.Protobuf;
 using Microsoft.Azure.WebJobs.Host;
 using Microsoft.Azure.WebJobs.Host.Executors;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Moq;
 using Xunit;
+using P = Microsoft.DurableTask.Protobuf;
 
 namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 {
@@ -25,6 +27,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
     {
         private const string NoWorkerInitializedMessage = "Did not find any initialized language workers";
         private const string AssemblyNotLoadedMessage = "Could not load file or assembly";
+        private const string WorkerDrainingMessageMarker = "[DurableTask:WorkerDraining]";
 
         [Fact]
         [Trait("Category", PlatformSpecificHelpers.TestCategory)]
@@ -143,6 +146,187 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 () => middleware.CallActivityAsync(dispatchContext, () => Task.CompletedTask));
         }
 
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public async Task CallActivityAsync_WorkerDrainingException_ThrowsSessionAbortedException()
+        {
+            // Arrange: an activity failure whose message contains the worker-draining marker indicates the
+            // worker completed the activity while shutting down. The activity should be aborted and retried
+            // on a healthy worker rather than recording a result produced during shutdown.
+            var exception = new Exception(
+                $"The worker is shutting down and will not commit this result. {WorkerDrainingMessageMarker}");
+
+            (OutOfProcMiddleware middleware, DispatchMiddlewareContext dispatchContext) = this.SetupActivityTest(exception);
+
+            await Assert.ThrowsAsync<SessionAbortedException>(
+                () => middleware.CallActivityAsync(dispatchContext, () => Task.CompletedTask));
+        }
+
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public async Task CallActivityAsync_WorkerDrainingException_NestedInInnerException_ThrowsSessionAbortedException()
+        {
+            // Arrange: the worker-draining marker may be nested in an inner exception after crossing the
+            // gRPC boundary. The host should still detect it by walking the inner-exception chain.
+            var exception = new Exception(
+                "Function invocation failed.",
+                new InvalidOperationException(
+                    $"The worker is shutting down and will not commit this result. {WorkerDrainingMessageMarker}"));
+
+            (OutOfProcMiddleware middleware, DispatchMiddlewareContext dispatchContext) = this.SetupActivityTest(exception);
+
+            await Assert.ThrowsAsync<SessionAbortedException>(
+                () => middleware.CallActivityAsync(dispatchContext, () => Task.CompletedTask));
+        }
+
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public async Task CallActivityAsync_UnrelatedFailure_DoesNotThrowSessionAbortedException()
+        {
+            // Arrange: an ordinary activity failure (no worker-draining marker, not a platform-level error)
+            // should be reported as a failed activity result, NOT trigger the draining retry path.
+            var exception = new Exception("Function 'TestActivity' failed with an unhandled exception.");
+
+            (OutOfProcMiddleware middleware, DispatchMiddlewareContext dispatchContext) = this.SetupActivityTest(exception);
+
+            // Act: should NOT throw — the activity failure flows through to a failed ActivityExecutionResult.
+            await middleware.CallActivityAsync(dispatchContext, () => Task.CompletedTask);
+
+            // Assert: the middleware should have set an activity result on the dispatch context.
+            ActivityExecutionResult result = dispatchContext.GetProperty<ActivityExecutionResult>();
+            Assert.NotNull(result);
+        }
+
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public async Task CallOrchestratorAsync_WorkerDrainingResponseWithFailedResult_ThrowsSessionAbortedException()
+        {
+            // Arrange: the orchestration failed AND the worker flagged the response as produced while
+            // draining (shutting down). The host should abort and requeue so it is retried on a healthy
+            // worker rather than recording the failure.
+            var response = new P.OrchestratorResponse
+            {
+                InstanceId = "test-instance-id",
+                IsWorkerDraining = true,
+            };
+
+            (OutOfProcMiddleware middleware, DispatchMiddlewareContext dispatchContext) =
+                this.SetupOrchestratorTestWithResponse(EncodeProtobuf(response), succeeded: false);
+
+            await Assert.ThrowsAsync<SessionAbortedException>(
+                () => middleware.CallOrchestratorAsync(dispatchContext, () => Task.CompletedTask));
+        }
+
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public async Task CallOrchestratorAsync_WorkerDrainingResponseWithSucceededResult_DoesNotThrowSessionAbortedException()
+        {
+            // Arrange: the worker flagged draining but the orchestration still completed successfully.
+            // The draining retry only applies to failed results, so a successful result should be committed.
+            var response = new P.OrchestratorResponse
+            {
+                InstanceId = "test-instance-id",
+                IsWorkerDraining = true,
+            };
+
+            (OutOfProcMiddleware middleware, DispatchMiddlewareContext dispatchContext) =
+                this.SetupOrchestratorTestWithResponse(EncodeProtobuf(response), succeeded: true);
+
+            // Act: should NOT throw — a successful result is committed even when the draining flag is set.
+            await middleware.CallOrchestratorAsync(dispatchContext, () => Task.CompletedTask);
+
+            // Assert: the middleware should have set an orchestrator result on the dispatch context.
+            OrchestratorExecutionResult result = dispatchContext.GetProperty<OrchestratorExecutionResult>();
+            Assert.NotNull(result);
+        }
+
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public async Task CallOrchestratorAsync_NotDrainingResponse_DoesNotThrowSessionAbortedException()
+        {
+            // Arrange: a normal (non-draining) orchestrator response should be committed, not aborted.
+            var response = new P.OrchestratorResponse
+            {
+                InstanceId = "test-instance-id",
+                IsWorkerDraining = false,
+            };
+
+            (OutOfProcMiddleware middleware, DispatchMiddlewareContext dispatchContext) =
+                this.SetupOrchestratorTestWithResponse(EncodeProtobuf(response));
+
+            // Act: should NOT throw — the orchestration result flows through to the dispatch pipeline.
+            await middleware.CallOrchestratorAsync(dispatchContext, () => Task.CompletedTask);
+
+            // Assert: the middleware should have set an orchestrator result on the dispatch context.
+            OrchestratorExecutionResult result = dispatchContext.GetProperty<OrchestratorExecutionResult>();
+            Assert.NotNull(result);
+        }
+
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public async Task CallEntityAsync_WorkerDrainingResponseWithFailedResult_ThrowsSessionAbortedException()
+        {
+            // Arrange: the entity batch failed AND the worker flagged the response as produced while
+            // draining (shutting down). The host should abort and requeue so it is retried on a healthy
+            // worker rather than recording the failure.
+            var response = new P.EntityBatchResult
+            {
+                CompletionToken = "test-completion-token",
+                IsWorkerDraining = true,
+            };
+
+            (OutOfProcMiddleware middleware, DispatchMiddlewareContext dispatchContext) =
+                this.SetupEntityTestWithResponse(EncodeProtobuf(response), succeeded: false);
+
+            await Assert.ThrowsAsync<SessionAbortedException>(
+                () => middleware.CallEntityAsync(dispatchContext, () => Task.CompletedTask));
+        }
+
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public async Task CallEntityAsync_WorkerDrainingResponseWithSucceededResult_DoesNotThrowSessionAbortedException()
+        {
+            // Arrange: the worker flagged draining but the entity batch still completed successfully.
+            // The draining retry only applies to failed results, so a successful result should be committed.
+            var response = new P.EntityBatchResult
+            {
+                CompletionToken = "test-completion-token",
+                IsWorkerDraining = true,
+            };
+
+            (OutOfProcMiddleware middleware, DispatchMiddlewareContext dispatchContext) =
+                this.SetupEntityTestWithResponse(EncodeProtobuf(response), succeeded: true);
+
+            // Act: should NOT throw — a successful result is committed even when the draining flag is set.
+            await middleware.CallEntityAsync(dispatchContext, () => Task.CompletedTask);
+
+            // Assert: the middleware should have set an entity batch result on the dispatch context.
+            EntityBatchResult result = dispatchContext.GetProperty<EntityBatchResult>();
+            Assert.NotNull(result);
+        }
+
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public async Task CallEntityAsync_NotDrainingResponse_DoesNotThrowSessionAbortedException()
+        {
+            // Arrange: a normal (non-draining) entity batch result should be committed, not aborted.
+            var response = new P.EntityBatchResult
+            {
+                CompletionToken = "test-completion-token",
+                IsWorkerDraining = false,
+            };
+
+            (OutOfProcMiddleware middleware, DispatchMiddlewareContext dispatchContext) =
+                this.SetupEntityTestWithResponse(EncodeProtobuf(response));
+
+            // Act: should NOT throw — the entity result flows through to the dispatch pipeline.
+            await middleware.CallEntityAsync(dispatchContext, () => Task.CompletedTask);
+
+            // Assert: the middleware should have set an entity batch result on the dispatch context.
+            EntityBatchResult result = dispatchContext.GetProperty<EntityBatchResult>();
+            Assert.NotNull(result);
+        }
+
         public static IEnumerable<object[]> PlatformLevelExceptions()
         {
             // FunctionTimeoutException (top-level)
@@ -215,6 +399,37 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             return (middleware, dispatchContext);
         }
 
+        private (OutOfProcMiddleware middleware, DispatchMiddlewareContext context) SetupOrchestratorTestWithResponse(string base64Response, bool succeeded = true)
+        {
+            (OutOfProcMiddleware middleware, DispatchMiddlewareContext dispatchContext)
+                = this.CreateMiddlewareWithInvocation(base64Response, "TestOrchestrator", FunctionType.Orchestrator, succeeded);
+
+            var orchestrationState = new OrchestrationRuntimeState(
+                [
+                    new ExecutionStartedEvent(-1, null) { Name = "TestOrchestrator" },
+                ]);
+
+            dispatchContext.SetProperty(orchestrationState);
+            dispatchContext.SetProperty(new OrchestrationInstance { InstanceId = "test-instance-id" });
+
+            return (middleware, dispatchContext);
+        }
+
+        private (OutOfProcMiddleware middleware, DispatchMiddlewareContext context) SetupEntityTestWithResponse(string base64Response, bool succeeded = true)
+        {
+            (OutOfProcMiddleware middleware, DispatchMiddlewareContext dispatchContext)
+                = this.CreateMiddlewareWithInvocation(base64Response, "TestEntity", FunctionType.Entity, succeeded);
+
+            dispatchContext.SetProperty(new EntityBatchRequest
+            {
+                InstanceId = "@TestEntity@test-key",
+                EntityState = null,
+                Operations = new List<OperationRequest>(),
+            });
+
+            return (middleware, dispatchContext);
+        }
+
         private (OutOfProcMiddleware middleware, DispatchMiddlewareContext context) CreateMiddleware(
             Exception executorException, string functionName, FunctionType functionType)
         {
@@ -225,6 +440,40 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 .Setup(e => e.TryExecuteAsync(It.IsAny<TriggeredFunctionData>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new FunctionResult(false, executorException));
 
+            return (new OutOfProcMiddleware(RegisterAndGetExtension(extension, functionName, functionType, mockExecutor)), CreateDispatchContext(functionType));
+        }
+
+        // Creates a middleware that drives the InvokeHandler with the given base64-encoded protobuf
+        // response, exercising the host's response-parsing path (including the IsWorkerDraining flag read)
+        // the same way a real out-of-proc worker invocation would. The succeeded flag controls whether the
+        // resulting FunctionResult reports success or failure, since the worker-draining retry only triggers
+        // when the function result is failed.
+        private (OutOfProcMiddleware middleware, DispatchMiddlewareContext context) CreateMiddlewareWithInvocation(
+            string base64Response, string functionName, FunctionType functionType, bool succeeded = true)
+        {
+            DurableTaskExtension extension = CreateDurableTaskExtension();
+
+            var mockExecutor = new Mock<ITriggeredFunctionExecutor>();
+            mockExecutor
+                .Setup(e => e.TryExecuteAsync(It.IsAny<TriggeredFunctionData>(), It.IsAny<CancellationToken>()))
+                .Returns<TriggeredFunctionData, CancellationToken>(async (data, ct) =>
+                {
+                    // The middleware supplies an InvokeHandler that expects the user-code invoker to return
+                    // a Task<object> whose result is the base64 protobuf response string.
+#pragma warning disable CS0618 // Type or member is obsolete (approved for use by this extension)
+                    await data.InvokeHandler(() => Task.FromResult<object>(base64Response));
+#pragma warning restore CS0618
+                    return succeeded
+                        ? new FunctionResult(true)
+                        : new FunctionResult(false, new Exception("Function invocation failed."));
+                });
+
+            return (new OutOfProcMiddleware(RegisterAndGetExtension(extension, functionName, functionType, mockExecutor)), CreateDispatchContext(functionType));
+        }
+
+        private static DurableTaskExtension RegisterAndGetExtension(
+            DurableTaskExtension extension, string functionName, FunctionType functionType, Mock<ITriggeredFunctionExecutor> mockExecutor)
+        {
             var name = new FunctionName(functionName);
 
             switch (functionType)
@@ -240,6 +489,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                     break;
             }
 
+            return extension;
+        }
+
+        private static DispatchMiddlewareContext CreateDispatchContext(FunctionType functionType)
+        {
             var dispatchContext = new DispatchMiddlewareContext();
 
             // Orchestrators and entities require WorkItemMetadata; activities do not.
@@ -248,7 +502,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 dispatchContext.SetProperty(CreateWorkItemMetadata(isExtendedSession: false, includeState: false));
             }
 
-            return (new OutOfProcMiddleware(extension), dispatchContext);
+            return dispatchContext;
+        }
+
+        private static string EncodeProtobuf(IMessage message)
+        {
+            return Convert.ToBase64String(message.ToByteArray());
         }
 
         private static DurableTaskExtension CreateDurableTaskExtension()

--- a/test/FunctionsV2/Tests/Unit/OutOfProcMiddlewareTests.cs
+++ b/test/FunctionsV2/Tests/Unit/OutOfProcMiddlewareTests.cs
@@ -21,6 +21,7 @@ using Moq;
 using Xunit;
 using P = Microsoft.DurableTask.Protobuf;
 
+#nullable enable
 namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 {
     public class OutOfProcMiddlewareTests
@@ -538,7 +539,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         private static WorkItemMetadata CreateWorkItemMetadata(bool isExtendedSession, bool includeState)
         {
             // WorkItemMetadata has an internal constructor, so we use reflection to create it.
-            ConstructorInfo ctor = typeof(WorkItemMetadata).GetConstructor(
+            ConstructorInfo? ctor = typeof(WorkItemMetadata).GetConstructor(
                 BindingFlags.Instance | BindingFlags.NonPublic,
                 binder: null,
                 [typeof(bool), typeof(bool)],


### PR DESCRIPTION
# Summary
## What changed?
This PR introduces a new worker drain signal in the case of Function execution - if this signal is set and the Function failed, we will retry the execution rather than permanently failing it.

## Why is this change needed?
We have this signal for host shutdown but this is decoupled from worker shutdown. 

## Issues / work items
- Resolves #3452 


# Project checklist
- [ ] Documentation changes are not required
  - [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
- [ ] Release notes are not required for the next release
  - [ ] Otherwise: Notes added to `release_notes.md`
- [ ] Backport is not required
  - [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
- [ ] All required tests have been added/updated (unit tests, E2E tests)
- [ ] No extra work is required to be leveraged by OutOfProc SDKs
  - [ ] Otherwise: Work tracked here: #issue_or_pr_in_each_sdk
- [ ] No change to the version of the `WebJobs.Extensions.DurableTask` package
  - [ ] Otherwise: Major/minor updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
- [ ] No EventIds were added to `EventSource` logs
  - [ ] Otherwise: Ensure EventIds are within the supported range in the existing Windows infrastructure (validate via deployed telemetry). If needed, extend the range via a PR such as https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files
- [ ] This change should be added to the `v2.x` branch
  - [ ] Otherwise: This change applies exclusively to `WebJobs.Extensions.DurableTask` v3.x and will be retained only in the `dev` and `main` branches
- [ ] Breaking change?
  - [ ] If yes:
    - Impact:
    - Migration guidance:
---

# AI-assisted code disclosure (required)
## Was an AI tool used? (select one)
- [ ] No
- [ ] Yes, AI helped write parts of this PR (e.g., GitHub Copilot)
- [ ] Yes, an AI agent generated most of this PR

If AI was used:
- Tool(s):
- AI-assisted areas/files:
- What you changed after AI output:

AI verification (required if AI was used):
- [ ] I understand the code and can explain it
- [ ] I verified referenced APIs/types exist and are correct
- [ ] I reviewed edge cases/failure paths (timeouts, retries, cancellation, exceptions)
- [ ] I reviewed concurrency/async behavior
- [ ] I checked for unintended breaking or behavior changes

---

# Testing
## Automated tests
- Result: Passed / Failed (link logs if failed)

## Manual validation (only if runtime/behavior changed)
- Environment (OS, .NET version, components):
- Steps + observed results:
  1.
  2.
  3.
- Evidence (optional):

---

# Notes for reviewers
- N/A
