### PR TITLE
[Performance] Pool out-of-process protobuf response decoding

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/OutOfProcMiddleware.cs
+++ b/src/WebJobs.Extensions.DurableTask/OutOfProcMiddleware.cs
@@ -149,8 +149,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                             "sending the function result back to the host.");
                     }
 
-                    byte[] triggerReturnValueBytes = Convert.FromBase64String(triggerReturnValue);
-                    P.OrchestratorResponse response = P.OrchestratorResponse.Parser.ParseFrom(triggerReturnValueBytes);
+                    P.OrchestratorResponse response =
+                        ProtobufUtils.Base64Decode(triggerReturnValue, P.OrchestratorResponse.Parser);
 
                     workerRequiresHistory = response.RequiresHistory;
 
@@ -395,8 +395,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                             "sending the function result back to the host.");
                     }
 
-                    byte[] triggerReturnValueBytes = Convert.FromBase64String(triggerReturnValue);
-                    P.EntityBatchResult response = P.EntityBatchResult.Parser.ParseFrom(triggerReturnValueBytes);
+                    P.EntityBatchResult response =
+                        ProtobufUtils.Base64Decode(triggerReturnValue, P.EntityBatchResult.Parser);
                     workerRequiresEntityState = response.RequiresState;
                     context.Result = response.ToEntityBatchResult(this.Options.DefaultVersion);
 

--- a/src/WebJobs.Extensions.DurableTask/ProtobufUtils.cs
+++ b/src/WebJobs.Extensions.DurableTask/ProtobufUtils.cs
@@ -441,6 +441,53 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             }
         }
 
+        public static T Base64Decode<T>(string encodedMessage, MessageParser<T> parser)
+            where T : IMessage<T>
+        {
+            return Base64Decode(encodedMessage, parser, ArrayPool<byte>.Shared);
+        }
+
+        internal static T Base64Decode<T>(
+            string encodedMessage,
+            MessageParser<T> parser,
+            ArrayPool<byte> bufferPool)
+            where T : IMessage<T>
+        {
+            ReadOnlySpan<char> encodedSpan = encodedMessage.AsSpan();
+            int base64CharacterCount = encodedSpan.Length;
+
+            // Convert ignores these whitespace characters, so exclude them from the pooled buffer size.
+            int firstWhitespaceIndex = encodedSpan.IndexOfAny(" \t\r\n");
+            if (firstWhitespaceIndex >= 0)
+            {
+                for (int i = firstWhitespaceIndex; i < encodedSpan.Length; i++)
+                {
+                    if (encodedSpan[i] is ' ' or '\t' or '\r' or '\n')
+                    {
+                        base64CharacterCount--;
+                    }
+                }
+            }
+
+            int maxDecodedLength = checked((base64CharacterCount / 4) * 3);
+            byte[] rentedBuffer = bufferPool.Rent(maxDecodedLength);
+            try
+            {
+                if (Convert.TryFromBase64String(encodedMessage, rentedBuffer, out int bytesWritten))
+                {
+                    return parser.ParseFrom(rentedBuffer, 0, bytesWritten);
+                }
+            }
+            finally
+            {
+                // Match Base64Encode's policy: pooled protobuf payload buffers are not cleared.
+                bufferPool.Return(rentedBuffer, clearArray: false);
+            }
+
+            // Preserve Convert.FromBase64String's exact exception behavior for malformed input.
+            return parser.ParseFrom(Convert.FromBase64String(encodedMessage));
+        }
+
         internal static FailureDetails? GetFailureDetails(P.TaskFailureDetails? failureDetails)
         {
             if (failureDetails == null)

--- a/src/WebJobs.Extensions.DurableTask/ProtobufUtils.cs
+++ b/src/WebJobs.Extensions.DurableTask/ProtobufUtils.cs
@@ -453,6 +453,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             ArrayPool<byte> bufferPool)
             where T : IMessage<T>
         {
+            encodedMessage = encodedMessage ?? throw new ArgumentNullException(nameof(encodedMessage));
+            parser = parser ?? throw new ArgumentNullException(nameof(parser));
+            bufferPool = bufferPool ?? throw new ArgumentNullException(nameof(bufferPool));
+
             ReadOnlySpan<char> encodedSpan = encodedMessage.AsSpan();
             int base64CharacterCount = encodedSpan.Length;
 

--- a/test/FunctionsV2/Tests/Unit/ProtobufUtilsTests.cs
+++ b/test/FunctionsV2/Tests/Unit/ProtobufUtilsTests.cs
@@ -202,6 +202,25 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             AssertBufferReturned(pool, encoded);
         }
 
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public void Base64Decode_NullArguments_ThrowArgumentNullExceptionBeforeRenting()
+        {
+            var pool = new TrackingByteArrayPool();
+
+            ArgumentNullException encodedMessageException = Assert.Throws<ArgumentNullException>(
+                () => ProtobufUtils.Base64Decode(null, P.OrchestratorResponse.Parser, pool));
+            ArgumentNullException parserException = Assert.Throws<ArgumentNullException>(
+                () => ProtobufUtils.Base64Decode<P.OrchestratorResponse>(string.Empty, null, pool));
+            ArgumentNullException bufferPoolException = Assert.Throws<ArgumentNullException>(
+                () => ProtobufUtils.Base64Decode(string.Empty, P.OrchestratorResponse.Parser, null));
+
+            Assert.Equal("encodedMessage", encodedMessageException.ParamName);
+            Assert.Equal("parser", parserException.ParamName);
+            Assert.Equal("bufferPool", bufferPoolException.ParamName);
+            Assert.Equal(0, pool.RentCount);
+        }
+
         /// <summary>
         /// Tests that ToEntityBatchResult properly passes the default version to all actions.
         /// </summary>
