### PR TITLE
Log unexpected local gRPC failures

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/Grpc/AspNetCoreLocalGrpcListener.cs
+++ b/src/WebJobs.Extensions.DurableTask/Grpc/AspNetCoreLocalGrpcListener.cs
@@ -144,6 +144,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Grpc
                         services.AddSingleton(this.extension);
                         services.AddGrpc(options =>
                         {
+                            options.Interceptors.Add<TaskHubGrpcExceptionInterceptor>();
                             options.MaxReceiveMessageSize = int.MaxValue;
                             options.MaxSendMessageSize = int.MaxValue;
                         });

--- a/src/WebJobs.Extensions.DurableTask/Grpc/AspNetCoreLocalGrpcListener.cs
+++ b/src/WebJobs.Extensions.DurableTask/Grpc/AspNetCoreLocalGrpcListener.cs
@@ -142,6 +142,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Grpc
                     builder.ConfigureServices(services =>
                     {
                         services.AddSingleton(this.extension);
+
+                        // Register the interceptor in DI so DefaultGrpcInterceptorActivator resolves
+                        // this singleton instead of constructing a new instance for every RPC.
+                        services.AddSingleton<TaskHubGrpcExceptionInterceptor>();
                         services.AddGrpc(options =>
                         {
                             options.Interceptors.Add<TaskHubGrpcExceptionInterceptor>();

--- a/src/WebJobs.Extensions.DurableTask/Grpc/TaskHubGrpcExceptionInterceptor.cs
+++ b/src/WebJobs.Extensions.DurableTask/Grpc/TaskHubGrpcExceptionInterceptor.cs
@@ -1,0 +1,82 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#nullable enable
+using System;
+using System.Threading.Tasks;
+using Grpc.Core;
+using Grpc.Core.Interceptors;
+
+namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Grpc
+{
+    internal sealed class TaskHubGrpcExceptionInterceptor : Interceptor
+    {
+        private readonly DurableTaskExtension extension;
+
+        public TaskHubGrpcExceptionInterceptor(DurableTaskExtension extension)
+        {
+            this.extension = extension ?? throw new ArgumentNullException(nameof(extension));
+        }
+
+        public override async Task<TResponse> UnaryServerHandler<TRequest, TResponse>(
+            TRequest request,
+            ServerCallContext context,
+            UnaryServerMethod<TRequest, TResponse> continuation)
+        {
+            try
+            {
+                return await continuation(request, context);
+            }
+            catch (Exception exception) when (ShouldLog(exception, context))
+            {
+                this.LogException(context, exception);
+                throw;
+            }
+        }
+
+        public override async Task ServerStreamingServerHandler<TRequest, TResponse>(
+            TRequest request,
+            IServerStreamWriter<TResponse> responseStream,
+            ServerCallContext context,
+            ServerStreamingServerMethod<TRequest, TResponse> continuation)
+        {
+            try
+            {
+                await continuation(request, responseStream, context);
+            }
+            catch (Exception exception) when (ShouldLog(exception, context))
+            {
+                this.LogException(context, exception);
+                throw;
+            }
+        }
+
+        private static bool ShouldLog(Exception exception, ServerCallContext context)
+        {
+            if (context.CancellationToken.IsCancellationRequested)
+            {
+                return false;
+            }
+
+            if (exception is TaskHubRpcException)
+            {
+                return true;
+            }
+
+            return exception is not RpcException;
+        }
+
+        private void LogException(ServerCallContext context, Exception exception)
+        {
+            Exception exceptionToLog = exception is TaskHubRpcException rpcException
+                ? rpcException.Cause
+                : exception;
+
+            this.extension.TraceHelper.ExtensionWarningEvent(
+                this.extension.Options.HubName,
+                instanceId: string.Empty,
+                functionName: string.Empty,
+                message: $"Unhandled exception in local gRPC call '{context.Method}': {exceptionToLog}");
+        }
+    }
+}

--- a/src/WebJobs.Extensions.DurableTask/Grpc/TaskHubGrpcExceptionInterceptor.cs
+++ b/src/WebJobs.Extensions.DurableTask/Grpc/TaskHubGrpcExceptionInterceptor.cs
@@ -11,6 +11,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Grpc
 {
     internal sealed class TaskHubGrpcExceptionInterceptor : Interceptor
     {
+        // gRPC metadata key used by clients to target a task hub other than the host's default.
+        // Kept in sync with TaskHubGrpcServer.GetAttribute, which uses it to select the provider.
+        private const string TaskHubMetadataKey = "Durable-TaskHub";
+
         private readonly DurableTaskExtension extension;
 
         public TaskHubGrpcExceptionInterceptor(DurableTaskExtension extension)
@@ -73,10 +77,20 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Grpc
                 : exception;
 
             this.extension.TraceHelper.ExtensionWarningEvent(
-                this.extension.Options.HubName,
+                this.GetHubName(context),
                 instanceId: string.Empty,
                 functionName: string.Empty,
                 message: $"Unhandled exception in local gRPC call '{context.Method}': {exceptionToLog}");
+        }
+
+        /// <summary>
+        /// Resolves the task hub the failing call targeted. Clients can address a non-default hub
+        /// through request metadata, so the host's configured hub is only a fallback.
+        /// </summary>
+        private string GetHubName(ServerCallContext context)
+        {
+            string? taskHub = context.RequestHeaders.GetValue(TaskHubMetadataKey);
+            return string.IsNullOrWhiteSpace(taskHub) ? this.extension.Options.HubName : taskHub;
         }
     }
 }

--- a/src/WebJobs.Extensions.DurableTask/Grpc/TaskHubRpcException.cs
+++ b/src/WebJobs.Extensions.DurableTask/Grpc/TaskHubRpcException.cs
@@ -1,0 +1,20 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#nullable enable
+using System;
+using Grpc.Core;
+
+namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Grpc
+{
+    internal sealed class TaskHubRpcException : RpcException
+    {
+        public TaskHubRpcException(Status status, Exception cause)
+            : base(status)
+        {
+            this.Cause = cause ?? throw new ArgumentNullException(nameof(cause));
+        }
+
+        public Exception Cause { get; }
+    }
+}

--- a/src/WebJobs.Extensions.DurableTask/TaskHubGrpcServer.cs
+++ b/src/WebJobs.Extensions.DurableTask/TaskHubGrpcServer.cs
@@ -17,6 +17,7 @@ using DurableTask.Core.Serializing.Internal;
 using Google.Protobuf.WellKnownTypes;
 using Grpc.Core;
 using Microsoft.Azure.WebJobs.Extensions.DurableTask.Correlation;
+using Microsoft.Azure.WebJobs.Extensions.DurableTask.Grpc;
 using Newtonsoft.Json;
 using DTCore = DurableTask.Core;
 using P = Microsoft.DurableTask.Protobuf;
@@ -42,16 +43,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             return Task.FromResult(new Empty());
         }
 
-        public override Task<P.CreateTaskHubResponse> CreateTaskHub(P.CreateTaskHubRequest request, ServerCallContext context)
+        public async override Task<P.CreateTaskHubResponse> CreateTaskHub(P.CreateTaskHubRequest request, ServerCallContext context)
         {
-            this.GetDurabilityProvider(context).CreateAsync(request.RecreateIfExists);
-            return Task.FromResult(new P.CreateTaskHubResponse());
+            await this.GetDurabilityProvider(context).CreateAsync(request.RecreateIfExists);
+            return new P.CreateTaskHubResponse();
         }
 
-        public override Task<P.DeleteTaskHubResponse> DeleteTaskHub(P.DeleteTaskHubRequest request, ServerCallContext context)
+        public async override Task<P.DeleteTaskHubResponse> DeleteTaskHub(P.DeleteTaskHubRequest request, ServerCallContext context)
         {
-            this.GetDurabilityProvider(context).DeleteAsync();
-            return Task.FromResult(new P.DeleteTaskHubResponse());
+            await this.GetDurabilityProvider(context).DeleteAsync();
+            return new P.DeleteTaskHubResponse();
         }
 
         public async override Task<P.CreateInstanceResponse> StartInstance(P.CreateInstanceRequest request, ServerCallContext context)
@@ -129,6 +130,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             {
                 throw new RpcException(new Status(StatusCode.InvalidArgument, $"Invalid argument for start instance request for instance ID {request.InstanceId}: {ex.Message}"));
             }
+            catch (OperationCanceledException) when (context.CancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
             catch (Exception ex)
             {
                 this.extension.TraceHelper.ExtensionWarningEvent(
@@ -172,10 +177,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     throw new RpcException(new Status(StatusCode.FailedPrecondition, "The orchestration instance with the provided instance id is not running."));
                 }
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is not OperationCanceledException || !context.CancellationToken.IsCancellationRequested)
             {
                 // Any other unexpected exceptions.
-                throw new RpcException(new Status(StatusCode.Unknown, ex.Message));
+                throw new TaskHubRpcException(new Status(StatusCode.Unknown, ex.Message), ex);
             }
 
             return new P.RaiseEventResponse();
@@ -347,10 +352,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 // Rewind is not supported by the underlying storage provider.
                 throw new RpcException(new Status(StatusCode.Unimplemented, ex.Message));
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is not OperationCanceledException || !context.CancellationToken.IsCancellationRequested)
             {
                 // Any other unexpected exceptions.
-                throw new RpcException(new Status(StatusCode.Unknown, ex.Message));
+                throw new TaskHubRpcException(new Status(StatusCode.Unknown, ex.Message), ex);
             }
 
             return new P.RewindInstanceResponse();
@@ -456,10 +461,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 // Purging is not supported by the underlying storage provider.
                 throw new RpcException(new Status(StatusCode.Unimplemented, ex.Message));
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is not OperationCanceledException || !context.CancellationToken.IsCancellationRequested)
             {
                 // Wrap all other exceptions in an RpcException.
-                throw new RpcException(new Status(StatusCode.Internal, $"Failed during purging instances: {ex.Message}"));
+                throw new TaskHubRpcException(
+                    new Status(StatusCode.Internal, $"Failed during purging instances: {ex.Message}"),
+                    ex);
             }
         }
 
