### PR TITLE
Update Azurite CI workflows to Node 22

### DIFF
--- a/.github/workflows/E2ETest.yml
+++ b/.github/workflows/E2ETest.yml
@@ -58,9 +58,9 @@ jobs:
           dotnet-version: 10.0.x
 
       - name: Set up Node.js (needed for Azurite)
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: '22.x'
 
       - name: Set up Python
         if: matrix.language.name == 'python'
@@ -162,9 +162,9 @@ jobs:
           dotnet-version: 10.0.x
 
       - name: Set up Node.js (needed for Azurite)
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: '22.x'
           
       - name: Set up Python
         uses: actions/setup-python@v2

--- a/.github/workflows/dep-version-validation.yml
+++ b/.github/workflows/dep-version-validation.yml
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/setup-dotnet@v4
         with: { dotnet-version: '8.0.x' }
       - uses: actions/setup-node@v4
-        with: { node-version: '20.x' }
+        with: { node-version: '22.x' }
       - run: npm install -g azure-functions-core-tools@4 --unsafe-perm true
 
       - name: Parse and bump Worker extension version
@@ -159,7 +159,7 @@ jobs:
       - uses: actions/setup-dotnet@v4
         with: { dotnet-version: '8.0.x' }
       - uses: actions/setup-node@v4
-        with: { node-version: '20.x' }
+        with: { node-version: '22.x' }
       - run: npm install -g azure-functions-core-tools@4 --unsafe-perm true
 
       - name: Parse and bump WebJobs extension version

--- a/.github/workflows/smoketest-dotnet-isolated-v4.yml
+++ b/.github/workflows/smoketest-dotnet-isolated-v4.yml
@@ -79,14 +79,18 @@ jobs:
     - name: Set up Node.js (needed for Azurite)
       uses: actions/setup-node@v4
       with:
-        node-version: '20.x'
+        node-version: '22.x'
+
+    - name: Resolve Azurite version
+      id: azurite-version
+      run: echo "version=$(npm view azurite version)" >> "$GITHUB_OUTPUT"
 
     - name: Cache Azurite
       id: cache-azurite
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: .azurite
-        key: ${{ runner.os }}-azurite-v2
+        key: ${{ runner.os }}-node22-azurite-${{ steps.azurite-version.outputs.version }}
 
     - name: Install Azurite
       if: steps.cache-azurite.outputs.cache-hit != 'true'
@@ -95,7 +99,7 @@ jobs:
         New-Item -ItemType Directory -Path .azurite -Force
         Set-Location .azurite
         '{"name":"azurite-local","private":true}' | Set-Content package.json
-        npm install azurite
+        npm install azurite@${{ steps.azurite-version.outputs.version }}
 
     - name: Start Azurite
       shell: pwsh

--- a/.github/workflows/validate-build-analyzer.yml
+++ b/.github/workflows/validate-build-analyzer.yml
@@ -50,7 +50,7 @@ jobs:
     - name: Set up Node.js (needed for Azurite)
       uses: actions/setup-node@v4
       with:
-        node-version: '20.x'
+        node-version: '22.x'
 
     - name: Cache npm packages
       uses: actions/cache@v4
@@ -86,4 +86,3 @@ jobs:
 
     - name: Run Analyzer tests
       run: dotnet test ./test/WebJobs.Extensions.DurableTask.Analyzers.Test/WebJobs.Extensions.DurableTask.Analyzers.Test.csproj --no-build
-

--- a/.github/workflows/validate-build-e2e.yml
+++ b/.github/workflows/validate-build-e2e.yml
@@ -57,7 +57,7 @@ jobs:
     - name: Set up Node.js (needed for Azurite)
       uses: actions/setup-node@v4
       with:
-        node-version: '20.x'
+        node-version: '22.x'
 
     - name: Cache npm packages
       uses: actions/cache@v4

--- a/.github/workflows/validate-build-scale.yml
+++ b/.github/workflows/validate-build-scale.yml
@@ -48,7 +48,7 @@ jobs:
     - name: Set up Node.js (needed for Azurite)
       uses: actions/setup-node@v4
       with:
-        node-version: '20.x'
+        node-version: '22.x'
 
     - name: Cache npm packages
       uses: actions/cache@v4
@@ -106,7 +106,7 @@ jobs:
       - name: Set up Node.js (needed for Azurite)
         uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: '22.x'
 
       - name: Install and Start Azurite
         run: |
@@ -171,9 +171,9 @@ jobs:
           global-json-file: global.json
 
       - name: Set up Node.js (needed for Azurite)
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: '18.x'
+          node-version: '22.x'
 
       - name: Install Azurite
         run: npm install -g azurite
@@ -248,9 +248,9 @@ jobs:
           global-json-file: global.json
 
       - name: Set up Node.js (needed for Azurite)
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: '18.x'
+          node-version: '22.x'
 
       - name: Install Azurite
         run: npm install -g azurite


### PR DESCRIPTION
## Summary
- update all CI jobs that install the latest Azurite release from Node 18/20 to Node 22
- update affected `actions/setup-node` usages from v3 to v4
- key the cached Azurite installation by Node major and the resolved Azurite version, and install that exact version

## Validation
- parsed all six changed workflow files as YAML
- confirmed all 11 Azurite install sites use Node 22
- ran `git diff --check`