@@ -688,6 +707,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
                 // Overwrite returned storage so parsed messages cannot rely on pooled memory.
                 Array.Fill(array, (byte)0);
+                this.rentedBuffer = null;
             }
         }
     }

--- a/test/FunctionsV2/Tests/Unit/ProtobufUtilsTests.cs
+++ b/test/FunctionsV2/Tests/Unit/ProtobufUtilsTests.cs
@@ -2,7 +2,10 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
+using System.Buffers;
+using System.Linq;
 using DurableTask.Core.Entities.OperationFormat;
+using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
 using Xunit;
 using CoreOrchestrationStatus = global::DurableTask.Core.OrchestrationStatus;
@@ -62,6 +65,148 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             Assert.Equal("TestOrchestrator", startOrchestrationResult.Name);
             Assert.Equal("test-instance-id", startOrchestrationResult.InstanceId);
             Assert.Equal(expectedVersion, startOrchestrationResult.Version);
+        }
+
+        [Theory]
+        [InlineData(32)]
+        [InlineData(1024 * 1024)]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public void Base64Decode_OrchestratorResponse_RoundTripsAndReturnsBuffer(int customStatusLength)
+        {
+            var expected = new P.OrchestratorResponse
+            {
+                InstanceId = "test-instance",
+                CustomStatus = new string('x', customStatusLength),
+                RequiresHistory = true,
+            };
+            expected.Actions.Add(new P.OrchestratorAction
+            {
+                Id = 42,
+                CompleteOrchestration = new P.CompleteOrchestrationAction
+                {
+                    Result = "\"done\"",
+                    FailureDetails = new P.TaskFailureDetails
+                    {
+                        ErrorType = "TestError",
+                        ErrorMessage = "Test failure details",
+                    },
+                },
+            });
+            string encoded = Convert.ToBase64String(expected.ToByteArray());
+            var pool = new TrackingByteArrayPool();
+
+            P.OrchestratorResponse actual =
+                ProtobufUtils.Base64Decode(encoded, P.OrchestratorResponse.Parser, pool);
+
+            Assert.Equal(expected, actual);
+            AssertBufferReturned(pool, encoded);
+        }
+
+        [Theory]
+        [InlineData(32)]
+        [InlineData(1024 * 1024)]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public void Base64Decode_EntityBatchResult_RoundTripsAndReturnsBuffer(int entityStateLength)
+        {
+            var expected = new P.EntityBatchResult
+            {
+                EntityState = new string('x', entityStateLength),
+                CompletionToken = "test-token",
+                FailureDetails = new P.TaskFailureDetails
+                {
+                    ErrorType = "TestError",
+                    ErrorMessage = "Test failure details",
+                },
+                RequiresState = true,
+            };
+            expected.Results.Add(new P.OperationResult
+            {
+                Success = new P.OperationResultSuccess
+                {
+                    Result = "\"done\"",
+                },
+            });
+            string encoded = Convert.ToBase64String(expected.ToByteArray());
+            var pool = new TrackingByteArrayPool();
+
+            P.EntityBatchResult actual =
+                ProtobufUtils.Base64Decode(encoded, P.EntityBatchResult.Parser, pool);
+
+            Assert.Equal(expected, actual);
+            AssertBufferReturned(pool, encoded);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public void Base64Decode_MalformedBase64_ThrowsAndReturnsBuffer(bool orchestratorResponse)
+        {
+            FormatException expectedException =
+                Assert.Throws<FormatException>(() => Convert.FromBase64String("not-base64"));
+            var pool = new TrackingByteArrayPool();
+            FormatException actualException;
+
+            if (orchestratorResponse)
+            {
+                actualException = Assert.Throws<FormatException>(
+                    () => ProtobufUtils.Base64Decode("not-base64", P.OrchestratorResponse.Parser, pool));
+            }
+            else
+            {
+                actualException = Assert.Throws<FormatException>(
+                    () => ProtobufUtils.Base64Decode("not-base64", P.EntityBatchResult.Parser, pool));
+            }
+
+            Assert.Equal(expectedException.Message, actualException.Message);
+            AssertBufferReturned(pool, "not-base64");
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public void Base64Decode_MalformedProtobuf_ThrowsAndReturnsBuffer(bool orchestratorResponse)
+        {
+            string encoded = Convert.ToBase64String([0x80]);
+            var pool = new TrackingByteArrayPool();
+            InvalidProtocolBufferException expectedException;
+            InvalidProtocolBufferException actualException;
+
+            if (orchestratorResponse)
+            {
+                expectedException = Assert.Throws<InvalidProtocolBufferException>(
+                    () => P.OrchestratorResponse.Parser.ParseFrom(Convert.FromBase64String(encoded)));
+                actualException = Assert.Throws<InvalidProtocolBufferException>(
+                    () => ProtobufUtils.Base64Decode(encoded, P.OrchestratorResponse.Parser, pool));
+            }
+            else
+            {
+                expectedException = Assert.Throws<InvalidProtocolBufferException>(
+                    () => P.EntityBatchResult.Parser.ParseFrom(Convert.FromBase64String(encoded)));
+                actualException = Assert.Throws<InvalidProtocolBufferException>(
+                    () => ProtobufUtils.Base64Decode(encoded, P.EntityBatchResult.Parser, pool));
+            }
+
+            Assert.Equal(expectedException.Message, actualException.Message);
+            AssertBufferReturned(pool, encoded);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public void Base64Decode_WhitespaceOnly_DoesNotOverRent(bool orchestratorResponse)
+        {
+            string encoded = $"\t\r\n{new string(' ', 1024 * 1024)}";
+            var pool = new TrackingByteArrayPool();
+
+            IMessage actual = orchestratorResponse
+                ? ProtobufUtils.Base64Decode(encoded, P.OrchestratorResponse.Parser, pool)
+                : ProtobufUtils.Base64Decode(encoded, P.EntityBatchResult.Parser, pool);
+
+            Assert.Equal(0, actual.CalculateSize());
+            AssertBufferReturned(pool, encoded);
         }
 
         /// <summary>
@@ -506,6 +651,51 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
             // Assert
             Assert.Null(filter.RuntimeStatus);
+        }
+
+        private static void AssertBufferReturned(TrackingByteArrayPool pool, string encoded)
+        {
+            int base64CharacterCount = encoded.Count(
+                character => character != ' ' && character != '\t' && character != '\r' && character != '\n');
+            Assert.Equal(1, pool.RentCount);
+            Assert.Equal(checked((base64CharacterCount / 4) * 3), pool.MinimumLength);
+            Assert.Equal(1, pool.ReturnCount);
+            Assert.False(pool.ClearArray);
+        }
+
+        private sealed class TrackingByteArrayPool : ArrayPool<byte>
+        {
+            private byte[] rentedBuffer;
+
+            public int RentCount { get; private set; }
+
+            public int MinimumLength { get; private set; }
+
+            public int ReturnCount { get; private set; }
+
+            public bool ClearArray { get; private set; }
+
+            public override byte[] Rent(int minimumLength)
+            {
+                Assert.Null(this.rentedBuffer);
+                this.RentCount++;
+                this.MinimumLength = minimumLength;
+
+                // Dirty trailing bytes ensure the parser only reads the valid decoded segment.
+                this.rentedBuffer = new byte[checked(minimumLength + 64)];
+                Array.Fill(this.rentedBuffer, byte.MaxValue);
+                return this.rentedBuffer;
+            }
+
+            public override void Return(byte[] array, bool clearArray = false)
+            {
+                Assert.Same(this.rentedBuffer, array);
+                this.ReturnCount++;
+                this.ClearArray = clearArray;
+
+                // Overwrite returned storage so parsed messages cannot rely on pooled memory.
+                Array.Fill(array, (byte)0);
+            }
         }
     }
 }