@@ -523,10 +530,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             {
                 throw new RpcException(new Status(StatusCode.FailedPrecondition, $"Non-terminal instance with this instance ID already exists: {ex.Message}"));
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is not OperationCanceledException || !context.CancellationToken.IsCancellationRequested)
             {
                 // Any other unexpected exceptions.
-                throw new RpcException(new Status(StatusCode.Unknown, ex.Message));
+                throw new TaskHubRpcException(new Status(StatusCode.Unknown, ex.Message), ex);
             }
         }
 
@@ -642,13 +649,21 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     await responseStream.WriteAsync(historyChunk);
                 }
             }
-            catch (OperationCanceledException)
+            catch (OperationCanceledException) when (context.CancellationToken.IsCancellationRequested)
             {
                 throw new RpcException(new Status(StatusCode.Cancelled, $"Orchestration history streaming cancelled for instance {request.InstanceId}"));
             }
+            catch (OperationCanceledException ex)
+            {
+                throw new TaskHubRpcException(
+                    new Status(StatusCode.Cancelled, $"Orchestration history streaming cancelled for instance {request.InstanceId}"),
+                    ex);
+            }
             catch (Exception ex)
             {
-                throw new RpcException(new Status(StatusCode.Internal, $"Failed to stream orchestration history for instance {request.InstanceId}: {ex.Message}"));
+                throw new TaskHubRpcException(
+                    new Status(StatusCode.Internal, $"Failed to stream orchestration history for instance {request.InstanceId}: {ex.Message}"),
+                    ex);
             }
         }
 
