### PR TITLE
Microsoft durable worker dispatch mode plumbing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,6 +162,8 @@ PublishProfiles/
 
 # NuGet Packages
 *.nupkg
+# Temporary local dev feed for the unreleased DurableTask WorkerDispatchMode packages
+local-packages/
 # The packages folder can be ignored because of Package Restore
 **/packages/*
 # except build/, which is used as an MSBuild target.

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,11 +14,14 @@
     <PackageVersion Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.WebApiCompatShim" Version="2.3.0" />
     <PackageVersion Include="Microsoft.Azure.DurableTask.ApplicationInsights" Version="0.11.0" />
-    <PackageVersion Include="Microsoft.Azure.DurableTask.AzureStorage" Version="2.9.1" />
+    <!-- TEMPORARY dev-loop shim (see nuget.config 'local-workerdispatch' source): pinned to a locally-packed
+         build carrying the unreleased WorkerDispatchMode change. Revert to the released versions
+         (AzureStorage 2.9.1 / Core 3.9.0) once that change ships to nuget.org. -->
+    <PackageVersion Include="Microsoft.Azure.DurableTask.AzureStorage" Version="9999.0.0-workerdispatch" />
     <PackageVersion Include="Microsoft.Azure.DurableTask.Netherite" Version="3.1.1" />
     <PackageVersion Include="Microsoft.DurableTask.AzureManagedBackend" Version="1.3.0" />
     <PackageVersion Include="Microsoft.DurableTask.SqlServer" Version="1.5.2" />
-    <PackageVersion Include="Microsoft.Azure.DurableTask.Core" Version="3.9.0" />
+    <PackageVersion Include="Microsoft.Azure.DurableTask.Core" Version="9999.0.0-workerdispatch" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Core" Version="2.51.0" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Abstractions" Version="1.3.0" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Storage.Blobs" Version="6.7.0" />

--- a/nuget.config
+++ b/nuget.config
@@ -4,5 +4,9 @@
   <packageSources>
     <clear/>
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <!-- TEMPORARY dev-loop shim: local feed for the unreleased DurableTask WorkerDispatchMode change.
+         Remove this source (and revert the 9999.0.0-workerdispatch versions in Directory.Packages.props)
+         once Microsoft.Azure.DurableTask.AzureStorage with WorkerDispatchMode is published. -->
+    <add key="local-workerdispatch" value="local-packages" />
   </packageSources>
 </configuration>

--- a/src/WebJobs.Extensions.DurableTask/AzureStorageDurabilityProviderFactory.cs
+++ b/src/WebJobs.Extensions.DurableTask/AzureStorageDurabilityProviderFactory.cs
@@ -15,6 +15,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         private const string LoggerName = "Host.Triggers.DurableTask.AzureStorage";
         internal const string ProviderName = "AzureStorage";
 
+        // When set, this environment variable overrides the host.json WorkerDispatchMode option.
+        // This lets every pod in a deployment share the same host.json while selecting its dispatch
+        // mode via a single per-deployment environment variable.
+        internal const string WorkerDispatchModeEnvironmentVariable = "DURABLE_WORKER_DISPATCH_MODE";
+
         private readonly DurableTaskOptions options;
         private readonly IStorageServiceClientProviderFactory clientProviderFactory;
         private readonly AzureStorageOptions azureStorageOptions;
@@ -226,6 +231,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 PartitionTableOperationTimeout = this.azureStorageOptions.PartitionTableOperationTimeout,
                 QueueClientMessageEncoding = this.azureStorageOptions.QueueClientMessageEncoding,
                 UseInstanceTableEtag = this.azureStorageOptions.UseInstanceTableEtag,
+                WorkerDispatchMode = this.ResolveWorkerDispatchMode(),
             };
 
             if (this.inConsumption)
@@ -253,6 +259,27 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         public void SetUseSeparateQueueForEntityWorkItems(bool newValue)
         {
             this.useSeparateQueueForEntityWorkItems = newValue;
+        }
+
+        // Resolves the effective worker dispatch mode with the following precedence:
+        // DURABLE_WORKER_DISPATCH_MODE environment variable > host.json WorkerDispatchMode option > Both.
+        private WorkerDispatchMode ResolveWorkerDispatchMode()
+        {
+            string envValue = this.nameResolver.Resolve(WorkerDispatchModeEnvironmentVariable);
+            if (string.IsNullOrWhiteSpace(envValue))
+            {
+                return this.azureStorageOptions.WorkerDispatchMode;
+            }
+
+            if (Enum.TryParse(envValue.Trim(), ignoreCase: true, out WorkerDispatchMode mode)
+                && Enum.IsDefined(typeof(WorkerDispatchMode), mode))
+            {
+                return mode;
+            }
+
+            throw new InvalidOperationException(
+                $"The value '{envValue}' for the {WorkerDispatchModeEnvironmentVariable} environment variable is invalid. " +
+                $"Valid values are: {string.Join(", ", Enum.GetNames(typeof(WorkerDispatchMode)))}.");
         }
     }
  }

--- a/src/WebJobs.Extensions.DurableTask/Options/AzureStorageOptions.cs
+++ b/src/WebJobs.Extensions.DurableTask/Options/AzureStorageOptions.cs
@@ -258,6 +258,18 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         public bool UseInstanceTableEtag { get; set; } = false;
 
         /// <summary>
+        /// Gets or sets which kinds of work this worker instance dispatches, allowing orchestrations
+        /// (including entities) and activities to be scaled independently across separate deployments
+        /// that share the same task hub.
+        /// </summary>
+        /// <remarks>
+        /// The default is <see cref="WorkerDispatchMode.Both"/>, which preserves the historical behavior.
+        /// This value can be overridden per deployment via the <c>DURABLE_WORKER_DISPATCH_MODE</c> environment
+        /// variable, which takes precedence over this host.json setting.
+        /// </remarks>
+        public WorkerDispatchMode WorkerDispatchMode { get; set; } = WorkerDispatchMode.Both;
+
+        /// <summary>
         /// Throws an exception if the provided hub name violates any naming conventions for the storage provider.
         /// </summary>
         public void ValidateHubName(string hubName)

--- a/test/FunctionsV2/Tests/Unit/AzureStorageDurabilityProviderFactoryTests.cs
+++ b/test/FunctionsV2/Tests/Unit/AzureStorageDurabilityProviderFactoryTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using DurableTask.AzureStorage;
 using Microsoft.Azure.WebJobs;
 using Microsoft.Azure.WebJobs.Extensions.DurableTask;
 using Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests;
@@ -238,6 +239,127 @@ namespace WebJobs.Extensions.DurableTask.Tests.V2
             var provider = factory.GetDurabilityProvider();
 
             Assert.Equal("Storage", provider.ConnectionName);
+        }
+
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public void DefaultWorkerDispatchMode_IsBoth()
+        {
+            var clientProviderFactory = new TestStorageServiceClientProviderFactory();
+            var mockOptions = new OptionsWrapper<DurableTaskOptions>(new DurableTaskOptions());
+            var nameResolver = new Mock<INameResolver>().Object;
+            var factory = new AzureStorageDurabilityProviderFactory(
+                mockOptions,
+                clientProviderFactory,
+                nameResolver,
+                NullLoggerFactory.Instance,
+                TestHelpers.GetMockPlatformInformationService());
+
+            var settings = factory.GetAzureStorageOrchestrationServiceSettings();
+
+            Assert.Equal(WorkerDispatchMode.Both, settings.WorkerDispatchMode);
+        }
+
+        [Theory]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        [InlineData("Both", WorkerDispatchMode.Both)]
+        [InlineData("Orchestrator", WorkerDispatchMode.Orchestrator)]
+        [InlineData("Activity", WorkerDispatchMode.Activity)]
+        public void HostJsonWorkerDispatchMode_IsMapped(string hostJsonValue, WorkerDispatchMode expected)
+        {
+            var clientProviderFactory = new TestStorageServiceClientProviderFactory();
+            var options = new DurableTaskOptions();
+            options.StorageProvider.Add("WorkerDispatchMode", hostJsonValue);
+
+            var mockOptions = new OptionsWrapper<DurableTaskOptions>(options);
+            var nameResolver = new Mock<INameResolver>().Object;
+            var factory = new AzureStorageDurabilityProviderFactory(
+                mockOptions,
+                clientProviderFactory,
+                nameResolver,
+                NullLoggerFactory.Instance,
+                TestHelpers.GetMockPlatformInformationService());
+
+            var settings = factory.GetAzureStorageOrchestrationServiceSettings();
+
+            Assert.Equal(expected, settings.WorkerDispatchMode);
+        }
+
+        [Theory]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        [InlineData("Activity", WorkerDispatchMode.Activity)]
+        [InlineData("activity", WorkerDispatchMode.Activity)]
+        [InlineData("ORCHESTRATOR", WorkerDispatchMode.Orchestrator)]
+        public void EnvironmentVariable_OverridesHostJson_CaseInsensitively(string envValue, WorkerDispatchMode expected)
+        {
+            var clientProviderFactory = new TestStorageServiceClientProviderFactory();
+            var options = new DurableTaskOptions();
+
+            // host.json requests Orchestrator, but the environment variable must win.
+            options.StorageProvider.Add("WorkerDispatchMode", "Orchestrator");
+
+            var mockOptions = new OptionsWrapper<DurableTaskOptions>(options);
+            var nameResolver = new SimpleNameResolver(new Dictionary<string, string>()
+            {
+                { "DURABLE_WORKER_DISPATCH_MODE", envValue },
+            });
+
+            var factory = new AzureStorageDurabilityProviderFactory(
+                mockOptions,
+                clientProviderFactory,
+                nameResolver,
+                NullLoggerFactory.Instance,
+                TestHelpers.GetMockPlatformInformationService());
+
+            var settings = factory.GetAzureStorageOrchestrationServiceSettings();
+
+            Assert.Equal(expected, settings.WorkerDispatchMode);
+        }
+
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public void EnvironmentVariable_AppliesWhenHostJsonUnset()
+        {
+            var clientProviderFactory = new TestStorageServiceClientProviderFactory();
+            var mockOptions = new OptionsWrapper<DurableTaskOptions>(new DurableTaskOptions());
+            var nameResolver = new SimpleNameResolver(new Dictionary<string, string>()
+            {
+                { "DURABLE_WORKER_DISPATCH_MODE", "Orchestrator" },
+            });
+
+            var factory = new AzureStorageDurabilityProviderFactory(
+                mockOptions,
+                clientProviderFactory,
+                nameResolver,
+                NullLoggerFactory.Instance,
+                TestHelpers.GetMockPlatformInformationService());
+
+            var settings = factory.GetAzureStorageOrchestrationServiceSettings();
+
+            Assert.Equal(WorkerDispatchMode.Orchestrator, settings.WorkerDispatchMode);
+        }
+
+        [Theory]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        [InlineData("Orchestratorr")]
+        [InlineData("99")]
+        public void InvalidEnvironmentVariable_Throws(string envValue)
+        {
+            var clientProviderFactory = new TestStorageServiceClientProviderFactory();
+            var mockOptions = new OptionsWrapper<DurableTaskOptions>(new DurableTaskOptions());
+            var nameResolver = new SimpleNameResolver(new Dictionary<string, string>()
+            {
+                { "DURABLE_WORKER_DISPATCH_MODE", envValue },
+            });
+
+            var factory = new AzureStorageDurabilityProviderFactory(
+                mockOptions,
+                clientProviderFactory,
+                nameResolver,
+                NullLoggerFactory.Instance,
+                TestHelpers.GetMockPlatformInformationService());
+
+            Assert.Throws<InvalidOperationException>(() => factory.GetAzureStorageOrchestrationServiceSettings());
         }
     }
 }


### PR DESCRIPTION
# Summary
## What changed?
- Expose the durable worker dispatch mode proposed in https://github.com/Azure/durabletask/pull/1375. Accepts `DURABLE_WORKER_DISPATCH_MODE` env var or equivalent host.json value

## Why is this change needed?
- Enables users to selectively have worker pools serve just orchestrator or activity jobs. Prevents noisy neighbour scenarios wherein the partition limited (Azure Storage Backend) orchestrator workers may waste compute on activities.

## Issues / work items
- Resolves #
- Related #

---

# Project checklist
- [ ] Documentation changes are not required
  - [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
- [ ] Release notes are not required for the next release
  - [ ] Otherwise: Notes added to `release_notes.md`
- [ ] Backport is not required
  - [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
- [ ] All required tests have been added/updated (unit tests, E2E tests)
- [ ] No extra work is required to be leveraged by OutOfProc SDKs
  - [ ] Otherwise: Work tracked here: #issue_or_pr_in_each_sdk
- [ ] No change to the version of the `WebJobs.Extensions.DurableTask` package
  - [ ] Otherwise: Major/minor updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
- [ ] No EventIds were added to `EventSource` logs
  - [ ] Otherwise: Ensure EventIds are within the supported range in the existing Windows infrastructure (validate via deployed telemetry). If needed, extend the range via a PR such as https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files
- [ ] This change should be added to the `v2.x` branch
  - [ ] Otherwise: This change applies exclusively to `WebJobs.Extensions.DurableTask` v3.x and will be retained only in the `dev` and `main` branches
- [ ] Breaking change?
  - [ ] If yes:
    - Impact:
    - Migration guidance:
---

# AI-assisted code disclosure (required)
## Was an AI tool used? (select one)
- [ ] No
- [ ] Yes, AI helped write parts of this PR (e.g., GitHub Copilot)
- [x] Yes, an AI agent generated most of this PR

If AI was used:
- Tool(s): Copilot
- AI-assisted areas/files:
- What you changed after AI output:

AI verification (required if AI was used):
- [ ] I understand the code and can explain it
- [ ] I verified referenced APIs/types exist and are correct
- [ ] I reviewed edge cases/failure paths (timeouts, retries, cancellation, exceptions)
- [ ] I reviewed concurrency/async behavior
- [ ] I checked for unintended breaking or behavior changes

---

# Testing
## Automated tests
- Result: Passed / Failed (link logs if failed)

## Manual validation (only if runtime/behavior changed)
- Environment (OS, .NET version, components):
- Steps + observed results:
  1.
  2.
  3.
- Evidence (optional):

---

# Notes for reviewers
- N/A
