### PR TITLE
Honor configured worker serializer for JsonElement orchestration input (#2851)

### DIFF
--- a/src/Worker.Extensions.DurableTask/FunctionsOrchestrationContext.InputConverter.cs
+++ b/src/Worker.Extensions.DurableTask/FunctionsOrchestrationContext.InputConverter.cs
@@ -12,12 +12,11 @@ internal sealed partial class FunctionsOrchestrationContext
     {
         public abstract T Get<T>();
 
-        public static InputConverter Create(
-            object? baseInput, DataConverter converter, JsonSerializerOptions jsonOptions)
+        public static InputConverter Create(object? baseInput, DataConverter converter)
         {
             return baseInput switch
             {
-                JsonElement json => new JsonElementInputConverter(json, jsonOptions),
+                JsonElement json => new JsonElementInputConverter(json, converter),
                 null => NullInputConverter.Instance,
                 _ => new DefaultInputConverter(baseInput, converter),
             };
@@ -44,17 +43,21 @@ internal sealed partial class FunctionsOrchestrationContext
     private class JsonElementInputConverter : InputConverter
     {
         private readonly JsonElement json;
-        private readonly JsonSerializerOptions jsonOptions;
+        private readonly DataConverter converter;
 
-        public JsonElementInputConverter(JsonElement json, JsonSerializerOptions jsonOptions)
+        public JsonElementInputConverter(JsonElement json, DataConverter converter)
         {
             this.json = json;
-            this.jsonOptions = jsonOptions;
+            this.converter = converter;
         }
 
         public override T Get<T>()
         {
-            return this.json.Deserialize<T>(this.jsonOptions)!;
+            // Deserialize using the configured worker DataConverter (the same converter the inner
+            // context used to deserialize the raw input to 'object'), so that a user-configured
+            // serializer is honored instead of the global JsonSerializerOptions. See issues #2851
+            // and #2995.
+            return this.converter.Deserialize<T>(this.json.GetRawText())!;
         }
     }
 

--- a/src/Worker.Extensions.DurableTask/FunctionsOrchestrationContext.InputConverter.cs
+++ b/src/Worker.Extensions.DurableTask/FunctionsOrchestrationContext.InputConverter.cs
@@ -42,13 +42,17 @@ internal sealed partial class FunctionsOrchestrationContext
 
     private class JsonElementInputConverter : InputConverter
     {
-        private readonly JsonElement json;
         private readonly DataConverter converter;
+        private readonly string serializedInput;
 
         public JsonElementInputConverter(JsonElement json, DataConverter converter)
         {
-            this.json = json;
             this.converter = converter;
+
+            // Capture the raw JSON once. GetInput<T>() may be called multiple times (the owning
+            // FunctionsOrchestrationContext caches this converter instance), so computing the raw
+            // text here avoids re-allocating the full JSON string on every call.
+            this.serializedInput = json.GetRawText();
         }
 
         public override T Get<T>()
@@ -57,7 +61,7 @@ internal sealed partial class FunctionsOrchestrationContext
             // context used to deserialize the raw input to 'object'), so that a user-configured
             // serializer is honored instead of the global JsonSerializerOptions. See issues #2851
             // and #2995.
-            return this.converter.Deserialize<T>(this.json.GetRawText())!;
+            return this.converter.Deserialize<T>(this.serializedInput)!;
         }
     }
 

--- a/src/Worker.Extensions.DurableTask/FunctionsOrchestrationContext.cs
+++ b/src/Worker.Extensions.DurableTask/FunctionsOrchestrationContext.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.DurableTask;
@@ -19,7 +18,6 @@ internal sealed partial class FunctionsOrchestrationContext : TaskOrchestrationC
 {
     private readonly TaskOrchestrationContext innerContext;
     private readonly FunctionContext functionContext;
-    private readonly JsonSerializerOptions jsonOptions;
 
     private readonly DurableTaskWorkerOptions options;
 
@@ -34,8 +32,6 @@ internal sealed partial class FunctionsOrchestrationContext : TaskOrchestrationC
         this.functionContext = functionContext;
         this.options = this.functionContext.InstanceServices
             .GetRequiredService<IOptions<DurableTaskWorkerOptions>>().Value;
-        this.jsonOptions = functionContext.InstanceServices
-            .GetRequiredService<IOptions<JsonSerializerOptions>>().Value;
         this.LoggerFactory = functionContext.InstanceServices.GetRequiredService<ILoggerFactory>();
     }
 
@@ -74,7 +70,7 @@ internal sealed partial class FunctionsOrchestrationContext : TaskOrchestrationC
         // once based on the declared input type of the orchestrator. Since we do not know the
         // desired input type upfront, we were initialized to object. So we must serialize and
         // deserialize again to convert to our desired type.
-        this.inputConverter ??= InputConverter.Create(input, this.options.DataConverter, this.jsonOptions);
+        this.inputConverter ??= InputConverter.Create(input, this.options.DataConverter);
         return this.inputConverter.Get<T>();
     }
 

--- a/test/Worker.Extensions.DurableTask.Tests/FunctionsOrchestrationContextInputConverterTests.cs
+++ b/test/Worker.Extensions.DurableTask.Tests/FunctionsOrchestrationContextInputConverterTests.cs
@@ -1,0 +1,134 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using Microsoft.Azure.Functions.Worker.Extensions.DurableTask;
+using Microsoft.DurableTask;
+using Microsoft.DurableTask.Worker;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using CoreOrchestrationContext = DurableTask.Core.OrchestrationContext;
+
+namespace Microsoft.Azure.Functions.Worker.Tests;
+
+/// <summary>
+/// Regression tests for https://github.com/Azure/azure-functions-durable-extension/issues/2851
+/// (and the related https://github.com/Azure/azure-functions-durable-extension/issues/2995):
+/// when an orchestration input arrives as a <see cref="JsonElement"/> (the common case, since the
+/// inner context deserializes the raw input to <c>object</c>), it must be converted to the target
+/// type using the *configured* worker serializer (<see cref="DurableTaskWorkerOptions.DataConverter"/>),
+/// not the global Functions <see cref="JsonSerializerOptions"/>. Previously the JsonElement path used
+/// the global options, so a user-configured serializer (e.g. camelCase, or IncludeFields for value
+/// tuples) was silently ignored and inputs deserialized to null/default.
+/// </summary>
+public class FunctionsOrchestrationContextInputConverterTests
+{
+    [Fact]
+    public void GetInput_JsonElementValueTuple_UsesConfiguredSerializer_IncludeFields()
+    {
+        // #2995: value tuples only (de)serialize when IncludeFields = true. Configure it on the worker
+        // serializer; the global options intentionally leave it false to prove which one is used.
+        var configured = new TestJsonDataConverter(new JsonSerializerOptions { IncludeFields = true });
+        JsonElement input = JsonSerializer.SerializeToElement(
+            (First: "hello", Last: "world"),
+            new JsonSerializerOptions { IncludeFields = true });
+
+        (string First, string Last) result = GetInput<(string First, string Last)>(input, configured);
+
+        Assert.Equal("hello", result.First);
+        Assert.Equal("world", result.Last);
+    }
+
+    [Fact]
+    public void GetInput_JsonElementCamelCase_UsesConfiguredSerializer_NamingPolicy()
+    {
+        // #2851: a camelCase-configured worker serializer must be honored. The wire payload is camelCase;
+        // the default (global) options are case-sensitive and would fail to bind the PascalCase properties.
+        var configured = new TestJsonDataConverter(new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
+        JsonElement input = JsonSerializer.SerializeToElement(
+            new Person { FirstName = "Ada", LastName = "Lovelace" },
+            new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
+
+        Person? result = GetInput<Person>(input, configured);
+
+        Assert.NotNull(result);
+        Assert.Equal("Ada", result!.FirstName);
+        Assert.Equal("Lovelace", result.LastName);
+    }
+
+    private static T GetInput<T>(JsonElement input, DataConverter configuredConverter)
+    {
+        var workerOptions = new DurableTaskWorkerOptions { DataConverter = configuredConverter };
+
+        // Global Functions JSON options are intentionally default: they do NOT enable IncludeFields
+        // or a camelCase naming policy, so if the JsonElement path (incorrectly) used them the
+        // assertions above would fail.
+        FunctionContext functionContext = CreateFunctionContext(workerOptions, new JsonSerializerOptions());
+
+        var inner = new Mock<TaskOrchestrationContext>();
+        inner.Setup(c => c.GetInput<object>()).Returns(input);
+        inner.Setup(c => c.Name).Returns(new TaskName("TestOrchestration"));
+        inner.Setup(c => c.InstanceId).Returns("test-instance-id");
+        inner.Setup(c => c.Properties).Returns(new Dictionary<string, object?>());
+
+        var context = new FunctionsOrchestrationContext(inner.Object, functionContext);
+
+        // GetInput asserts it runs on the orchestrator thread; emulate that for the duration of the call.
+        CoreOrchestrationContext.IsOrchestratorThread = true;
+        try
+        {
+            return context.GetInput<T>();
+        }
+        finally
+        {
+            CoreOrchestrationContext.IsOrchestratorThread = false;
+        }
+    }
+
+    private static FunctionContext CreateFunctionContext(
+        DurableTaskWorkerOptions workerOptions, JsonSerializerOptions jsonOptions)
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<ILoggerFactory>(NullLoggerFactory.Instance);
+        services.AddSingleton(Options.Create(workerOptions));
+        services.AddSingleton(Options.Create(jsonOptions));
+        IServiceProvider provider = services.BuildServiceProvider();
+
+        var mock = new Mock<FunctionContext>();
+        mock.Setup(c => c.InstanceServices).Returns(provider);
+        return mock.Object;
+    }
+
+    private sealed class Person
+    {
+        public string? FirstName { get; set; }
+
+        public string? LastName { get; set; }
+    }
+
+    // Mirrors the production ObjectConverterShim: a DataConverter backed by System.Text.Json options.
+    private sealed class TestJsonDataConverter : DataConverter
+    {
+        private readonly JsonSerializerOptions options;
+
+        public TestJsonDataConverter(JsonSerializerOptions options)
+        {
+            this.options = options;
+        }
+
+        public override string? Serialize(object? value)
+        {
+            return value is null ? null : JsonSerializer.Serialize(value, this.options);
+        }
+
+        public override object? Deserialize(string? data, Type targetType)
+        {
+            return data is null ? null : JsonSerializer.Deserialize(data, targetType, this.options);
+        }
+    }
+}

--- a/test/Worker.Extensions.DurableTask.Tests/FunctionsOrchestrationContextInputConverterTests.cs
+++ b/test/Worker.Extensions.DurableTask.Tests/FunctionsOrchestrationContextInputConverterTests.cs
@@ -78,7 +78,10 @@ public class FunctionsOrchestrationContextInputConverterTests
 
         var context = new FunctionsOrchestrationContext(inner.Object, functionContext);
 
-        // GetInput asserts it runs on the orchestrator thread; emulate that for the duration of the call.
+        // GetInput asserts it runs on the orchestrator thread; emulate that for the duration of the
+        // call. Save and restore the original flag value so the mutation of this static field does
+        // not leak into other tests when the runner executes tests in parallel.
+        bool originalIsOrchestratorThread = CoreOrchestrationContext.IsOrchestratorThread;
         CoreOrchestrationContext.IsOrchestratorThread = true;
         try
         {
@@ -86,7 +89,7 @@ public class FunctionsOrchestrationContextInputConverterTests
         }
         finally
         {
-            CoreOrchestrationContext.IsOrchestratorThread = false;
+            CoreOrchestrationContext.IsOrchestratorThread = originalIsOrchestratorThread;
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes #2851 (and the orchestration-input half of #2995).

When a .NET isolated orchestrator calls `context.GetInput<T>()`, the input arrives as a `System.Text.Json.JsonElement` — the inner `TaskOrchestrationContext` deserializes the raw payload to `object`, which System.Text.Json materializes as a `JsonElement`. `FunctionsOrchestrationContext` then converts that `JsonElement` to `T`.

The bug: that conversion used the **global** `IOptions<JsonSerializerOptions>` instead of the **configured** `DurableTaskWorkerOptions.DataConverter`. So if a user configures the worker serializer:

```csharp
.ConfigureFunctionsWorkerDefaults(workerOptions =>
{
    workerOptions.Serializer = new JsonObjectSerializer(new JsonSerializerOptions
    {
        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
        // or IncludeFields = true, needed for value tuples (#2995)
    });
})
```

...those options were silently ignored for orchestration inputs, and the input deserialized to `null`/default. Note the activity-side path (`ActivityInputConverter`) and the non-`JsonElement` orchestration path (`DefaultInputConverter`) already use `options.DataConverter` — only the `JsonElement` branch was inconsistent.

## Fix

Route the `JsonElement` branch through the same `DataConverter` that produced it (`converter.Deserialize<T>(json.GetRawText())`), matching the `DefaultInputConverter` and activity-side behavior. This is correct by construction: the element was produced by `options.DataConverter`, so it is deserialized back with the same converter. The now-unused global `JsonSerializerOptions` dependency is removed.

## Tests

Added `FunctionsOrchestrationContextInputConverterTests` with two regression tests that configure a custom worker serializer and a deliberately-default global options, then assert `GetInput<T>()` honors the configured serializer:

- **Value tuple** (`IncludeFields = true`) — directly covers #2995.
- **camelCase naming policy** — directly covers #2851.

Both **fail on `dev`** (input comes back `null`) and **pass with this change**. Full worker unit suite: `97 passed, 0 failed` on `net8.0`; solution builds on `net8.0` and `net10.0`.