@@ -743,7 +758,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             {
                 // Any other unexpected exceptions. RpcException and cancellation are excluded above so a
                 // client cancellation/deadline surfaces as StatusCode.Cancelled rather than Unknown.
-                throw new RpcException(new Status(StatusCode.Unknown, ex.Message));
+                throw new TaskHubRpcException(new Status(StatusCode.Unknown, ex.Message), ex);
             }
         }
 

--- a/test/FunctionsV2/Tests/Unit/LocalGrpcListenerTests.cs
+++ b/test/FunctionsV2/Tests/Unit/LocalGrpcListenerTests.cs
@@ -2,10 +2,16 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Net;
 using System.Net.Sockets;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
+using DurableTask.Core;
+using DurableTask.Core.History;
+using Grpc.Core;
+using Grpc.Net.Client;
 using Microsoft.Azure.WebJobs.Extensions.DurableTask.Grpc;
 using Microsoft.Azure.WebJobs.Host.TestCommon;
 using Microsoft.Extensions.Logging;
@@ -14,6 +20,7 @@ using Microsoft.Extensions.Options;
 using Moq;
 using Xunit;
 using Xunit.Abstractions;
+using P = Microsoft.DurableTask.Protobuf;
 
 namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 {
@@ -59,6 +66,291 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             // Test boh two version of grpc lisnter mode can start and stop successfully.
             var internalMode = (LocalGrpcListenerMode)(int)testMode;
             await this.GrpcListener_StartAndStopSuccessfully(internalMode);
+        }
+
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public async Task TestGrpcListener_LogsUnhandledGetInstanceExceptions()
+        {
+            const string InstanceId = "test-instance";
+            const string ErrorMessage = "The durability provider failed.";
+
+            var providerException = new InvalidOperationException(ErrorMessage);
+            DurabilityProvider durabilityProvider = CreateFailingGetStateProvider(InstanceId, providerException);
+
+            RpcException rpcException = await this.InvokeFailingRpcAsync(
+                "UnhandledGetInstanceException",
+                durabilityProvider,
+                async client => await client.GetInstanceAsync(
+                    new P.GetInstanceRequest { InstanceId = InstanceId }).ResponseAsync);
+
+            Assert.Equal(StatusCode.Unknown, rpcException.StatusCode);
+            this.AssertWarning(ErrorMessage, "GetInstance", nameof(InvalidOperationException));
+        }
+
+        [Theory]
+        [InlineData(true, "create", "CreateTaskHub")]
+        [InlineData(false, "delete", "DeleteTaskHub")]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public async Task TestGrpcListener_LogsUnhandledTaskHubManagementExceptions(
+            bool createTaskHub,
+            string operation,
+            string methodName)
+        {
+            string errorMessage = $"The durability provider failed to {operation} the task hub.";
+
+            var providerException = new InvalidOperationException(errorMessage);
+            var orchestrationService = new Mock<IOrchestrationService>();
+            Func<P.TaskHubSidecarService.TaskHubSidecarServiceClient, Task> invoke;
+            if (createTaskHub)
+            {
+                orchestrationService
+                    .Setup(service => service.CreateAsync(It.IsAny<bool>()))
+                    .Returns(Task.FromException(providerException));
+                invoke = async client => await client.CreateTaskHubAsync(new P.CreateTaskHubRequest()).ResponseAsync;
+            }
+            else
+            {
+                orchestrationService
+                    .Setup(service => service.DeleteAsync())
+                    .Returns(Task.FromException(providerException));
+                invoke = async client => await client.DeleteTaskHubAsync(new P.DeleteTaskHubRequest()).ResponseAsync;
+            }
+
+            DurabilityProvider durabilityProvider = CreateDurabilityProvider(
+                orchestrationService.Object,
+                new Mock<IOrchestrationServiceClient>().Object);
+
+            RpcException rpcException = await this.InvokeFailingRpcAsync(
+                $"Unhandled{methodName}Exception",
+                durabilityProvider,
+                invoke);
+
+            Assert.Equal(StatusCode.Unknown, rpcException.StatusCode);
+            this.AssertWarning(errorMessage, methodName, nameof(InvalidOperationException));
+        }
+
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public async Task TestGrpcListener_DoesNotLogStartInstanceClientCancellation()
+        {
+            const string InstanceId = "test-instance";
+
+            var providerCalled = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            Mock<DurabilityProvider> durabilityProvider = CreateDurabilityProviderMock(
+                new Mock<IOrchestrationService>().Object,
+                new Mock<IOrchestrationServiceClient>().Object);
+            durabilityProvider
+                .Setup(provider => provider.CreateTaskOrchestrationAsync(
+                    It.IsAny<TaskMessage>(),
+                    It.IsAny<OrchestrationStatus[]>(),
+                    It.IsAny<CancellationToken>()))
+                .Returns(
+                    async (
+                        TaskMessage message,
+                        OrchestrationStatus[] dedupeStatuses,
+                        CancellationToken cancellationToken) =>
+                    {
+                        providerCalled.TrySetResult(true);
+                        await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+                    });
+
+            RpcException rpcException = await this.InvokeFailingRpcAsync(
+                "StartInstanceClientCancellation",
+                durabilityProvider.Object,
+                async client =>
+                {
+                    using var cancellation = new CancellationTokenSource();
+                    using AsyncUnaryCall<P.CreateInstanceResponse> call = client.StartInstanceAsync(
+                        new P.CreateInstanceRequest
+                        {
+                            InstanceId = InstanceId,
+                            Name = "TestOrchestration",
+                        },
+                        cancellationToken: cancellation.Token);
+
+                    await providerCalled.Task.WaitAsync(TimeSpan.FromSeconds(5));
+                    cancellation.Cancel();
+                    await call.ResponseAsync;
+                });
+
+            Assert.Equal(StatusCode.Cancelled, rpcException.StatusCode);
+            Assert.DoesNotContain(
+                this.loggerProvider.GetAllLogMessages(),
+                message => message.Level == LogLevel.Warning &&
+                    message.FormattedMessage.Contains("StartInstance"));
+        }
+
+        [Theory]
+        [InlineData(false, nameof(ApplicationException))]
+        [InlineData(true, nameof(OperationCanceledException))]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public async Task TestGrpcListener_LogsUnexpectedWrappedRpcExceptions(
+            bool providerCanceled,
+            string exceptionType)
+        {
+            const string InstanceId = "test-instance";
+            const string Reason = "test-rewind";
+            const string ErrorMessage = "The durability provider failed to rewind the instance.";
+
+            Exception providerException = providerCanceled
+                ? new OperationCanceledException(ErrorMessage)
+                : new ApplicationException(ErrorMessage);
+            var orchestrationState = new OrchestrationState
+            {
+                Name = "TestOrchestration",
+                OrchestrationInstance = new OrchestrationInstance
+                {
+                    ExecutionId = "test-execution",
+                    InstanceId = InstanceId,
+                },
+                OrchestrationStatus = OrchestrationStatus.Failed,
+            };
+            var orchestrationServiceClient = new Mock<IOrchestrationServiceClient>();
+            orchestrationServiceClient
+                .Setup(client => client.GetOrchestrationStateAsync(InstanceId, (string)null))
+                .ReturnsAsync(orchestrationState);
+            orchestrationServiceClient
+                .Setup(client => client.GetOrchestrationStateAsync(InstanceId, It.IsAny<bool>()))
+                .ReturnsAsync(new List<OrchestrationState> { orchestrationState });
+            Mock<DurabilityProvider> durabilityProvider = CreateDurabilityProviderMock(
+                new Mock<IOrchestrationService>().Object,
+                orchestrationServiceClient.Object);
+            durabilityProvider
+                .Setup(provider => provider.RewindAsync(InstanceId, Reason))
+                .ThrowsAsync(providerException);
+
+            RpcException rpcException = await this.InvokeFailingRpcAsync(
+                "UnexpectedWrappedRpcException",
+                durabilityProvider.Object,
+                async client => await client.RewindInstanceAsync(
+                    new P.RewindInstanceRequest
+                    {
+                        InstanceId = InstanceId,
+                        Reason = Reason,
+                    }).ResponseAsync);
+
+            Assert.Equal(StatusCode.Unknown, rpcException.StatusCode);
+            Assert.Equal(ErrorMessage, rpcException.Status.Detail);
+            this.AssertWarning(ErrorMessage, "RewindInstance", exceptionType);
+        }
+
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public async Task TestGrpcListener_PreservesPurgeStatusForProviderCancellation()
+        {
+            const string InstanceId = "@test-entity";
+            const string ErrorMessage = "The durability provider canceled the purge operation.";
+
+            var providerException = new OperationCanceledException(ErrorMessage);
+            var orchestrationServiceClient = new Mock<IOrchestrationServiceClient>();
+            orchestrationServiceClient
+                .As<IOrchestrationServicePurgeClient>()
+                .Setup(client => client.PurgeInstanceStateAsync(InstanceId))
+                .ThrowsAsync(providerException);
+            DurabilityProvider durabilityProvider = CreateDurabilityProvider(
+                new Mock<IOrchestrationService>().Object,
+                orchestrationServiceClient.Object);
+
+            RpcException rpcException = await this.InvokeFailingRpcAsync(
+                "PurgeProviderCancellation",
+                durabilityProvider,
+                async client => await client.PurgeInstancesAsync(
+                    new P.PurgeInstancesRequest { InstanceId = InstanceId }).ResponseAsync);
+
+            Assert.Equal(StatusCode.Internal, rpcException.StatusCode);
+            Assert.Contains(ErrorMessage, rpcException.Status.Detail);
+            this.AssertWarning(ErrorMessage, "PurgeInstances", nameof(OperationCanceledException));
+        }
+
+        [Theory]
+        [InlineData(false, StatusCode.Internal, "The durability provider failed while streaming.", nameof(InvalidOperationException))]
+        [InlineData(true, StatusCode.Cancelled, "The durability provider canceled history streaming.", nameof(OperationCanceledException))]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public async Task TestGrpcListener_LogsUnhandledStreamingExceptions(
+            bool providerCanceled,
+            StatusCode expectedStatus,
+            string errorMessage,
+            string exceptionType)
+        {
+            const string InstanceId = "test-instance";
+
+            Exception providerException = providerCanceled
+                ? new OperationCanceledException(errorMessage)
+                : new InvalidOperationException(errorMessage);
+            DurabilityProvider durabilityProvider = CreateFailingStreamHistoryProvider(InstanceId, providerException);
+
+            RpcException rpcException = await this.InvokeFailingRpcAsync(
+                "UnhandledStreamingException",
+                durabilityProvider,
+                async client =>
+                {
+                    using AsyncServerStreamingCall<P.HistoryChunk> call = client.StreamInstanceHistory(
+                        new P.StreamInstanceHistoryRequest { InstanceId = InstanceId });
+                    await call.ResponseStream.MoveNext(default);
+                });
+
+            Assert.Equal(expectedStatus, rpcException.StatusCode);
+            this.AssertWarning(errorMessage, "StreamInstanceHistory", exceptionType);
+        }
+
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public async Task TestGrpcListener_DoesNotLogStreamingClientCancellation()
+        {
+            const string InstanceId = "test-instance";
+            const string ErrorMessage = "The response stream was already canceled.";
+
+            var providerCalled = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            DurabilityProvider durabilityProvider = CreateCancelingStreamHistoryProvider(
+                InstanceId,
+                providerCalled,
+                ErrorMessage);
+
+            RpcException rpcException = await this.InvokeFailingRpcAsync(
+                "StreamingClientCancellation",
+                durabilityProvider,
+                async client =>
+                {
+                    using var cancellation = new CancellationTokenSource();
+                    using AsyncServerStreamingCall<P.HistoryChunk> call = client.StreamInstanceHistory(
+                        new P.StreamInstanceHistoryRequest { InstanceId = InstanceId },
+                        cancellationToken: cancellation.Token);
+
+                    await providerCalled.Task.WaitAsync(TimeSpan.FromSeconds(5));
+                    cancellation.Cancel();
+                    await call.ResponseStream.MoveNext(default);
+                });
+
+            Assert.Equal(StatusCode.Cancelled, rpcException.StatusCode);
+            Assert.DoesNotContain(
+                this.loggerProvider.GetAllLogMessages(),
+                message => message.Level == LogLevel.Warning &&
+                    message.FormattedMessage.Contains(ErrorMessage));
+        }
+
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public async Task TestGrpcListener_DoesNotLogHandledRpcExceptions()
+        {
+            const string InstanceId = "missing-instance";
+
+            DurabilityProvider durabilityProvider = CreateEmptyGetStateProvider(InstanceId);
+            RpcException rpcException = await this.InvokeFailingRpcAsync(
+                "HandledRpcException",
+                durabilityProvider,
+                async client =>
+                {
+                    using AsyncServerStreamingCall<P.HistoryChunk> call = client.StreamInstanceHistory(
+                        new P.StreamInstanceHistoryRequest { InstanceId = InstanceId });
+                    await call.ResponseStream.MoveNext(default);
+                });
+
+            Assert.Equal(StatusCode.NotFound, rpcException.StatusCode);
+            Assert.DoesNotContain(
+                this.loggerProvider.GetAllLogMessages(),
+                message => message.Level == LogLevel.Warning &&
+                    message.FormattedMessage.Contains("StreamInstanceHistory"));
         }
 
         [Theory]
