### PR TITLE
Optimize typed interface discovery during startup

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/TypedCodeProvider.cs
+++ b/src/WebJobs.Extensions.DurableTask/TypedCodeProvider.cs
@@ -2,8 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
+using System.IO;
 using System.Reflection;
 
 namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
@@ -27,6 +26,21 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         public const string TypedDurableOrchestrationStarter = "TypedDurableOrchestrationStarter";
         public const string ITypedDurableOrchestrationStarter = "ITypedDurableOrchestrationStarter";
 
+        private const string TypedDurableOrchestrationContextFullName =
+            Namespace + "." + TypedDurableOrchestrationContext;
+
+        private const string TypedDurableClientFullName =
+            Namespace + "." + TypedDurableClient;
+
+        private const string TypedDurableOrchestrationCallerFullName =
+            Namespace + "." + TypedDurableOrchestrationCaller;
+
+        private const string TypedDurableActivityCallerFullName =
+            Namespace + "." + TypedDurableActivityCaller;
+
+        private const string TypedDurableOrchestrationStarterFullName =
+            Namespace + "." + TypedDurableOrchestrationStarter;
+
         private Type typedDurableOrchestrationContextType;
         private Type typedDurableClientType;
 
@@ -42,26 +56,80 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
         public void Initialize()
         {
-            var types = AppDomain.CurrentDomain.GetAssemblies().SelectMany(t =>
+            this.Initialize(AppDomain.CurrentDomain.GetAssemblies());
+        }
+
+        internal void Initialize(Assembly[] assemblies)
+        {
+            this.typedDurableOrchestrationContextType = null;
+            this.typedDurableClientType = null;
+            this.typedDurableOrchestrationCallerType = null;
+            this.typedDurableActivityCallerType = null;
+            this.typedDurableOrchestrationStarterType = null;
+            this.IsInitialized = false;
+
+            foreach (Assembly assembly in assemblies)
             {
+                Type typedDurableOrchestrationContextType = this.typedDurableOrchestrationContextType;
+                Type typedDurableClientType = this.typedDurableClientType;
+                Type typedDurableOrchestrationCallerType = this.typedDurableOrchestrationCallerType;
+                Type typedDurableActivityCallerType = this.typedDurableActivityCallerType;
+                Type typedDurableOrchestrationStarterType = this.typedDurableOrchestrationStarterType;
+
                 try
                 {
-                    return t.DefinedTypes;
+                    typedDurableOrchestrationContextType ??= assembly.GetType(
+                        TypedDurableOrchestrationContextFullName,
+                        throwOnError: false,
+                        ignoreCase: false);
+                    typedDurableClientType ??= assembly.GetType(
+                        TypedDurableClientFullName,
+                        throwOnError: false,
+                        ignoreCase: false);
+                    typedDurableOrchestrationCallerType ??= assembly.GetType(
+                        TypedDurableOrchestrationCallerFullName,
+                        throwOnError: false,
+                        ignoreCase: false);
+                    typedDurableActivityCallerType ??= assembly.GetType(
+                        TypedDurableActivityCallerFullName,
+                        throwOnError: false,
+                        ignoreCase: false);
+                    typedDurableOrchestrationStarterType ??= assembly.GetType(
+                        TypedDurableOrchestrationStarterFullName,
+                        throwOnError: false,
+                        ignoreCase: false);
                 }
-                catch
+                catch (Exception exception) when (IsAssemblyInspectionException(exception))
                 {
-                    return new List<TypeInfo>();
+                    continue;
                 }
-            }).ToList();
 
-            this.typedDurableOrchestrationContextType = types.FirstOrDefault(t => t.FullName == $"{Namespace}.{TypedDurableOrchestrationContext}");
-            this.typedDurableClientType = types.FirstOrDefault(t => t.FullName == $"{Namespace}.{TypedDurableClient}");
+                this.typedDurableOrchestrationContextType = typedDurableOrchestrationContextType;
+                this.typedDurableClientType = typedDurableClientType;
+                this.typedDurableOrchestrationCallerType = typedDurableOrchestrationCallerType;
+                this.typedDurableActivityCallerType = typedDurableActivityCallerType;
+                this.typedDurableOrchestrationStarterType = typedDurableOrchestrationStarterType;
 
-            this.typedDurableOrchestrationCallerType = types.FirstOrDefault(t => t.FullName == $"{Namespace}.{TypedDurableOrchestrationCaller}");
-            this.typedDurableActivityCallerType = types.FirstOrDefault(t => t.FullName == $"{Namespace}.{TypedDurableActivityCaller}");
-            this.typedDurableOrchestrationStarterType = types.FirstOrDefault(t => t.FullName == $"{Namespace}.{TypedDurableOrchestrationStarter}");
+                if (this.AreAllTypesResolved())
+                {
+                    this.IsInitialized = true;
+                    return;
+                }
+            }
+        }
 