--- a/test/FunctionsV2/Tests/Unit/ProtobufUtilsTests.cs
+++ b/test/FunctionsV2/Tests/Unit/ProtobufUtilsTests.cs
@@ -145,18 +145,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             FormatException expectedException =
                 Assert.Throws<FormatException>(() => Convert.FromBase64String("not-base64"));
             var pool = new TrackingByteArrayPool();
-            FormatException actualException;
+            Action decode = orchestratorResponse
+                ? () => ProtobufUtils.Base64Decode("not-base64", P.OrchestratorResponse.Parser, pool)
+                : () => ProtobufUtils.Base64Decode("not-base64", P.EntityBatchResult.Parser, pool);
 
-            if (orchestratorResponse)
-            {
-                actualException = Assert.Throws<FormatException>(
-                    () => ProtobufUtils.Base64Decode("not-base64", P.OrchestratorResponse.Parser, pool));
-            }
-            else
-            {
-                actualException = Assert.Throws<FormatException>(
-                    () => ProtobufUtils.Base64Decode("not-base64", P.EntityBatchResult.Parser, pool));
-            }
+            FormatException actualException = Assert.Throws<FormatException>(decode);
 
             Assert.Equal(expectedException.Message, actualException.Message);
             AssertBufferReturned(pool, "not-base64");


