### PR TITLE
feat: recognize the native worker runtime (gRPC durable protocol)

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/AzureStorageDurabilityProviderFactory.cs
+++ b/src/WebJobs.Extensions.DurableTask/AzureStorageDurabilityProviderFactory.cs
@@ -77,6 +77,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             WorkerRuntimeType runtimeType = platformInfo.GetWorkerRuntimeType();
             if (runtimeType == WorkerRuntimeType.DotNetIsolated ||
                 runtimeType == WorkerRuntimeType.Java ||
+                runtimeType == WorkerRuntimeType.Native ||
+                runtimeType == WorkerRuntimeType.Golang ||
                 runtimeType == WorkerRuntimeType.Custom)
             {
                 this.useSeparateQueueForEntityWorkItems = true;

--- a/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
@@ -166,8 +166,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             this.telemetryActivator = telemetryActivator;
             this.telemetryActivator?.Initialize(logger);
 
-            // Starting with .NET isolated and Java, we have a more efficient out-of-process
-            // function invocation protocol. Other languages will use the existing protocol.
+            // The gRPC-based out-of-process invocation protocol (MiddlewarePassthrough) is the more
+            // efficient protocol used by the compiled / newer-SDK runtimes: .NET isolated, Java, the
+            // native worker (e.g. Go), and custom handlers. The remaining script languages (Python,
+            // Node.js, PowerShell) start on the legacy HTTP protocol below and may upgrade to gRPC
+            // during function indexing if their metadata requests it (see ConfigureForGrpcProtocol).
             WorkerRuntimeType runtimeType = this.PlatformInformationService.GetWorkerRuntimeType();
             if (runtimeType == WorkerRuntimeType.DotNetIsolated ||
                 runtimeType == WorkerRuntimeType.Java ||

--- a/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
@@ -171,6 +171,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             WorkerRuntimeType runtimeType = this.PlatformInformationService.GetWorkerRuntimeType();
             if (runtimeType == WorkerRuntimeType.DotNetIsolated ||
                 runtimeType == WorkerRuntimeType.Java ||
+                runtimeType == WorkerRuntimeType.Native ||
+                runtimeType == WorkerRuntimeType.Golang ||
                 runtimeType == WorkerRuntimeType.Custom)
             {
                 this.ConfigureForGrpcProtocol();
@@ -261,6 +263,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                         // dotnet-isolated and java use a gRPC server instead of the HTTP server
                         WorkerRuntimeType.DotNetIsolated => false,
                         WorkerRuntimeType.Java => false,
+
+                        // the native worker (e.g. golang) uses the gRPC protocol, so it never starts the HTTP RPC server
+                        WorkerRuntimeType.Native => false,
+                        WorkerRuntimeType.Golang => false,
 
                         // everything else - assume the HTTP server
                         WorkerRuntimeType.Python => true, // This method will only be called for Python if we already know that we are using the HTTP protocol

--- a/src/WebJobs.Extensions.DurableTask/IPlatformInformation.cs
+++ b/src/WebJobs.Extensions.DurableTask/IPlatformInformation.cs
@@ -62,6 +62,20 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         Custom,
 
         /// <summary>
+        /// Native worker runtime, out-of-process via the gRPC protocol. This is the
+        /// FUNCTIONS_WORKER_RUNTIME value ("native") used by compiled-language workers
+        /// such as the Azure Functions Go worker.
+        /// </summary>
+        Native,
+
+        /// <summary>
+        /// Go (golang), out-of-process via the gRPC protocol. This matches the Go
+        /// worker provider's declared language; some host builds surface it as the
+        /// FUNCTIONS_WORKER_RUNTIME value instead of "native".
+        /// </summary>
+        Golang,
+
+        /// <summary>
         /// Unknown worker runtime.
         /// </summary>
         Unknown,

--- a/test/FunctionsV2/Tests/Unit/AzureStorageDurabilityProviderFactoryTests.cs
+++ b/test/FunctionsV2/Tests/Unit/AzureStorageDurabilityProviderFactoryTests.cs
@@ -78,6 +78,50 @@ namespace WebJobs.Extensions.DurableTask.Tests.V2
             Assert.Equal(25, settings.MaxStorageOperationConcurrency);
         }
 
+        [Theory]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        [InlineData(WorkerRuntimeType.Native)]
+        [InlineData(WorkerRuntimeType.Golang)]
+        public void GrpcRuntimes_UseSeparateQueueForEntityWorkItems(WorkerRuntimeType runtimeType)
+        {
+            var clientProviderFactory = new TestStorageServiceClientProviderFactory();
+            var mockOptions = new OptionsWrapper<DurableTaskOptions>(new DurableTaskOptions());
+            var nameResolver = new Mock<INameResolver>().Object;
+            var factory = new AzureStorageDurabilityProviderFactory(
+                mockOptions,
+                clientProviderFactory,
+                nameResolver,
+                NullLoggerFactory.Instance,
+                TestHelpers.GetMockPlatformInformationService(language: runtimeType));
+
+            var settings = factory.GetAzureStorageOrchestrationServiceSettings();
+
+            // The native worker runtimes use the gRPC protocol, which requires a separate
+            // queue for entity work items (matching .NET isolated / Java behavior).
+            Assert.True(settings.UseSeparateQueueForEntityWorkItems);
+        }
+
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public void InProcRuntime_DoesNotUseSeparateQueueForEntityWorkItems()
+        {
+            var clientProviderFactory = new TestStorageServiceClientProviderFactory();
+            var mockOptions = new OptionsWrapper<DurableTaskOptions>(new DurableTaskOptions());
+            var nameResolver = new Mock<INameResolver>().Object;
+            var factory = new AzureStorageDurabilityProviderFactory(
+                mockOptions,
+                clientProviderFactory,
+                nameResolver,
+                NullLoggerFactory.Instance,
+                TestHelpers.GetMockPlatformInformationService(language: WorkerRuntimeType.DotNet));
+
+            var settings = factory.GetAzureStorageOrchestrationServiceSettings();
+
+            // The in-process .NET runtime keeps the shared queue (this default is flipped
+            // to true only for the gRPC-based runtimes).
+            Assert.False(settings.UseSeparateQueueForEntityWorkItems);
+        }
+
         [Fact]
         [Trait("Category", PlatformSpecificHelpers.TestCategory)]
         public void ConsumptionDefaultsAreNotAlwaysApplied()

--- a/test/FunctionsV2/Tests/Unit/LocalGrpcListenerTests.cs
+++ b/test/FunctionsV2/Tests/Unit/LocalGrpcListenerTests.cs
@@ -502,7 +502,31 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             Assert.Contains("transient", ex.Message);
         }
 
+        /// <summary>
+        /// Verifies that the native worker runtimes (the Go worker reports either "native" or,
+        /// defensively, "golang") select the gRPC protocol (MiddlewarePassthrough) at extension
+        /// initialization rather than the legacy HTTP-correlation shim (OrchestratorShim). When
+        /// MiddlewarePassthrough is selected the local HTTP RPC server is never started — the
+        /// runtime communicates durable operations over the local gRPC sidecar instead.
+        /// </summary>
+        [Theory]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        [InlineData(WorkerRuntimeType.Native)]
+        [InlineData(WorkerRuntimeType.Golang)]
+        public void TestNativeRuntime_SelectsGrpcProtocol(WorkerRuntimeType runtimeType)
+        {
+            using DurableTaskExtension extension = this.CreateExtension("NativeRuntimeProtocol", runtimeType);
+
+            Assert.Equal(OutOfProcOrchestrationProtocol.MiddlewarePassthrough, extension.OutOfProcProtocol);
+            Assert.NotEqual(OutOfProcOrchestrationProtocol.OrchestratorShim, extension.OutOfProcProtocol);
+        }
+
         private DurableTaskExtension CreateExtension(string hubName)
+        {
+            return this.CreateExtension(hubName, WorkerRuntimeType.DotNetIsolated);
+        }
+
+        private DurableTaskExtension CreateExtension(string hubName, WorkerRuntimeType runtimeType)
         {
             var options = new DurableTaskOptions { HubName = hubName };
             var wrappedOptions = new OptionsWrapper<DurableTaskOptions>(options);
@@ -512,7 +536,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 new TestStorageServiceClientProviderFactory(),
                 nameResolver,
                 NullLoggerFactory.Instance,
-                TestHelpers.GetMockPlatformInformationService(language: WorkerRuntimeType.DotNetIsolated));
+                TestHelpers.GetMockPlatformInformationService(language: runtimeType));
 
             return new DurableTaskExtension(
                 wrappedOptions,
@@ -521,7 +545,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 new[] { serviceFactory },
                 new TestHostShutdownNotificationService(),
                 new DurableHttpMessageHandlerFactory(),
-                platformInformationService: TestHelpers.GetMockPlatformInformationService(language: WorkerRuntimeType.DotNetIsolated));
+                platformInformationService: TestHelpers.GetMockPlatformInformationService(language: runtimeType));
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary

