### PR TITLE
Correct StartNewAsync 'silently replaced' remarks to reflect OverridableExistingInstanceStates

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/ContextInterfaces/IDurableOrchestrationClient.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextInterfaces/IDurableOrchestrationClient.cs
@@ -122,8 +122,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// overwritten depends on the existing instance's runtime status and on the
         /// <see cref="DurableTaskOptions.OverridableExistingInstanceStates"/> option. By default
         /// (<see cref="OverridableStates.NonRunningStates"/>), the existing instance is only overwritten when it is in a
-        /// terminated, failed, canceled, or completed state; if it is still pending, running, suspended, or continued-as-new, the
-        /// call fails rather than silently replacing it. Set the option to <see cref="OverridableStates.AnyState"/> to
+        /// terminated, failed, canceled, or completed state; if it is still pending, running, suspended, or continued-as-new, an
+        /// exception is thrown rather than silently replacing it. Set the option to <see cref="OverridableStates.AnyState"/> to
         /// always overwrite the existing instance.
         /// </remarks>
         /// <param name="orchestratorFunctionName">The name of the orchestrator function to start.</param>
@@ -161,8 +161,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// overwritten depends on the existing instance's runtime status and on the
         /// <see cref="DurableTaskOptions.OverridableExistingInstanceStates"/> option. By default
         /// (<see cref="OverridableStates.NonRunningStates"/>), the existing instance is only overwritten when it is in a
-        /// terminated, failed, canceled, or completed state; if it is still pending, running, suspended, or continued-as-new, the
-        /// call fails rather than silently replacing it. Set the option to <see cref="OverridableStates.AnyState"/> to
+        /// terminated, failed, canceled, or completed state; if it is still pending, running, suspended, or continued-as-new, an
+        /// exception is thrown rather than silently replacing it. Set the option to <see cref="OverridableStates.AnyState"/> to
         /// always overwrite the existing instance.
         /// </remarks>
         /// <param name="orchestratorFunctionName">The name of the orchestrator function to start.</param>

--- a/src/WebJobs.Extensions.DurableTask/ContextInterfaces/IDurableOrchestrationClient.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextInterfaces/IDurableOrchestrationClient.cs
@@ -161,7 +161,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// overwritten depends on the existing instance's runtime status and on the
         /// <see cref="DurableTaskOptions.OverridableExistingInstanceStates"/> option. By default
         /// (<see cref="OverridableStates.NonRunningStates"/>), the existing instance is only overwritten when it is in a
-        /// terminated, failed, or completed state; if it is still pending, running, suspended, or continued-as-new, the
+        /// terminated, failed, canceled, or completed state; if it is still pending, running, suspended, or continued-as-new, the
         /// call fails rather than silently replacing it. Set the option to <see cref="OverridableStates.AnyState"/> to
         /// always overwrite the existing instance.
         /// </remarks>

--- a/src/WebJobs.Extensions.DurableTask/ContextInterfaces/IDurableOrchestrationClient.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextInterfaces/IDurableOrchestrationClient.cs
@@ -122,7 +122,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// overwritten depends on the existing instance's runtime status and on the
         /// <see cref="DurableTaskOptions.OverridableExistingInstanceStates"/> option. By default
         /// (<see cref="OverridableStates.NonRunningStates"/>), the existing instance is only overwritten when it is in a
-        /// terminated, failed, or completed state; if it is still pending, running, suspended, or continued-as-new, the
+        /// terminated, failed, canceled, or completed state; if it is still pending, running, suspended, or continued-as-new, the
         /// call fails rather than silently replacing it. Set the option to <see cref="OverridableStates.AnyState"/> to
         /// always overwrite the existing instance.
         /// </remarks>

--- a/src/WebJobs.Extensions.DurableTask/ContextInterfaces/IDurableOrchestrationClient.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextInterfaces/IDurableOrchestrationClient.cs
@@ -117,6 +117,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// <summary>
         /// Starts a new execution of the specified orchestrator function.
         /// </summary>
+        /// <remarks>
+        /// If an orchestration instance with the specified <paramref name="instanceId"/> already exists, whether it is
+        /// overwritten depends on the existing instance's runtime status and on the
+        /// <see cref="DurableTaskOptions.OverridableExistingInstanceStates"/> option. By default
+        /// (<see cref="OverridableStates.NonRunningStates"/>), the existing instance is only overwritten when it is in a
+        /// terminated, failed, or completed state; if it is still pending, running, suspended, or continued-as-new, the
+        /// call fails rather than silently replacing it. Set the option to <see cref="OverridableStates.AnyState"/> to
+        /// always overwrite the existing instance.
+        /// </remarks>
         /// <param name="orchestratorFunctionName">The name of the orchestrator function to start.</param>
         /// <param name="instanceId">The ID to use for the new orchestration instance.</param>
         /// <returns>A task that completes when the orchestration is started. The task contains the instance id of the started
@@ -148,8 +157,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// Starts a new instance of the specified orchestrator function.
         /// </summary>
         /// <remarks>
-        /// If an orchestration instance with the specified ID already exists, the existing instance
-        /// will be silently replaced by this new instance.
+        /// If an orchestration instance with the specified <paramref name="instanceId"/> already exists, whether it is
+        /// overwritten depends on the existing instance's runtime status and on the
+        /// <see cref="DurableTaskOptions.OverridableExistingInstanceStates"/> option. By default
+        /// (<see cref="OverridableStates.NonRunningStates"/>), the existing instance is only overwritten when it is in a
+        /// terminated, failed, or completed state; if it is still pending, running, suspended, or continued-as-new, the
+        /// call fails rather than silently replacing it. Set the option to <see cref="OverridableStates.AnyState"/> to
+        /// always overwrite the existing instance.
         /// </remarks>
         /// <param name="orchestratorFunctionName">The name of the orchestrator function to start.</param>
         /// <param name="instanceId">The ID to use for the new orchestration instance.</param>


### PR DESCRIPTION
## Summary
The `<remarks>` for `IDurableOrchestrationClient.StartNewAsync` claimed an existing instance with the same ID *"will be silently replaced by this new instance."* That is inaccurate and has confused users (#2112, #2334).

**Actual behavior** (verified via `DurableClient.CreateOrchestrationInstanceAndTraceAsync` -> `GetStatusesNotToOverride` -> `OverridableStates.ToDedupeStatuses`):
- `DurableTaskOptions.OverridableExistingInstanceStates` defaults to `OverridableStates.NonRunningStates`.
- With that default, an existing instance is only overwritten when it is in a **terminated, failed, or completed** state.
- If the existing instance is **Pending, Running, Suspended, or ContinuedAsNew**, the start call **fails** instead of silently replacing it.
- Set the option to `OverridableStates.AnyState` to always overwrite.

## Changes
- Corrected the `<remarks>` on the `StartNewAsync<T>(string, string, T)` overload.
- Added the same clarification to the `StartNewAsync(string, string)` overload, which also accepts a caller-supplied `instanceId` but previously had no remarks.

Documentation-only change (XML-doc comments).

Fixes #2112
Fixes #2334