### PR TITLE
Fix disabled activity/entity functions poison-looping instead of failing gracefully

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -24,7 +24,7 @@
 
 ### Bug Fixes
 
-- Fixed a poison loop where dispatching a disabled-but-still-deployed activity or entity function caused in-flight orchestrations to retry indefinitely (throwing `ArgumentNullException('executor')`) instead of failing gracefully. Such registered-but-inactive functions are now treated as unavailable and fail deterministically. (#3471)
+- Fixed a poison loop where dispatching a disabled-but-still-deployed activity or entity function caused in-flight orchestrations to retry indefinitely (e.g. throwing `ArgumentNullException('executor')` on the activity dispatch path) instead of failing gracefully. Such registered-but-inactive functions are now treated as unavailable and fail deterministically. (#3471)
 
 ### Breaking Changes
 

--- a/release_notes.md
+++ b/release_notes.md
@@ -24,6 +24,8 @@
 
 ### Bug Fixes
 
+- Fixed a poison loop where dispatching a disabled-but-still-deployed activity or entity function caused in-flight orchestrations to retry indefinitely (throwing `ArgumentNullException('executor')`) instead of failing gracefully. Such registered-but-inactive functions are now treated as unavailable and fail deterministically. (#3471)
+
 ### Breaking Changes
 
 ### Dependency Updates

--- a/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
@@ -708,7 +708,22 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             RegisteredFunctionInfo info;
             if (!this.knownActivities.TryGetValue(activityFunction, out info))
             {
+                // The activity function is not registered at all (e.g. it was deleted or renamed).
                 return new TaskNonexistentActivityShim(this, name);
+            }
+
+            if (info.Executor == null)
+            {
+                // The activity function was indexed (so it is present in knownActivities) but no
+                // listener was ever started for it. This happens when the function is disabled but
+                // still deployed: the binding provider registers the name with a null executor
+                // during indexing, and the disabled function's listener never replaces it. Returning
+                // a shim that fails deterministically — instead of constructing a TaskActivityShim
+                // with a null executor, which throws ArgumentNullException during object construction
+                // and causes the work item to be abandoned and retried forever (a poison loop) — lets
+                // the orchestration receive a catchable failure.
+                // See https://github.com/Azure/azure-functions-durable-extension/issues/3471.
+                return new TaskNonexistentActivityShim(this, name, isDisabled: true);
             }
 
             return new TaskActivityShim(this, info.Executor, this.HostLifetimeService, name);
@@ -1077,11 +1092,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
             WrappedFunctionResult result;
 
-            if (entityShim.OperationBatch.Count > 0 && !this.HostLifetimeService.OnStopping.IsCancellationRequested)
+            RegisteredFunctionInfo entityFunctionInfo = entityShim.GetFunctionInfo();
+            bool functionUnavailable = entityFunctionInfo?.Executor == null;
+
+            if (entityShim.OperationBatch.Count > 0
+                && !this.HostLifetimeService.OnStopping.IsCancellationRequested
+                && !functionUnavailable)
             {
                 // 3a. (function execution) Start the functions invocation pipeline (billing, logging, bindings, and timeout tracking).
                 result = await FunctionExecutionHelper.ExecuteFunctionInOrchestrationMiddleware(
-                    entityShim.GetFunctionInfo().Executor,
+                    entityFunctionInfo.Executor,
                     new TriggeredFunctionData
                     {
                         TriggerValue = entityShim.Context,
@@ -1174,6 +1194,42 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     throw new SessionAbortedException(
                         $"An internal error occurred while attempting to execute '{entityContext.FunctionName}'.",
                         result.Exception);
+                }
+            }
+            else if (functionUnavailable
+                && entityShim.OperationBatch.Count > 0
+                && !this.HostLifetimeService.OnStopping.IsCancellationRequested)
+            {
+                // The entity function is registered/indexed but has no active listener — e.g. it is
+                // disabled but still deployed, or was deleted/renamed. Rather than dereferencing a
+                // null executor (which would surface as a transient work-item failure and poison-loop
+                // the batch forever), fail every operation in the batch deterministically. Each
+                // operation gets an exception response and is recorded as an application (not internal)
+                // error, so the batch is not aborted/retried. This mirrors the graceful handling in
+                // OutOfProcMiddleware.CallEntityAsync and the activity GetObject path.
+                // See https://github.com/Azure/azure-functions-durable-extension/issues/3471.
+                entityShim.AddTraceFlag(EntityTraceFlags.FunctionUnavailable);
+
+                this.TraceHelper.ExtensionWarningEvent(
+                    this.Options.HubName,
+                    entityContext.Name,
+                    entityContext.InstanceId,
+                    $"The entity function '{entityContext.Name}' is disabled or does not exist. Failing {entityShim.OperationBatch.Count} operation(s) deterministically instead of retrying indefinitely.");
+
+                var failureMessage = this.GetInvalidEntityFunctionMessage(entityContext.Name);
+                entityShim.SetFunctionInvocationCallback(() => throw new FunctionFailedException(failureMessage));
+
+                if (entityContext.InternalError == null)
+                {
+                    try
+                    {
+                        await entityShim.ExecuteBatch(this.HostLifetimeService.OnStopping);
+                        await next();
+                    }
+                    catch (Exception e)
+                    {
+                        entityContext.CaptureInternalError(e, entityShim);
+                    }
                 }
             }
             else

--- a/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
@@ -1533,7 +1533,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         internal string GetInvalidEntityFunctionMessage(string name)
         {
             string message = $"The function '{name}' doesn't exist, is disabled, or is not an entity function. Additional info: ";
-            if (this.knownOrchestrators.Keys.Count > 0)
+            if (this.knownEntities.Keys.Count > 0)
             {
                 message += $"The following are the known entity functions: '{string.Join("', '", this.knownEntities.Keys)}'.";
             }

--- a/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
@@ -1214,7 +1214,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     this.Options.HubName,
                     entityContext.Name,
                     entityContext.InstanceId,
-                    $"The entity function '{entityContext.Name}' is disabled or does not exist. Failing {entityShim.OperationBatch.Count} operation(s) deterministically instead of retrying indefinitely.");
+                    $"The entity function '{entityContext.Name}' is disabled or does not exist. Failing {entityShim.OperationBatch.Count} operation(s).");
 
                 var failureMessage = this.GetInvalidEntityFunctionMessage(entityContext.Name);
                 entityShim.SetFunctionInvocationCallback(() => throw new FunctionFailedException(failureMessage));

--- a/src/WebJobs.Extensions.DurableTask/EntityScheduler/EntityTraceFlags.cs
+++ b/src/WebJobs.Extensions.DurableTask/EntityScheduler/EntityTraceFlags.cs
@@ -28,6 +28,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         // the execution bypassed the functions middleware because no user code is called
         public const char DirectExecution = 'D';
 
+        // the entity function was registered/indexed but has no active listener (e.g. disabled but
+        // still deployed): the batch is failed deterministically instead of dereferencing a null executor
+        public const char FunctionUnavailable = 'U';
+
         // an internal error was captured
         public const char InternalError = '!';
 

--- a/src/WebJobs.Extensions.DurableTask/Listener/TaskEntityShim.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/TaskEntityShim.cs
@@ -316,7 +316,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         {
             async Task ExecuteOperationsInBatch()
             {
-                if (this.GetFunctionInfo().IsOutOfProc)
+                // GetFunctionInfo() can be null when the entity function is registered/indexed but has
+                // no active listener (e.g. disabled but still deployed). In that case the caller has
+                // set a throwing invocation callback, so we take the per-operation (in-proc) path and
+                // let each operation fail deterministically rather than dereferencing a null executor.
+                if (this.GetFunctionInfo()?.IsOutOfProc == true)
                 {
                     // process all operations in the batch using a single function call
                     await this.ExecuteOutOfProcBatch();

--- a/src/WebJobs.Extensions.DurableTask/Listener/TaskEntityShim.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/TaskEntityShim.cs
@@ -316,16 +316,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         {
             async Task ExecuteOperationsInBatch()
             {
-                // Only use the single-call out-of-proc batch path for a runnable out-of-proc entity.
-                // For an unavailable entity (disabled but still deployed, or deleted/renamed)
-                // GetFunctionInfo() is null, so functionInfo?.Executor is null and we fall through to
-                // the per-operation in-proc path. That matters because for the unavailable case
-                // EntityMiddleware sets an invocation callback that throws synchronously: the in-proc
-                // path invokes it inside a per-operation try/catch and records a deterministic
-                // application error, whereas ExecuteOutOfProcBatch would let the synchronous throw
-                // bubble out of the batch and be recorded as an internal error (aborting and retrying
-                // the work item — the poison loop this guards against). The Executor null-check also
-                // defends against a registered-but-null-executor RegisteredFunctionInfo.
+                // A disabled/deleted entity is registered with a null executor. In that case, fall
+                // through to the per-operation loop below, which runs EntityMiddleware's throwing
+                // callback inside a per-operation try/catch and records a deterministic failure.
+                // ExecuteOutOfProcBatch would instead let that throw abort + retry the batch (the
+                // poison loop this guards against). See https://github.com/Azure/azure-functions-durable-extension/issues/3471.
                 RegisteredFunctionInfo functionInfo = this.GetFunctionInfo();
                 if (functionInfo?.Executor != null && functionInfo.IsOutOfProc)
                 {

--- a/src/WebJobs.Extensions.DurableTask/Listener/TaskEntityShim.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/TaskEntityShim.cs
@@ -316,13 +316,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         {
             async Task ExecuteOperationsInBatch()
             {
-                // Only take the single-call out-of-proc batch path for a genuinely runnable out-of-proc
-                // entity (non-null executor). When the executor is null — the entity is registered/indexed
-                // but has no active listener (e.g. disabled but still deployed) — the caller has set a
-                // throwing invocation callback; that callback throws synchronously, so routing it through
-                // ExecuteOutOfProcBatch would bubble the exception out of the batch and reintroduce the
-                // transient failure / poison loop. Instead we always take the per-operation (in-proc) path
-                // for an unavailable entity, so each operation fails deterministically.
+                // Only use the single-call out-of-proc batch path for a runnable out-of-proc entity.
+                // For an unavailable entity (disabled but still deployed, or deleted/renamed)
+                // GetFunctionInfo() is null, so functionInfo?.Executor is null and we fall through to
+                // the per-operation in-proc path. That matters because for the unavailable case
+                // EntityMiddleware sets an invocation callback that throws synchronously: the in-proc
+                // path invokes it inside a per-operation try/catch and records a deterministic
+                // application error, whereas ExecuteOutOfProcBatch would let the synchronous throw
+                // bubble out of the batch and be recorded as an internal error (aborting and retrying
+                // the work item — the poison loop this guards against). The Executor null-check also
+                // defends against a registered-but-null-executor RegisteredFunctionInfo.
                 RegisteredFunctionInfo functionInfo = this.GetFunctionInfo();
                 if (functionInfo?.Executor != null && functionInfo.IsOutOfProc)
                 {

--- a/src/WebJobs.Extensions.DurableTask/Listener/TaskEntityShim.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/TaskEntityShim.cs
@@ -316,11 +316,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         {
             async Task ExecuteOperationsInBatch()
             {
-                // GetFunctionInfo() can be null when the entity function is registered/indexed but has
-                // no active listener (e.g. disabled but still deployed). In that case the caller has
-                // set a throwing invocation callback, so we take the per-operation (in-proc) path and
-                // let each operation fail deterministically rather than dereferencing a null executor.
-                if (this.GetFunctionInfo()?.IsOutOfProc == true)
+                // Only take the single-call out-of-proc batch path for a genuinely runnable out-of-proc
+                // entity (non-null executor). When the executor is null — the entity is registered/indexed
+                // but has no active listener (e.g. disabled but still deployed) — the caller has set a
+                // throwing invocation callback; that callback throws synchronously, so routing it through
+                // ExecuteOutOfProcBatch would bubble the exception out of the batch and reintroduce the
+                // transient failure / poison loop. Instead we always take the per-operation (in-proc) path
+                // for an unavailable entity, so each operation fails deterministically.
+                RegisteredFunctionInfo functionInfo = this.GetFunctionInfo();
+                if (functionInfo?.Executor != null && functionInfo.IsOutOfProc)
                 {
                     // process all operations in the batch using a single function call
                     await this.ExecuteOutOfProcBatch();

--- a/src/WebJobs.Extensions.DurableTask/Listener/TaskNonexistentActivityShim.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/TaskNonexistentActivityShim.cs
@@ -9,22 +9,51 @@ using DurableTask.Core.Exceptions;
 
 namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Listener
 {
+    /// <summary>
+    /// Task activity implementation used when an activity cannot be executed because it is not an
+    /// active, runnable function. This covers two cases:
+    /// <list type="bullet">
+    /// <item>the activity function does not exist (e.g. it was deleted or renamed), and</item>
+    /// <item>the activity function is registered/indexed but has no active listener because it is
+    /// disabled but still deployed (its <see cref="RegisteredFunctionInfo.Executor"/> is <c>null</c>).</item>
+    /// </list>
+    /// In both cases we surface a deterministic <see cref="TaskFailureException"/> from
+    /// <see cref="Run"/> so the orchestration receives a catchable failure, rather than throwing
+    /// during object construction (which DTFx treats as a transient work-item failure and retries
+    /// forever — a poison loop). See https://github.com/Azure/azure-functions-durable-extension/issues/3471.
+    /// </summary>
     internal class TaskNonexistentActivityShim : TaskActivity
     {
         private readonly DurableTaskExtension config;
         private readonly string activityName;
+        private readonly bool isDisabled;
 
         public TaskNonexistentActivityShim(
             DurableTaskExtension config,
-            string activityName)
+            string activityName,
+            bool isDisabled = false)
         {
             this.config = config;
             this.activityName = activityName;
+            this.isDisabled = isDisabled;
         }
 
         public override string Run(TaskContext context, string input)
         {
-            string message = $"Activity function '{this.activityName}' does not exist.";
+            if (this.isDisabled)
+            {
+                // Emit a warning so operators can diagnose why an in-flight orchestration's activity
+                // started failing after a deploy that disabled (but kept) the activity function.
+                this.config.TraceHelper.ExtensionWarningEvent(
+                    hubName: this.config.Options.HubName,
+                    functionName: this.activityName,
+                    instanceId: context.OrchestrationInstance?.InstanceId ?? string.Empty,
+                    message: $"Activity function '{this.activityName}' was scheduled but is disabled (registered without an active listener). Failing the activity deterministically instead of retrying indefinitely.");
+            }
+
+            string message = this.isDisabled
+                ? $"Activity function '{this.activityName}' is disabled."
+                : $"Activity function '{this.activityName}' does not exist.";
             Exception exceptionToReport = new FunctionFailedException(message);
 
             throw new TaskFailureException(

--- a/src/WebJobs.Extensions.DurableTask/Listener/TaskNonexistentActivityShim.cs
+++ b/src/WebJobs.Extensions.DurableTask/Listener/TaskNonexistentActivityShim.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Listener
                     hubName: this.config.Options.HubName,
                     functionName: this.activityName,
                     instanceId: context.OrchestrationInstance?.InstanceId ?? string.Empty,
-                    message: $"Activity function '{this.activityName}' was scheduled but is disabled (registered without an active listener). Failing the activity deterministically instead of retrying indefinitely.");
+                    message: $"Activity function '{this.activityName}' was scheduled but is disabled. Failing the activity.");
             }
 
             string message = this.isDisabled

--- a/src/WebJobs.Extensions.DurableTask/OutOfProcMiddleware.cs
+++ b/src/WebJobs.Extensions.DurableTask/OutOfProcMiddleware.cs
@@ -537,7 +537,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 // Fail the activity call with an error explaining that the function name is invalid.
                 // This covers two cases that must both fail deterministically rather than poison-loop:
                 //   1. the activity is not registered (deleted/renamed), and
-                //   2. the activity is registered/indexed but disabled but still deployed, so it has
+                //   2. the activity is registered/indexed but is disabled and still deployed, so it has
                 //      no active listener and its Executor is null. Dereferencing that null executor
                 //      below would surface as a transient runtime failure and retry the work item
                 //      forever. See https://github.com/Azure/azure-functions-durable-extension/issues/3471.

--- a/src/WebJobs.Extensions.DurableTask/OutOfProcMiddleware.cs
+++ b/src/WebJobs.Extensions.DurableTask/OutOfProcMiddleware.cs
@@ -531,9 +531,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 return;
             }
 
-            if (!this.extension.TryGetActivityInfo(functionName, out RegisteredFunctionInfo? function))
+            if (!this.extension.TryGetActivityInfo(functionName, out RegisteredFunctionInfo? function)
+                || function?.Executor == null)
             {
                 // Fail the activity call with an error explaining that the function name is invalid.
+                // This covers two cases that must both fail deterministically rather than poison-loop:
+                //   1. the activity is not registered (deleted/renamed), and
+                //   2. the activity is registered/indexed but disabled but still deployed, so it has
+                //      no active listener and its Executor is null. Dereferencing that null executor
+                //      below would surface as a transient runtime failure and retry the work item
+                //      forever. See https://github.com/Azure/azure-functions-durable-extension/issues/3471.
                 string errorMessage = this.extension.GetInvalidActivityFunctionMessage(functionName.Name);
                 dispatchContext.SetProperty(new ActivityExecutionResult
                 {

--- a/src/WebJobs.Extensions.DurableTask/OutOfProcMiddleware.cs
+++ b/src/WebJobs.Extensions.DurableTask/OutOfProcMiddleware.cs
@@ -338,8 +338,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 });
             }
 
-            if (functionInfo == null)
+            if (functionInfo?.Executor == null)
             {
+                // The entity is not registered (deleted/renamed) or is registered/indexed but disabled
+                // but still deployed, so it has no active listener (null executor). Fail the batch
+                // deterministically instead of dereferencing the null executor below, which would
+                // surface as a transient failure and retry the work item forever.
+                // See https://github.com/Azure/azure-functions-durable-extension/issues/3471.
                 SetErrorResult(new FailureDetails(
                     errorType: "EntityFunctionNotFound",
                     errorMessage: this.extension.GetInvalidEntityFunctionMessage(functionName.Name),

--- a/test/FunctionsV2/Tests/Unit/DisabledFunctionDispatchTests.cs
+++ b/test/FunctionsV2/Tests/Unit/DisabledFunctionDispatchTests.cs
@@ -1,0 +1,119 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#nullable enable
+
+using System;
+using DurableTask.AzureStorage;
+using DurableTask.Core;
+using DurableTask.Core.Exceptions;
+using Microsoft.Azure.WebJobs.Extensions.DurableTask.Listener;
+using Microsoft.Azure.WebJobs.Host.Executors;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
+{
+    /// <summary>
+    /// Tests for how the DTFx activity object manager (<see cref="DurableTaskExtension"/>'s
+    /// <see cref="INameVersionObjectManager{T}.GetObject"/>) handles activities that are registered
+    /// but not runnable — specifically disabled-but-still-deployed functions, which are indexed with a
+    /// null executor. See https://github.com/Azure/azure-functions-durable-extension/issues/3471.
+    /// </summary>
+    public class DisabledFunctionDispatchTests
+    {
+        private static readonly TaskContext TestTaskContext =
+            new TaskContext(new OrchestrationInstance { InstanceId = "test-instance", ExecutionId = "test-execution" });
+
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public void GetObject_DisabledActivity_ReturnsShimThatFailsAsDisabled()
+        {
+            // Arrange: simulate indexing of a disabled-but-deployed activity. The binding provider
+            // registers the name during indexing with a null executor, and because the function is
+            // disabled its listener never runs to replace that null. So knownActivities contains the
+            // entry with Executor == null.
+            var extension = CreateExtension();
+            extension.RegisterActivity(new FunctionName("DisabledActivity"), executor: null!);
+
+            var objectManager = (INameVersionObjectManager<TaskActivity>)extension;
+
+            // Act: GetObject must NOT throw ArgumentNullException (the pre-fix poison-loop behavior).
+            var shim = objectManager.GetObject("DisabledActivity", version: string.Empty);
+
+            // Assert: we get a shim that fails deterministically with a "disabled" message.
+            var disabledShim = Assert.IsType<TaskNonexistentActivityShim>(shim);
+
+            TaskFailureException failure = Assert.Throws<TaskFailureException>(
+                () => disabledShim.Run(TestTaskContext, "null"));
+            Assert.Contains("DisabledActivity", failure.Message);
+            Assert.Contains("is disabled", failure.Message);
+        }
+
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public void GetObject_NonexistentActivity_ReturnsShimThatFailsAsNonexistent()
+        {
+            // Arrange: an activity that was never registered at all (e.g. deleted/renamed).
+            var extension = CreateExtension();
+
+            var objectManager = (INameVersionObjectManager<TaskActivity>)extension;
+
+            // Act
+            var shim = objectManager.GetObject("GhostActivity", version: string.Empty);
+
+            // Assert: still a graceful, deterministic failure — but with a "does not exist" message.
+            var nonexistentShim = Assert.IsType<TaskNonexistentActivityShim>(shim);
+
+            TaskFailureException failure = Assert.Throws<TaskFailureException>(
+                () => nonexistentShim.Run(TestTaskContext, "null"));
+            Assert.Contains("GhostActivity", failure.Message);
+            Assert.Contains("does not exist", failure.Message);
+        }
+
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public void GetObject_ActiveActivity_ReturnsRealActivityShim()
+        {
+            // Arrange: a normally registered activity with an active listener/executor.
+            var extension = CreateExtension();
+            var mockExecutor = new Mock<ITriggeredFunctionExecutor>();
+            extension.RegisterActivity(new FunctionName("ActiveActivity"), mockExecutor.Object);
+
+            var objectManager = (INameVersionObjectManager<TaskActivity>)extension;
+
+            // Act
+            var shim = objectManager.GetObject("ActiveActivity", version: string.Empty);
+
+            // Assert: the real activity shim (which delegates to the executor) is returned.
+            Assert.IsType<TaskActivityShim>(shim);
+        }
+
+        private static DurableTaskExtension CreateExtension()
+        {
+            var options = new DurableTaskOptions
+            {
+                HubName = "TestHub",
+                WebhookUriProviderOverride = () => new Uri("https://localhost"),
+            };
+
+            return new DurableTaskExtension(
+                new OptionsWrapper<DurableTaskOptions>(options),
+                NullLoggerFactory.Instance,
+                TestHelpers.GetTestNameResolver(),
+                [
+                    new AzureStorageDurabilityProviderFactory(
+                        new OptionsWrapper<DurableTaskOptions>(options),
+                        new TestStorageServiceClientProviderFactory(),
+                        TestHelpers.GetTestNameResolver(),
+                        NullLoggerFactory.Instance,
+                        TestHelpers.GetMockPlatformInformationService()),
+                ],
+                new TestHostShutdownNotificationService(),
+                new DurableHttpMessageHandlerFactory(),
+                platformInformationService: TestHelpers.GetMockPlatformInformationService());
+        }
+    }
+}

--- a/test/FunctionsV2/Tests/Unit/DisabledFunctionDispatchTests.cs
+++ b/test/FunctionsV2/Tests/Unit/DisabledFunctionDispatchTests.cs
@@ -91,6 +91,23 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             Assert.IsType<TaskActivityShim>(shim);
         }
 
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public void GetInvalidEntityFunctionMessage_ListsRegisteredEntities_WhenNoOrchestratorsExist()
+        {
+            // Guards the diagnosability of the disabled-entity failure path: the message must reflect
+            // the registered ENTITIES, not orchestrators. Previously the helper checked
+            // knownOrchestrators.Count to decide whether to list entities, so with entities registered
+            // but no orchestrators it wrongly reported "No entity functions are currently registered!".
+            var extension = CreateExtension();
+            extension.RegisterEntity(new FunctionName("MyEntity"), new RegisteredFunctionInfo(executor: null!, isOutOfProc: true));
+
+            string message = extension.GetInvalidEntityFunctionMessage("SomeMissingEntity");
+
+            Assert.Contains("MyEntity", message);
+            Assert.DoesNotContain("No entity functions are currently registered", message);
+        }
+
         private static DurableTaskExtension CreateExtension()
         {
             var options = new DurableTaskOptions

--- a/test/FunctionsV2/Tests/Unit/DisabledFunctionDispatchTests.cs
+++ b/test/FunctionsV2/Tests/Unit/DisabledFunctionDispatchTests.cs
@@ -93,6 +93,46 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
         [Fact]
         [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public void DisabledEntity_IsTreatedAsUnavailableByClassicDispatch()
+        {
+            // The classic (in-proc / HTTP-protocol) entity dispatch path in EntityMiddleware treats an
+            // entity as unavailable when GetEntityInfo(name)?.Executor is null, which is exactly the
+            // state of a disabled-but-still-deployed entity: the binding provider registers it during
+            // indexing (null executor) and the disabled function's listener never replaces it. That
+            // signal drives the deterministic per-operation failure path in TaskEntityShim.ExecuteBatch
+            // instead of a null-executor dereference / poison loop. The full dispatch is covered
+            // end-to-end by the Node/Python entity E2E tests.
+            // See https://github.com/Azure/azure-functions-durable-extension/issues/3471.
+            var extension = CreateExtension();
+
+            // Disabled via a null RegisteredFunctionInfo — how the binding provider registers a
+            // disabled entity during indexing.
+            extension.RegisterEntity(new FunctionName("DisabledEntityNullInfo"), entityInfo: null);
+
+            // Defense-in-depth: a non-null info whose executor is null must also be treated as unavailable.
+            extension.RegisterEntity(new FunctionName("DisabledEntityNullExecutor"), new RegisteredFunctionInfo(executor: null!, isOutOfProc: true));
+
+            // A normally registered entity is available.
+            var mockExecutor = new Mock<ITriggeredFunctionExecutor>();
+            extension.RegisterEntity(new FunctionName("ActiveEntity"), new RegisteredFunctionInfo(mockExecutor.Object, isOutOfProc: true));
+
+            // The unavailable entities have no active executor (EntityMiddleware's functionUnavailable check).
+            Assert.Null(extension.GetEntityInfo(new FunctionName("DisabledEntityNullInfo"))?.Executor);
+
+            RegisteredFunctionInfo nullExecutorInfo = extension.GetEntityInfo(new FunctionName("DisabledEntityNullExecutor"));
+            Assert.NotNull(nullExecutorInfo);
+            Assert.Null(nullExecutorInfo.Executor);
+            Assert.False(nullExecutorInfo.HasActiveListener);
+
+            // The active entity is runnable.
+            RegisteredFunctionInfo activeInfo = extension.GetEntityInfo(new FunctionName("ActiveEntity"));
+            Assert.NotNull(activeInfo);
+            Assert.NotNull(activeInfo.Executor);
+            Assert.True(activeInfo.HasActiveListener);
+        }
+
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
         public void GetInvalidEntityFunctionMessage_ListsRegisteredEntities_WhenNoOrchestratorsExist()
         {
             // Guards the diagnosability of the disabled-entity failure path: the message must reflect

--- a/test/FunctionsV2/Tests/Unit/OutOfProcMiddlewareTests.cs
+++ b/test/FunctionsV2/Tests/Unit/OutOfProcMiddlewareTests.cs
@@ -145,6 +145,34 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
         [Fact]
         [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public async Task CallActivityAsync_DisabledActivity_FailsDeterministicallyWithoutAbort()
+        {
+            // Reproduces https://github.com/Azure/azure-functions-durable-extension/issues/3471 for the
+            // passthrough/out-of-proc activity middleware. A disabled-but-still-deployed activity is
+            // indexed (present in knownActivities) but has a null executor because its listener never
+            // started. The middleware must fail the activity with a deterministic TaskFailedEvent instead
+            // of dereferencing the null executor (which surfaced as a SessionAbortedException and made the
+            // work item retry forever).
+            DurableTaskExtension extension = CreateDurableTaskExtension();
+            extension.RegisterActivity(new FunctionName("TestActivity"), executor: null!);
+
+            var middleware = new OutOfProcMiddleware(extension);
+            var dispatchContext = new DispatchMiddlewareContext();
+            dispatchContext.SetProperty(new TaskScheduledEvent(-1) { Name = "TestActivity" });
+            dispatchContext.SetProperty(new OrchestrationInstance { InstanceId = "test-instance-id" });
+
+            // Act: must NOT throw (no SessionAbortedException / NullReferenceException poison loop).
+            await middleware.CallActivityAsync(dispatchContext, () => Task.CompletedTask);
+
+            // Assert: a deterministic (non-transient) failure was set on the dispatch context.
+            ActivityExecutionResult result = dispatchContext.GetProperty<ActivityExecutionResult>();
+            Assert.NotNull(result);
+            TaskFailedEvent failedEvent = Assert.IsType<TaskFailedEvent>(result.ResponseEvent);
+            Assert.Contains("TestActivity", failedEvent.Reason);
+        }
+
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
         public void TryGetStructuredFailureDetails_StructuredPayload_ReturnsFailureDetailsWithProperties()
         {
             // Arrange: an out-of-proc worker exception whose message embeds a serialized

--- a/test/FunctionsV2/Tests/Unit/OutOfProcMiddlewareTests.cs
+++ b/test/FunctionsV2/Tests/Unit/OutOfProcMiddlewareTests.cs
@@ -173,6 +173,38 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
         [Fact]
         [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public async Task CallEntityAsync_DisabledEntity_FailsDeterministicallyWithoutAbort()
+        {
+            // Reproduces https://github.com/Azure/azure-functions-durable-extension/issues/3471 for the
+            // passthrough/out-of-proc entity middleware. A disabled-but-still-deployed entity is indexed
+            // (present in knownEntities) but has a null executor because its listener never started. The
+            // middleware must fail the batch with a non-retriable FailureDetails result instead of
+            // dereferencing the null executor (which surfaced as a transient failure and retried forever).
+            DurableTaskExtension extension = CreateDurableTaskExtension();
+            extension.RegisterEntity(new FunctionName("TestEntity"), new RegisteredFunctionInfo(executor: null!, isOutOfProc: true));
+
+            var middleware = new OutOfProcMiddleware(extension);
+            var dispatchContext = new DispatchMiddlewareContext();
+            dispatchContext.SetProperty(new EntityBatchRequest
+            {
+                InstanceId = "@TestEntity@test-key",
+                EntityState = null,
+                Operations = new List<OperationRequest>(),
+            });
+            dispatchContext.SetProperty(CreateWorkItemMetadata(isExtendedSession: false, includeState: false));
+
+            // Act: must NOT throw (no SessionAbortedException / NullReferenceException poison loop).
+            await middleware.CallEntityAsync(dispatchContext, () => Task.CompletedTask);
+
+            // Assert: a deterministic, non-retriable failure was set on the dispatch context.
+            EntityBatchResult result = dispatchContext.GetProperty<EntityBatchResult>();
+            Assert.NotNull(result);
+            Assert.NotNull(result.FailureDetails);
+            Assert.Contains("TestEntity", result.FailureDetails.ErrorMessage);
+        }
+
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
         public void TryGetStructuredFailureDetails_StructuredPayload_ReturnsFailureDetailsWithProperties()
         {
             // Arrange: an out-of-proc worker exception whose message embeds a serialized

--- a/test/e2e/Apps/BasicDotNetIsolated/CallDisabledFunctions.cs
+++ b/test/e2e/Apps/BasicDotNetIsolated/CallDisabledFunctions.cs
@@ -1,0 +1,36 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.DurableTask;
+using Microsoft.DurableTask.Entities;
+
+namespace Microsoft.Azure.Durable.Tests.E2E;
+
+// Orchestrations that schedule work against the disabled-but-still-deployed functions
+// (DisabledActivity / DisabledEntity). These are used by DisabledOrchestrationTests to verify that
+// dispatching a disabled function fails the orchestration deterministically instead of poison-looping
+// forever. See https://github.com/Azure/azure-functions-durable-extension/issues/3471.
+public static class CallDisabledFunctions
+{
+    [Function(nameof(CallDisabledActivity))]
+    public static async Task<string> CallDisabledActivity(
+        [OrchestrationTrigger] TaskOrchestrationContext context)
+    {
+        // DisabledActivity is indexed but has no active listener (its executor is null), so this
+        // must surface as a deterministic activity failure rather than hanging forever.
+        return await context.CallActivityAsync<string>(nameof(DisabledActivity), "hello");
+    }
+
+    [Function(nameof(CallDisabledEntity))]
+    public static async Task<string> CallDisabledEntity(
+        [OrchestrationTrigger] TaskOrchestrationContext context)
+    {
+        var entityId = new EntityInstanceId(nameof(DisabledEntity), "disabled-key");
+
+        // DisabledEntity is indexed but has no active listener, so calling an operation on it must
+        // fail deterministically rather than poison-looping the entity work item forever.
+        await context.Entities.CallEntityAsync(entityId, "someOperation");
+        return "should not reach here";
+    }
+}

--- a/test/e2e/Apps/BasicJava/local.settings.json
+++ b/test/e2e/Apps/BasicJava/local.settings.json
@@ -2,6 +2,7 @@
   "IsEncrypted": false,
   "Values": {
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
-    "FUNCTIONS_WORKER_RUNTIME": "java"
+    "FUNCTIONS_WORKER_RUNTIME": "java",
+    "AzureWebJobs.DisabledActivity.Disabled": "true"
   }
 }

--- a/test/e2e/Apps/BasicJava/src/main/java/com/function/DisabledActivity.java
+++ b/test/e2e/Apps/BasicJava/src/main/java/com/function/DisabledActivity.java
@@ -31,8 +31,7 @@ public class DisabledActivity {
      */
     @FunctionName("DisabledActivity")
     public String disabledActivity(
-            @DurableActivityTrigger(name = "input") String input,
-            final ExecutionContext context) {
+            @DurableActivityTrigger(name = "input") String input) {
         return input;
     }
 }

--- a/test/e2e/Apps/BasicJava/src/main/java/com/function/DisabledActivity.java
+++ b/test/e2e/Apps/BasicJava/src/main/java/com/function/DisabledActivity.java
@@ -1,0 +1,38 @@
+package com.function;
+
+import com.microsoft.azure.functions.annotation.*;
+import com.microsoft.azure.functions.*;
+
+import com.microsoft.durabletask.*;
+import com.microsoft.durabletask.azurefunctions.DurableActivityTrigger;
+import com.microsoft.durabletask.azurefunctions.DurableOrchestrationTrigger;
+
+/**
+ * Disabled-but-still-deployed activity plus an orchestrator that schedules it. Used by
+ * DisabledOrchestrationTests to validate that dispatching a disabled activity fails the orchestration
+ * deterministically instead of poison-looping forever.
+ * See https://github.com/Azure/azure-functions-durable-extension/issues/3471.
+ */
+public class DisabledActivity {
+    /**
+     * Orchestrator that schedules the disabled-but-still-deployed DisabledActivity. Because the
+     * activity has no active listener, the dispatch must fail the orchestration deterministically.
+     */
+    @FunctionName("CallDisabledActivity")
+    public String callDisabledActivity(
+            @DurableOrchestrationTrigger(name = "ctx") TaskOrchestrationContext ctx) {
+        return ctx.callActivity("DisabledActivity", "hello", String.class).await();
+    }
+
+    /**
+     * Activity function DisabledActivity. Disabled at runtime via the
+     * AzureWebJobs.DisabledActivity.Disabled app setting in local.settings.json, so no listener is
+     * started for it even though it is still deployed/indexed.
+     */
+    @FunctionName("DisabledActivity")
+    public String disabledActivity(
+            @DurableActivityTrigger(name = "input") String input,
+            final ExecutionContext context) {
+        return input;
+    }
+}

--- a/test/e2e/Apps/BasicNode/local.settings.json
+++ b/test/e2e/Apps/BasicNode/local.settings.json
@@ -2,6 +2,8 @@
   "IsEncrypted": false,
   "Values": {
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
-    "FUNCTIONS_WORKER_RUNTIME": "node"
+    "FUNCTIONS_WORKER_RUNTIME": "node",
+    "AzureWebJobs.DisabledActivity.Disabled": "true",
+    "AzureWebJobs.DisabledEntity.Disabled": "true"
   }
 }

--- a/test/e2e/Apps/BasicNode/src/functions/CallDisabledFunctions.ts
+++ b/test/e2e/Apps/BasicNode/src/functions/CallDisabledFunctions.ts
@@ -1,0 +1,24 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+import * as df from 'durable-functions';
+import { OrchestrationContext, OrchestrationHandler } from 'durable-functions';
+
+// Orchestrator that schedules the disabled-but-still-deployed DisabledActivity. Because the activity
+// has no active listener, the dispatch must fail the orchestration deterministically instead of
+// poison-looping forever. See https://github.com/Azure/azure-functions-durable-extension/issues/3471.
+const CallDisabledActivity: OrchestrationHandler = function* (context: OrchestrationContext) {
+    return yield context.df.callActivity('DisabledActivity', 'hello');
+};
+
+df.app.orchestration('CallDisabledActivity', CallDisabledActivity);
+
+// Companion orchestrator for the entity dispatch path: calling an operation on the disabled-but-still-
+// deployed DisabledEntity must fail the orchestration deterministically rather than poison-looping.
+const CallDisabledEntity: OrchestrationHandler = function* (context: OrchestrationContext) {
+    const entityId = new df.EntityId('DisabledEntity', 'disabled-key');
+    yield context.df.callEntity(entityId, 'someOperation');
+    return 'should not reach here';
+};
+
+df.app.orchestration('CallDisabledEntity', CallDisabledEntity);

--- a/test/e2e/Apps/BasicNode/src/functions/DisabledActivity.ts
+++ b/test/e2e/Apps/BasicNode/src/functions/DisabledActivity.ts
@@ -1,0 +1,12 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+import * as df from 'durable-functions';
+import { ActivityHandler } from 'durable-functions';
+
+// Disabled at runtime via the AzureWebJobs.DisabledActivity.Disabled app setting in
+// local.settings.json. Used by DisabledOrchestrationTests to validate that scheduling a
+// disabled-but-still-deployed activity fails the orchestration gracefully instead of poison-looping.
+const DisabledActivity: ActivityHandler = (input: string): string => input;
+
+df.app.activity('DisabledActivity', { handler: DisabledActivity });

--- a/test/e2e/Apps/BasicNode/src/functions/DisabledEntity.ts
+++ b/test/e2e/Apps/BasicNode/src/functions/DisabledEntity.ts
@@ -1,0 +1,14 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+import * as df from 'durable-functions';
+import { EntityContext, EntityHandler } from 'durable-functions';
+
+// Disabled at runtime via the AzureWebJobs.DisabledEntity.Disabled app setting in
+// local.settings.json. Used by DisabledOrchestrationTests to validate that calling an operation on a
+// disabled-but-still-deployed entity fails the orchestration gracefully instead of poison-looping.
+const DisabledEntity: EntityHandler<unknown> = (context: EntityContext<unknown>) => {
+    context.df.return(null);
+};
+
+df.app.entity('DisabledEntity', DisabledEntity);

--- a/test/e2e/Apps/BasicPowerShell/CallDisabledActivity/function.json
+++ b/test/e2e/Apps/BasicPowerShell/CallDisabledActivity/function.json
@@ -1,0 +1,9 @@
+{
+  "bindings": [
+    {
+      "name": "Context",
+      "type": "orchestrationTrigger",
+      "direction": "in"
+    }
+  ]
+}

--- a/test/e2e/Apps/BasicPowerShell/CallDisabledActivity/run.ps1
+++ b/test/e2e/Apps/BasicPowerShell/CallDisabledActivity/run.ps1
@@ -1,0 +1,15 @@
+#
+# Copyright (c) Microsoft. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+#
+
+# Orchestrator that schedules the disabled-but-still-deployed DisabledActivity. Because the activity
+# has no active listener, the dispatch must fail the orchestration deterministically instead of
+# poison-looping forever. See https://github.com/Azure/azure-functions-durable-extension/issues/3471.
+param($Context)
+
+$output = @()
+
+$output += Invoke-DurableActivity -FunctionName 'DisabledActivity' -Input 'hello'
+
+$output

--- a/test/e2e/Apps/BasicPowerShell/DisabledActivity/function.json
+++ b/test/e2e/Apps/BasicPowerShell/DisabledActivity/function.json
@@ -1,0 +1,9 @@
+{
+  "bindings": [
+    {
+      "name": "name",
+      "type": "activityTrigger",
+      "direction": "in"
+    }
+  ]
+}

--- a/test/e2e/Apps/BasicPowerShell/DisabledActivity/run.ps1
+++ b/test/e2e/Apps/BasicPowerShell/DisabledActivity/run.ps1
@@ -1,0 +1,11 @@
+#
+# Copyright (c) Microsoft. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+#
+
+# Disabled at runtime via the AzureWebJobs.DisabledActivity.Disabled app setting in
+# local.settings.json. Used by DisabledOrchestrationTests to validate that scheduling a
+# disabled-but-still-deployed activity fails the orchestration gracefully instead of poison-looping.
+param($name)
+
+$name

--- a/test/e2e/Apps/BasicPowerShell/local.settings.json
+++ b/test/e2e/Apps/BasicPowerShell/local.settings.json
@@ -4,6 +4,7 @@
     "FUNCTIONS_WORKER_RUNTIME": "powershell",
     "FUNCTIONS_WORKER_RUNTIME_VERSION": "7.4",
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
-    "ExternalDurablePowerShellSDK": "true"
+    "ExternalDurablePowerShellSDK": "true",
+    "AzureWebJobs.DisabledActivity.Disabled": "true"
   }
 }

--- a/test/e2e/Apps/BasicPython/disabled_functions.py
+++ b/test/e2e/Apps/BasicPython/disabled_functions.py
@@ -1,0 +1,42 @@
+#
+# Copyright (c) Microsoft. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+#
+
+import azure.durable_functions as df
+
+bp = df.Blueprint()
+
+
+# Disabled at runtime via the AzureWebJobs.DisabledActivity.Disabled app setting in
+# local.settings.json. Used by DisabledOrchestrationTests to validate that scheduling a
+# disabled-but-still-deployed activity fails the orchestration gracefully instead of poison-looping.
+@bp.activity_trigger(input_name="input")
+def DisabledActivity(input: str) -> str:
+    return input
+
+
+# Disabled at runtime via the AzureWebJobs.DisabledEntity.Disabled app setting in
+# local.settings.json. Used by DisabledOrchestrationTests to validate that calling an operation on a
+# disabled-but-still-deployed entity fails the orchestration gracefully instead of poison-looping.
+@bp.entity_trigger(context_name="context")
+def DisabledEntity(context):
+    context.set_result(None)
+
+
+# Orchestrator that schedules the disabled-but-still-deployed DisabledActivity. Because the activity
+# has no active listener, the dispatch must fail the orchestration deterministically instead of
+# poison-looping forever. See https://github.com/Azure/azure-functions-durable-extension/issues/3471.
+@bp.orchestration_trigger(context_name="context", orchestration="CallDisabledActivity")
+def call_disabled_activity(context: df.DurableOrchestrationContext):
+    result = yield context.call_activity("DisabledActivity", "hello")
+    return result
+
+
+# Companion orchestrator for the entity dispatch path: calling an operation on the disabled-but-still-
+# deployed DisabledEntity must fail the orchestration deterministically rather than poison-looping.
+@bp.orchestration_trigger(context_name="context", orchestration="CallDisabledEntity")
+def call_disabled_entity(context: df.DurableOrchestrationContext):
+    entityId = df.EntityId("DisabledEntity", "disabled-key")
+    _ = yield context.call_entity(entityId, "someOperation")
+    return "should not reach here"

--- a/test/e2e/Apps/BasicPython/function_app.py
+++ b/test/e2e/Apps/BasicPython/function_app.py
@@ -20,6 +20,7 @@ from timeout_orchestration import bp as timeout_orchestration_bp
 from purge_orchestration_history import bp as purge_orchestration_history_bp
 from class_based_entities import bp as class_based_entities_bp
 from is_replaying_checks import bp as is_replaying_checks_bp
+from disabled_functions import bp as disabled_functions_bp
 
 app = func.FunctionApp(http_auth_level=func.AuthLevel.ANONYMOUS)
 
@@ -59,3 +60,4 @@ app.register_blueprint(timeout_orchestration_bp)
 app.register_blueprint(purge_orchestration_history_bp)
 app.register_blueprint(class_based_entities_bp)
 app.register_blueprint(is_replaying_checks_bp)
+app.register_blueprint(disabled_functions_bp)

--- a/test/e2e/Apps/BasicPython/local.settings.json
+++ b/test/e2e/Apps/BasicPython/local.settings.json
@@ -3,6 +3,8 @@
   "Values": {
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "FUNCTIONS_WORKER_RUNTIME": "python",
-    "APPLICATIONINSIGHTS_CONNECTION_STRING": "InstrumentationKey=xxxx;IngestionEndpoint =https://xxxx.applicationinsights.azure.com/;LiveEndpoint=https://xxxx.livediagnostics.monitor.azure.com/"
+    "APPLICATIONINSIGHTS_CONNECTION_STRING": "InstrumentationKey=xxxx;IngestionEndpoint =https://xxxx.applicationinsights.azure.com/;LiveEndpoint=https://xxxx.livediagnostics.monitor.azure.com/",
+    "AzureWebJobs.DisabledActivity.Disabled": "true",
+    "AzureWebJobs.DisabledEntity.Disabled": "true"
   }
 }

--- a/test/e2e/Tests/Tests/DisabledOrchestrationTests.cs
+++ b/test/e2e/Tests/Tests/DisabledOrchestrationTests.cs
@@ -45,17 +45,15 @@ public class DisabledOrchestrationTests
     // construction / execution, which DTFx treated as a transient error and retried indefinitely, so
     // the orchestration stayed Running forever (this test would time out waiting for "Failed").
     //
-    // The disabled functions (DisabledActivity/DisabledEntity) and the caller orchestrations only
-    // exist in the dotnet-isolated app, so the non-dotnet languages are skipped. MSSQL and DTS are
-    // skipped because their orchestration-failure output differs from Azure Storage (mirroring the
-    // skips on ErrorHandlingTests.OrchestratorWithUncaughtActivityException_ShouldFail).
+    // Runs on every language (each app defines a disabled DisabledActivity + a CallDisabledActivity
+    // orchestrator). "DisabledActivity" is a substring of the caller orchestrator name, so it appears
+    // in the failure output regardless of how each language formats it. MSSQL and DTS are skipped for
+    // the same reason as ErrorHandlingTests.OrchestratorWithUncaughtActivityException_ShouldFail:
+    // those backends don't reliably surface activity-failure output on the orchestration status
+    // (durabletask-mssql#287 and the DTS work item linked there).
     [Fact]
-    [Trait("DTS", "Skip")]
-    [Trait("MSSQL", "Skip")]
-    [Trait("PowerShell", "Skip")]
-    [Trait("Python", "Skip")]
-    [Trait("Node", "Skip")]
-    [Trait("Java", "Skip")]
+    [Trait("MSSQL", "Skip")] // Activity-failure output is not surfaced on MSSQL: https://github.com/microsoft/durabletask-mssql/issues/287
+    [Trait("DTS", "Skip")] // DTS will fail this test unless this bug is fixed: https://msazure.visualstudio.com/Antares/_workitems/edit/31779638
     public async Task Orchestration_CallingDisabledActivity_FailsGracefully()
     {
         using HttpResponseMessage response = await HttpHelpers.InvokeHttpTrigger(
@@ -78,16 +76,15 @@ public class DisabledOrchestrationTests
     // disabled-but-still-deployed entity must fail the orchestration deterministically rather than
     // poison-looping the entity work item forever.
     //
-    // Scoped to dotnet-isolated + Azure Storage: the disabled entity only exists in the dotnet-isolated
-    // app, and durable entities are not supported on the MSSQL/DTS backends (mirroring the skips on
-    // ErrorHandlingTests.OrchestratorWithUncaughtEntityException_ShouldFail).
+    // Runs on the languages whose durable SDK supports entities (dotnet-isolated, Node, Python).
+    // PowerShell and Java are skipped because durable entities are not implemented in those SDKs, and
+    // MSSQL/DTS are skipped because durable entities are not supported on those backends — the same
+    // skips as ErrorHandlingTests.OrchestratorWithUncaughtEntityException_ShouldFail.
     [Fact]
-    [Trait("DTS", "Skip")]
-    [Trait("MSSQL", "Skip")]
-    [Trait("PowerShell", "Skip")]
-    [Trait("Python", "Skip")]
-    [Trait("Node", "Skip")]
-    [Trait("Java", "Skip")]
+    [Trait("MSSQL", "Skip")] // Durable entities are not supported on the MSSQL backend
+    [Trait("DTS", "Skip")] // DTS will fail this test unless this bug is fixed: https://msazure.visualstudio.com/Antares/_workitems/edit/31779638
+    [Trait("PowerShell", "Skip")] // Durable entities are not implemented in the PowerShell SDK
+    [Trait("Java", "Skip")] // Durable entities are not implemented in the Java SDK
     public async Task Orchestration_CallingDisabledEntity_FailsGracefully()
     {
         using HttpResponseMessage response = await HttpHelpers.InvokeHttpTrigger(

--- a/test/e2e/Tests/Tests/DisabledOrchestrationTests.cs
+++ b/test/e2e/Tests/Tests/DisabledOrchestrationTests.cs
@@ -7,9 +7,10 @@ using Xunit.Abstractions;
 
 namespace Microsoft.Azure.Durable.Tests.DotnetIsolatedE2E;
 
-// Validates that the app starts and active orchestrations run normally when
-// disabled durable functions (DisabledOrchestration, DisabledActivity,
-// DisabledEntity) are also registered.
+// Validates behavior when disabled-but-still-deployed durable functions (DisabledOrchestration,
+// DisabledActivity, DisabledEntity) are registered: the app starts and active orchestrations run
+// normally, and scheduling work against a disabled activity/entity fails the orchestration
+// deterministically instead of poison-looping forever (issue #3471).
 [Collection(Constants.FunctionAppCollectionName)]
 public class DisabledOrchestrationTests
 {
@@ -43,7 +44,18 @@ public class DisabledOrchestrationTests
     // instead of poison-looping forever. Before the fix the activity dispatch threw during shim
     // construction / execution, which DTFx treated as a transient error and retried indefinitely, so
     // the orchestration stayed Running forever (this test would time out waiting for "Failed").
+    //
+    // The disabled functions (DisabledActivity/DisabledEntity) and the caller orchestrations only
+    // exist in the dotnet-isolated app, so the non-dotnet languages are skipped. MSSQL and DTS are
+    // skipped because their orchestration-failure output differs from Azure Storage (mirroring the
+    // skips on ErrorHandlingTests.OrchestratorWithUncaughtActivityException_ShouldFail).
     [Fact]
+    [Trait("DTS", "Skip")]
+    [Trait("MSSQL", "Skip")]
+    [Trait("PowerShell", "Skip")]
+    [Trait("Python", "Skip")]
+    [Trait("Node", "Skip")]
+    [Trait("Java", "Skip")]
     public async Task Orchestration_CallingDisabledActivity_FailsGracefully()
     {
         using HttpResponseMessage response = await HttpHelpers.InvokeHttpTrigger(
@@ -65,7 +77,17 @@ public class DisabledOrchestrationTests
     // Companion to the activity test above, for the entity dispatch path: calling an operation on a
     // disabled-but-still-deployed entity must fail the orchestration deterministically rather than
     // poison-looping the entity work item forever.
+    //
+    // Scoped to dotnet-isolated + Azure Storage: the disabled entity only exists in the dotnet-isolated
+    // app, and durable entities are not supported on the MSSQL/DTS backends (mirroring the skips on
+    // ErrorHandlingTests.OrchestratorWithUncaughtEntityException_ShouldFail).
     [Fact]
+    [Trait("DTS", "Skip")]
+    [Trait("MSSQL", "Skip")]
+    [Trait("PowerShell", "Skip")]
+    [Trait("Python", "Skip")]
+    [Trait("Node", "Skip")]
+    [Trait("Java", "Skip")]
     public async Task Orchestration_CallingDisabledEntity_FailsGracefully()
     {
         using HttpResponseMessage response = await HttpHelpers.InvokeHttpTrigger(

--- a/test/e2e/Tests/Tests/DisabledOrchestrationTests.cs
+++ b/test/e2e/Tests/Tests/DisabledOrchestrationTests.cs
@@ -37,4 +37,49 @@ public class DisabledOrchestrationTests
         Assert.Equal("Completed", details.RuntimeStatus);
         Assert.Contains("Hello Tokyo!", details.Output);
     }
+
+    // Reproduces https://github.com/Azure/azure-functions-durable-extension/issues/3471: an
+    // orchestration that schedules a disabled-but-still-deployed activity must fail deterministically
+    // instead of poison-looping forever. Before the fix the activity dispatch threw during shim
+    // construction / execution, which DTFx treated as a transient error and retried indefinitely, so
+    // the orchestration stayed Running forever (this test would time out waiting for "Failed").
+    [Fact]
+    public async Task Orchestration_CallingDisabledActivity_FailsGracefully()
+    {
+        using HttpResponseMessage response = await HttpHelpers.InvokeHttpTrigger(
+            "StartOrchestration",
+            "?orchestrationName=CallDisabledActivity");
+
+        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
+
+        string statusQueryGetUri = await DurableHelpers.ParseStatusQueryGetUriAsync(response);
+
+        // Must reach a terminal Failed state promptly; a poison loop would leave it Running.
+        await DurableHelpers.WaitForOrchestrationStateAsync(statusQueryGetUri, "Failed", 30);
+
+        var details = await DurableHelpers.GetRunningOrchestrationDetailsAsync(statusQueryGetUri);
+        Assert.Equal("Failed", details.RuntimeStatus);
+        Assert.Contains("DisabledActivity", details.Output);
+    }
+
+    // Companion to the activity test above, for the entity dispatch path: calling an operation on a
+    // disabled-but-still-deployed entity must fail the orchestration deterministically rather than
+    // poison-looping the entity work item forever.
+    [Fact]
+    public async Task Orchestration_CallingDisabledEntity_FailsGracefully()
+    {
+        using HttpResponseMessage response = await HttpHelpers.InvokeHttpTrigger(
+            "StartOrchestration",
+            "?orchestrationName=CallDisabledEntity");
+
+        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
+
+        string statusQueryGetUri = await DurableHelpers.ParseStatusQueryGetUriAsync(response);
+
+        await DurableHelpers.WaitForOrchestrationStateAsync(statusQueryGetUri, "Failed", 30);
+
+        var details = await DurableHelpers.GetRunningOrchestrationDetailsAsync(statusQueryGetUri);
+        Assert.Equal("Failed", details.RuntimeStatus);
+        Assert.Contains("DisabledEntity", details.Output);
+    }
 }

--- a/test/e2e/Tests/Tests/DisabledOrchestrationTests.cs
+++ b/test/e2e/Tests/Tests/DisabledOrchestrationTests.cs
@@ -77,12 +77,15 @@ public class DisabledOrchestrationTests
     // poison-looping the entity work item forever.
     //
     // Runs on the languages whose durable SDK supports entities (dotnet-isolated, Node, Python).
-    // PowerShell and Java are skipped because durable entities are not implemented in those SDKs, and
-    // MSSQL/DTS are skipped because durable entities are not supported on those backends — the same
-    // skips as ErrorHandlingTests.OrchestratorWithUncaughtEntityException_ShouldFail.
+    // PowerShell and Java are skipped because durable entities are not implemented in those SDKs.
+    // MSSQL is skipped because durable entities are not supported on that backend. DTS *does* support
+    // entities, but — like the activity test above and
+    // ErrorHandlingTests.OrchestratorWithUncaughtEntityException_ShouldFail — this test asserts on the
+    // failure being surfaced in the orchestration status output, which DTS does not do reliably until
+    // the referenced bug is fixed.
     [Fact]
     [Trait("MSSQL", "Skip")] // Durable entities are not supported on the MSSQL backend
-    [Trait("DTS", "Skip")] // DTS will fail this test unless this bug is fixed: https://msazure.visualstudio.com/Antares/_workitems/edit/31779638
+    [Trait("DTS", "Skip")] // DTS supports entities, but doesn't surface the failure in status output until this bug is fixed: https://msazure.visualstudio.com/Antares/_workitems/edit/31779638
     [Trait("PowerShell", "Skip")] // Durable entities are not implemented in the PowerShell SDK
     [Trait("Java", "Skip")] // Durable entities are not implemented in the Java SDK
     public async Task Orchestration_CallingDisabledEntity_FailsGracefully()


### PR DESCRIPTION
## Summary

Fixes #3471.

When a function is **disabled but still deployed**, it is still **indexed** (its trigger binding is created, so it lands in `knownActivities`/`knownEntities`) but no **listener** is started, so its `RegisteredFunctionInfo.Executor` stays `null`. When DTFx later dispatches such a function for an in-flight orchestration, the extension dereferenced that null executor. Because the failure happened during object construction / before user code, DTFx treated it as a **transient** work-item failure and abandoned + retried it forever — a permanent poison loop (`ArgumentNullException('executor')` every ~10s), with the orchestration never progressing and never failing.

This is a common migration footgun: introduce `MyActivity_V2`, disable the old `MyActivity` but keep it deployed, and any orchestration that was in-flight when the swap happened poison-loops after the next restart.

## Root cause & dispatch-path review

`null` executor already means "registered but inactive" in the codebase (`RegisteredFunctionInfo.HasActiveListener`). I reviewed every dispatch path for the same registered-with-null pattern:

| Path | Classic (in-proc) middleware | Passthrough (`OutOfProcMiddleware`) |
|---|---|---|
| **Activity** | `GetObject` built `TaskActivityShim(null)` → **ArgumentNullException** ❌ | `CallActivityAsync` dereferenced `function.Executor` → **NRE → SessionAborted** ❌ |
| **Orchestrator** | `OrchestrationMiddleware` handles `info == null` ✅ | `CallOrchestratorAsync` handles `function == null` ✅ |
| **Entity** | `EntityMiddleware` dereferenced `GetFunctionInfo().Executor` → **NRE** ❌ | `CallEntityAsync` handles `functionInfo == null` ✅ |

`GetObject` (the activity object manager) is invoked by DTFx for **both** middleware flavors, so the activity fix is required for every language.

## Changes

1. **`TaskNonexistentActivityShim`** — carry an `isDisabled` flag so the failure message distinguishes *"is disabled"* from *"does not exist"*, and emit a warning trace when a disabled activity is dispatched.
2. **`DurableTaskExtension` activity `GetObject`** — when the activity is found but `Executor == null`, return the graceful shim instead of constructing `TaskActivityShim(null)`.
3. **`OutOfProcMiddleware.CallActivityAsync`** — treat `function?.Executor == null` like a missing function and fail with a deterministic `TaskFailedEvent`.
4. **`DurableTaskExtension.EntityMiddleware` + `TaskEntityShim.ExecuteBatch`** — for the classic entity path, fail every operation in the batch deterministically (via a throwing invocation callback that reuses the existing per-operation application-error machinery) instead of dereferencing null / aborting + retrying. Regression-safe: the new branch is gated on `functionUnavailable`, so registered entities take the exact same path as before. Host-shutdown stays transient (gated on `!OnStopping`).
5. **Orchestrator** paths already fail disabled functions gracefully — no change.

In all cases the orchestration now receives a deterministic, catchable failure (`FunctionFailedException`) instead of an infinite poison loop.

## Tests

- **Unit** (`DisabledFunctionDispatchTests`): `GetObject` returns the disabled shim (with an *"is disabled"* failure) for a null-executor activity, the nonexistent shim (*"does not exist"*) otherwise, and the real `TaskActivityShim` when an executor is present.
- **Unit** (`OutOfProcMiddlewareTests`): `CallActivityAsync` with a null-executor activity sets a `TaskFailedEvent` and does **not** throw `SessionAbortedException`.
- **E2E** (`DisabledOrchestrationTests`, .NET isolated): new orchestrations schedule the disabled activity/entity; the tests assert the orchestration reaches `Failed` promptly (a poison loop would leave it `Running`).

### Validation performed
- Extension + all test projects build with 0 warnings/errors.
- 4 new unit tests pass.
- In-proc regression run against Azurite: 14 entity tests pass — including all 8 `DurableEntity_CallFaultyEntity` variants, which exercise the exact per-operation application-error machinery the entity fix reuses — plus the nonexistent activity/orchestrator tests.