### PR TITLE
Gate suppressed replay traces before sanitization

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/EndToEndTraceHelper.cs
+++ b/src/WebJobs.Extensions.DurableTask/EndToEndTraceHelper.cs
@@ -220,10 +220,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             bool isReplay,
             int taskEventId = -1)
         {
-            this.SanitizeString(input, out string loggerInput, out string sanitizedInput);
-
             if (this.ShouldLogEvent(isReplay))
             {
+                this.SanitizeString(input, out string loggerInput, out string sanitizedInput);
+
                 EtwEventSource.Instance.FunctionStarting(
                     hubName,
                     LocalAppName,
@@ -308,10 +308,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             bool isReplay,
             int taskEventId = -1)
         {
-            this.SanitizeString(output, out string loggerOutput, out string sanitizedOutput);
-
             if (this.ShouldLogEvent(isReplay))
             {
+                this.SanitizeString(output, out string loggerOutput, out string sanitizedOutput);
+
                 EtwEventSource.Instance.FunctionCompleted(
                     hubName,
                     LocalAppName,
@@ -449,8 +449,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             bool isReplay,
             int taskEventId = -1)
         {
+            if (!this.ShouldLogEvent(isReplay))
+            {
+                return;
+            }
+
             this.SanitizeException(exception, out string loggerReason, out string sanitizedReason);
-            this.FunctionFailed(hubName, functionName, instanceId, loggerReason, sanitizedReason, functionType, isReplay, taskEventId);
+            this.WriteFunctionFailed(hubName, functionName, instanceId, loggerReason, sanitizedReason, functionType, isReplay, taskEventId);
         }
 
         public void FunctionFailed(
@@ -463,25 +468,40 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             bool isReplay,
             int taskEventId = -1)
         {
-            if (this.ShouldLogEvent(isReplay))
+            if (!this.ShouldLogEvent(isReplay))
             {
-                EtwEventSource.Instance.FunctionFailed(
-                    hubName,
-                    LocalAppName,
-                    LocalSlotName,
-                    functionName,
-                    taskEventId,
-                    instanceId,
-                    sanitizedReason,
-                    functionType.ToString(),
-                    ExtensionVersion,
-                    isReplay);
-
-                this.logger.LogError(
-                    "{instanceId}: Function '{functionName} ({functionType})' failed with an error. Reason: {reason}. IsReplay: {isReplay}. State: {state}. RuntimeStatus: {runtimeStatus}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}. SequenceNumber: {sequenceNumber}. TaskEventId: {taskEventId}",
-                    instanceId, functionName, functionType, reason, isReplay, FunctionState.Failed, OrchestrationRuntimeStatus.Failed, hubName,
-                    LocalAppName, LocalSlotName, ExtensionVersion, this.sequenceNumber++, taskEventId);
+                return;
             }
+
+            this.WriteFunctionFailed(hubName, functionName, instanceId, reason, sanitizedReason, functionType, isReplay, taskEventId);
+        }
+
+        private void WriteFunctionFailed(
+            string hubName,
+            string functionName,
+            string instanceId,
+            string reason,
+            string sanitizedReason,
+            FunctionType functionType,
+            bool isReplay,
+            int taskEventId)
+        {
+            EtwEventSource.Instance.FunctionFailed(
+                hubName,
+                LocalAppName,
+                LocalSlotName,
+                functionName,
+                taskEventId,
+                instanceId,
+                sanitizedReason,
+                functionType.ToString(),
+                ExtensionVersion,
+                isReplay);
+
+            this.logger.LogError(
+                "{instanceId}: Function '{functionName} ({functionType})' failed with an error. Reason: {reason}. IsReplay: {isReplay}. State: {state}. RuntimeStatus: {runtimeStatus}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}. SequenceNumber: {sequenceNumber}. TaskEventId: {taskEventId}",
+                instanceId, functionName, functionType, reason, isReplay, FunctionState.Failed, OrchestrationRuntimeStatus.Failed, hubName,
+                LocalAppName, LocalSlotName, ExtensionVersion, this.sequenceNumber++, taskEventId);
         }
 
         public void FunctionAborted(
@@ -519,11 +539,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
            double duration,
            bool isReplay)
         {
-            this.SanitizeString(input, out string loggerInput, out string sanitizedInput);
-            this.SanitizeString(output, out string loggerOutput, out string sanitizedOutput);
-
             if (this.ShouldLogEvent(isReplay))
             {
+                this.SanitizeString(input, out string loggerInput, out string sanitizedInput);
+                this.SanitizeString(output, out string loggerOutput, out string sanitizedOutput);
+
                 EtwEventSource.Instance.OperationCompleted(
                     hubName,
                     LocalAppName,
@@ -557,6 +577,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
            double duration,
            bool isReplay)
         {
+            if (!this.ShouldLogEvent(isReplay))
+            {
+                return;
+            }
+
             this.SanitizeString(input, out string loggerInput, out string sanitizedInput);
             this.SanitizeException(exception, out string loggerException, out string sanitizedException);
             this.OperationFailed(hubName, functionName, instanceId, operationId, operationName, sanitizedInput, loggerInput, sanitizedException, loggerException, duration, isReplay);
@@ -573,6 +598,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
            double duration,
            bool isReplay)
         {
+            if (!this.ShouldLogEvent(isReplay))
+            {
+                return;
+            }
+
             this.SanitizeString(input, out string loggerInput, out string sanitizedInput);
             this.SanitizeString(exception, out string loggerException, out string sanitizedException);
             this.OperationFailed(hubName, functionName, instanceId, operationId, operationName, sanitizedInput, loggerInput, sanitizedException, loggerException, duration, isReplay);
@@ -591,28 +621,25 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
            double duration,
            bool isReplay)
         {
-            if (this.ShouldLogEvent(isReplay))
-            {
-                EtwEventSource.Instance.OperationFailed(
-                    hubName,
-                    LocalAppName,
-                    LocalSlotName,
-                    functionName,
-                    instanceId,
-                    operationId,
-                    operationName,
-                    sanitizedInput,
-                    sanitizedException,
-                    duration,
-                    FunctionType.Entity.ToString(),
-                    ExtensionVersion,
-                    isReplay);
+            EtwEventSource.Instance.OperationFailed(
+                hubName,
+                LocalAppName,
+                LocalSlotName,
+                functionName,
+                instanceId,
+                operationId,
+                operationName,
+                sanitizedInput,
+                sanitizedException,
+                duration,
+                FunctionType.Entity.ToString(),
+                ExtensionVersion,
+                isReplay);
 
-                this.logger.LogError(
-                    "{instanceId}: Function '{functionName} ({functionType})' failed '{operationName}' operation {operationId} after {duration}ms with exception {exception}. Input: {input}. IsReplay: {isReplay}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}. SequenceNumber: {sequenceNumber}.",
-                    instanceId, functionName, FunctionType.Entity, operationName, operationId, duration, loggerException, loggerInput, isReplay, hubName,
-                    LocalAppName, LocalSlotName, ExtensionVersion, this.sequenceNumber++);
-            }
+            this.logger.LogError(
+                "{instanceId}: Function '{functionName} ({functionType})' failed '{operationName}' operation {operationId} after {duration}ms with exception {exception}. Input: {input}. IsReplay: {isReplay}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}. SequenceNumber: {sequenceNumber}.",
+                instanceId, functionName, FunctionType.Entity, operationName, operationId, duration, loggerException, loggerInput, isReplay, hubName,
+                LocalAppName, LocalSlotName, ExtensionVersion, this.sequenceNumber++);
         }
 
         public void ExternalEventRaised(
@@ -623,10 +650,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             string input,
             bool isReplay)
         {
-            this.SanitizeString(input, out string _, out string sanitizedInput);
-
             if (this.ShouldLogEvent(isReplay))
             {
+                this.SanitizeString(input, out string _, out string sanitizedInput);
+
                 FunctionType functionType = FunctionType.Orchestrator;
 
                 EtwEventSource.Instance.ExternalEventRaised(
@@ -742,10 +769,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             string result,
             bool isReplay)
         {
-            this.SanitizeString(result, out string _, out string sanitizedResult);
-
             if (this.ShouldLogEvent(isReplay))
             {
+                this.SanitizeString(result, out string _, out string sanitizedResult);
+
                 EtwEventSource.Instance.EntityResponseReceived(
                     hubName,
                     LocalAppName,

--- a/test/FunctionsV2/Tests/Unit/EndToEndTraceHelperTests.cs
+++ b/test/FunctionsV2/Tests/Unit/EndToEndTraceHelperTests.cs
@@ -4,6 +4,7 @@
 #nullable enable
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.Azure.WebJobs.Extensions.DurableTask;
 using Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests;
 using Microsoft.Extensions.Logging;
@@ -14,6 +15,63 @@ namespace WebJobs.Extensions.DurableTask.Tests.V2
 {
     public class EndToEndTraceHelperTests
     {
+        private const string HubName = "TestHub";
+        private const string FunctionName = "TraceFunction";
+        private const string InstanceId = "trace-instance";
+        private const string Input = "sensitive input";
+        private const string Output = "sensitive output";
+        private const string OperationInput = "operation input";
+        private const string OperationOutput = "operation output";
+        private const string SerializedException = "serialized exception";
+
+        public enum ReplayTraceMethod
+        {
+            FunctionStarting,
+            FunctionCompleted,
+            FunctionFailedException,
+            FunctionFailedStrings,
+            OperationCompleted,
+            OperationFailedException,
+            OperationFailedString,
+            ExternalEventRaised,
+            EntityResponseReceived,
+        }
+
+        public static IEnumerable<object[]> ReplayTraceCases
+        {
+            get
+            {
+                foreach (ReplayTraceMethod traceMethod in Enum.GetValues(typeof(ReplayTraceMethod)))
+                {
+                    foreach (bool shouldTraceRawData in new[] { false, true })
+                    {
+                        yield return new object[] { traceMethod, false, false, shouldTraceRawData };
+                        yield return new object[] { traceMethod, false, true, shouldTraceRawData };
+                        yield return new object[] { traceMethod, true, false, shouldTraceRawData };
+                        yield return new object[] { traceMethod, true, true, shouldTraceRawData };
+                    }
+                }
+            }
+        }
+
+        public static IEnumerable<object[]> ExceptionReplayCases
+        {
+            get
+            {
+                foreach (ReplayTraceMethod traceMethod in new[]
+                {
+                    ReplayTraceMethod.FunctionFailedException,
+                    ReplayTraceMethod.OperationFailedException,
+                })
+                {
+                    yield return new object[] { traceMethod, false, false };
+                    yield return new object[] { traceMethod, false, true };
+                    yield return new object[] { traceMethod, true, false };
+                    yield return new object[] { traceMethod, true, true };
+                }
+            }
+        }
+
         [Theory]
         [InlineData(true, "DO NOT LOG ME")]
         [InlineData(false, "DO NOT LOG ME")]
@@ -107,6 +165,84 @@ namespace WebJobs.Extensions.DurableTask.Tests.V2
             }
         }
 
+        [Theory]
+        [MemberData(nameof(ReplayTraceCases))]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public void ReplayAwareTraceMethodsRespectReplayConfiguration(
+            ReplayTraceMethod traceMethod,
+            bool isReplay,
+            bool traceReplayEvents,
+            bool shouldTraceRawData)
+        {
+            var logEntries = new List<LogEntry>();
+            var traceHelper = new EndToEndTraceHelper(
+                logger: new TestLogger(logEntries),
+                traceReplayEvents: traceReplayEvents,
+                shouldTraceRawData: shouldTraceRawData);
+            var exception = new InvalidOperationException("operation failure");
+
+            InvokeTraceMethod(traceHelper, traceMethod, isReplay, exception);
+
+            bool shouldLog = !isReplay || traceReplayEvents;
+            if (shouldLog)
+            {
+                LogEntry entry = Assert.Single(logEntries);
+                AssertTraceEntry(entry, traceMethod, isReplay, shouldTraceRawData, exception);
+            }
+            else
+            {
+                Assert.Empty(logEntries);
+            }
+
+            traceHelper.ExtensionWarningEvent(HubName, FunctionName, InstanceId, "sequence probe");
+
+            LogEntry sequenceProbe = logEntries.Last();
+            Assert.Equal(shouldLog ? 1L : 0L, GetStateValue<long>(sequenceProbe, "sequenceNumber"));
+        }
+
+        [Theory]
+        [MemberData(nameof(ExceptionReplayCases))]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public void FailureTraceExceptionFormattingRespectsReplayConfiguration(
+            ReplayTraceMethod traceMethod,
+            bool isReplay,
+            bool traceReplayEvents)
+        {
+            var exception = new TrackingException(throwOnToString: false);
+            var traceHelper = new EndToEndTraceHelper(
+                logger: new TestLogger(new List<LogEntry>()),
+                traceReplayEvents: traceReplayEvents);
+
+            InvokeTraceMethod(traceHelper, traceMethod, isReplay, exception);
+
+            Assert.Equal(!isReplay || traceReplayEvents ? 1 : 0, exception.ToStringCalls);
+        }
+
+        [Theory]
+        [InlineData(ReplayTraceMethod.FunctionFailedException)]
+        [InlineData(ReplayTraceMethod.OperationFailedException)]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public void SuppressedReplayFailureDoesNotEvaluateThrowingException(ReplayTraceMethod traceMethod)
+        {
+            var suppressedException = new TrackingException(throwOnToString: true);
+            var suppressedTraceHelper = new EndToEndTraceHelper(
+                logger: new TestLogger(new List<LogEntry>()),
+                traceReplayEvents: false);
+
+            InvokeTraceMethod(suppressedTraceHelper, traceMethod, isReplay: true, suppressedException);
+
+            Assert.Equal(0, suppressedException.ToStringCalls);
+
+            var enabledException = new TrackingException(throwOnToString: true);
+            var enabledTraceHelper = new EndToEndTraceHelper(
+                logger: new TestLogger(new List<LogEntry>()),
+                traceReplayEvents: true);
+
+            Assert.Throws<InvalidOperationException>(
+                () => InvokeTraceMethod(enabledTraceHelper, traceMethod, isReplay: true, enabledException));
+            Assert.Equal(1, enabledException.ToStringCalls);
+        }
+
         [Fact]
         [Trait("Category", PlatformSpecificHelpers.TestCategory)]
         public void ClientOperationReceived_LogsWhenInvocationIdProvided()
@@ -176,16 +312,247 @@ namespace WebJobs.Extensions.DurableTask.Tests.V2
             Assert.Empty(logMessages);
         }
 
+        private static void InvokeTraceMethod(
+            EndToEndTraceHelper traceHelper,
+            ReplayTraceMethod traceMethod,
+            bool isReplay,
+            Exception exception)
+        {
+            switch (traceMethod)
+            {
+                case ReplayTraceMethod.FunctionStarting:
+                    traceHelper.FunctionStarting(
+                        HubName,
+                        FunctionName,
+                        InstanceId,
+                        Input,
+                        FunctionType.Orchestrator,
+                        isReplay,
+                        taskEventId: 42);
+                    break;
+                case ReplayTraceMethod.FunctionCompleted:
+                    traceHelper.FunctionCompleted(
+                        HubName,
+                        FunctionName,
+                        InstanceId,
+                        Output,
+                        continuedAsNew: false,
+                        FunctionType.Orchestrator,
+                        isReplay,
+                        taskEventId: 42);
+                    break;
+                case ReplayTraceMethod.FunctionFailedException:
+                    traceHelper.FunctionFailed(
+                        HubName,
+                        FunctionName,
+                        InstanceId,
+                        exception,
+                        FunctionType.Orchestrator,
+                        isReplay,
+                        taskEventId: 42);
+                    break;
+                case ReplayTraceMethod.FunctionFailedStrings:
+                    traceHelper.FunctionFailed(
+                        HubName,
+                        FunctionName,
+                        InstanceId,
+                        reason: "preformatted reason",
+                        sanitizedReason: "preformatted sanitized reason",
+                        FunctionType.Orchestrator,
+                        isReplay,
+                        taskEventId: 42);
+                    break;
+                case ReplayTraceMethod.OperationCompleted:
+                    traceHelper.OperationCompleted(
+                        HubName,
+                        FunctionName,
+                        InstanceId,
+                        operationId: "operation-id",
+                        operationName: "operation",
+                        OperationInput,
+                        OperationOutput,
+                        duration: 12.5,
+                        isReplay);
+                    break;
+                case ReplayTraceMethod.OperationFailedException:
+                    traceHelper.OperationFailed(
+                        HubName,
+                        FunctionName,
+                        InstanceId,
+                        operationId: "operation-id",
+                        operationName: "operation",
+                        OperationInput,
+                        exception,
+                        duration: 12.5,
+                        isReplay);
+                    break;
+                case ReplayTraceMethod.OperationFailedString:
+                    traceHelper.OperationFailed(
+                        HubName,
+                        FunctionName,
+                        InstanceId,
+                        operationId: "operation-id",
+                        operationName: "operation",
+                        OperationInput,
+                        SerializedException,
+                        duration: 12.5,
+                        isReplay);
+                    break;
+                case ReplayTraceMethod.ExternalEventRaised:
+                    traceHelper.ExternalEventRaised(
+                        HubName,
+                        FunctionName,
+                        InstanceId,
+                        eventName: "event-name",
+                        input: Input,
+                        isReplay);
+                    break;
+                case ReplayTraceMethod.EntityResponseReceived:
+                    traceHelper.EntityResponseReceived(
+                        HubName,
+                        FunctionName,
+                        FunctionType.Orchestrator,
+                        InstanceId,
+                        operationId: "operation-id",
+                        result: Output,
+                        isReplay);
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(traceMethod), traceMethod, null);
+            }
+        }
+
+        private static void AssertTraceEntry(
+            LogEntry entry,
+            ReplayTraceMethod traceMethod,
+            bool isReplay,
+            bool shouldTraceRawData,
+            Exception exception)
+        {
+            Assert.Equal(GetExpectedLogLevel(traceMethod), entry.Level);
+            Assert.Equal(default(EventId), entry.EventId);
+            Assert.Equal(GetExpectedTemplate(traceMethod), GetStateValue<string>(entry, "{OriginalFormat}"));
+            Assert.Equal(InstanceId, GetStateValue<string>(entry, "instanceId"));
+            Assert.Equal(FunctionName, GetStateValue<string>(entry, "functionName"));
+            Assert.Equal(HubName, GetStateValue<string>(entry, "hubName"));
+            Assert.Equal(0L, GetStateValue<long>(entry, "sequenceNumber"));
+            Assert.Null(entry.Exception);
+            Assert.NotEmpty(entry.Message);
+
+            switch (traceMethod)
+            {
+                case ReplayTraceMethod.FunctionStarting:
+                    Assert.Equal(GetLoggerPayload(Input, shouldTraceRawData), GetStateValue<string>(entry, "input"));
+                    Assert.Equal(isReplay, GetStateValue<bool>(entry, "isReplay"));
+                    Assert.Equal(42, GetStateValue<int>(entry, "taskEventId"));
+                    break;
+                case ReplayTraceMethod.FunctionCompleted:
+                    Assert.Equal(GetLoggerPayload(Output, shouldTraceRawData), GetStateValue<string>(entry, "output"));
+                    Assert.Equal(isReplay, GetStateValue<bool>(entry, "isReplay"));
+                    Assert.Equal(42, GetStateValue<int>(entry, "taskEventId"));
+                    break;
+                case ReplayTraceMethod.FunctionFailedException:
+                    Assert.Equal(GetLoggerException(exception, shouldTraceRawData), GetStateValue<string>(entry, "reason"));
+                    Assert.Equal(isReplay, GetStateValue<bool>(entry, "isReplay"));
+                    Assert.Equal(42, GetStateValue<int>(entry, "taskEventId"));
+                    break;
+                case ReplayTraceMethod.FunctionFailedStrings:
+                    Assert.Equal("preformatted reason", GetStateValue<string>(entry, "reason"));
+                    Assert.Equal(isReplay, GetStateValue<bool>(entry, "isReplay"));
+                    Assert.Equal(42, GetStateValue<int>(entry, "taskEventId"));
+                    break;
+                case ReplayTraceMethod.OperationCompleted:
+                    Assert.Equal(GetLoggerPayload(OperationInput, shouldTraceRawData), GetStateValue<string>(entry, "input"));
+                    Assert.Equal(GetLoggerPayload(OperationOutput, shouldTraceRawData), GetStateValue<string>(entry, "output"));
+                    Assert.Equal(isReplay, GetStateValue<bool>(entry, "isReplay"));
+                    break;
+                case ReplayTraceMethod.OperationFailedException:
+                    Assert.Equal(GetLoggerPayload(OperationInput, shouldTraceRawData), GetStateValue<string>(entry, "input"));
+                    Assert.Equal(GetLoggerException(exception, shouldTraceRawData), GetStateValue<string>(entry, "exception"));
+                    Assert.Equal(isReplay, GetStateValue<bool>(entry, "isReplay"));
+                    break;
+                case ReplayTraceMethod.OperationFailedString:
+                    Assert.Equal(GetLoggerPayload(OperationInput, shouldTraceRawData), GetStateValue<string>(entry, "input"));
+                    Assert.Equal(GetLoggerPayload(SerializedException, shouldTraceRawData), GetStateValue<string>(entry, "exception"));
+                    Assert.Equal(isReplay, GetStateValue<bool>(entry, "isReplay"));
+                    break;
+                case ReplayTraceMethod.ExternalEventRaised:
+                case ReplayTraceMethod.EntityResponseReceived:
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(traceMethod), traceMethod, null);
+            }
+        }
+
+        private static LogLevel GetExpectedLogLevel(ReplayTraceMethod traceMethod)
+        {
+            return traceMethod == ReplayTraceMethod.FunctionFailedException
+                || traceMethod == ReplayTraceMethod.FunctionFailedStrings
+                || traceMethod == ReplayTraceMethod.OperationFailedException
+                || traceMethod == ReplayTraceMethod.OperationFailedString
+                ? LogLevel.Error
+                : LogLevel.Information;
+        }
+
+        private static string GetExpectedTemplate(ReplayTraceMethod traceMethod)
+        {
+            switch (traceMethod)
+            {
+                case ReplayTraceMethod.FunctionStarting:
+                    return "{instanceId}: Function '{functionName} ({functionType})' started. IsReplay: {isReplay}. Input: {input}. State: {state}. RuntimeStatus: {runtimeStatus}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}. SequenceNumber: {sequenceNumber}. TaskEventId: {taskEventId}";
+                case ReplayTraceMethod.FunctionCompleted:
+                    return "{instanceId}: Function '{functionName} ({functionType})' completed. ContinuedAsNew: {continuedAsNew}. IsReplay: {isReplay}. Output: {output}. State: {state}. RuntimeStatus: {runtimeStatus}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}. SequenceNumber: {sequenceNumber}. TaskEventId: {taskEventId}";
+                case ReplayTraceMethod.FunctionFailedException:
+                case ReplayTraceMethod.FunctionFailedStrings:
+                    return "{instanceId}: Function '{functionName} ({functionType})' failed with an error. Reason: {reason}. IsReplay: {isReplay}. State: {state}. RuntimeStatus: {runtimeStatus}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}. SequenceNumber: {sequenceNumber}. TaskEventId: {taskEventId}";
+                case ReplayTraceMethod.OperationCompleted:
+                    return "{instanceId}: Function '{functionName} ({functionType})' completed '{operationName}' operation {operationId} in {duration}ms. IsReplay: {isReplay}. Input: {input}. Output: {output}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}. SequenceNumber: {sequenceNumber}.";
+                case ReplayTraceMethod.OperationFailedException:
+                case ReplayTraceMethod.OperationFailedString:
+                    return "{instanceId}: Function '{functionName} ({functionType})' failed '{operationName}' operation {operationId} after {duration}ms with exception {exception}. Input: {input}. IsReplay: {isReplay}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}. SequenceNumber: {sequenceNumber}.";
+                case ReplayTraceMethod.ExternalEventRaised:
+                    return "{instanceId}: Function '{functionName} ({functionType})' received a '{eventName}' event. State: {state}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}. SequenceNumber: {sequenceNumber}.";
+                case ReplayTraceMethod.EntityResponseReceived:
+                    return "{instanceId}: Function '{functionName} ({functionType})' received an entity response. OperationId: {operationId}. State: {state}. HubName: {hubName}. AppName: {appName}. SlotName: {slotName}. ExtensionVersion: {extensionVersion}. SequenceNumber: {sequenceNumber}.";
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(traceMethod), traceMethod, null);
+            }
+        }
+
+        private static string GetLoggerPayload(string payload, bool shouldTraceRawData)
+        {
+            return shouldTraceRawData ? payload : $"(Redacted {payload.Length} characters)";
+        }
+
+        private static string GetLoggerException(Exception exception, bool shouldTraceRawData)
+        {
+            return shouldTraceRawData
+                ? exception.ToString()
+                : $"{exception.GetType().FullName}\n{exception.StackTrace}";
+        }
+
+        private static T GetStateValue<T>(LogEntry entry, string key)
+        {
+            KeyValuePair<string, object?> value = Assert.Single(entry.State, item => item.Key == key);
+            return Assert.IsType<T>(value.Value);
+        }
+
         /// <summary>
         /// Simple test logger that captures log messages.
         /// </summary>
         private class TestLogger : ILogger
         {
-            private readonly List<string> messages;
+            private readonly List<string>? messages;
+            private readonly List<LogEntry>? entries;
 
             public TestLogger(List<string> messages)
             {
                 this.messages = messages;
+            }
+
+            public TestLogger(List<LogEntry> entries)
+            {
+                this.entries = entries;
             }
 
             public IDisposable? BeginScope<TState>(TState state)
@@ -200,7 +567,67 @@ namespace WebJobs.Extensions.DurableTask.Tests.V2
                 Exception? exception,
                 Func<TState, Exception?, string> formatter)
             {
-                this.messages.Add(formatter(state, exception));
+                string message = formatter(state, exception);
+                this.messages?.Add(message);
+                this.entries?.Add(new LogEntry(
+                    logLevel,
+                    eventId,
+                    state is IEnumerable<KeyValuePair<string, object?>> structuredState
+                        ? structuredState.ToList()
+                        : new List<KeyValuePair<string, object?>>(),
+                    exception,
+                    message));
+            }
+        }
+
+        private sealed class LogEntry
+        {
+            public LogEntry(
+                LogLevel level,
+                EventId eventId,
+                IReadOnlyList<KeyValuePair<string, object?>> state,
+                Exception? exception,
+                string message)
+            {
+                this.Level = level;
+                this.EventId = eventId;
+                this.State = state;
+                this.Exception = exception;
+                this.Message = message;
+            }
+
+            public LogLevel Level { get; }
+
+            public EventId EventId { get; }
+
+            public IReadOnlyList<KeyValuePair<string, object?>> State { get; }
+
+            public Exception? Exception { get; }
+
+            public string Message { get; }
+        }
+
+        private sealed class TrackingException : Exception
+        {
+            private readonly bool throwOnToString;
+
+            public TrackingException(bool throwOnToString)
+                : base("tracking exception")
+            {
+                this.throwOnToString = throwOnToString;
+            }
+
+            public int ToStringCalls { get; private set; }
+
+            public override string ToString()
+            {
+                this.ToStringCalls++;
+                if (this.throwOnToString)
+                {
+                    throw new InvalidOperationException("TrackingException.ToString was evaluated.");
+                }
+
+                return "tracking exception string";
             }
         }
     }


### PR DESCRIPTION
## Summary

- Gate replay-aware `EndToEndTraceHelper` entry points before payload redaction, exception stringification, and downstream enum formatting.
- Cover function start/completion/failure, entity operation completion/failure, external events, and entity responses across the full `(isReplay, TraceReplayEvents)` matrix and both raw/redacted ILogger modes.
- Keep shared failure emitters gate-free after public overloads validate eligibility, so enabled paths perform only one replay check.

## Allocation rationale

When `isReplay` is true and `TraceReplayEvents` is false, these events are discarded. The early gates now avoid constructing one or two `"(Redacted N characters)"` strings per suppressed event and avoid `Exception.ToString()` plus sanitized stack text on suppressed failures. This removes work entirely instead of introducing delegates, closures, or caching on hot replay paths.

## Observability compatibility

For replay events when tracing is enabled, and for every non-replay event, the ETW and ILogger emitters are unchanged: event ordering remains ETW before ILogger; log levels, templates, structured property names and values, raw-vs-redacted payload selection, replay flags, task event IDs, durations, exception arguments, and sequence-number increments are preserved. Suppressed replay events still emit neither ETW nor ILogger telemetry and still do not increment the sequence number.

## Tests

- `dotnet test test\FunctionsV2\WebJobs.Extensions.DurableTask.Tests.V2.csproj --no-restore --filter "FullyQualifiedName~EndToEndTraceHelperTests" --logger "console;verbosity=minimal"`
  - Passed: 93/93 on `net8.0`; 93/93 on `net10.0`.
- `dotnet test test\FunctionsV2\WebJobs.Extensions.DurableTask.Tests.V2.csproj -f net8.0 --no-restore --filter "FullyQualifiedName~OutOfProcTests.CallHttpActionOrchestration|FullyQualifiedName~OutOfProcTests.LockEntitiesAction" --logger "console;verbosity=minimal"`
  - Passed: 10/10 on `net8.0`.
- `dotnet test test\FunctionsV2\WebJobs.Extensions.DurableTask.Tests.V2.csproj -f net8.0 --no-restore --filter "FullyQualifiedName~HelloWorldOrchestration_ValidateReplayEventLogs|FullyQualifiedName~DurableEntity_SignalAndCallStringStore|FullyQualifiedName~DurableEntity_CallFaultyEntity" --logger "console;verbosity=minimal"`
  - Environment-blocked before test bodies: 12/12 cases failed in the shared fixture with `UnauthorizedAccessException: Error Starting ETW: Access Denied (Administrator rights required to start ETW)`.

Fixes #3489