@@ -526,6 +818,37 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             return this.CreateExtension(hubName, WorkerRuntimeType.DotNetIsolated);
         }
 
+        private async Task<RpcException> InvokeFailingRpcAsync(
+            string hubName,
+            DurabilityProvider durabilityProvider,
+            Func<P.TaskHubSidecarService.TaskHubSidecarServiceClient, Task> invoke)
+        {
+            using DurableTaskExtension extension = this.CreateExtension(hubName, durabilityProvider);
+            ILocalGrpcListener listener = LocalGrpcListener.Create(extension, LocalGrpcListenerMode.AspNetCore);
+
+            try
+            {
+                await listener.StartAsync(default);
+                using GrpcChannel channel = GrpcChannel.ForAddress(listener.ListenAddress);
+                var client = new P.TaskHubSidecarService.TaskHubSidecarServiceClient(channel);
+                return await Assert.ThrowsAsync<RpcException>(() => invoke(client));
+            }
+            finally
+            {
+                await listener.StopAsync(default);
+            }
+        }
+
+        private void AssertWarning(string errorMessage, string methodName, string exceptionType)
+        {
+            LogMessage warning = Assert.Single(
+                this.loggerProvider.GetAllLogMessages(),
+                message => message.Level == LogLevel.Warning &&
+                    message.FormattedMessage.Contains(errorMessage));
+            Assert.Contains(methodName, warning.FormattedMessage);
+            Assert.Contains(exceptionType, warning.FormattedMessage);
+        }
+
         private DurableTaskExtension CreateExtension(string hubName, WorkerRuntimeType runtimeType)
         {
             var options = new DurableTaskOptions { HubName = hubName };
@@ -546,6 +869,171 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 new TestHostShutdownNotificationService(),
                 new DurableHttpMessageHandlerFactory(),
                 platformInformationService: TestHelpers.GetMockPlatformInformationService(language: runtimeType));
