### PR TITLE
Add analyzer DF0114 flagging ConfigureAwait(false) in orchestrators (fixes #995)

### DIFF
--- a/src/WebJobs.Extensions.DurableTask.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/WebJobs.Extensions.DurableTask.Analyzers/AnalyzerReleases.Unshipped.md
@@ -2,4 +2,5 @@
 
 Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
+DF0114 | Orchestrator | Warning | ConfigureAwaitAnalyzer
 DF0115 | Activity | Warning | ActivityTriggerParameterAnalyzer

--- a/src/WebJobs.Extensions.DurableTask.Analyzers/Analyzers/Orchestrator/ConfigureAwaitAnalyzer.cs
+++ b/src/WebJobs.Extensions.DurableTask.Analyzers/Analyzers/Orchestrator/ConfigureAwaitAnalyzer.cs
@@ -39,6 +39,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
                         && identifierName.Parent is MemberAccessExpressionSyntax memberAccessExpression
                         && memberAccessExpression.Name == identifierName
                         && memberAccessExpression.Parent is InvocationExpressionSyntax invocationExpression
+                        && IsAwaited(invocationExpression)
                         && !ContinuesOnCapturedContext(invocationExpression))
                     {
                         var diagnostic = Diagnostic.Create(Rule, memberAccessExpression.GetLocation(), "ConfigureAwait");
@@ -54,6 +55,18 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
             }
 
             return diagnosedIssue;
+        }
+
+        private static bool IsAwaited(InvocationExpressionSyntax invocationExpression)
+        {
+            SyntaxNode expression = invocationExpression;
+            while (expression.Parent is ParenthesizedExpressionSyntax parenthesizedExpression)
+            {
+                expression = parenthesizedExpression;
+            }
+
+            return expression.Parent is AwaitExpressionSyntax awaitExpression &&
+                awaitExpression.Expression == expression;
         }
 
         // ConfigureAwait(true) preserves the orchestration SynchronizationContext (identical to a normal await),

