### PR TITLE
Fix malformed reason placeholder in .NET isolated management URIs (#2705)

### DIFF
--- a/src/Worker.Extensions.DurableTask/DurableTaskClientExtensions.cs
+++ b/src/Worker.Extensions.DurableTask/DurableTaskClientExtensions.cs
@@ -262,10 +262,10 @@ public static class DurableTaskClientExtensions
             RestartPostUri = BuildUrl($"{instanceUrl}/restart", commonQueryParameters),
             SendEventPostUri = BuildUrl($"{instanceUrl}/raiseEvent/{{eventName}}", commonQueryParameters),
             StatusQueryGetUri = BuildUrl(instanceUrl, commonQueryParameters),
-            TerminatePostUri = BuildUrl($"{instanceUrl}/terminate", "reason={{text}}", commonQueryParameters),
-            RewindPostUri = BuildUrl($"{instanceUrl}/rewind", "reason={{text}}", commonQueryParameters),
-            SuspendPostUri =  BuildUrl($"{instanceUrl}/suspend", "reason={{text}}", commonQueryParameters),
-            ResumePostUri =  BuildUrl($"{instanceUrl}/resume", "reason={{text}}", commonQueryParameters)
+            TerminatePostUri = BuildUrl($"{instanceUrl}/terminate", "reason={text}", commonQueryParameters),
+            RewindPostUri = BuildUrl($"{instanceUrl}/rewind", "reason={text}", commonQueryParameters),
+            SuspendPostUri =  BuildUrl($"{instanceUrl}/suspend", "reason={text}", commonQueryParameters),
+            ResumePostUri =  BuildUrl($"{instanceUrl}/resume", "reason={text}", commonQueryParameters)
         };
     }
 

--- a/test/Worker.Extensions.DurableTask.Tests/FunctionsDurableTaskClientTests.cs
+++ b/test/Worker.Extensions.DurableTask.Tests/FunctionsDurableTaskClientTests.cs
@@ -256,6 +256,7 @@ namespace Microsoft.Azure.Functions.Worker.Tests
             Assert.Equal($"{BaseUrl}/instances/{instanceId}/raiseEvent/{{eventName}}", payload.SendEventPostUri);
             Assert.Equal($"{BaseUrl}/instances/{instanceId}", payload.StatusQueryGetUri);
             Assert.Equal($"{BaseUrl}/instances/{instanceId}/terminate?reason={{text}}", payload.TerminatePostUri);
+            Assert.Equal($"{BaseUrl}/instances/{instanceId}/rewind?reason={{text}}", payload.RewindPostUri);
             Assert.Equal($"{BaseUrl}/instances/{instanceId}/suspend?reason={{text}}", payload.SuspendPostUri);
             Assert.Equal($"{BaseUrl}/instances/{instanceId}/resume?reason={{text}}", payload.ResumePostUri);
         }

--- a/test/Worker.Extensions.DurableTask.Tests/FunctionsDurableTaskClientTests.cs
+++ b/test/Worker.Extensions.DurableTask.Tests/FunctionsDurableTaskClientTests.cs
@@ -255,9 +255,9 @@ namespace Microsoft.Azure.Functions.Worker.Tests
             Assert.Equal($"{BaseUrl}/instances/{instanceId}/restart", payload.RestartPostUri);
             Assert.Equal($"{BaseUrl}/instances/{instanceId}/raiseEvent/{{eventName}}", payload.SendEventPostUri);
             Assert.Equal($"{BaseUrl}/instances/{instanceId}", payload.StatusQueryGetUri);
-            Assert.Equal($"{BaseUrl}/instances/{instanceId}/terminate?reason={{{{text}}}}", payload.TerminatePostUri);
-            Assert.Equal($"{BaseUrl}/instances/{instanceId}/suspend?reason={{{{text}}}}", payload.SuspendPostUri);
-            Assert.Equal($"{BaseUrl}/instances/{instanceId}/resume?reason={{{{text}}}}", payload.ResumePostUri);
+            Assert.Equal($"{BaseUrl}/instances/{instanceId}/terminate?reason={{text}}", payload.TerminatePostUri);
+            Assert.Equal($"{BaseUrl}/instances/{instanceId}/suspend?reason={{text}}", payload.SuspendPostUri);
+            Assert.Equal($"{BaseUrl}/instances/{instanceId}/resume?reason={{text}}", payload.ResumePostUri);
         }
 
         private static void AssertOrhcestrationMetadata(OrchestrationMetadata expectedResult, dynamic actualResult)


### PR DESCRIPTION
Fixes #2705.

### Problem
In the .NET isolated model, `CreateHttpManagementPayload` produced management URIs with a malformed reason placeholder — e.g. `.../terminate?reason={{text}}` (doubled braces) instead of `.../terminate?reason={text}`. This affected `terminatePostUri`, `rewindPostUri`, `suspendPostUri` and `resumePostUri`, and diverged from the in-proc host output.

### Root cause
`DurableTaskClientExtensions.CreateHttpManagementPayload` passed the reason as a **non-interpolated** string literal `"reason={{text}}"` to `BuildUrl`. In a plain C# string literal `{{` is not an escape sequence, so the doubled braces were emitted verbatim. `BuildUrl` only concatenates, so nothing collapsed them. (The neighboring `SendEventPostUri` uses an interpolated `\$"...{{eventName}}"` string, where `{{` correctly collapses to a single brace — which is likely why the discrepancy was missed.)

The in-proc host (`HttpApiHandler`) emits single-brace `reason={text}` placeholders, so this brings the isolated model in line.

### Fix
- Use single-brace `"reason={text}"` for the terminate/rewind/suspend/resume URIs.
- Update `FunctionsDurableTaskClientTests`, which previously asserted the doubled-brace output.

### Testing
`FunctionsDurableTaskClientTests` pass on net8.0 (11/11).