### PR TITLE
Fix analyzer NullReferenceException when a class has multiple orchestrators (#2591)

### DIFF
--- a/src/WebJobs.Extensions.DurableTask.Analyzers/MethodInformation.cs
+++ b/src/WebJobs.Extensions.DurableTask.Analyzers/MethodInformation.cs
@@ -9,15 +9,30 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
 {
     public class MethodInformation
     {
+        private IList<InvocationExpressionSyntax> invocations;
+
+        private HashSet<MethodInformation> parents;
+
         public SemanticModel SemanticModel { get; set; }
 
         public SyntaxNode Declaration { get; set; }
 
         public ISymbol DeclarationSymbol { get; set; }
 
-        public IList<InvocationExpressionSyntax> Invocations { get; set; } = new List<InvocationExpressionSyntax>();
+        // Lazily initialized so that a MethodInformation instance does not allocate these collections up front
+        // (and so callers that assign via object initializers do not trigger redundant allocations). Keeping the
+        // collections non-null also prevents NullReferenceExceptions when they are mutated during method collection.
+        public IList<InvocationExpressionSyntax> Invocations
+        {
+            get => this.invocations ?? (this.invocations = new List<InvocationExpressionSyntax>());
+            set => this.invocations = value;
+        }
 
-        public HashSet<MethodInformation> Parents { get; set; } = new HashSet<MethodInformation>();
+        public HashSet<MethodInformation> Parents
+        {
+            get => this.parents ?? (this.parents = new HashSet<MethodInformation>());
+            set => this.parents = value;
+        }
 
         public override bool Equals(object obj)
         {

--- a/src/WebJobs.Extensions.DurableTask.Analyzers/MethodInformation.cs
+++ b/src/WebJobs.Extensions.DurableTask.Analyzers/MethodInformation.cs
@@ -15,9 +15,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
 
         public ISymbol DeclarationSymbol { get; set; }
 
-        public IList<InvocationExpressionSyntax> Invocations { get; set; }
+        public IList<InvocationExpressionSyntax> Invocations { get; set; } = new List<InvocationExpressionSyntax>();
 
-        public HashSet<MethodInformation> Parents { get; set; }
+        public HashSet<MethodInformation> Parents { get; set; } = new HashSet<MethodInformation>();
 
         public override bool Equals(object obj)
         {

--- a/test/WebJobs.Extensions.DurableTask.Analyzers.Test/Orchestrator/MethodInvocationAnalyzerTests.cs
+++ b/test/WebJobs.Extensions.DurableTask.Analyzers.Test/Orchestrator/MethodInvocationAnalyzerTests.cs
@@ -400,6 +400,45 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers.Test.Orchestr
             VerifyCSharpDiagnostic(test, expectedDiagnostics);
         }
 
+        [TestMethod]
+        public void MethodCalls_MultipleOrchestrators_DirectOrchestratorCall()
+        {
+            // Regression test for https://github.com/Azure/azure-functions-durable-extension/issues/2591:
+            // two orchestrator methods in the same class, where one directly invokes the other, used to
+            // cause the analyzer to throw a NullReferenceException while collecting orchestrator methods.
+            var test = @"
+    using System;
+    using System.Threading.Tasks;
+    using System.Collections.Generic;
+    using Microsoft.Azure.WebJobs;
+    using Microsoft.Azure.WebJobs.Extensions.DurableTask;
+
+    namespace VSSample
+    {
+        public static class HelloSequence
+        {
+            [FunctionName(""WorkflowV1"")]
+            public static async Task<List<string>> RunOrchestratorV1(
+            [OrchestrationTrigger] IDurableOrchestrationContext context)
+            {
+                return new List<string>();
+            }
+
+            [FunctionName(""WorkflowV2"")]
+            public static async Task<List<string>> RunOrchestratorV2(
+            [OrchestrationTrigger] IDurableOrchestrationContext context)
+            {
+                return await RunOrchestratorV1(context);
+            }
+        }
+    }";
+
+            // Before the fix this scenario caused the analyzer to throw a NullReferenceException,
+            // which surfaces as an AD0001 "analyzer failure" diagnostic. After the fix no diagnostics
+            // are produced because neither orchestrator contains non-deterministic code.
+            VerifyCSharpDiagnostic(test);
+        }
+
         protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
         {
             return new DeterministicMethodAnalyzer();


### PR DESCRIPTION
## Summary
Fixes #2591.

The Durable Task analyzer threw a `NullReferenceException` at compile time (surfaced as `AD0001`) when a class contained **two orchestrator methods and one directly invoked the other** — matching the repro in the issue.

## Root cause
`MethodInformation.Invocations` and `MethodInformation.Parents` were auto-properties with no initializer, so they defaulted to `null`. `OrchestratorMethodCollector.FindOrchestratorMethods` creates a `MethodInformation` without setting them. When a second orchestrator's body invokes the first (already-collected) orchestrator, `FindInvokedMethods` runs:

```csharp
existingMethodInformation.Invocations.Add(invocation); // NRE: Invocations was null
existingMethodInformation.Parents.Add(parentMethodInformation); // NRE: Parents was null
```

Because the invoked orchestrator's `MethodInformation` came from `FindOrchestratorMethods` (null collections), the `.Add(...)` calls threw. This only reproduces when both methods are recognized orchestrators and one calls the other directly, which is why it needed a specific repro project.

## Fix
Initialize both collections so they are never null. Reads in `MethodInvocationAnalyzer` already null-check, and an empty collection yields the same behavior (no diagnostics) — so this only removes the crash.

## Testing
Added a regression test `MethodCalls_MultipleOrchestrators_DirectOrchestratorCall` covering two orchestrators where one calls the other. Verified it **fails without the fix** (`AD0001` NRE on the `WorkflowV2` declaration) and **passes with it**. Full analyzer suite: **159/159 passing** (net8.0).