--- a/src/WebJobs.Extensions.DurableTask.Analyzers/Analyzers/Orchestrator/ConfigureAwaitAnalyzer.cs
+++ b/src/WebJobs.Extensions.DurableTask.Analyzers/Analyzers/Orchestrator/ConfigureAwaitAnalyzer.cs
@@ -1,0 +1,73 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
+{
+    public class ConfigureAwaitAnalyzer
+    {
+        public const string DiagnosticId = "DF0114";
+
+        private static readonly LocalizableString Title = new LocalizableResourceString(nameof(Resources.ConfigureAwaitAnalyzerTitle), Resources.ResourceManager, typeof(Resources));
+        private static readonly LocalizableString MessageFormat = new LocalizableResourceString(nameof(Resources.DeterministicAnalyzerMessageFormat), Resources.ResourceManager, typeof(Resources));
+        private static readonly LocalizableString Description = new LocalizableResourceString(nameof(Resources.DeterministicAnalyzerDescription), Resources.ResourceManager, typeof(Resources));
+        private const string Category = SupportedCategories.Orchestrator;
+        public const DiagnosticSeverity Severity = DiagnosticSeverity.Warning;
+
+        public static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, Category, Severity, isEnabledByDefault: true, description: Description,
+            customTags: WellKnownDiagnosticTags.CompilationEnd);
+
+        public static bool RegisterDiagnostic(CompilationAnalysisContext context, SyntaxNode method)
+        {
+            var diagnosedIssue = false;
+
+            foreach (SyntaxNode descendant in method.DescendantNodes())
+            {
+                if (descendant is IdentifierNameSyntax identifierName)
+                {
+                    var identifierText = identifierName.Identifier.ValueText;
+
+                    // ConfigureAwait(false) moves the continuation off the orchestration SynchronizationContext
+                    // and breaks deterministic replay. It is detected syntactically (like Task.ContinueWith) so it
+                    // is caught even when the awaited task is an activity or sub-orchestrator call whose type may
+                    // not fully bind during analysis.
+                    if (identifierText == "ConfigureAwait"
+                        && identifierName.Parent is MemberAccessExpressionSyntax memberAccessExpression
+                        && memberAccessExpression.Parent is InvocationExpressionSyntax invocationExpression
+                        && !ContinuesOnCapturedContext(invocationExpression))
+                    {
+                        var diagnostic = Diagnostic.Create(Rule, memberAccessExpression.GetLocation(), "ConfigureAwait");
+
+                        if (context.Compilation.ContainsSyntaxTree(method.SyntaxTree))
+                        {
+                            context.ReportDiagnostic(diagnostic);
+                        }
+
+                        diagnosedIssue = true;
+                    }
+                }
+            }
+
+            return diagnosedIssue;
+        }
+
+        // ConfigureAwait(true) preserves the orchestration SynchronizationContext (identical to a normal await),
+        // so it is safe. Only ConfigureAwait(false) - or a non-literal argument we cannot prove is true - is flagged.
+        private static bool ContinuesOnCapturedContext(InvocationExpressionSyntax invocationExpression)
+        {
+            foreach (ArgumentSyntax argument in invocationExpression.ArgumentList.Arguments)
+            {
+                if (argument.Expression.IsKind(SyntaxKind.TrueLiteralExpression))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/WebJobs.Extensions.DurableTask.Analyzers/Analyzers/Orchestrator/ConfigureAwaitAnalyzer.cs
+++ b/src/WebJobs.Extensions.DurableTask.Analyzers/Analyzers/Orchestrator/ConfigureAwaitAnalyzer.cs
@@ -37,6 +37,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
                     // not fully bind during analysis.
                     if (identifierText == "ConfigureAwait"
                         && identifierName.Parent is MemberAccessExpressionSyntax memberAccessExpression
+                        && memberAccessExpression.Name == identifierName
                         && memberAccessExpression.Parent is InvocationExpressionSyntax invocationExpression
                         && !ContinuesOnCapturedContext(invocationExpression))
                     {

--- a/src/WebJobs.Extensions.DurableTask.Analyzers/Analyzers/Orchestrator/ConfigureAwaitAnalyzer.cs
+++ b/src/WebJobs.Extensions.DurableTask.Analyzers/Analyzers/Orchestrator/ConfigureAwaitAnalyzer.cs
@@ -57,18 +57,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
         }
 
         // ConfigureAwait(true) preserves the orchestration SynchronizationContext (identical to a normal await),
-        // so it is safe. Only ConfigureAwait(false) - or a non-literal argument we cannot prove is true - is flagged.
+        // so it is safe. Only the standard one-argument form is exempted; additional arguments indicate a
+        // different overload whose behavior cannot be proven safe without symbol binding.
         private static bool ContinuesOnCapturedContext(InvocationExpressionSyntax invocationExpression)
         {
-            foreach (ArgumentSyntax argument in invocationExpression.ArgumentList.Arguments)
-            {
-                if (argument.Expression.IsKind(SyntaxKind.TrueLiteralExpression))
-                {
-                    return true;
-                }
-            }
-
-            return false;
+            SeparatedSyntaxList<ArgumentSyntax> arguments = invocationExpression.ArgumentList.Arguments;
+            return arguments.Count == 1 &&
+                arguments[0].Expression.IsKind(SyntaxKind.TrueLiteralExpression);
         }
     }
 }

--- a/src/WebJobs.Extensions.DurableTask.Analyzers/Analyzers/Orchestrator/ConfigureAwaitAnalyzer.cs
+++ b/src/WebJobs.Extensions.DurableTask.Analyzers/Analyzers/Orchestrator/ConfigureAwaitAnalyzer.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 
@@ -40,7 +39,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
                         && memberAccessExpression.Name == identifierName
                         && memberAccessExpression.Parent is InvocationExpressionSyntax invocationExpression
                         && IsAwaited(invocationExpression, method, semanticModel)
-                        && !ContinuesOnCapturedContext(invocationExpression))
+                        && !ContinuesOnCapturedContext(invocationExpression, semanticModel))
                     {
                         var diagnostic = Diagnostic.Create(Rule, memberAccessExpression.GetLocation(), "ConfigureAwait");
 
@@ -63,8 +62,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
             SemanticModel semanticModel)
         {
             ExpressionSyntax expression = GetOutermostParenthesizedExpression(invocationExpression);
-            if (expression.Parent is AwaitExpressionSyntax awaitExpression &&
-                awaitExpression.Expression == expression)
+            if (IsDirectlyAwaited(expression))
+            {
+                return true;
+            }
+
+            if (expression.Parent is AssignmentExpressionSyntax directAssignment &&
+                directAssignment.Right == expression &&
+                IsDirectlyAwaited(directAssignment))
             {
                 return true;
             }
@@ -94,6 +99,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
             }
 
             return false;
+        }
+
+        private static bool IsDirectlyAwaited(ExpressionSyntax expression)
+        {
+            expression = GetOutermostParenthesizedExpression(expression);
+            return expression.Parent is AwaitExpressionSyntax awaitExpression &&
+                awaitExpression.Expression == expression;
         }
 
         private static ExpressionSyntax GetOutermostParenthesizedExpression(ExpressionSyntax expression)
@@ -133,14 +145,23 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
             return false;
         }
 
-        // ConfigureAwait(true) preserves the orchestration SynchronizationContext (identical to a normal await),
-        // so it is safe. Only the standard one-argument form is exempted; additional arguments indicate a
-        // different overload whose behavior cannot be proven safe without symbol binding.
-        private static bool ContinuesOnCapturedContext(InvocationExpressionSyntax invocationExpression)
+        // A compile-time constant true preserves the orchestration SynchronizationContext (identical to a normal
+        // await), so it is safe. Only the standard one-argument form is exempted; additional arguments indicate a
+        // different overload whose behavior cannot be proven safe.
+        private static bool ContinuesOnCapturedContext(
+            InvocationExpressionSyntax invocationExpression,
+            SemanticModel semanticModel)
         {
             SeparatedSyntaxList<ArgumentSyntax> arguments = invocationExpression.ArgumentList.Arguments;
-            return arguments.Count == 1 &&
-                arguments[0].Expression.IsKind(SyntaxKind.TrueLiteralExpression);
+            if (arguments.Count != 1)
+            {
+                return false;
+            }
+
+            Optional<object> constantValue = semanticModel.GetConstantValue(arguments[0].Expression);
+            return constantValue.HasValue &&
+                constantValue.Value is bool continueOnCapturedContext &&
+                continueOnCapturedContext;
         }
     }
 }