-            this.IsInitialized = this.typedDurableOrchestrationContextType != null &&
+        private static bool IsAssemblyInspectionException(Exception exception)
+        {
+            return exception is FileNotFoundException ||
+                exception is FileLoadException ||
+                exception is BadImageFormatException ||
+                exception is TypeLoadException ||
+                exception is ReflectionTypeLoadException;
+        }
+
+        private bool AreAllTypesResolved()
+        {
+            return this.typedDurableOrchestrationContextType != null &&
                 this.typedDurableClientType != null &&
                 this.typedDurableOrchestrationCallerType != null &&
                 this.typedDurableActivityCallerType != null &&

--- a/test/FunctionsV2/Tests/Unit/TypedCodeProviderTests.cs
+++ b/test/FunctionsV2/Tests/Unit/TypedCodeProviderTests.cs
@@ -1,0 +1,289 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using System.Reflection.Emit;
+using Moq;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
+{
+    public class TypedCodeProviderTests
+    {
+        private const string TypedDurableOrchestrationContextFullName =
+            TypedCodeProvider.Namespace + "." + TypedCodeProvider.TypedDurableOrchestrationContext;
+
+        private const string TypedDurableClientFullName =
+            TypedCodeProvider.Namespace + "." + TypedCodeProvider.TypedDurableClient;
+
+        private const string TypedDurableOrchestrationCallerFullName =
+            TypedCodeProvider.Namespace + "." + TypedCodeProvider.TypedDurableOrchestrationCaller;
+
+        private const string TypedDurableActivityCallerFullName =
+            TypedCodeProvider.Namespace + "." + TypedCodeProvider.TypedDurableActivityCaller;
+
+        private const string TypedDurableOrchestrationStarterFullName =
+            TypedCodeProvider.Namespace + "." + TypedCodeProvider.TypedDurableOrchestrationStarter;
+
+        private static readonly string[] RequiredTypeNames =
+        {
+            TypedDurableOrchestrationContextFullName,
+            TypedDurableClientFullName,
+            TypedDurableOrchestrationCallerFullName,
+            TypedDurableActivityCallerFullName,
+            TypedDurableOrchestrationStarterFullName,
+        };
+
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public void Initialize_NoGeneratedTypes_IsNotInitialized()
+        {
+            var provider = new TypedCodeProvider();
+
+            provider.Initialize(new[] { CreateAssembly() });
+
+            Assert.False(provider.IsInitialized);
+            Assert.Null(provider.TypedDurableOrchestrationContextType);
+            Assert.Null(provider.TypedDurableClientType);
+        }
+
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public void Initialize_PartialGeneratedTypes_IsNotInitialized()
+        {
+            Assembly assembly = CreateAssembly(
+                TypedDurableOrchestrationContextFullName,
+                TypedDurableClientFullName,
+                TypedDurableOrchestrationCallerFullName,
+                TypedDurableActivityCallerFullName);
+            var provider = new TypedCodeProvider();
+
+            provider.Initialize(new[] { assembly });
+
+            Assert.False(provider.IsInitialized);
+            Assert.Same(
+                assembly.GetType(TypedDurableOrchestrationContextFullName, throwOnError: false, ignoreCase: false),
+                provider.TypedDurableOrchestrationContextType);
+            Assert.Same(
+                assembly.GetType(TypedDurableClientFullName, throwOnError: false, ignoreCase: false),
+                provider.TypedDurableClientType);
+        }
+
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public void Initialize_AllGeneratedTypesAcrossAssemblies_IsInitialized()
+        {
+            Assembly contextAssembly = CreateAssembly(
+                TypedDurableOrchestrationContextFullName,
+                TypedDurableOrchestrationCallerFullName);
+            Assembly clientAssembly = CreateAssembly(
+                TypedDurableClientFullName,
+                TypedDurableOrchestrationStarterFullName);
+            Assembly activityAssembly = CreateAssembly(TypedDurableActivityCallerFullName);
+            var provider = new TypedCodeProvider();
+
+            provider.Initialize(new[] { contextAssembly, clientAssembly, activityAssembly });
+
+            Assert.True(provider.IsInitialized);
+            Assert.Same(
+                contextAssembly.GetType(TypedDurableOrchestrationContextFullName, throwOnError: false, ignoreCase: false),
+                provider.TypedDurableOrchestrationContextType);
+            Assert.Same(
+                clientAssembly.GetType(TypedDurableClientFullName, throwOnError: false, ignoreCase: false),
+                provider.TypedDurableClientType);
+        }
+
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public void Initialize_TypeNamesDifferOnlyByCase_IsNotInitialized()
+        {
+            string[] typeNames = Array.ConvertAll(RequiredTypeNames, name => name.ToLowerInvariant());
+            var provider = new TypedCodeProvider();
+
+            provider.Initialize(new[] { CreateAssembly(typeNames) });
+
+            Assert.False(provider.IsInitialized);
+        }
+
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public void Initialize_DoesNotEnumerateDefinedTypes()
+        {
+            var assembly = new Mock<Assembly>(MockBehavior.Strict);
+            assembly
+                .Setup(a => a.GetType(It.IsAny<string>(), false, false))
+                .Returns((string _, bool _, bool _) => null);
+            assembly
+                .SetupGet(a => a.DefinedTypes)
+                .Throws(new InvalidOperationException("DefinedTypes must not be enumerated."));
+            var provider = new TypedCodeProvider();
+
+            provider.Initialize(new[] { assembly.Object });
+
+            Assert.False(provider.IsInitialized);
+            assembly.VerifyGet(a => a.DefinedTypes, Times.Never);
+            assembly.Verify(
+                a => a.GetType(It.IsAny<string>(), false, false),
+                Times.Exactly(RequiredTypeNames.Length));
+        }
+
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public void Initialize_AllTypesFound_DoesNotInspectRemainingAssemblies()
+        {
+            Assembly completeAssembly = CreateAssembly(RequiredTypeNames);
+            var uninspectedAssembly = new Mock<Assembly>(MockBehavior.Strict);
+            var provider = new TypedCodeProvider();
+
+            provider.Initialize(new[] { completeAssembly, uninspectedAssembly.Object });
+
+            Assert.True(provider.IsInitialized);
+            uninspectedAssembly.VerifyNoOtherCalls();
+        }
+
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public void Initialize_AssemblyTypeLookupFails_ContinuesWithRemainingAssemblies()
+        {
+            var uninspectableAssembly = new Mock<Assembly>(MockBehavior.Strict);
+            uninspectableAssembly
+                .Setup(a => a.GetType(It.IsAny<string>(), false, false))
+                .Throws(new FileLoadException("Assembly cannot be inspected."));
+            Assembly completeAssembly = CreateAssembly(RequiredTypeNames);
+            var provider = new TypedCodeProvider();
+
+            provider.Initialize(new[] { uninspectableAssembly.Object, completeAssembly });
+
+            Assert.True(provider.IsInitialized);
+        }
+
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public void Initialize_UnexpectedTypeLookupFailure_IsNotSwallowed()
+        {
+            var assembly = new Mock<Assembly>(MockBehavior.Strict);
+            assembly
+                .Setup(a => a.GetType(It.IsAny<string>(), false, false))
+                .Throws(new ApplicationException("Unexpected lookup failure."));
+            var provider = new TypedCodeProvider();
+
+            Assert.Throws<ApplicationException>(() => provider.Initialize(new[] { assembly.Object }));
+        }
+
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public void Initialize_AllGeneratedTypes_PreservesTypedInstantiation()
+        {
+            var types = new Dictionary<string, Type>
+            {
+                [TypedDurableOrchestrationContextFullName] = typeof(TestTypedDurableOrchestrationContext),
+                [TypedDurableClientFullName] = typeof(TestTypedDurableClient),
+                [TypedDurableOrchestrationCallerFullName] = typeof(TestTypedDurableOrchestrationCaller),
+                [TypedDurableActivityCallerFullName] = typeof(TestTypedDurableActivityCaller),
+                [TypedDurableOrchestrationStarterFullName] = typeof(TestTypedDurableOrchestrationStarter),
+            };
+            var assembly = new Mock<Assembly>(MockBehavior.Strict);
+            assembly
+                .Setup(a => a.GetType(It.IsAny<string>(), false, false))
+                .Returns((string name, bool _, bool _) => types.TryGetValue(name, out Type type) ? type : null);
+            var provider = new TypedCodeProvider();
+            IDurableOrchestrationContext context = Mock.Of<IDurableOrchestrationContext>();
+            IDurableClient client = Mock.Of<IDurableClient>();
+
+            provider.Initialize(new[] { assembly.Object });
+
+            var typedContext = Assert.IsType<TestTypedDurableOrchestrationContext>(
+                provider.InstantiateTypedDurableOrchestrationContext(context));
+            var typedClient = Assert.IsType<TestTypedDurableClient>(
+                provider.InstantiateTypedDurableClient(client));
+            Assert.Same(context, typedContext.Context);
+            Assert.Same(context, typedContext.OrchestrationCaller.Context);
+            Assert.Same(context, typedContext.ActivityCaller.Context);
+            Assert.Same(client, typedClient.Client);
+            Assert.Same(client, typedClient.OrchestrationStarter.Client);
+        }
+
+        private static Assembly CreateAssembly(params string[] typeNames)
+        {
+            var assemblyName = new AssemblyName($"TypedCodeProviderTests_{Guid.NewGuid():N}");
+            AssemblyBuilder assembly = AssemblyBuilder.DefineDynamicAssembly(
+                assemblyName,
+                AssemblyBuilderAccess.RunAndCollect);
+            ModuleBuilder module = assembly.DefineDynamicModule("Main");
+
+            foreach (string typeName in typeNames)
+            {
+                module.DefineType(typeName, TypeAttributes.Public).CreateTypeInfo();
+            }
+
+            return assembly;
+        }
+
+        private sealed class TestTypedDurableOrchestrationContext
+        {
+            public TestTypedDurableOrchestrationContext(
+                IDurableOrchestrationContext context,
+                TestTypedDurableOrchestrationCaller orchestrationCaller,
+                TestTypedDurableActivityCaller activityCaller)
+            {
+                this.Context = context;
+                this.OrchestrationCaller = orchestrationCaller;
+                this.ActivityCaller = activityCaller;
+            }
+
+            public IDurableOrchestrationContext Context { get; }
+
+            public TestTypedDurableOrchestrationCaller OrchestrationCaller { get; }
+
+            public TestTypedDurableActivityCaller ActivityCaller { get; }
+        }
+
+        private sealed class TestTypedDurableClient
+        {
+            public TestTypedDurableClient(
+                IDurableClient client,
+                TestTypedDurableOrchestrationStarter orchestrationStarter)
+            {
+                this.Client = client;
+                this.OrchestrationStarter = orchestrationStarter;
+            }
+
+            public IDurableClient Client { get; }
+
+            public TestTypedDurableOrchestrationStarter OrchestrationStarter { get; }
+        }
+
+        private sealed class TestTypedDurableOrchestrationCaller
+        {
+            public TestTypedDurableOrchestrationCaller(IDurableOrchestrationContext context)
+            {
+                this.Context = context;
+            }
+
+            public IDurableOrchestrationContext Context { get; }
+        }
+
+        private sealed class TestTypedDurableActivityCaller
+        {
+            public TestTypedDurableActivityCaller(IDurableOrchestrationContext context)
+            {
+                this.Context = context;
+            }
+
+            public IDurableOrchestrationContext Context { get; }
+        }
+
+        private sealed class TestTypedDurableOrchestrationStarter
+        {
+            public TestTypedDurableOrchestrationStarter(IDurableClient client)
+            {
+                this.Client = client;
+            }
+
+            public IDurableClient Client { get; }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- replace global `DefinedTypes` enumeration and list materialization with targeted `Assembly.GetType` lookups for the five generated implementation types
- keep eager discovery during `DurableTaskExtension` construction and stop scanning as soon as all required types are resolved
- add focused regression coverage for absent, partial, complete, split-assembly, case-sensitive, early-stop, inspection-failure, and typed-instantiation behavior

## Performance rationale
The startup path now performs only case-sensitive lookups for unresolved generated type names and never enumerates unrelated types. This implements the lookup shape from the directional benchmark in #3486 (61.5 ms / 1.94 MB for full enumeration versus 0.31 ms / 10.6 KB for targeted lookup). This repository has no benchmark harness, so tests structurally assert that `DefinedTypes` is never touched and that assembly inspection stops after all five types are found.

## Backward compatibility
- no public API, binding name, configuration, or serialization changes
- preserves eager lifecycle timing, exact case-sensitive full names, first-match assembly order, and support for the five types being split across arbitrary loaded assemblies
- preserves all-or-nothing `IsInitialized` semantics and existing typed client/context construction
- preserves normal startup when typed interfaces are absent and typed binding registration when all required implementations are present
- skips expected assembly/type load failures per assembly while allowing unexpected failures to surface instead of broadly swallowing them

## Validation
Tests were added first; the initial targeted net8.0 run failed with CS1501 because the assembly-scoped initialization seam did not yet exist.

- `dotnet test test\FunctionsV2\WebJobs.Extensions.DurableTask.Tests.V2.csproj --filter "FullyQualifiedName~TypedCodeProviderTests" --no-restore --nologo`
  - net8.0: 9 passed, 0 failed
  - net10.0: 9 passed, 0 failed
- `dotnet build src\WebJobs.Extensions.DurableTask\WebJobs.Extensions.DurableTask.csproj --configuration Release --no-restore --nologo`
  - succeeded for net8.0 and net10.0 with 0 warnings and 0 errors

Fixes #3486