+        }
+
+        private DurableTaskExtension CreateExtension(string hubName, DurabilityProvider durabilityProvider)
+        {
+            var options = new DurableTaskOptions { HubName = hubName };
+            var wrappedOptions = new OptionsWrapper<DurableTaskOptions>(options);
+            var serviceFactory = new Mock<IDurabilityProviderFactory>();
+            serviceFactory.SetupGet(factory => factory.Name).Returns(AzureStorageDurabilityProviderFactory.ProviderName);
+            serviceFactory.Setup(factory => factory.GetDurabilityProvider()).Returns(durabilityProvider);
+            serviceFactory
+                .Setup(factory => factory.GetDurabilityProvider(It.IsAny<DurableClientAttribute>()))
+                .Returns(durabilityProvider);
+
+            var loggerFactory = new LoggerFactory(new[] { this.loggerProvider });
+            return new DurableTaskExtension(
+                wrappedOptions,
+                loggerFactory,
+                TestHelpers.GetTestNameResolver(),
+                new[] { serviceFactory.Object },
+                new TestHostShutdownNotificationService(),
+                new DurableHttpMessageHandlerFactory(),
+                platformInformationService: TestHelpers.GetMockPlatformInformationService(
+                    language: WorkerRuntimeType.DotNetIsolated));
+        }
+
+        private static DurabilityProvider CreateFailingGetStateProvider(string instanceId, Exception exception)
+        {
+            var orchestrationServiceClient = new Mock<IOrchestrationServiceClient>();
+            orchestrationServiceClient
+                .Setup(client => client.GetOrchestrationStateAsync(instanceId, It.IsAny<string>()))
+                .ThrowsAsync(exception);
+            orchestrationServiceClient
+                .Setup(client => client.GetOrchestrationStateAsync(instanceId, It.IsAny<bool>()))
+                .ThrowsAsync(exception);
+
+            return CreateDurabilityProvider(
+                new Mock<IOrchestrationService>().Object,
+                orchestrationServiceClient.Object);
+        }
+
+        private static DurabilityProvider CreateEmptyGetStateProvider(string instanceId)
+        {
+            var orchestrationServiceClient = new Mock<IOrchestrationServiceClient>();
+            orchestrationServiceClient
+                .Setup(client => client.GetOrchestrationStateAsync(instanceId, It.IsAny<bool>()))
+                .ReturnsAsync(new List<OrchestrationState>());
+
+            return CreateDurabilityProvider(
+                new Mock<IOrchestrationService>().Object,
+                orchestrationServiceClient.Object);
+        }
+
+        private static DurabilityProvider CreateFailingStreamHistoryProvider(string instanceId, Exception exception)
+        {
+            var orchestrationServiceClient = new Mock<IOrchestrationServiceClient>();
+            orchestrationServiceClient
+                .Setup(client => client.GetOrchestrationStateAsync(instanceId, It.IsAny<bool>()))
+                .ReturnsAsync(new List<OrchestrationState>
+                {
+                    new OrchestrationState
+                    {
+                        CreatedTime = DateTime.UtcNow,
+                        LastUpdatedTime = DateTime.UtcNow,
+                        Name = "TestOrchestration",
+                        OrchestrationInstance = new OrchestrationInstance
+                        {
+                            ExecutionId = "test-execution",
+                            InstanceId = instanceId,
+                        },
+                        OrchestrationStatus = OrchestrationStatus.Running,
+                    },
+                });
+
+            Mock<DurabilityProvider> durabilityProvider = CreateDurabilityProviderMock(
+                new Mock<IOrchestrationService>().Object,
+                orchestrationServiceClient.Object);
+            durabilityProvider
+                .Setup(provider => provider.StreamOrchestrationHistoryAsync(
+                    instanceId,
+                    It.IsAny<CancellationToken>()))
+                .ThrowsAsync(exception);
+
+            return durabilityProvider.Object;
+        }
+
+        private static DurabilityProvider CreateCancelingStreamHistoryProvider(
+            string instanceId,
+            TaskCompletionSource<bool> providerCalled,
+            string errorMessage)
+        {
+            var orchestrationServiceClient = new Mock<IOrchestrationServiceClient>();
+            orchestrationServiceClient
+                .Setup(client => client.GetOrchestrationStateAsync(instanceId, It.IsAny<bool>()))
+                .ReturnsAsync(new List<OrchestrationState>
+                {
+                    new OrchestrationState
+                    {
+                        CreatedTime = DateTime.UtcNow,
+                        LastUpdatedTime = DateTime.UtcNow,
+                        Name = "TestOrchestration",
+                        OrchestrationInstance = new OrchestrationInstance
+                        {
+                            ExecutionId = "test-execution",
+                            InstanceId = instanceId,
+                        },
+                        OrchestrationStatus = OrchestrationStatus.Running,
+                    },
+                });
+
+            Mock<DurabilityProvider> durabilityProvider = CreateDurabilityProviderMock(
+                new Mock<IOrchestrationService>().Object,
+                orchestrationServiceClient.Object);
+            durabilityProvider
+                .Setup(provider => provider.StreamOrchestrationHistoryAsync(
+                    instanceId,
+                    It.IsAny<CancellationToken>()))
+                .Returns(
+                    (string requestedInstanceId, CancellationToken cancellationToken) =>
+                        Task.FromResult<IAsyncEnumerable<HistoryEvent>>(
+                            ThrowAfterCancellationAsync(providerCalled, errorMessage, cancellationToken)));
+
+            return durabilityProvider.Object;
+        }
+
+        private static async IAsyncEnumerable<HistoryEvent> ThrowAfterCancellationAsync(
+            TaskCompletionSource<bool> providerCalled,
+            string errorMessage,
+            [EnumeratorCancellation] CancellationToken cancellationToken)
+        {
+            providerCalled.TrySetResult(true);
+            try
+            {
+                await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw new InvalidOperationException(errorMessage);
+            }
+
+            yield break;
+        }
+
+        private static DurabilityProvider CreateDurabilityProvider(
+            IOrchestrationService orchestrationService,
+            IOrchestrationServiceClient orchestrationServiceClient)
+        {
+            return CreateDurabilityProviderMock(orchestrationService, orchestrationServiceClient).Object;
+        }
+
+        private static Mock<DurabilityProvider> CreateDurabilityProviderMock(
+            IOrchestrationService orchestrationService,
+            IOrchestrationServiceClient orchestrationServiceClient)
+        {
+            var durabilityProvider = new Mock<DurabilityProvider>(
+                "Test",
+                orchestrationService,
+                orchestrationServiceClient,
+                "TestConnection")
+            {
+                CallBase = true,
+            };
+            durabilityProvider
+                .Setup(provider => provider.SetUseSeparateQueueForEntityWorkItems(It.IsAny<bool>()));
+
+            return durabilityProvider;
         }
 
         /// <summary>

