### PR TITLE
[Performance] Make deterministic GUID generation allocation-free

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/GuidManager.cs
+++ b/src/WebJobs.Extensions.DurableTask/GuidManager.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
+using System.Buffers;
 using System.Security.Cryptography;
 using System.Text;
 
@@ -12,9 +13,17 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
     /// </summary>
     internal static class GuidManager
     {
+        private const int NamespaceByteCount = 16;
+        private const int Sha1HashByteCount = 20;
+        private const int StackBufferByteCount = 256;
+
         internal const string DnsNamespaceValue = "9e952958-5e33-4daf-827f-2fa12937b875";
         internal const string UrlNamespaceValue = "9e952959-5e33-4daf-827f-2fa12937b875";
         internal const string IsoOidNamespaceValue = "9e952960-5e33-4daf-827f-2fa12937b875";
+
+        private static readonly Guid DnsNamespaceGuid = new Guid(DnsNamespaceValue);
+        private static readonly Guid UrlNamespaceGuid = new Guid(UrlNamespaceValue);
+        private static readonly Guid IsoOidNamespaceGuid = new Guid(IsoOidNamespaceValue);
 
         internal enum DeterministicGuidVersion
         {
@@ -39,41 +48,71 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 throw new ArgumentException("Please provide value for 'name'");
             }
 
-            Guid namespaceValueGuid = Guid.Parse(namespaceValue);
+            Guid namespaceValueGuid = ParseNamespace(namespaceValue);
+            int nameByteCount = Encoding.UTF8.GetByteCount(name);
+            int hashInputByteCount = NamespaceByteCount + nameByteCount;
+            byte[] rentedBuffer = null;
 
-            byte[] nameByteArray = Encoding.UTF8.GetBytes(name);
-            byte[] namespaceValueByteArray = namespaceValueGuid.ToByteArray();
-            SwapByteArrayValues(namespaceValueByteArray);
-
-            byte[] hashByteArray;
-            using (HashAlgorithm hashAlgorithm = version == DeterministicGuidVersion.V5
-                ? (HashAlgorithm)SHA1.Create() /* CodeQL [SM02196] Suppressed: SHA1 is not used for cryptographic purposes here. The information being hashed is not sensitive,
-                                                  and the goal is to generate a deterministic Guid. We cannot update to SHA2-based algorithms without breaking
-                                                  customers' inflight orchestrations. */
-                : MD5.Create()) /* CodeQL [SM02196] Suppressed: MD5 is not used for cryptographic purposes here. The information being hashed is not sensitive,
-                                   and the goal is to generate a deterministic Guid. We cannot update to SHA2-based algorithms without breaking
-                                   customers' inflight orchestrations. */
+            try
             {
-                hashAlgorithm.TransformBlock(namespaceValueByteArray, 0, namespaceValueByteArray.Length, null, 0);
-                hashAlgorithm.TransformFinalBlock(nameByteArray, 0, nameByteArray.Length);
-                hashByteArray = hashAlgorithm.Hash;
+                Span<byte> hashInput = hashInputByteCount <= StackBufferByteCount
+                    ? stackalloc byte[hashInputByteCount]
+                    : (rentedBuffer = ArrayPool<byte>.Shared.Rent(hashInputByteCount)).AsSpan(0, hashInputByteCount);
+                Span<byte> namespaceBytes = hashInput.Slice(0, NamespaceByteCount);
+                namespaceValueGuid.TryWriteBytes(namespaceBytes);
+                SwapByteArrayValues(namespaceBytes);
+                Encoding.UTF8.GetBytes(name.AsSpan(), hashInput.Slice(NamespaceByteCount));
+
+                Span<byte> hashBytes = stackalloc byte[Sha1HashByteCount];
+                if (version == DeterministicGuidVersion.V5)
+                {
+                    // CodeQL [SM02196] Suppressed: SHA1 is required for replay-compatible RFC 4122 V5 GUIDs.
+                    SHA1.HashData(hashInput, hashBytes);
+                }
+                else
+                {
+                    // CodeQL [SM02196] Suppressed: MD5 is required for replay-compatible RFC 4122 V3 GUIDs.
+                    MD5.HashData(hashInput, hashBytes);
+                }
+
+                int versionValue = version == DeterministicGuidVersion.V5 ? 5 : 3;
+                hashBytes[6] = (byte)((hashBytes[6] & 0x0F) | (versionValue << 4));
+                hashBytes[8] = (byte)((hashBytes[8] & 0x3F) | 0x80);
+                Span<byte> guidBytes = hashBytes.Slice(0, NamespaceByteCount);
+                SwapByteArrayValues(guidBytes);
+
+                return new Guid(guidBytes);
             }
-
-            byte[] newGuidByteArray = new byte[16];
-            Array.Copy(hashByteArray, 0, newGuidByteArray, 0, 16);
-
-            int versionValue = version == DeterministicGuidVersion.V5 ? 5 : 3;
-
-            newGuidByteArray[6] = (byte)((newGuidByteArray[6] & 0x0F) | (versionValue << 4));
-
-            newGuidByteArray[8] = (byte)((newGuidByteArray[8] & 0x3F) | 0x80);
-
-            SwapByteArrayValues(newGuidByteArray);
-
-            return new Guid(newGuidByteArray);
+            finally
+            {
+                if (rentedBuffer != null)
+                {
+                    ArrayPool<byte>.Shared.Return(rentedBuffer);
+                }
+            }
         }
 