Teaches the host to recognize the native worker runtime (`FUNCTIONS_WORKER_RUNTIME=native`, what the Go worker reports) and route it through the gRPC durable protocol (MiddlewarePassthrough) instead of the legacy HTTP-correlation shim. It also recognizes `golang` defensively.

This is the host side of Phase 1 of Durable Functions for the Go worker. The worker side is Azure/azure-functions-golang-worker#44, which has the full design write-up for how durable runs on the Go worker. The two are meant to be reviewed and merged together. Without this change the host fails to parse the runtime value, falls back to the HTTP shim, and the durable bindings (`orchestrationTrigger`, `activityTrigger`, `durableClient`) never bind for the Go worker.

## Why gRPC for this runtime

Native out-of-process workers talk to the durable extension over the local gRPC sidecar (`TaskHubSidecarService`), the same path dotnet-isolated and Java use, not the legacy HTTP shim. So `native` and `golang` should land in the existing gRPC branch alongside the other compiled and newer-SDK runtimes, with the local HTTP RPC endpoint disabled for them.

## Changes

- **`IPlatformInformation` / `WorkerRuntimeType`.** Add `Native` (parses `native`, the primary value) and keep `Golang` (parses `golang`, defensive).
- **`DurableTaskExtension`.** Both runtimes select the gRPC MiddlewarePassthrough protocol, and `LocalRpcEndpointEnabled` is false for them since native workers use the gRPC sidecar exclusively.
- **`AzureStorageDurabilityProviderFactory`.** Default `UseSeparateQueueForEntityWorkItems` to true for the new runtimes, matching the other gRPC-based runtimes.

## Tests

- `TestNativeRuntime_SelectsGrpcProtocol` asserts `Native` and `Golang` pick MiddlewarePassthrough rather than the HTTP shim.
- `GrpcRuntimes_UseSeparateQueueForEntityWorkItems` plus an in-process .NET counter-test pin the entity-queue default for the new runtimes.
- Both pass on net8.0 and net10.0.

## Validation

With this change present in the host, the Go worker's HelloCities and ProcessExpense orchestrations run to Completed on a real host (Core Tools 4.12.0).

## Related PRs

- Go worker durable support and design doc: Azure/azure-functions-golang-worker#44