### PR DESCRIPTION
# Summary
## What changed?
- Added a shared pooled base64 decode/protobuf parse helper for out-of-process responses.
- Routed both orchestrator and entity batch responses through the helper.
- Added small, 1 MiB, malformed-base64, malformed-protobuf, whitespace, valid-segment, null-argument, and pool-lifetime coverage for both message types.

## Why is this change needed?
- `Convert.FromBase64String` allocated a response-sized managed `byte[]` on every turn, including LOH-sized arrays for large responses.
- The new normal path computes a checked decoded bound, rents from `ArrayPool<byte>.Shared`, decodes with `Convert.TryFromBase64String`, and parses only `[0, bytesWritten]`, eliminating that full decoded-array allocation while retaining the protobuf object graph required by the response.

## Issues / work items
- Fixes #3487

## Compatibility guarantees
- The contract remains the same base64-encoded protobuf bytes; there is no worker SDK, schema, public API, or wire-format change.
- Existing action, custom-status, failure-details, `RequiresHistory`, and `RequiresState` handling is unchanged.
- Existing orchestrator/entity null and empty response guards are unchanged.
- Malformed base64 falls back to `Convert.FromBase64String` after returning the pool buffer, preserving its exception behavior; malformed protobuf uses the same parser and exception behavior.
- Parsing completes before the buffer is returned, only the valid decoded segment is exposed to protobuf, and no pooled memory is retained.
- Buffer clearing matches the existing request-side `Base64Encode` policy (`clearArray: false`).