--- a/test/FunctionsV2/Tests/Unit/LocalGrpcListenerTests.cs
+++ b/test/FunctionsV2/Tests/Unit/LocalGrpcListenerTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using System.Net.Sockets;
 using System.Runtime.CompilerServices;
@@ -48,6 +49,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
     public class LocalGrpcListenerTests
     {
+        private const string TaskHubMetadataKey = "Durable-TaskHub";
+
+        // Host's configured hub for the task hub attribution test. Must be a constant so it can be
+        // referenced from [InlineData].
+        private const string AttributionDefaultHubName = "AttributionDefaultHub";
+
         private readonly ITestOutputHelper output;
         private readonly TestLoggerProvider loggerProvider;
 
@@ -86,6 +93,38 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
             Assert.Equal(StatusCode.Unknown, rpcException.StatusCode);
             this.AssertWarning(ErrorMessage, "GetInstance", nameof(InvalidOperationException));
+        }
+
+        [Theory]
+        [InlineData("AttributionOtherHub", "AttributionOtherHub")]
+        [InlineData(null, AttributionDefaultHubName)]
+        [InlineData("", AttributionDefaultHubName)]
+        [InlineData("   ", AttributionDefaultHubName)]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public async Task TestGrpcListener_AttributesWarningToTaskHubFromRequestHeader(
+            string requestTaskHub,
+            string expectedHubName)
+        {
+            const string InstanceId = "test-instance";
+            const string ErrorMessage = "The durability provider failed.";
+
+            var providerException = new InvalidOperationException(ErrorMessage);
+            DurabilityProvider durabilityProvider = CreateFailingGetStateProvider(InstanceId, providerException);
+
+            Metadata headers = requestTaskHub is null
+                ? null
+                : new Metadata { { TaskHubMetadataKey, requestTaskHub } };
+
+            RpcException rpcException = await this.InvokeFailingRpcAsync(
+                AttributionDefaultHubName,
+                durabilityProvider,
+                async client => await client.GetInstanceAsync(
+                    new P.GetInstanceRequest { InstanceId = InstanceId },
+                    headers).ResponseAsync);
+
+            Assert.Equal(StatusCode.Unknown, rpcException.StatusCode);
+            LogMessage warning = this.AssertWarning(ErrorMessage, "GetInstance", nameof(InvalidOperationException));
+            Assert.Equal(expectedHubName, GetLoggedHubName(warning));
         }
 
         [Theory]