-        private static void SwapByteArrayValues(byte[] byteArray)
+        private static Guid ParseNamespace(string namespaceValue)
+        {
+            if (namespaceValue == UrlNamespaceValue)
+            {
+                return UrlNamespaceGuid;
+            }
+
+            if (namespaceValue == DnsNamespaceValue)
+            {
+                return DnsNamespaceGuid;
+            }
+
+            if (namespaceValue == IsoOidNamespaceValue)
+            {
+                return IsoOidNamespaceGuid;
+            }
+
+            return Guid.Parse(namespaceValue);
+        }
+
+        private static void SwapByteArrayValues(Span<byte> byteArray)
         {
             SwapByteArrayElements(byteArray, 0, 3);
             SwapByteArrayElements(byteArray, 1, 2);
@@ -81,7 +120,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             SwapByteArrayElements(byteArray, 6, 7);
         }
 
-        private static void SwapByteArrayElements(byte[] byteArray, int left, int right)
+        private static void SwapByteArrayElements(Span<byte> byteArray, int left, int right)
         {
             byte temp = byteArray[left];
             byteArray[left] = byteArray[right];

--- a/test/FunctionsV2/Tests/Unit/GuidManagerTests.cs
+++ b/test/FunctionsV2/Tests/Unit/GuidManagerTests.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
+using System.Security.Cryptography;
+using System.Text;
 using Xunit;
 
 #pragma warning disable xUnit1025 // InlineData should be unique within the Theory it belongs to
@@ -9,6 +11,155 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 {
     public class GuidManagerTests
     {
+        private const string ArbitraryNamespaceValue = "{00112233-4455-6677-8899-AABBCCDDEEFF}";
+        private const int Version3 = (int)GuidManager.DeterministicGuidVersion.V3;
+        private const int Version5 = (int)GuidManager.DeterministicGuidVersion.V5;
+
+        [Theory]
+        [InlineData(GuidManager.DnsNamespaceValue, "durable-orchestration", Version3, "88d69f57-f159-341d-9480-c426fac9a13e")]
+        [InlineData(GuidManager.DnsNamespaceValue, "durable-orchestration", Version5, "6d46c360-942e-5558-8c07-d342dff008f0")]
+        [InlineData(GuidManager.UrlNamespaceValue, "durable-orchestration", Version3, "c4b8d656-a124-3e7c-9b3d-af865b7796d5")]
+        [InlineData(GuidManager.UrlNamespaceValue, "durable-orchestration", Version5, "6f29a180-0cf5-57ec-8693-6040fb49c731")]
+        [InlineData(GuidManager.IsoOidNamespaceValue, "durable-orchestration", Version3, "c1f7db5c-d329-33e4-87f3-48c8890ab69b")]
+        [InlineData(GuidManager.IsoOidNamespaceValue, "durable-orchestration", Version5, "ee4f9759-7b7e-5e72-83c7-a57ede615128")]
+        [InlineData(ArbitraryNamespaceValue, "instance_2026-07-27T20:30:10.3440000Z_42", Version3, "06c3aff0-9ad6-3592-a23a-880db62f1653")]
+        [InlineData(ArbitraryNamespaceValue, "instance_2026-07-27T20:30:10.3440000Z_42", Version5, "ad300818-c0c4-54d1-b99b-f12d2ee182a5")]
+        [InlineData(ArbitraryNamespaceValue, "café/東京/🚀", Version3, "d5242313-770a-3c00-845c-dd8bc3ea4b34")]
+        [InlineData(ArbitraryNamespaceValue, "café/東京/🚀", Version5, "5ed369f7-9646-51cb-be03-6cf98db5fb83")]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public void CreateDeterministicGuid_MatchesGoldenVector(
+            string namespaceValue,
+            string name,
+            int versionValue,
+            string expected)
+        {
+            var version = (GuidManager.DeterministicGuidVersion)versionValue;
+            Guid actual = GuidManager.CreateDeterministicGuid(namespaceValue, name, version);
+
+            Assert.Equal(new Guid(expected), actual);
+        }
+
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public void CreateDeterministicGuid_DefaultsToVersion5()
+        {
+            Guid actual = GuidManager.CreateDeterministicGuid(
+                ArbitraryNamespaceValue,
+                "instance_2026-07-27T20:30:10.3440000Z_42");
+
+            Assert.Equal(new Guid("ad300818-c0c4-54d1-b99b-f12d2ee182a5"), actual);
+        }
+
+        [Theory]
+        [InlineData(Version3, "420d27c1-f527-3646-930d-16638a2c49d5")]
+        [InlineData(Version5, "3a99fafb-17c3-5efd-a656-06a7a55fb83a")]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public void CreateDeterministicGuid_MatchesGoldenVector_ForLongName(
+            int versionValue,
+            string expected)
+        {
+            string name = new string('x', 1024) + "終";
+            var version = (GuidManager.DeterministicGuidVersion)versionValue;
+
+            Guid actual = GuidManager.CreateDeterministicGuid(ArbitraryNamespaceValue, name, version);
+
+            Assert.Equal(new Guid(expected), actual);
+        }
+
+        [Theory]
+        [InlineData(null, "name")]
+        [InlineData("", "name")]
+        [InlineData("not-a-guid", "name")]
+        [InlineData(" ", "name")]
+        [InlineData(GuidManager.UrlNamespaceValue, null)]
+        [InlineData(GuidManager.UrlNamespaceValue, "")]
+        [InlineData("not-a-guid", null)]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public void CreateDeterministicGuid_PreservesInvalidInputExceptions(string namespaceValue, string name)
+        {
+            Exception expected = Record.Exception(
+                () => CreateReferenceDeterministicGuid(namespaceValue, name, GuidManager.DeterministicGuidVersion.V5));
+            Exception actual = Record.Exception(
+                () => GuidManager.CreateDeterministicGuid(namespaceValue, name, GuidManager.DeterministicGuidVersion.V5));
+
+            Assert.NotNull(expected);
+            Assert.NotNull(actual);
+            Assert.Equal(expected.GetType(), actual.GetType());
+            Assert.Equal(expected.Message, actual.Message);
+            Assert.Equal((expected as ArgumentException)?.ParamName, (actual as ArgumentException)?.ParamName);
+        }
+
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public void CreateDeterministicGuid_PreservesUnknownVersionBehavior()
+        {
+            var version = (GuidManager.DeterministicGuidVersion)123;
+
+            Guid expected = CreateReferenceDeterministicGuid(GuidManager.UrlNamespaceValue, "name", version);
+            Guid actual = GuidManager.CreateDeterministicGuid(GuidManager.UrlNamespaceValue, "name", version);
+
+            Assert.Equal(expected, actual);
+            Assert.Equal(
+                GuidManager.CreateDeterministicGuid(GuidManager.UrlNamespaceValue, "name", GuidManager.DeterministicGuidVersion.V3),
+                actual);
+        }
+
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public void CreateDeterministicGuid_MatchesReferenceImplementation_ForRandomInputs()
+        {
+            const string CharacterSet = "abcXYZ019-_/ \0é中\uD83D\uDE80";
+            var random = new Random(3488);
+
+            for (int iteration = 0; iteration < 2048; iteration++)
+            {
+                var namespaceBytes = new byte[16];
+                random.NextBytes(namespaceBytes);
+                Guid namespaceGuid = new Guid(namespaceBytes);
+                string namespaceValue = FormatNamespace(namespaceGuid, iteration);
+                var nameCharacters = new char[random.Next(1, 1025)];
+                for (int characterIndex = 0; characterIndex < nameCharacters.Length; characterIndex++)
+                {
+                    nameCharacters[characterIndex] = CharacterSet[random.Next(CharacterSet.Length)];
+                }
+
+                string name = new string(nameCharacters);
+                GuidManager.DeterministicGuidVersion version = iteration % 2 == 0
+                    ? GuidManager.DeterministicGuidVersion.V3
+                    : GuidManager.DeterministicGuidVersion.V5;
+
+                Guid expected = CreateReferenceDeterministicGuid(namespaceValue, name, version);
+                Guid actual = GuidManager.CreateDeterministicGuid(namespaceValue, name, version);
+
+                Assert.Equal(expected, actual);
+            }
+        }
+
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public void CreateDeterministicGuid_DoesNotAllocateForRepresentativeName()
+        {
+            const string Name = "instance_2026-07-27T20:30:10.3440000Z_42";
+            const int Iterations = 1000;
+
+            for (int iteration = 0; iteration < 10; iteration++)
+            {
+                GuidManager.CreateDeterministicGuid(GuidManager.UrlNamespaceValue, Name);
+            }
+
+            int checksum = 0;
+            long allocatedBefore = GC.GetAllocatedBytesForCurrentThread();
+            for (int iteration = 0; iteration < Iterations; iteration++)
+            {
+                checksum += GuidManager.CreateDeterministicGuid(GuidManager.UrlNamespaceValue, Name).GetHashCode();
+            }
+
+            long allocatedBytes = GC.GetAllocatedBytesForCurrentThread() - allocatedBefore;
+
+            Assert.NotEqual(0, checksum);
+            Assert.Equal(0, allocatedBytes);
+        }
+
         [Theory]
         [InlineData(GuidManager.DnsNamespaceValue)]
         [InlineData(GuidManager.UrlNamespaceValue)]
@@ -48,6 +199,78 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             Guid firstGuid = GuidManager.CreateDeterministicGuid(firstNamespaceValue, name);
             Guid secondGuid = GuidManager.CreateDeterministicGuid(secondNamespaceValue, name);
             Assert.NotEqual(firstGuid, secondGuid);
+        }
+
+        private static Guid CreateReferenceDeterministicGuid(
+            string namespaceValue,
+            string name,
+            GuidManager.DeterministicGuidVersion version)
+        {
+            if (string.IsNullOrEmpty(namespaceValue))
+            {
+                throw new ArgumentException("Please provide value for 'namespace'");
+            }
+
+            if (string.IsNullOrEmpty(name))
+            {
+                throw new ArgumentException("Please provide value for 'name'");
+            }
+
+            Guid namespaceValueGuid = Guid.Parse(namespaceValue);
+
+            byte[] nameByteArray = Encoding.UTF8.GetBytes(name);
+            byte[] namespaceValueByteArray = namespaceValueGuid.ToByteArray();
+            SwapByteArrayValues(namespaceValueByteArray);
+
+            byte[] hashByteArray;
+            using (HashAlgorithm hashAlgorithm = version == GuidManager.DeterministicGuidVersion.V5
+                ? (HashAlgorithm)SHA1.Create()
+                : MD5.Create())
+            {
+                hashAlgorithm.TransformBlock(namespaceValueByteArray, 0, namespaceValueByteArray.Length, null, 0);
+                hashAlgorithm.TransformFinalBlock(nameByteArray, 0, nameByteArray.Length);
+                hashByteArray = hashAlgorithm.Hash;
+            }
+
+            var newGuidByteArray = new byte[16];
+            Array.Copy(hashByteArray, 0, newGuidByteArray, 0, newGuidByteArray.Length);
+
+            int versionValue = version == GuidManager.DeterministicGuidVersion.V5 ? 5 : 3;
+            newGuidByteArray[6] = (byte)((newGuidByteArray[6] & 0x0F) | (versionValue << 4));
+            newGuidByteArray[8] = (byte)((newGuidByteArray[8] & 0x3F) | 0x80);
+            SwapByteArrayValues(newGuidByteArray);
+
+            return new Guid(newGuidByteArray);
+        }
+
+        private static string FormatNamespace(Guid namespaceGuid, int iteration)
+        {
+            switch (iteration % 4)
+            {
+                case 0:
+                    return namespaceGuid.ToString("D");
+                case 1:
+                    return namespaceGuid.ToString("B").ToUpperInvariant();
+                case 2:
+                    return namespaceGuid.ToString("N");
+                default:
+                    return namespaceGuid.ToString("P");
+            }
+        }
+
+        private static void SwapByteArrayValues(byte[] byteArray)
+        {
+            SwapByteArrayElements(byteArray, 0, 3);
+            SwapByteArrayElements(byteArray, 1, 2);
+            SwapByteArrayElements(byteArray, 4, 5);
+            SwapByteArrayElements(byteArray, 6, 7);
+        }
+
+        private static void SwapByteArrayElements(byte[] byteArray, int left, int right)
+        {
+            byte temp = byteArray[left];
+            byteArray[left] = byteArray[right];
+            byteArray[right] = temp;
         }
     }
 }