--- a/src/WebJobs.Extensions.DurableTask.Analyzers/Analyzers/Orchestrator/ConfigureAwaitAnalyzer.cs
+++ b/src/WebJobs.Extensions.DurableTask.Analyzers/Analyzers/Orchestrator/ConfigureAwaitAnalyzer.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
         public static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, Category, Severity, isEnabledByDefault: true, description: Description,
             customTags: WellKnownDiagnosticTags.CompilationEnd);
 
-        public static bool RegisterDiagnostic(CompilationAnalysisContext context, SyntaxNode method)
+        public static bool RegisterDiagnostic(CompilationAnalysisContext context, SemanticModel semanticModel, SyntaxNode method)
         {
             var diagnosedIssue = false;
 
@@ -39,7 +39,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
                         && identifierName.Parent is MemberAccessExpressionSyntax memberAccessExpression
                         && memberAccessExpression.Name == identifierName
                         && memberAccessExpression.Parent is InvocationExpressionSyntax invocationExpression
-                        && IsAwaited(invocationExpression)
+                        && IsAwaited(invocationExpression, method, semanticModel)
                         && !ContinuesOnCapturedContext(invocationExpression))
                     {
                         var diagnostic = Diagnostic.Create(Rule, memberAccessExpression.GetLocation(), "ConfigureAwait");
@@ -57,16 +57,80 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
             return diagnosedIssue;
         }
 
-        private static bool IsAwaited(InvocationExpressionSyntax invocationExpression)
+        private static bool IsAwaited(
+            InvocationExpressionSyntax invocationExpression,
+            SyntaxNode method,
+            SemanticModel semanticModel)
         {
-            SyntaxNode expression = invocationExpression;
-            while (expression.Parent is ParenthesizedExpressionSyntax parenthesizedExpression)
+            ExpressionSyntax expression = GetOutermostParenthesizedExpression(invocationExpression);
+            if (expression.Parent is AwaitExpressionSyntax awaitExpression &&
+                awaitExpression.Expression == expression)
+            {
+                return true;
+            }
+
+            if (!TryGetCapturedSymbol(expression, semanticModel, out ISymbol capturedSymbol))
+            {
+                return false;
+            }
+
+            foreach (SyntaxNode descendant in method.DescendantNodes())
+            {
+                if (descendant is AwaitExpressionSyntax laterAwait &&
+                    laterAwait.SpanStart > invocationExpression.SpanStart)
+                {
+                    ExpressionSyntax awaitedExpression = laterAwait.Expression;
+                    while (awaitedExpression is ParenthesizedExpressionSyntax parenthesizedExpression)
+                    {
+                        awaitedExpression = parenthesizedExpression.Expression;
+                    }
+
+                    if (SyntaxNodeUtils.TryGetISymbol(semanticModel, awaitedExpression, out ISymbol awaitedSymbol) &&
+                        SymbolEqualityComparer.Default.Equals(capturedSymbol, awaitedSymbol))
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        private static ExpressionSyntax GetOutermostParenthesizedExpression(ExpressionSyntax expression)
+        {
+            while (expression.Parent is ParenthesizedExpressionSyntax parenthesizedExpression &&
+                parenthesizedExpression.Expression == expression)
             {
                 expression = parenthesizedExpression;
             }
 
-            return expression.Parent is AwaitExpressionSyntax awaitExpression &&
-                awaitExpression.Expression == expression;
+            return expression;
+        }
+
+        private static bool TryGetCapturedSymbol(
+            ExpressionSyntax expression,
+            SemanticModel semanticModel,
+            out ISymbol capturedSymbol)
+        {
+            if (expression.Parent is EqualsValueClauseSyntax equalsValueClause &&
+                equalsValueClause.Value == expression &&
+                equalsValueClause.Parent is VariableDeclaratorSyntax variableDeclarator)
+            {
+                capturedSymbol = semanticModel.GetDeclaredSymbol(variableDeclarator);
+                return capturedSymbol != null;
+            }
+
+            if (expression.Parent is AssignmentExpressionSyntax assignmentExpression &&
+                assignmentExpression.Right == expression)
+            {
+                return SyntaxNodeUtils.TryGetISymbol(
+                    semanticModel,
+                    assignmentExpression.Left,
+                    out capturedSymbol);
+            }
+
+            capturedSymbol = null;
+            return false;
         }
 
         // ConfigureAwait(true) preserves the orchestration SynchronizationContext (identical to a normal await),

--- a/src/WebJobs.Extensions.DurableTask.Analyzers/Analyzers/Orchestrator/DeterministicMethodAnalyzer.cs
+++ b/src/WebJobs.Extensions.DurableTask.Analyzers/Analyzers/Orchestrator/DeterministicMethodAnalyzer.cs
@@ -68,7 +68,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
                     | TimerAnalyzer.RegisterDiagnostic(context, semanticModel, methodDeclaration)
                     | CancellationTokenAnalyzer.RegisterDiagnostic(context, methodDeclaration)
                     | BindingAnalyzer.RegisterDiagnostic(context, semanticModel, methodDeclaration)
-                    | ConfigureAwaitAnalyzer.RegisterDiagnostic(context, methodDeclaration)
+                    | ConfigureAwaitAnalyzer.RegisterDiagnostic(context, semanticModel, methodDeclaration)
                     | DependencyInjectionAnalyzer.RegisterDiagnostic(context, methodDeclaration))
                 {
                     methodInvocationAnalyzer.RegisterDiagnostics(context, methodInformation);

--- a/src/WebJobs.Extensions.DurableTask.Analyzers/Analyzers/Orchestrator/DeterministicMethodAnalyzer.cs
+++ b/src/WebJobs.Extensions.DurableTask.Analyzers/Analyzers/Orchestrator/DeterministicMethodAnalyzer.cs
@@ -32,7 +32,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
                     CancellationTokenAnalyzer.Rule,
                     BindingAnalyzer.Rule,
                     MethodInvocationAnalyzer.Rule,
-                    DependencyInjectionAnalyzer.Rule);
+                    DependencyInjectionAnalyzer.Rule,
+                    ConfigureAwaitAnalyzer.Rule);
             }
         }
 
