### PR TITLE
Fix empty operation names with Distributed Tracing V2 (#3156)

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -25,6 +25,7 @@
 ### Bug Fixes
 
 - Fixed a poison loop where dispatching a disabled-but-still-deployed activity or entity function caused in-flight orchestrations to retry indefinitely (e.g. throwing `ArgumentNullException('executor')` on the activity dispatch path) instead of failing gracefully. Such registered-but-inactive functions are now treated as unavailable and fail deterministically. (#3471)
+- Fixed empty Application Insights operation names for Distributed Tracing V2 orchestration and activity telemetry when instance ID suffixes are disabled. (#3156)
 
 ### Breaking Changes
 

--- a/src/WebJobs.Extensions.DurableTask/Correlation/DurableTaskInstanceIdTelemetryInitializer.cs
+++ b/src/WebJobs.Extensions.DurableTask/Correlation/DurableTaskInstanceIdTelemetryInitializer.cs
@@ -4,6 +4,7 @@
 using System.Diagnostics;
 using Microsoft.ApplicationInsights.Channel;
 using Microsoft.ApplicationInsights.Extensibility;
+using Microsoft.ApplicationInsights.Extensibility.Implementation;
 
 #nullable enable
 
@@ -20,6 +21,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Correlation
 
         public void Initialize(ITelemetry telemetry)
         {
+            if (telemetry is OperationTelemetry operationTelemetry &&
+                string.IsNullOrEmpty(telemetry.Context.Operation.Name) &&
+                !string.IsNullOrEmpty(operationTelemetry.Name))
+            {
+                telemetry.Context.Operation.Name = operationTelemetry.Name;
+            }
+
             if (!this.includeInstanceId)
             {
                 return;
@@ -33,7 +41,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Correlation
 
             // Check if it is an orchestration, activity, or entity span
             string? type = activity.GetTagItem(Schema.Task.Type) as string;
-            string? operation = activity.GetTagItem(Schema.Task.Operation) as string;
 
             // Support orchestration, activity, and entity spans
             if (type != TraceActivityConstants.Orchestration &&
@@ -42,6 +49,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Correlation
             {
                 return;
             }
+
+            string? operation = activity.GetTagItem(Schema.Task.Operation) as string;
 
             // Exclude create_orchestration spans via operation tag
             if (operation == TraceActivityConstants.CreateOrchestration)
@@ -52,12 +61,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Correlation
             string? instanceId = activity.GetTagItem(Schema.Task.InstanceId) as string;
             if (!string.IsNullOrEmpty(instanceId))
             {
-                // If the operation name is empty, use the activity display name
-                if (string.IsNullOrEmpty(telemetry.Context.Operation.Name))
-                {
-                    telemetry.Context.Operation.Name = activity.DisplayName;
-                }
-
                 // Append instance ID to operation name if not already present
                 if (!telemetry.Context.Operation.Name.Contains(instanceId))
                 {

--- a/src/WebJobs.Extensions.DurableTask/Correlation/DurableTaskInstanceIdTelemetryInitializer.cs
+++ b/src/WebJobs.Extensions.DurableTask/Correlation/DurableTaskInstanceIdTelemetryInitializer.cs
@@ -61,6 +61,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Correlation
             string? instanceId = activity.GetTagItem(Schema.Task.InstanceId) as string;
             if (!string.IsNullOrEmpty(instanceId))
             {
+                if (string.IsNullOrEmpty(telemetry.Context.Operation.Name))
+                {
+                    telemetry.Context.Operation.Name = activity.DisplayName;
+                }
+
                 // Append instance ID to operation name if not already present
                 if (!telemetry.Context.Operation.Name.Contains(instanceId))
                 {

--- a/test/FunctionsV2/Helpers/DurableTaskInstanceIdTelemetryInitializerTests.cs
+++ b/test/FunctionsV2/Helpers/DurableTaskInstanceIdTelemetryInitializerTests.cs
@@ -169,6 +169,36 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         }
 
         /// <summary>
+        /// Verifies that telemetry without its own Name falls back to the current Activity display name.
+        /// </summary>
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public void Initialize_WithNonOperationTelemetryAndEmptyOperationName_SetsFromActivityAndAppends()
+        {
+            // Arrange
+            var initializer = new DurableTaskInstanceIdTelemetryInitializer(true);
+            var telemetry = new ExceptionTelemetry();
+
+            using var activity = new Activity("orchestration:Function1");
+            activity.SetTag(Schema.Task.Type, TraceActivityConstants.Orchestration);
+            activity.SetTag(Schema.Task.InstanceId, "test-instance-id");
+            activity.Start();
+
+            try
+            {
+                // Act
+                initializer.Initialize(telemetry);
+
+                // Assert
+                Assert.Equal("orchestration:Function1 (test-instance-id)", telemetry.Context.Operation.Name);
+            }
+            finally
+            {
+                activity.Stop();
+            }
+        }
+
+        /// <summary>
         /// Verifies that activity function spans (not to be confused with System.Diagnostics.Activity)
         /// also have the instance ID appended when the feature is enabled.
         /// </summary>

--- a/test/FunctionsV2/Helpers/DurableTaskInstanceIdTelemetryInitializerTests.cs
+++ b/test/FunctionsV2/Helpers/DurableTaskInstanceIdTelemetryInitializerTests.cs
@@ -9,9 +9,8 @@ using Xunit;
 namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 {
     /// <summary>
-    /// Tests for <see cref="DurableTaskInstanceIdTelemetryInitializer"/> which appends
-    /// the orchestration instance ID to the Application Insights Operation.Name for
-    /// better filtering and searching in the Failures and Performance tabs.
+    /// Tests for <see cref="DurableTaskInstanceIdTelemetryInitializer"/> which populates
+    /// Application Insights Operation.Name and optionally appends the orchestration instance ID.
     /// </summary>
     public class DurableTaskInstanceIdTelemetryInitializerTests
     {
@@ -80,6 +79,27 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         }
 
         /// <summary>
+        /// Verifies that disabling instance ID suffixes does not leave the operation name empty.
+        /// </summary>
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public void Initialize_WithIncludeInstanceIdFalseAndNoCurrentActivity_SetsFromTelemetryName()
+        {
+            // Arrange
+            var initializer = new DurableTaskInstanceIdTelemetryInitializer(false);
+            var telemetry = new DependencyTelemetry
+            {
+                Name = "orchestration:Function1",
+            };
+
+            // Act
+            initializer.Initialize(telemetry);
+
+            // Assert
+            Assert.Equal("orchestration:Function1", telemetry.Context.Operation.Name);
+        }
+
+        /// <summary>
         /// Verifies that create_orchestration spans are excluded from instance ID appending.
         /// The instance ID should only appear on the orchestration execution span, not the
         /// span that represents the client scheduling the orchestration.
@@ -115,17 +135,19 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
         /// <summary>
         /// Verifies that when Operation.Name is empty (which can happen in the Failures tab),
-        /// the initializer first sets it from the Activity.DisplayName before appending the instance ID.
+        /// the initializer first sets it from the telemetry name before appending the instance ID.
         /// This fixes the issue where failures show an empty operation name.
         /// </summary>
         [Fact]
         [Trait("Category", PlatformSpecificHelpers.TestCategory)]
-        public void Initialize_WithEmptyOperationName_SetsFromActivityAndAppends()
+        public void Initialize_WithEmptyOperationName_SetsFromTelemetryNameAndAppends()
         {
             // Arrange
             var initializer = new DurableTaskInstanceIdTelemetryInitializer(true);
-            var telemetry = new DependencyTelemetry();
-            telemetry.Context.Operation.Name = null; // Empty
+            var telemetry = new DependencyTelemetry
+            {
+                Name = "orchestration:Function1",
+            };
 
             using var activity = new Activity("orchestration:Function1");
             activity.SetTag(Schema.Task.Type, TraceActivityConstants.Orchestration);

--- a/test/FunctionsV2/Tests/E2E/CorrelationEndToEndTests.cs
+++ b/test/FunctionsV2/Tests/E2E/CorrelationEndToEndTests.cs
@@ -10,6 +10,7 @@ using DurableTask.Core;
 using Microsoft.ApplicationInsights.Channel;
 using Microsoft.ApplicationInsights.DataContracts;
 using Microsoft.ApplicationInsights.Extensibility.Implementation;
+using Microsoft.Azure.WebJobs.Extensions.DurableTask.Correlation;
 using Microsoft.Azure.WebJobs.Extensions.DurableTask.Options;
 using Microsoft.Azure.WebJobs.Host.TestCommon;
 using Moq;
@@ -92,6 +93,35 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             // Using actual.First() because there's only one Request Telemetry where the name is "DtActivity Hello"
             RequestTelemetry dtActivityReqTelemetry = traceTelemetry.First(x => x.GetType() == typeof(RequestTelemetry) && x.Name.Contains(TraceConstants.Activity)) as RequestTelemetry;
             Assert.Equal("Hello", dtActivityReqTelemetry.Context.Operation.Name);
+        }
+
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public async Task DistributedTracingV2_DefaultOperationNames_ArePopulated()
+        {
+            string[] orchestrationFunctionNames =
+            {
+                nameof(TestOrchestrations.SayHelloWithActivity),
+            };
+
+            var result = await this.ExecuteOrchestrationWithExceptionAsync(
+                orchestrationFunctionNames,
+                "DistributedTracingV2OperationNames",
+                "world",
+                extendedSessions: false,
+                protocol: "W3CTraceContext",
+                version: DurableDistributedTracingVersion.V2);
+
+            List<OperationTelemetry> durableTaskTelemetry = result.Item1
+                .Where(telemetry =>
+                    telemetry.Name.StartsWith($"{TraceActivityConstants.Orchestration}:", StringComparison.Ordinal) ||
+                    telemetry.Name.StartsWith($"{TraceActivityConstants.Activity}:", StringComparison.Ordinal))
+                .ToList();
+
+            Assert.NotEmpty(durableTaskTelemetry);
+            Assert.All(
+                durableTaskTelemetry,
+                telemetry => Assert.Equal(telemetry.Name, telemetry.Context.Operation.Name));
         }
 
         [Theory]
@@ -177,13 +207,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 string testName,
                 object input,
                 bool extendedSessions,
-                string protocol)
+                string protocol,
+                DurableDistributedTracingVersion version = DurableDistributedTracingVersion.V1)
         {
             ConcurrentQueue<ITelemetry> sendItems = new ConcurrentQueue<ITelemetry>();
             TraceOptions traceOptions = new TraceOptions()
             {
                 DistributedTracingEnabled = true,
                 DistributedTracingProtocol = protocol,
+                Version = version,
             };
             DurableTaskOptions options = new DurableTaskOptions();
             options.Tracing = traceOptions;
@@ -377,7 +409,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         private IEnumerable<OperationTelemetry> FilterOperationTelemetry(IEnumerable<OperationTelemetry> operationTelemetries)
         {
             return operationTelemetries.Where(
-                p => p.Name.Contains(TraceConstants.Activity) || p.Name.Contains(TraceConstants.Orchestrator) || p.Name.Contains(TraceConstants.Client) || p.Name.Contains("Operation"));
+                p => p.Name.Contains(TraceConstants.Activity) ||
+                    p.Name.Contains(TraceConstants.Orchestrator) ||
+                    p.Name.Contains(TraceConstants.Client) ||
+                    p.Name.Contains("Operation") ||
+                    p.Name.StartsWith($"{TraceActivityConstants.Orchestration}:", StringComparison.Ordinal) ||
+                    p.Name.StartsWith($"{TraceActivityConstants.Activity}:", StringComparison.Ordinal));
         }
 
         private List<ITelemetry> ConvertTo(ConcurrentQueue<ITelemetry> queue)


### PR DESCRIPTION
# Summary
## What changed?
- Populate an empty Application Insights `operation_Name` from the existing `OperationTelemetry.Name`.
- Preserve the existing opt-in orchestration instance ID suffix behavior.
- Add focused unit coverage and a real Distributed Tracing V2 orchestration/activity E2E regression.
- Add a release note for the user-visible bug fix.

## Why is this change needed?
- The V2 Durable Task telemetry exporter sets the request/dependency telemetry `Name`, but leaves `Context.Operation.Name` empty.
- The existing initializer only repaired that field when `IncludeInstanceIdInOperationName` was enabled, even though the option defaults to `false`.
- As a result, default V2 telemetry could appear under an empty operation name in Application Insights.

## Issues / work items
- Resolves #3156
- Related #3266

---

# Project checklist
- [x] Documentation changes are not required
  - [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
- [ ] Release notes are not required for the next release
  - [x] Otherwise: Notes added to `release_notes.md`
- [x] Backport is not required
  - [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
- [x] All required tests have been added/updated (unit tests, E2E tests)
- [x] No extra work is required to be leveraged by OutOfProc SDKs
  - [ ] Otherwise: Work tracked here: #issue_or_pr_in_each_sdk
- [x] No change to the version of the `WebJobs.Extensions.DurableTask` package
  - [ ] Otherwise: Major/minor updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
- [x] No EventIds were added to `EventSource` logs
  - [ ] Otherwise: Ensure EventIds are within the supported range in the existing Windows infrastructure (validate via deployed telemetry). If needed, extend the range via a PR such as https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files
- [ ] This change should be added to the `v2.x` branch
  - [x] Otherwise: This change applies exclusively to `WebJobs.Extensions.DurableTask` v3.x and will be retained only in the `dev` and `main` branches
- [ ] Breaking change?
  - [ ] If yes:
    - Impact:
    - Migration guidance:

---

# AI-assisted code disclosure (required)
## Was an AI tool used? (select one)
- [ ] No
- [ ] Yes, AI helped write parts of this PR (e.g., GitHub Copilot)
- [x] Yes, an AI agent generated most of this PR

If AI was used:
- Tool(s): GitHub Copilot CLI (GPT-5.6 Sol)
- AI-assisted areas/files: telemetry initializer, unit regression, correlation E2E regression, and release note
- What you changed after AI output: The initial `Activity.Current`-based implementation was rejected after the full E2E suite exposed missing ambient activity state. The final revision uses the telemetry's explicit `Name` value and was reviewed against the complete diff and local evidence.

AI verification (required if AI was used):
- [x] I understand the code and can explain it
- [x] I verified referenced APIs/types exist and are correct
- [x] I reviewed edge cases/failure paths (timeouts, retries, cancellation, exceptions)
- [x] I reviewed concurrency/async behavior
- [x] I checked for unintended breaking or behavior changes

---

# Testing
## Automated tests
- Result: Passed
  - Focused unit + V2 E2E regressions: 2/2
  - Non-operation telemetry regression: 1/1
  - `DurableTaskInstanceIdTelemetryInitializerTests`: 9/9 on .NET 8 and 9/9 on .NET 10
  - `CorrelationEndToEndTests`: 29/29 on .NET 8
  - New V2 E2E regression: 1/1 on .NET 10

## Manual validation (only if runtime/behavior changed)
- Environment (OS, .NET version, components): Windows, .NET 8/.NET 10, local Functions V2 test host, Azurite
- Steps + observed results:
  1. Ran the new V2 orchestration/activity E2E regression against the original implementation. The orchestration request, activity dependency, and activity request all had `Context.Operation.Name == null`.
  2. Applied the fix and reran the same path. Each operation name matched its existing telemetry name (`orchestration:SayHelloWithActivity` or `activity:Hello`).
  3. Ran the focused and full correlation test suites listed above.
  4. Deployed the PR build to a temporary Windows Consumption Function App with Application Insights and ran five `FunctionChaining` orchestrations. All five completed.
  5. Queried the ingested `requests` telemetry. The 25 requests were grouped under `activity:SayHelloActivity` (15), `orchestration:FunctionChaining` (5), and `DurableFunctionsPatterns_HttpStart` (5), with zero empty operation names.
- Evidence (optional): Local red/green and live Azure query screenshots were captured. The temporary Azure resource group was deleted after validation.

---

# Notes for reviewers
- Baseline operation-name population intentionally does not depend on `Activity.Current`; the full correlation suite demonstrated that ambient activity state is not always available when telemetry is initialized.
- Existing nonempty operation names are not overwritten, and instance ID suffixing remains opt-in.
- The upstream `Azure/durabletask` V2 exporter still omits `Context.Operation.Name`; this extension-side initializer fix provides immediate coverage without expanding this PR's scope.