### PR DESCRIPTION
# Summary
## What changed?
- Replaced per-call namespace/name/hash/GUID arrays and mutable `HashAlgorithm` instances with span-based encoding and one-shot hashing.
- Uses a conservative 256-byte stack threshold and always returns longer-name buffers rented from `ArrayPool<byte>`.
- Caches only the three immutable built-in namespace GUIDs; arbitrary namespace strings still use `Guid.Parse`.
- Added fixed V3/V5 golden vectors, exception parity tests, a 2,048-vector legacy-reference fuzz test, long/Unicode input coverage, and a zero-allocation assertion.

## Why is this change needed?
- Deterministic GUID generation runs during orchestration execution and replay. The previous implementation allocated 480 B per representative call in the test baseline (480,000 B over 1,000 calls); the optimized implementation measures 0 B steady-state on both target frameworks.
- The issue's directional benchmark measured roughly 2.5x helper CPU improvement for the same span/one-shot-hash design. This PR avoids adding benchmark-only dependencies and enforces the allocation target in the unit suite.

## Replay compatibility guarantee
- Outputs remain byte-for-byte identical: MD5/RFC 4122 V3 and SHA-1/RFC 4122 V5, UTF-8 encoding, namespace-then-name concatenation, network-byte-order swaps, version/variant bits, and default V5 behavior are unchanged.
- Arbitrary namespace formats, unknown enum fallback behavior, validation order, exception type/message, and argument metadata are covered against a test-only copy of the legacy implementation.
- Golden vectors cover every built-in namespace plus arbitrary, ASCII, non-ASCII, and pooled long-name inputs. The fuzz test covers both versions, all common GUID string formats, long names, and unpaired UTF-16 surrogate behavior.