@@ -67,6 +68,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
                     | TimerAnalyzer.RegisterDiagnostic(context, semanticModel, methodDeclaration)
                     | CancellationTokenAnalyzer.RegisterDiagnostic(context, methodDeclaration)
                     | BindingAnalyzer.RegisterDiagnostic(context, semanticModel, methodDeclaration)
+                    | ConfigureAwaitAnalyzer.RegisterDiagnostic(context, methodDeclaration)
                     | DependencyInjectionAnalyzer.RegisterDiagnostic(context, methodDeclaration))
                 {
                     methodInvocationAnalyzer.RegisterDiagnostics(context, methodInformation);

--- a/src/WebJobs.Extensions.DurableTask.Analyzers/Resources.Designer.cs
+++ b/src/WebJobs.Extensions.DurableTask.Analyzers/Resources.Designer.cs
@@ -250,6 +250,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to ConfigureAwait should not be used inside an orchestrator function.
+        /// </summary>
+        public static string ConfigureAwaitAnalyzerTitle {
+            get {
+                return ResourceManager.GetString("ConfigureAwaitAnalyzerTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to DateTime calls must be deterministic inside an orchestrator function.
         /// </summary>
         public static string DateTimeAnalyzerTitle {

--- a/src/WebJobs.Extensions.DurableTask.Analyzers/Resources.Designer.cs
+++ b/src/WebJobs.Extensions.DurableTask.Analyzers/Resources.Designer.cs
@@ -250,7 +250,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to ConfigureAwait should not be used inside an orchestrator function.
+        ///   Looks up a localized string similar to ConfigureAwait(false) should not be used inside an orchestrator function.
         /// </summary>
         public static string ConfigureAwaitAnalyzerTitle {
             get {

--- a/src/WebJobs.Extensions.DurableTask.Analyzers/Resources.resx
+++ b/src/WebJobs.Extensions.DurableTask.Analyzers/Resources.resx
@@ -180,6 +180,9 @@
   <data name="CancellationTokenAnalyzerTitle" xml:space="preserve">
     <value>CancellationToken should not be used as an orchestrator function parameter</value>
   </data>
+  <data name="ConfigureAwaitAnalyzerTitle" xml:space="preserve">
+    <value>ConfigureAwait should not be used inside an orchestrator function</value>
+  </data>
   <data name="DateTimeAnalyzerTitle" xml:space="preserve">
     <value>DateTime calls must be deterministic inside an orchestrator function</value>
   </data>

--- a/src/WebJobs.Extensions.DurableTask.Analyzers/Resources.resx
+++ b/src/WebJobs.Extensions.DurableTask.Analyzers/Resources.resx
@@ -181,7 +181,7 @@
     <value>CancellationToken should not be used as an orchestrator function parameter</value>
   </data>
   <data name="ConfigureAwaitAnalyzerTitle" xml:space="preserve">
-    <value>ConfigureAwait should not be used inside an orchestrator function</value>
+    <value>ConfigureAwait(false) should not be used inside an orchestrator function</value>
   </data>
   <data name="DateTimeAnalyzerTitle" xml:space="preserve">
     <value>DateTime calls must be deterministic inside an orchestrator function</value>

--- a/test/WebJobs.Extensions.DurableTask.Analyzers.Test/Orchestrator/ConfigureAwaitAnalyzerTests.cs
+++ b/test/WebJobs.Extensions.DurableTask.Analyzers.Test/Orchestrator/ConfigureAwaitAnalyzerTests.cs
@@ -73,6 +73,78 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers.Test.Orchestr
         }
 
         [TestMethod]
+        public void ConfigureAwait_ResultStoredThenAwaited_Diagnostic()
+        {
+            var test = @"
+    using System.Threading.Tasks;
+    using Microsoft.Azure.WebJobs;
+    using Microsoft.Azure.WebJobs.Extensions.DurableTask;
+
+    namespace VSSample
+    {
+        public static class HelloSequence
+        {
+            [FunctionName(""ConfigureAwaitAnalyzerTestCases"")]
+            public static async Task Run(
+            [OrchestrationTrigger] IDurableOrchestrationContext context)
+            {
+                var configuredAwaitable = context.CallActivityAsync<string>(""Function1_Hello"", ""Tokyo"").ConfigureAwait(false);
+                await configuredAwaitable;
+            }
+        }
+    }";
+            var expectedDiagnostics = new DiagnosticResult
+            {
+                Id = DiagnosticId,
+                Message = string.Format(Resources.DeterministicAnalyzerMessageFormat, "ConfigureAwait"),
+                Severity = Severity,
+                Locations =
+                    new[] {
+                            new DiagnosticResultLocation("Test0.cs", 14, 43)
+                        }
+            };
+
+            VerifyCSharpDiagnostic(test, expectedDiagnostics);
+        }
+
+        [TestMethod]
+        public void ConfigureAwait_ResultAssignedThenAwaited_Diagnostic()
+        {
+            var test = @"
+    using System.Runtime.CompilerServices;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.WebJobs;
+    using Microsoft.Azure.WebJobs.Extensions.DurableTask;
+
+    namespace VSSample
+    {
+        public static class HelloSequence
+        {
+            [FunctionName(""ConfigureAwaitAnalyzerTestCases"")]
+            public static async Task Run(
+            [OrchestrationTrigger] IDurableOrchestrationContext context)
+            {
+                ConfiguredTaskAwaitable<string> configuredAwaitable;
+                configuredAwaitable = context.CallActivityAsync<string>(""Function1_Hello"", ""Tokyo"").ConfigureAwait(false);
+                await configuredAwaitable;
+            }
+        }
+    }";
+            var expectedDiagnostics = new DiagnosticResult
+            {
+                Id = DiagnosticId,
+                Message = string.Format(Resources.DeterministicAnalyzerMessageFormat, "ConfigureAwait"),
+                Severity = Severity,
+                Locations =
+                    new[] {
+                            new DiagnosticResultLocation("Test0.cs", 16, 39)
+                        }
+            };
+
+            VerifyCSharpDiagnostic(test, expectedDiagnostics);
+        }
+
+        [TestMethod]
         public void ConfigureAwait_True_OnActivityCall_NoDiagnostic()
         {
             var test = @"
@@ -163,6 +235,39 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers.Test.Orchestr
             [OrchestrationTrigger] IDurableOrchestrationContext context)
             {
                 new ConfigurableOperation().ConfigureAwait(false);
+                await context.CallActivityAsync<string>(""Function1_Hello"", ""Tokyo"");
+            }
+        }
+    }";
+
+            VerifyCSharpDiagnostic(test);
+        }
+
+        [TestMethod]
+        public void ConfigureAwait_ResultStoredButNotAwaited_NoDiagnostic()
+        {
+            var test = @"
+    using System.Threading.Tasks;
+    using Microsoft.Azure.WebJobs;
+    using Microsoft.Azure.WebJobs.Extensions.DurableTask;
+
+    namespace VSSample
+    {
+        public class ConfigurableOperation
+        {
+            public Task ConfigureAwait(bool continueOnCapturedContext)
+            {
+                return Task.CompletedTask;
+            }
+        }
+
+        public static class HelloSequence
+        {
+            [FunctionName(""ConfigureAwaitAnalyzerTestCases"")]
+            public static async Task Run(
+            [OrchestrationTrigger] IDurableOrchestrationContext context)
+            {
+                var configuredAwaitable = new ConfigurableOperation().ConfigureAwait(false);
                 await context.CallActivityAsync<string>(""Function1_Hello"", ""Tokyo"");
             }
         }

--- a/test/WebJobs.Extensions.DurableTask.Analyzers.Test/Orchestrator/ConfigureAwaitAnalyzerTests.cs
+++ b/test/WebJobs.Extensions.DurableTask.Analyzers.Test/Orchestrator/ConfigureAwaitAnalyzerTests.cs
@@ -174,6 +174,38 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers.Test.Orchestr
             VerifyCSharpDiagnostic(test);
         }
 
+        [TestMethod]
+        public void ConfigureAwait_AsMemberAccessExpression_NoDiagnostic()
+        {
+            var test = @"
+    using System.Threading.Tasks;
+    using Microsoft.Azure.WebJobs;
+    using Microsoft.Azure.WebJobs.Extensions.DurableTask;
+
+    namespace VSSample
+    {
+        public static class ConfigureAwait
+        {
+            public static void Foo(bool value)
+            {
+            }
+        }
+
+        public static class HelloSequence
+        {
+            [FunctionName(""ConfigureAwaitAnalyzerTestCases"")]
+            public static async Task Run(
+            [OrchestrationTrigger] IDurableOrchestrationContext context)
+            {
+                ConfigureAwait.Foo(false);
+                await context.CallActivityAsync<string>(""Function1_Hello"", ""Tokyo"");
+            }
+        }
+    }";
+
+            VerifyCSharpDiagnostic(test);
+        }
+
         protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
         {
             return new DeterministicMethodAnalyzer();

--- a/test/WebJobs.Extensions.DurableTask.Analyzers.Test/Orchestrator/ConfigureAwaitAnalyzerTests.cs
+++ b/test/WebJobs.Extensions.DurableTask.Analyzers.Test/Orchestrator/ConfigureAwaitAnalyzerTests.cs
@@ -145,6 +145,42 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers.Test.Orchestr
         }
 
         [TestMethod]
+        public void ConfigureAwait_ResultAssignedInsideAwait_Diagnostic()
+        {
+            var test = @"
+    using System.Runtime.CompilerServices;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.WebJobs;
+    using Microsoft.Azure.WebJobs.Extensions.DurableTask;
+
+    namespace VSSample
+    {
+        public static class HelloSequence
+        {
+            [FunctionName(""ConfigureAwaitAnalyzerTestCases"")]
+            public static async Task Run(
+            [OrchestrationTrigger] IDurableOrchestrationContext context)
+            {
+                ConfiguredTaskAwaitable<string> configuredAwaitable;
+                await (configuredAwaitable = context.CallActivityAsync<string>(""Function1_Hello"", ""Tokyo"").ConfigureAwait(false));
+            }
+        }
+    }";
+            var expectedDiagnostics = new DiagnosticResult
+            {
+                Id = DiagnosticId,
+                Message = string.Format(Resources.DeterministicAnalyzerMessageFormat, "ConfigureAwait"),
+                Severity = Severity,
+                Locations =
+                    new[] {
+                            new DiagnosticResultLocation("Test0.cs", 16, 46)
+                        }
+            };
+
+            VerifyCSharpDiagnostic(test, expectedDiagnostics);
+        }
+
+        [TestMethod]
         public void ConfigureAwait_True_OnActivityCall_NoDiagnostic()
         {
             var test = @"
@@ -161,6 +197,31 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers.Test.Orchestr
             [OrchestrationTrigger] IDurableOrchestrationContext context)
             {
                 await context.CallActivityAsync<string>(""Function1_Hello"", ""Tokyo"").ConfigureAwait(true);
+            }
+        }
+    }";
+
+            VerifyCSharpDiagnostic(test);
+        }
+
+        [TestMethod]
+        public void ConfigureAwait_ConstantTrue_OnActivityCall_NoDiagnostic()
+        {
+            var test = @"
+    using System.Threading.Tasks;
+    using Microsoft.Azure.WebJobs;
+    using Microsoft.Azure.WebJobs.Extensions.DurableTask;
+
+    namespace VSSample
+    {
+        public static class HelloSequence
+        {
+            [FunctionName(""ConfigureAwaitAnalyzerTestCases"")]
+            public static async Task Run(
+            [OrchestrationTrigger] IDurableOrchestrationContext context)
+            {
+                const bool continueOnCapturedContext = true;
+                await context.CallActivityAsync<string>(""Function1_Hello"", ""Tokyo"").ConfigureAwait(continueOnCapturedContext);
             }
         }
     }";

--- a/test/WebJobs.Extensions.DurableTask.Analyzers.Test/Orchestrator/ConfigureAwaitAnalyzerTests.cs
+++ b/test/WebJobs.Extensions.DurableTask.Analyzers.Test/Orchestrator/ConfigureAwaitAnalyzerTests.cs
@@ -1,0 +1,182 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using TestHelper;
+
+namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers.Test.Orchestrator
+{
+    [TestClass]
+    public class ConfigureAwaitAnalyzerTests : CodeFixVerifier
+    {
+        private static readonly string DiagnosticId = ConfigureAwaitAnalyzer.DiagnosticId;
+        private static readonly DiagnosticSeverity Severity = DiagnosticSeverity.Warning;
+
+        [TestMethod]
+        public void ConfigureAwait_NoDiagnosticTestCase()
+        {
+            var test = @"
+    using System.Threading.Tasks;
+    using Microsoft.Azure.WebJobs;
+    using Microsoft.Azure.WebJobs.Extensions.DurableTask;
+
+    namespace VSSample
+    {
+        public static class HelloSequence
+        {
+            [FunctionName(""ConfigureAwaitAnalyzerTestCases"")]
+            public static async Task Run(
+            [OrchestrationTrigger] IDurableOrchestrationContext context)
+            {
+                await context.CallActivityAsync<string>(""Function1_Hello"", ""Tokyo"");
+            }
+        }
+    }";
+
+            VerifyCSharpDiagnostic(test);
+        }
+
+        [TestMethod]
+        public void ConfigureAwait_False_OnActivityCall()
+        {
+            var test = @"
+    using System.Threading.Tasks;
+    using Microsoft.Azure.WebJobs;
+    using Microsoft.Azure.WebJobs.Extensions.DurableTask;
+
+    namespace VSSample
+    {
+        public static class HelloSequence
+        {
+            [FunctionName(""ConfigureAwaitAnalyzerTestCases"")]
+            public static async Task Run(
+            [OrchestrationTrigger] IDurableOrchestrationContext context)
+            {
+                await context.CallActivityAsync<string>(""Function1_Hello"", ""Tokyo"").ConfigureAwait(false);
+            }
+        }
+    }";
+            var expectedDiagnostics = new DiagnosticResult
+            {
+                Id = DiagnosticId,
+                Message = string.Format(Resources.DeterministicAnalyzerMessageFormat, "ConfigureAwait"),
+                Severity = Severity,
+                Locations =
+                    new[] {
+                            new DiagnosticResultLocation("Test0.cs", 14, 23)
+                        }
+            };
+
+            VerifyCSharpDiagnostic(test, expectedDiagnostics);
+        }
+
+        [TestMethod]
+        public void ConfigureAwait_True_OnActivityCall_NoDiagnostic()
+        {
+            var test = @"
+    using System.Threading.Tasks;
+    using Microsoft.Azure.WebJobs;
+    using Microsoft.Azure.WebJobs.Extensions.DurableTask;
+
+    namespace VSSample
+    {
+        public static class HelloSequence
+        {
+            [FunctionName(""ConfigureAwaitAnalyzerTestCases"")]
+            public static async Task Run(
+            [OrchestrationTrigger] IDurableOrchestrationContext context)
+            {
+                await context.CallActivityAsync<string>(""Function1_Hello"", ""Tokyo"").ConfigureAwait(true);
+            }
+        }
+    }";
+
+            VerifyCSharpDiagnostic(test);
+        }
+
+        [TestMethod]
+        public void ConfigureAwait_InMethodCalledByOrchestrator()
+        {
+            var test = @"
+    using System.Threading.Tasks;
+    using Microsoft.Azure.WebJobs;
+    using Microsoft.Azure.WebJobs.Extensions.DurableTask;
+
+    namespace VSSample
+    {
+        public static class HelloSequence
+        {
+            [FunctionName(""ConfigureAwaitAnalyzerTestCases"")]
+            public static async Task Run(
+            [OrchestrationTrigger] IDurableOrchestrationContext context)
+            {
+                await DirectCall(context);
+            }
+
+            public static async Task DirectCall(IDurableOrchestrationContext context)
+            {
+                await context.CallActivityAsync<string>(""Function1_Hello"", ""Tokyo"").ConfigureAwait(false);
+            }
+        }
+    }";
+            var expectedDiagnostics = new DiagnosticResult[2];
+            expectedDiagnostics[0] = new DiagnosticResult
+            {
+                Id = MethodInvocationAnalyzer.DiagnosticId,
+                Message = string.Format(Resources.MethodAnalyzerMessageFormat, "DirectCall(context)"),
+                Severity = Severity,
+                Locations =
+                    new[] {
+                            new DiagnosticResultLocation("Test0.cs", 14, 23)
+                        }
+            };
+            expectedDiagnostics[1] = new DiagnosticResult
+            {
+                Id = DiagnosticId,
+                Message = string.Format(Resources.DeterministicAnalyzerMessageFormat, "ConfigureAwait"),
+                Severity = Severity,
+                Locations =
+                    new[] {
+                            new DiagnosticResultLocation("Test0.cs", 19, 23)
+                        }
+            };
+
+            VerifyCSharpDiagnostic(test, expectedDiagnostics);
+        }
+
+        [TestMethod]
+        public void ConfigureAwait_OutsideOrchestrator_NoDiagnostic()
+        {
+            var test = @"
+    using System.Threading.Tasks;
+    using Microsoft.Azure.WebJobs;
+    using Microsoft.Azure.WebJobs.Extensions.DurableTask;
+
+    namespace VSSample
+    {
+        public static class HelloSequence
+        {
+            [FunctionName(""ConfigureAwaitAnalyzerTestCases"")]
+            public static async Task Run(
+            [OrchestrationTrigger] IDurableOrchestrationContext context)
+            {
+            }
+
+            public static async Task NotAnOrchestrator()
+            {
+                await Task.Delay(1).ConfigureAwait(false);
+            }
+        }
+    }";
+
+            VerifyCSharpDiagnostic(test);
+        }
+
+        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+        {
+            return new DeterministicMethodAnalyzer();
+        }
+    }
+}

--- a/test/WebJobs.Extensions.DurableTask.Analyzers.Test/Orchestrator/ConfigureAwaitAnalyzerTests.cs
+++ b/test/WebJobs.Extensions.DurableTask.Analyzers.Test/Orchestrator/ConfigureAwaitAnalyzerTests.cs
@@ -97,6 +97,41 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers.Test.Orchestr
         }
 
         [TestMethod]
+        public void ConfigureAwait_NonLiteralArgument_Diagnostic()
+        {
+            var test = @"
+    using System.Threading.Tasks;
+    using Microsoft.Azure.WebJobs;
+    using Microsoft.Azure.WebJobs.Extensions.DurableTask;
+
+    namespace VSSample
+    {
+        public static class HelloSequence
+        {
+            [FunctionName(""ConfigureAwaitAnalyzerTestCases"")]
+            public static async Task Run(
+            [OrchestrationTrigger] IDurableOrchestrationContext context)
+            {
+                var continueOnCapturedContext = false;
+                await context.CallActivityAsync<string>(""Function1_Hello"", ""Tokyo"").ConfigureAwait(continueOnCapturedContext);
+            }
+        }
+    }";
+            var expectedDiagnostics = new DiagnosticResult
+            {
+                Id = DiagnosticId,
+                Message = string.Format(Resources.DeterministicAnalyzerMessageFormat, "ConfigureAwait"),
+                Severity = Severity,
+                Locations =
+                    new[] {
+                            new DiagnosticResultLocation("Test0.cs", 15, 23)
+                        }
+            };
+
+            VerifyCSharpDiagnostic(test, expectedDiagnostics);
+        }
+
+        [TestMethod]
         public void ConfigureAwait_InMethodCalledByOrchestrator()
         {
             var test = @"

--- a/test/WebJobs.Extensions.DurableTask.Analyzers.Test/Orchestrator/ConfigureAwaitAnalyzerTests.cs
+++ b/test/WebJobs.Extensions.DurableTask.Analyzers.Test/Orchestrator/ConfigureAwaitAnalyzerTests.cs
@@ -97,6 +97,48 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers.Test.Orchestr
         }
 
         [TestMethod]
+        public void ConfigureAwait_MultipleArgumentsIncludingTrue_Diagnostic()
+        {
+            var test = @"
+    using System.Threading.Tasks;
+    using Microsoft.Azure.WebJobs;
+    using Microsoft.Azure.WebJobs.Extensions.DurableTask;
+
+    namespace VSSample
+    {
+        public class ConfigurableOperation
+        {
+            public void ConfigureAwait(bool first, bool second)
+            {
+            }
+        }
+
+        public static class HelloSequence
+        {
+            [FunctionName(""ConfigureAwaitAnalyzerTestCases"")]
+            public static async Task Run(
+            [OrchestrationTrigger] IDurableOrchestrationContext context)
+            {
+                new ConfigurableOperation().ConfigureAwait(false, true);
+                await context.CallActivityAsync<string>(""Function1_Hello"", ""Tokyo"");
+            }
+        }
+    }";
+            var expectedDiagnostics = new DiagnosticResult
+            {
+                Id = DiagnosticId,
+                Message = string.Format(Resources.DeterministicAnalyzerMessageFormat, "ConfigureAwait"),
+                Severity = Severity,
+                Locations =
+                    new[] {
+                            new DiagnosticResultLocation("Test0.cs", 21, 17)
+                        }
+            };
+
+            VerifyCSharpDiagnostic(test, expectedDiagnostics);
+        }
+
+        [TestMethod]
         public void ConfigureAwait_NonLiteralArgument_Diagnostic()
         {
             var test = @"

--- a/test/WebJobs.Extensions.DurableTask.Analyzers.Test/Orchestrator/ConfigureAwaitAnalyzerTests.cs
+++ b/test/WebJobs.Extensions.DurableTask.Analyzers.Test/Orchestrator/ConfigureAwaitAnalyzerTests.cs
@@ -108,8 +108,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers.Test.Orchestr
     {
         public class ConfigurableOperation
         {
-            public void ConfigureAwait(bool first, bool second)
+            public Task ConfigureAwait(bool first, bool second)
             {
+                return Task.CompletedTask;
             }
         }
 
@@ -119,7 +120,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers.Test.Orchestr
             public static async Task Run(
             [OrchestrationTrigger] IDurableOrchestrationContext context)
             {
-                new ConfigurableOperation().ConfigureAwait(false, true);
+                await new ConfigurableOperation().ConfigureAwait(false, true);
                 await context.CallActivityAsync<string>(""Function1_Hello"", ""Tokyo"");
             }
         }
@@ -131,11 +132,43 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers.Test.Orchestr
                 Severity = Severity,
                 Locations =
                     new[] {
-                            new DiagnosticResultLocation("Test0.cs", 21, 17)
+                            new DiagnosticResultLocation("Test0.cs", 22, 23)
                         }
             };
 
             VerifyCSharpDiagnostic(test, expectedDiagnostics);
+        }
+
+        [TestMethod]
+        public void ConfigureAwait_NotAwaited_NoDiagnostic()
+        {
+            var test = @"
+    using System.Threading.Tasks;
+    using Microsoft.Azure.WebJobs;
+    using Microsoft.Azure.WebJobs.Extensions.DurableTask;
+
+    namespace VSSample
+    {
+        public class ConfigurableOperation
+        {
+            public void ConfigureAwait(bool continueOnCapturedContext)
+            {
+            }
+        }
+
+        public static class HelloSequence
+        {
+            [FunctionName(""ConfigureAwaitAnalyzerTestCases"")]
+            public static async Task Run(
+            [OrchestrationTrigger] IDurableOrchestrationContext context)
+            {
+                new ConfigurableOperation().ConfigureAwait(false);
+                await context.CallActivityAsync<string>(""Function1_Hello"", ""Tokyo"");
+            }
+        }
+    }";
+
+            VerifyCSharpDiagnostic(test);
         }
 
         [TestMethod]


