### PR TITLE
Suppress DF0109 for activity names using nameof() with FunctionsInDependencies (#2449)

### DIFF
--- a/src/WebJobs.Extensions.DurableTask.Analyzers/Analyzers/ActivityFunction/NameAnalyzer.cs
+++ b/src/WebJobs.Extensions.DurableTask.Analyzers/Analyzers/ActivityFunction/NameAnalyzer.cs
@@ -31,9 +31,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
         {
             foreach (var invocation in functionInvocations)
             {
-                // If invocation uses constant and there is no matching function name in function definition, trust the customer for correctness in case they are using 
-                // <FunctionsInDependencies>true</FunctionsInDependencies>
-                if (!functionDefinitions.Select(x => x.FunctionName).Contains(invocation.FunctionName) && !IsConstant(semanticModel, invocation.NameNode))
+                // If invocation uses a constant or nameof() and there is no matching function name in function definition, trust the customer for correctness in case they are using 
+                // <FunctionsInDependencies>true</FunctionsInDependencies>. nameof() is compiler-verified, so it is at least as safe as a constant string.
+                if (!functionDefinitions.Select(x => x.FunctionName).Contains(invocation.FunctionName) && !IsConstant(semanticModel, invocation.NameNode) && !IsNameOf(invocation.NameNode))
                 {
                     if (SyntaxNodeUtils.TryGetClosestString(invocation.FunctionName, functionDefinitions.Select(x => x.FunctionName), out string closestName))
                     {
@@ -54,6 +54,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
         private static bool IsConstant(SemanticModel semanticModel, SyntaxNode nameNode)
         {
             return SyntaxNodeUtils.TryGetFunctionNameInConstant(semanticModel, nameNode, out _);
+        }
+
+        private static bool IsNameOf(SyntaxNode nameNode)
+        {
+            return SyntaxNodeUtils.IsNameOfExpression(nameNode);
         }
     }
 }

--- a/src/WebJobs.Extensions.DurableTask.Analyzers/SyntaxNodeUtils.cs
+++ b/src/WebJobs.Extensions.DurableTask.Analyzers/SyntaxNodeUtils.cs
@@ -349,6 +349,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers
             return false;
         }
 
+        public static bool IsNameOfExpression(SyntaxNode node)
+        {
+            // A nameof(...) expression parses as an InvocationExpression whose expression is the
+            // contextual keyword 'nameof'. It is compiler-verified, so it can be trusted the same
+            // way a constant string is when resolving activity function names.
+            return node is InvocationExpressionSyntax invocation
+                && invocation.Expression is IdentifierNameSyntax identifier
+                && string.Equals(identifier.Identifier.Text, "nameof", StringComparison.Ordinal);
+        }
+
         private static bool TryGetFunctionNameInNameOfOperator(SyntaxNode node, out string functionName)
         {
             if (node != null && node.IsKind(SyntaxKind.InvocationExpression))

--- a/test/WebJobs.Extensions.DurableTask.Analyzers.Test/ActivityFunction/NameAnalyzerTests.cs
+++ b/test/WebJobs.Extensions.DurableTask.Analyzers.Test/ActivityFunction/NameAnalyzerTests.cs
@@ -142,6 +142,47 @@ namespace VSSample
         }
         
         [TestMethod]
+        public void Name_NoDiagnostic_UsesNameOfForFunctionInDependencies()
+        {
+            // Covers https://github.com/Azure/azure-functions-durable-extension/issues/2449
+            // When <FunctionsInDependencies>true</FunctionsInDependencies> is set, the referenced
+            // activity lives in another assembly and is therefore not among the locally-collected
+            // function definitions. nameof() is compiler-verified, so - like a constant string - it
+            // is trusted for correctness and DF0109 should not fire.
+            var test = @"
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Extensions.DurableTask;
+using Microsoft.WindowsAzure.Storage.Blob;
+using Microsoft.WindowsAzure.Storage.Queue;
+using Microsoft.WindowsAzure.Storage.Table;
+
+namespace VSSample
+{
+    public static class HelloSequence
+    {
+        [FunctionName(""NameAnalyzerTestCases"")]
+        public static async Task<string> Run(
+            [OrchestrationTrigger] IDurableOrchestrationContext context)
+        {
+            return await context.CallActivityAsync<string>(nameof(FunctionInDependency), ""Seattle"");
+        }
+    }
+
+    // Simulates a type that exists (so nameof compiles) but whose activity function is
+    // defined in a referenced assembly, not in this compilation.
+    public class FunctionInDependency
+    {
+    }
+}";
+            VerifyCSharpDiagnostic(test);
+        }
+
+        [TestMethod]
         public void Name_InvalidName_CloseRule()
         {
             var test = @"


### PR DESCRIPTION
## Summary
Fixes #2449.

The activity-name analyzer (`DF0109`) reports `Activity function '<name>' does not exist` when it cannot find the referenced activity in the current compilation. To support projects that set `<FunctionsInDependencies>true</FunctionsInDependencies>` (activities defined in a referenced assembly), the analyzer already **trusts a constant `string`** used as the activity name and suppresses the warning in that case.

However, `nameof(MyActivity)` was **not** given the same treatment, so users following the more type-safe pattern got a false positive — the exact scenario reported in #2449. As noted in the issue, `nameof(...)` is compiler-verified, so it is at least as safe as a magic constant string.

## Change
- `NameAnalyzer.ReportProblems`: also suppress `DF0109` when the activity-name node is a `nameof(...)` expression (mirrors the existing constant carve-out).
- `SyntaxNodeUtils.IsNameOfExpression`: precise detection of the `nameof` contextual keyword (an `InvocationExpression` whose expression identifier is `nameof`).

Locally-resolvable `nameof(...)` references were already fine; this only affects the case where the activity is not in the local compilation (dependencies), which is precisely when the developer opts into `FunctionsInDependencies`.

## Testing
- Added `Name_NoDiagnostic_UsesNameOfForFunctionInDependencies`, which reproduces #2449 (fails before the fix with `DF0109`, passes after).
- Full analyzer suite: **160/160 passing** on `net8.0`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
Copilot-Session: 47efed8f-40ca-43b8-8564-de5406bafbc0