### PR TITLE
Add analyzer DF0115 flagging ActivityTrigger parameter named 'data' (fixes #1062)

### DIFF
--- a/src/WebJobs.Extensions.DurableTask.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/WebJobs.Extensions.DurableTask.Analyzers/AnalyzerReleases.Unshipped.md
@@ -1,1 +1,5 @@
-﻿
+﻿### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|-------
+DF0115 | Activity | Warning | ActivityTriggerParameterAnalyzer

--- a/src/WebJobs.Extensions.DurableTask.Analyzers/Analyzers/ActivityFunction/ActivityTriggerParameterAnalyzer.cs
+++ b/src/WebJobs.Extensions.DurableTask.Analyzers/Analyzers/ActivityFunction/ActivityTriggerParameterAnalyzer.cs
@@ -1,0 +1,51 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class ActivityTriggerParameterAnalyzer : DiagnosticAnalyzer
+    {
+        public const string DiagnosticId = "DF0115";
+
+        // The activity trigger binding reserves this name for the raw JSON representation of the input.
+        // See ActivityTriggerAttributeBindingProvider.GetBindingDataContract.
+        private const string ReservedParameterName = "data";
+
+        private static readonly LocalizableString Title = new LocalizableResourceString(nameof(Resources.ActivityTriggerParameterAnalyzerTitle), Resources.ResourceManager, typeof(Resources));
+        private static readonly LocalizableString MessageFormat = new LocalizableResourceString(nameof(Resources.ActivityTriggerParameterAnalyzerMessageFormat), Resources.ResourceManager, typeof(Resources));
+        private static readonly LocalizableString Description = new LocalizableResourceString(nameof(Resources.ActivityTriggerParameterAnalyzerDescription), Resources.ResourceManager, typeof(Resources));
+        private const string Category = SupportedCategories.Activity;
+        public const DiagnosticSeverity Severity = DiagnosticSeverity.Warning;
+
+        public static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, Category, Severity, isEnabledByDefault: true, description: Description);
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(Rule); } }
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
+            context.RegisterSyntaxNodeAction(FindReservedActivityParameterName, SyntaxKind.Attribute);
+        }
+
+        public void FindReservedActivityParameterName(SyntaxNodeAnalysisContext context)
+        {
+            if (context.Node is AttributeSyntax attribute
+                && SyntaxNodeUtils.IsActivityTriggerAttribute(attribute)
+                && attribute.Parent?.Parent is ParameterSyntax parameter
+                && string.Equals(parameter.Identifier.ValueText, ReservedParameterName, StringComparison.OrdinalIgnoreCase))
+            {
+                var diagnostic = Diagnostic.Create(Rule, parameter.Identifier.GetLocation(), parameter.Identifier.ValueText);
+
+                context.ReportDiagnostic(diagnostic);
+            }
+        }
+    }
+}