### PR DESCRIPTION
## Summary

Fixes #995.

Using ConfigureAwait(false) inside an orchestrator function moves the awaited task's continuation off the orchestration `SynchronizationContext` and onto an arbitrary thread-pool thread, which breaks the deterministic, single-threaded replay guarantee that Durable Functions orchestrations depend on. As requested in the issue, this adds an analyzer rule to catch it at build time.

## Changes

- New orchestrator-determinism analyzer **`DF0114` (ConfigureAwaitAnalyzer)** that reports a warning on `ConfigureAwait` invocations inside collected orchestrator methods (and the methods they call, via the existing `DF0107` chain-of-blame).
- Wired into the `DeterministicMethodAnalyzer` umbrella (`SupportedDiagnostics` + the non-short-circuit `|` chain).
- Resource string, `Resources.Designer.cs` property, and `AnalyzerReleases.Unshipped.md` entry (RS2008).

## Design notes

- **Syntactic detection** (mirroring the existing `Task.ContinueWith` rule) rather than symbol-based. This is intentional: the awaited expression is typically an activity/sub-orchestrator call (e.g. `context.CallActivityAsync<T>(...).ConfigureAwait(false)`) whose type does not always fully bind during analysis, so a symbol lookup on the chained member access can return null.
- **`ConfigureAwait(true)` is treated as safe** and not flagged — it preserves the captured context and is identical to a normal `await`. This mirrors the existing `ContinueWith` / `ExecuteSynchronously` carve-out. `ConfigureAwait(false)` (and any non-literal argument that can't be proven `true`) is flagged.

## Testing

- New `ConfigureAwaitAnalyzerTests` (5 cases): no-ConfigureAwait, `false` on an activity call, `true` (no diagnostic), inside a method called by the orchestrator (`DF0107` + `DF0114`), and outside any orchestrator (no diagnostic).
- Full analyzer suite passes locally: **164/164** (159 existing + 5 new), `net8.0`, no StyleCop/RS warnings.