## Issues / work items
- Fixes #3488

---

# Project checklist
- [x] Documentation changes are not required
- [x] Release notes are not required for the next release
- [x] Backport is not required
- [x] All required tests have been added/updated (unit tests, E2E tests)
- [x] No extra work is required to be leveraged by OutOfProc SDKs
- [x] No change to the version of the `WebJobs.Extensions.DurableTask` package
- [x] No EventIds were added to `EventSource` logs
- [ ] This change should be added to the `v2.x` branch
- [ ] Breaking change?

---

# AI-assisted code disclosure (required)
## Was an AI tool used? (select one)
- [ ] No
- [ ] Yes, AI helped write parts of this PR (e.g., GitHub Copilot)
- [x] Yes, an AI agent generated most of this PR

If AI was used:
- Tool(s): GitHub Copilot
- AI-assisted areas/files: `GuidManager.cs`, `GuidManagerTests.cs`
- What you changed after AI output: The final implementation and tests were reviewed against the legacy byte pipeline, target framework APIs, allocation behavior, and replay E2E coverage.

AI verification (required if AI was used):
- [x] I understand the code and can explain it
- [x] I verified referenced APIs/types exist and are correct
- [x] I reviewed edge cases/failure paths (timeouts, retries, cancellation, exceptions)
- [x] I reviewed concurrency/async behavior
- [x] I checked for unintended breaking or behavior changes