@@ -839,7 +878,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             }
         }
 
-        private void AssertWarning(string errorMessage, string methodName, string exceptionType)
+        private LogMessage AssertWarning(string errorMessage, string methodName, string exceptionType)
         {
             LogMessage warning = Assert.Single(
                 this.loggerProvider.GetAllLogMessages(),
@@ -847,6 +886,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                     message.FormattedMessage.Contains(errorMessage));
             Assert.Contains(methodName, warning.FormattedMessage);
             Assert.Contains(exceptionType, warning.FormattedMessage);
+            return warning;
+        }
+
+        private static string GetLoggedHubName(LogMessage warning)
+        {
+            return warning.State.Single(pair => pair.Key == "hubName").Value?.ToString();
         }
 
         private DurableTaskExtension CreateExtension(string hubName, WorkerRuntimeType runtimeType)


### PR DESCRIPTION
## Summary
- add a centralized ASP.NET Core gRPC interceptor that records unexpected provider exceptions through `ExtensionWarningEvent`
- preserve existing client-facing gRPC status codes while retaining the original exception stack for host-side diagnostics
- suppress warnings for deliberate `RpcException` mappings and client-triggered cancellation
- await task-hub create/delete operations so asynchronous provider failures reach the exception boundary

## Validation
- `LocalGrpcListenerTests`: 30/30 passed on .NET 8
- `LocalGrpcListenerTests`: 30/30 passed on .NET 10
- Release build passed for both target frameworks with 0 warnings and 0 errors

Closes #3042