---

# Project checklist
- [x] Documentation changes are not required
- [x] Release notes are not required for the next release
- [x] Backport is not required
- [x] All required tests have been added/updated (unit tests, E2E tests)
- [x] No extra work is required to be leveraged by OutOfProc SDKs
- [x] No change to the version of the `WebJobs.Extensions.DurableTask` package
- [x] No EventIds were added to `EventSource` logs
- [ ] This change should be added to the `v2.x` branch
  - [x] This change applies exclusively to `WebJobs.Extensions.DurableTask` v3.x and will be retained only in the `dev` and `main` branches
- [x] Breaking change? No

---

# AI-assisted code disclosure (required)
## Was an AI tool used? (select one)
- [ ] No
- [ ] Yes, AI helped write parts of this PR (e.g., GitHub Copilot)
- [x] Yes, an AI agent generated most of this PR

If AI was used:
- Tool(s): GitHub Copilot CLI
- AI-assisted areas/files: pooled decode helper, middleware wiring, and focused unit tests
- What you changed after AI output: verified repository history and Google.Protobuf 3.21.5 APIs, reviewed whitespace/error/lifetime edge cases, addressed review findings, and validated both target frameworks

AI verification (required if AI was used):
- [x] I understand the code and can explain it
- [x] I verified referenced APIs/types exist and are correct
- [x] I reviewed edge cases/failure paths (timeouts, retries, cancellation, exceptions)
- [x] I reviewed concurrency/async behavior
- [x] I checked for unintended breaking or behavior changes

---

# Testing
## Automated tests
- `dotnet test test\FunctionsV2\WebJobs.Extensions.DurableTask.Tests.V2.csproj -f net8.0 --no-restore --filter "FullyQualifiedName~ProtobufUtilsTests|FullyQualifiedName~OutOfProcMiddlewareTests" --logger "console;verbosity=minimal"` — Passed: 57, Failed: 0, Skipped: 0.
- `dotnet test test\FunctionsV2\WebJobs.Extensions.DurableTask.Tests.V2.csproj -f net10.0 --no-restore --filter "FullyQualifiedName~ProtobufUtilsTests|FullyQualifiedName~OutOfProcMiddlewareTests" --logger "console;verbosity=minimal"` — Passed: 57, Failed: 0, Skipped: 0.
- `dotnet build src\WebJobs.Extensions.DurableTask\WebJobs.Extensions.DurableTask.csproj -c Release --no-restore --verbosity:minimal` — Succeeded for `net8.0` and `net10.0`; 0 warnings, 0 errors.
- `dotnet build test\FunctionsV2\WebJobs.Extensions.DurableTask.Tests.V2.csproj -c Release --no-restore --verbosity:minimal` — Succeeded for `net8.0` and `net10.0`; 0 warnings, 0 errors.

## Manual validation (only if runtime/behavior changed)
- N/A; the wire contract and externally observable behavior are unchanged.

---

# Notes for reviewers
- Dependency inspection confirmed `Google.Protobuf` 3.21.5 exposes `MessageParser<T>.ParseFrom(byte[], int, int)` on both target frameworks.