---

# Testing
## Automated tests
- `dotnet build .\test\FunctionsV2\WebJobs.Extensions.DurableTask.Tests.V2.csproj --configuration Release --framework net8.0 --no-restore --nologo --verbosity minimal`
  - Passed: 0 warnings, 0 errors.
- `dotnet build .\test\FunctionsV2\WebJobs.Extensions.DurableTask.Tests.V2.csproj --configuration Release --framework net10.0 --no-restore --nologo --verbosity minimal`
  - Passed: 0 warnings, 0 errors.
- `dotnet test .\test\FunctionsV2\WebJobs.Extensions.DurableTask.Tests.V2.csproj --configuration Release --framework net8.0 --no-build --filter "FullyQualifiedName~GuidManagerTests" --nologo --verbosity minimal`
  - Passed: 31/31.
- `dotnet test .\test\FunctionsV2\WebJobs.Extensions.DurableTask.Tests.V2.csproj --configuration Release --framework net10.0 --no-build --filter "FullyQualifiedName~GuidManagerTests" --nologo --verbosity minimal`
  - Passed: 31/31.
- `$env:AzureWebJobsStorage='UseDevelopmentStorage=true'; dotnet test .\test\FunctionsV2\WebJobs.Extensions.DurableTask.Tests.V2.csproj --configuration Release --framework <net8.0|net10.0> --no-build --filter "FullyQualifiedName~HelloWorldActivityTests.HelloWorldActivityWithNewGUID|FullyQualifiedName~HelloWorldActivityTests.VerifyUniqueGuids|FullyQualifiedName~HelloWorldActivityTests.VerifySameGuidsOnReplay" --nologo --verbosity minimal`
  - Passed: 6/6 on net8.0 and 6/6 on net10.0 against Azurite.

The Windows E2E harness normally starts an optional ETW listener that requires elevation. For the local E2E runs only, ETW capture was disabled in the built test binary; the source was restored before the final clean builds and is not part of this commit.

## Manual validation (only if runtime/behavior changed)
- Environment: Windows, .NET SDK 10.0.302, Azurite 3.35.0 with `--skipApiVersionCheck`.
- Observed result: deterministic GUID replay, uniqueness, and activity scenarios completed for extended sessions enabled and disabled on both target frameworks.

---

# Notes for reviewers
- Stack usage is bounded to 276 bytes (256-byte hash input plus 20-byte digest).
- The pooled buffer cannot escape the method and is returned from `finally`, including encoding or hashing failures.