--- a/src/WebJobs.Extensions.DurableTask.Analyzers/Analyzers/ActivityFunction/ActivityTriggerParameterAnalyzer.cs
+++ b/src/WebJobs.Extensions.DurableTask.Analyzers/Analyzers/ActivityFunction/ActivityTriggerParameterAnalyzer.cs
@@ -32,12 +32,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
         public override void Initialize(AnalysisContext context)
         {
             context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
+            context.EnableConcurrentExecution();
             context.RegisterSyntaxNodeAction(FindReservedActivityParameterName, SyntaxKind.Attribute);
         }
 
         public void FindReservedActivityParameterName(SyntaxNodeAnalysisContext context)
         {
-            if (context.Node is AttributeSyntax attribute
+            if (SyntaxNodeUtils.IsInsideFunction(context.SemanticModel, context.Node)
+                && context.Node is AttributeSyntax attribute
                 && SyntaxNodeUtils.IsActivityTriggerAttribute(attribute)
                 && attribute.Parent?.Parent is ParameterSyntax parameter
                 && string.Equals(parameter.Identifier.ValueText, ReservedParameterName, StringComparison.OrdinalIgnoreCase))

--- a/src/WebJobs.Extensions.DurableTask.Analyzers/Resources.Designer.cs
+++ b/src/WebJobs.Extensions.DurableTask.Analyzers/Resources.Designer.cs
@@ -169,7 +169,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The Durable Functions activity binding reserves the name &apos;data&apos; for the raw JSON representation of the activity input. Naming an ActivityTrigger parameter &apos;data&apos; overwrites that binding and causes a function indexation error at startup. Use a different parameter name.
+        ///   Looks up a localized string similar to The Durable Functions activity binding reserves the name &apos;data&apos; for the raw JSON representation of the activity input. Naming an ActivityTrigger parameter &apos;data&apos; overwrites that binding and causes a function indexing error at startup. Use a different parameter name.
         /// </summary>
         public static string ActivityTriggerParameterAnalyzerDescription {
             get {
@@ -178,7 +178,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The parameter name &apos;{0}&apos; is reserved by the activity trigger binding; rename the ActivityTrigger parameter to avoid a function indexation error.
+        ///   Looks up a localized string similar to The parameter name &apos;{0}&apos; is reserved by the activity trigger binding; rename the ActivityTrigger parameter to avoid a function indexing error.
         /// </summary>
         public static string ActivityTriggerParameterAnalyzerMessageFormat {
             get {

--- a/src/WebJobs.Extensions.DurableTask.Analyzers/Resources.Designer.cs
+++ b/src/WebJobs.Extensions.DurableTask.Analyzers/Resources.Designer.cs
@@ -169,6 +169,33 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The Durable Functions activity binding reserves the name &apos;data&apos; for the raw JSON representation of the activity input. Naming an ActivityTrigger parameter &apos;data&apos; overwrites that binding and causes a function indexation error at startup. Use a different parameter name.
+        /// </summary>
+        public static string ActivityTriggerParameterAnalyzerDescription {
+            get {
+                return ResourceManager.GetString("ActivityTriggerParameterAnalyzerDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The parameter name &apos;{0}&apos; is reserved by the activity trigger binding; rename the ActivityTrigger parameter to avoid a function indexation error.
+        /// </summary>
+        public static string ActivityTriggerParameterAnalyzerMessageFormat {
+            get {
+                return ResourceManager.GetString("ActivityTriggerParameterAnalyzerMessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to ActivityTrigger parameter must not use the reserved name &apos;data&apos;.
+        /// </summary>
+        public static string ActivityTriggerParameterAnalyzerTitle {
+            get {
+                return ResourceManager.GetString("ActivityTriggerParameterAnalyzerTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Code used in an orchestrator must not use await on non-Durable Functions methods.
         /// </summary>
         public static string AwaitAnalyzerMessageFormat {

--- a/src/WebJobs.Extensions.DurableTask.Analyzers/Resources.resx
+++ b/src/WebJobs.Extensions.DurableTask.Analyzers/Resources.resx
@@ -154,10 +154,10 @@
     <value>Activity function call return type doesn't match function definition return type</value>
   </data>
   <data name="ActivityTriggerParameterAnalyzerDescription" xml:space="preserve">
-    <value>The Durable Functions activity binding reserves the name 'data' for the raw JSON representation of the activity input. Naming an ActivityTrigger parameter 'data' overwrites that binding and causes a function indexation error at startup. Use a different parameter name.</value>
+    <value>The Durable Functions activity binding reserves the name 'data' for the raw JSON representation of the activity input. Naming an ActivityTrigger parameter 'data' overwrites that binding and causes a function indexing error at startup. Use a different parameter name.</value>
   </data>
   <data name="ActivityTriggerParameterAnalyzerMessageFormat" xml:space="preserve">
-    <value>The parameter name '{0}' is reserved by the activity trigger binding; rename the ActivityTrigger parameter to avoid a function indexation error</value>
+    <value>The parameter name '{0}' is reserved by the activity trigger binding; rename the ActivityTrigger parameter to avoid a function indexing error</value>
   </data>
   <data name="ActivityTriggerParameterAnalyzerTitle" xml:space="preserve">
     <value>ActivityTrigger parameter must not use the reserved name 'data'</value>

--- a/src/WebJobs.Extensions.DurableTask.Analyzers/Resources.resx
+++ b/src/WebJobs.Extensions.DurableTask.Analyzers/Resources.resx
@@ -153,6 +153,15 @@
   <data name="ActivityReturnTypeAnalyzerTitle" xml:space="preserve">
     <value>Activity function call return type doesn't match function definition return type</value>
   </data>
+  <data name="ActivityTriggerParameterAnalyzerDescription" xml:space="preserve">
+    <value>The Durable Functions activity binding reserves the name 'data' for the raw JSON representation of the activity input. Naming an ActivityTrigger parameter 'data' overwrites that binding and causes a function indexation error at startup. Use a different parameter name.</value>
+  </data>
+  <data name="ActivityTriggerParameterAnalyzerMessageFormat" xml:space="preserve">
+    <value>The parameter name '{0}' is reserved by the activity trigger binding; rename the ActivityTrigger parameter to avoid a function indexation error</value>
+  </data>
+  <data name="ActivityTriggerParameterAnalyzerTitle" xml:space="preserve">
+    <value>ActivityTrigger parameter must not use the reserved name 'data'</value>
+  </data>
   <data name="AwaitAnalyzerMessageFormat" xml:space="preserve">
     <value>Code used in an orchestrator must not use await on non-Durable Functions methods</value>
   </data>

--- a/test/WebJobs.Extensions.DurableTask.Analyzers.Test/ActivityFunction/ActivityTriggerParameterAnalyzerTests.cs
+++ b/test/WebJobs.Extensions.DurableTask.Analyzers.Test/ActivityFunction/ActivityTriggerParameterAnalyzerTests.cs
@@ -165,7 +165,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers.Test.Activity
         [TestMethod]
         public void ActivityTrigger_ParameterNamedData_NotInsideFunction_NoDiagnostic()
         {
-            // Reviewer case (PR #3474): DF0115 must only fire on actual Azure Functions. A helper, sample, or
+            // Regression guard: DF0115 must only fire on actual Azure Functions. A helper, sample, or
             // unit-test method that is annotated with [ActivityTrigger] but is NOT a Function (no [FunctionName])
             // must NOT be flagged. This is identical to ActivityTrigger_ParameterNamedData_Diagnostic except the
             // [FunctionName] attribute is absent, so the IsInsideFunction guard suppresses the diagnostic.

--- a/test/WebJobs.Extensions.DurableTask.Analyzers.Test/ActivityFunction/ActivityTriggerParameterAnalyzerTests.cs
+++ b/test/WebJobs.Extensions.DurableTask.Analyzers.Test/ActivityFunction/ActivityTriggerParameterAnalyzerTests.cs
@@ -1,0 +1,170 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using TestHelper;
+
+namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers.Test.ActivityFunction
+{
+    [TestClass]
+    public class ActivityTriggerParameterAnalyzerTests : CodeFixVerifier
+    {
+        private static readonly string DiagnosticId = ActivityTriggerParameterAnalyzer.DiagnosticId;
+        private static readonly DiagnosticSeverity Severity = DiagnosticSeverity.Warning;
+
+        [TestMethod]
+        public void ActivityTrigger_ParameterNotNamedData_NoDiagnostic()
+        {
+            var test = @"
+    using System.Threading.Tasks;
+    using Microsoft.Azure.WebJobs;
+    using Microsoft.Azure.WebJobs.Extensions.DurableTask;
+
+    namespace VSSample
+    {
+        public static class HelloSequence
+        {
+            [FunctionName(""MyActivity"")]
+            public static bool Run(
+                [ActivityTrigger] (string, int) request)
+            {
+                return true;
+            }
+        }
+    }";
+
+            VerifyCSharpDiagnostic(test);
+        }
+
+        [TestMethod]
+        public void ActivityTrigger_ParameterNamedData_Diagnostic()
+        {
+            var test = @"
+    using System.Threading.Tasks;
+    using Microsoft.Azure.WebJobs;
+    using Microsoft.Azure.WebJobs.Extensions.DurableTask;
+
+    namespace VSSample
+    {
+        public static class HelloSequence
+        {
+            [FunctionName(""MyActivity"")]
+            public static bool Run(
+                [ActivityTrigger] (string, int) data)
+            {
+                return true;
+            }
+        }
+    }";
+            var expectedDiagnostics = new DiagnosticResult
+            {
+                Id = DiagnosticId,
+                Message = string.Format(Resources.ActivityTriggerParameterAnalyzerMessageFormat, "data"),
+                Severity = Severity,
+                Locations =
+                    new[] {
+                            new DiagnosticResultLocation("Test0.cs", 12, 49)
+                        }
+            };
+
+            VerifyCSharpDiagnostic(test, expectedDiagnostics);
+        }
+
+        [TestMethod]
+        public void ActivityTrigger_ParameterNamedData_CaseInsensitive_Diagnostic()
+        {
+            var test = @"
+    using System.Threading.Tasks;
+    using Microsoft.Azure.WebJobs;
+    using Microsoft.Azure.WebJobs.Extensions.DurableTask;
+
+    namespace VSSample
+    {
+        public static class HelloSequence
+        {
+            [FunctionName(""MyActivity"")]
+            public static bool Run(
+                [ActivityTrigger] string Data)
+            {
+                return true;
+            }
+        }
+    }";
+            var expectedDiagnostics = new DiagnosticResult
+            {
+                Id = DiagnosticId,
+                Message = string.Format(Resources.ActivityTriggerParameterAnalyzerMessageFormat, "Data"),
+                Severity = Severity,
+                Locations =
+                    new[] {
+                            new DiagnosticResultLocation("Test0.cs", 12, 42)
+                        }
+            };
+
+            VerifyCSharpDiagnostic(test, expectedDiagnostics);
+        }
+
+        [TestMethod]
+        public void ActivityTrigger_WithActivityNameArgument_ParameterNamedData_Diagnostic()
+        {
+            var test = @"
+    using System.Threading.Tasks;
+    using Microsoft.Azure.WebJobs;
+    using Microsoft.Azure.WebJobs.Extensions.DurableTask;
+
+    namespace VSSample
+    {
+        public static class HelloSequence
+        {
+            [FunctionName(""MyActivity"")]
+            public static bool Run(
+                [ActivityTrigger(Activity = ""MyActivity"")] string data)
+            {
+                return true;
+            }
+        }
+    }";
+            var expectedDiagnostics = new DiagnosticResult
+            {
+                Id = DiagnosticId,
+                Message = string.Format(Resources.ActivityTriggerParameterAnalyzerMessageFormat, "data"),
+                Severity = Severity,
+                Locations =
+                    new[] {
+                            new DiagnosticResultLocation("Test0.cs", 12, 67)
+                        }
+            };
+
+            VerifyCSharpDiagnostic(test, expectedDiagnostics);
+        }
+
+        [TestMethod]
+        public void NonActivityTrigger_ParameterNamedData_NoDiagnostic()
+        {
+            var test = @"
+    using System.Threading.Tasks;
+    using Microsoft.Azure.WebJobs;
+    using Microsoft.Azure.WebJobs.Extensions.DurableTask;
+
+    namespace VSSample
+    {
+        public static class HelloSequence
+        {
+            public static bool NotAnActivity(string data)
+            {
+                return true;
+            }
+        }
+    }";
+
+            VerifyCSharpDiagnostic(test);
+        }
+
+        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+        {
+            return new ActivityTriggerParameterAnalyzer();
+        }
+    }
+}

--- a/test/WebJobs.Extensions.DurableTask.Analyzers.Test/ActivityFunction/ActivityTriggerParameterAnalyzerTests.cs
+++ b/test/WebJobs.Extensions.DurableTask.Analyzers.Test/ActivityFunction/ActivityTriggerParameterAnalyzerTests.cs
@@ -162,6 +162,79 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers.Test.Activity
             VerifyCSharpDiagnostic(test);
         }
 
+        [TestMethod]
+        public void ActivityTrigger_ParameterNamedData_NotInsideFunction_NoDiagnostic()
+        {
+            // Reviewer case (PR #3474): DF0115 must only fire on actual Azure Functions. A helper, sample, or
+            // unit-test method that is annotated with [ActivityTrigger] but is NOT a Function (no [FunctionName])
+            // must NOT be flagged. This is identical to ActivityTrigger_ParameterNamedData_Diagnostic except the
+            // [FunctionName] attribute is absent, so the IsInsideFunction guard suppresses the diagnostic.
+            var test = @"
+    using System.Threading.Tasks;
+    using Microsoft.Azure.WebJobs;
+    using Microsoft.Azure.WebJobs.Extensions.DurableTask;
+
+    namespace VSSample
+    {
+        public static class HelloSequence
+        {
+            public static bool Run(
+                [ActivityTrigger] (string, int) data)
+            {
+                return true;
+            }
+        }
+    }";
+
+            VerifyCSharpDiagnostic(test);
+        }
+
+        [TestMethod]
+        public void IsolatedWorkerActivityTrigger_ParameterNamedData_NoDiagnostic()
+        {
+            // The isolated-worker ActivityTrigger attribute shares the simple name "ActivityTrigger" with the
+            // in-proc (WebJobs) attribute, but it binds input via an InputConverter rather than the WebJobs
+            // binding-data contract, so naming its parameter 'data' is harmless and must NOT be flagged.
+            // Isolated-worker functions are marked with [Function], not [FunctionName]; because IsInsideFunction
+            // looks specifically for [FunctionName] (the in-proc marker), the guard excludes this method. Both the
+            // Function and ActivityTrigger attributes are stubbed inline so the test does not depend on the
+            // isolated-worker package.
+            var test = @"
+    using System;
+
+    namespace Microsoft.Azure.Functions.Worker
+    {
+        [AttributeUsage(AttributeTargets.Method)]
+        public sealed class FunctionAttribute : Attribute
+        {
+            public FunctionAttribute(string name) { }
+        }
+
+        [AttributeUsage(AttributeTargets.Parameter)]
+        public sealed class ActivityTriggerAttribute : Attribute
+        {
+            public string Activity { get; set; }
+        }
+    }
+
+    namespace VSSample
+    {
+        using Microsoft.Azure.Functions.Worker;
+
+        public static class HelloSequence
+        {
+            [Function(""MyActivity"")]
+            public static bool Run(
+                [ActivityTrigger] string data)
+            {
+                return true;
+            }
+        }
+    }";
+
+            VerifyCSharpDiagnostic(test);
+        }
+
         protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
         {
             return new ActivityTriggerParameterAnalyzer();


### PR DESCRIPTION
## Summary

Fixes #1062.

The Durable Functions activity trigger binding reserves the binding name `data` for the raw JSON representation of the activity input (see [`ActivityTriggerAttributeBindingProvider.GetBindingDataContract`](https://github.com/Azure/azure-functions-durable-extension/blob/dev/src/WebJobs.Extensions.DurableTask/Bindings/ActivityTriggerAttributeBindingProvider.cs)). When an `[ActivityTrigger]` parameter is itself named `data`, the reserved binding overwrites the parameter binding (the contract dictionary is case-insensitive), producing a confusing indexation error at startup:

> `Can't bind parameter 'data' to type 'System.ValueTuple...'`

As agreed in the issue discussion (`@ConnorMcMahon`: *"an analyzer is a great idea for this"*; `@cgillum`: *"an analyzer rule would be helpful here"*), this catches the problem at build time instead.

## Changes

- New Activity analyzer **`DF0115` (ActivityTriggerParameterAnalyzer)** that reports a warning when an `[ActivityTrigger]` parameter is named `data` (case-insensitive, matching the binding's case-insensitive contract). The message points the developer at the reserved name so they can rename the parameter.
- Resource strings, `Resources.Designer.cs` property, and `AnalyzerReleases.Unshipped.md` entry (RS2008).

## Design notes

- Standalone `[DiagnosticAnalyzer]` registered on `SyntaxKind.Attribute` (mirrors the existing `ClientAnalyzer` / `OrchestratorContextAnalyzer` binding rules). Attribute matching reuses `SyntaxNodeUtils.IsActivityTriggerAttribute`, so it also handles `[ActivityTrigger(Activity = "...")]`.
- Flags by **name only**, regardless of parameter type — the collision is purely on the binding name, and there is no legitimate reason to name the parameter `data`.

## Testing

- New `ActivityTriggerParameterAnalyzerTests` (5 cases): `data` tuple param (diagnostic), `Data` case-insensitive (diagnostic), non-`data` name (no diagnostic), attribute with `Activity` argument (diagnostic), and a `data` parameter on a non-activity method (no diagnostic).
- Full analyzer suite passes locally: **164/164** (159 existing + 5 new), `net8.0`, no StyleCop/RS warnings.