### PR TITLE
Fix purge requests with Python minimum dates

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
+++ b/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
@@ -610,15 +610,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
             IDurableOrchestrationClient client = this.GetClient(request);
             var queryNameValuePairs = request.GetQueryNameValuePairs();
-            string createdTimeFromValue = queryNameValuePairs[CreatedTimeFromParameter];
-            bool hasBareCreatedTimeFrom = queryNameValuePairs.GetValues(string.Empty)?
-                .Any(value => string.Equals(value, CreatedTimeFromParameter, StringComparison.OrdinalIgnoreCase)) == true;
-            DateTime createdTimeFrom;
-            if (createdTimeFromValue == null && !hasBareCreatedTimeFrom)
-            {
-                createdTimeFrom = DateTime.MinValue;
-            }
-            else if (!TryGetDateTimeQueryParameterValue(queryNameValuePairs, CreatedTimeFromParameter, out createdTimeFrom))
+            if (!TryGetDateTimeQueryParameterValue(queryNameValuePairs, CreatedTimeFromParameter, out DateTime createdTimeFrom))
             {
                 var badRequestResponse = request.CreateResponse(
                     HttpStatusCode.BadRequest,
@@ -805,10 +797,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             {
                 // Python's strftime can omit leading zeroes from years before 1000 on Linux.
                 string paddedValue = value.PadLeft(value.Length + 4 - yearSeparatorIndex, '0');
-                if (DateTime.TryParse(
+                if (DateTime.TryParseExact(
                         paddedValue,
+                        "yyyy-MM-dd'T'HH:mm:ss.ffffff'Z'",
                         CultureInfo.InvariantCulture,
-                        DateTimeStyles.RoundtripKind,
+                        DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
                         out dateTimeValue))
                 {
                     return true;

--- a/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
+++ b/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
@@ -789,6 +789,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         private static bool TryGetDateTimeQueryParameterValue(NameValueCollection queryStringNameValueCollection, string queryParameterName, out DateTime dateTimeValue)
         {
             string value = queryStringNameValueCollection[queryParameterName];
+            if (DateTime.TryParse(value, out dateTimeValue))
+            {
+                return true;
+            }
+
             int yearSeparatorIndex = value?.IndexOf('-') ?? -1;
             if (value != null &&
                 yearSeparatorIndex > 0 &&
@@ -799,16 +804,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 string paddedValue = value.PadLeft(value.Length + 4 - yearSeparatorIndex, '0');
                 if (DateTime.TryParseExact(
                         paddedValue,
-                        "yyyy-MM-dd'T'HH:mm:ss.ffffff'Z'",
+                        "yyyy-MM-dd'T'HH:mm:ss.ffffffK",
                         CultureInfo.InvariantCulture,
-                        DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
+                        DateTimeStyles.RoundtripKind,
                         out dateTimeValue))
                 {
                     return true;
                 }
             }
 
-            return DateTime.TryParse(value, out dateTimeValue);
+            return false;
         }
 
         private static bool TryGetBooleanQueryParameterValue(NameValueCollection queryStringNameValueCollection, string queryParameterName, out bool boolValue)

--- a/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
+++ b/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
@@ -610,7 +610,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
             IDurableOrchestrationClient client = this.GetClient(request);
             var queryNameValuePairs = request.GetQueryNameValuePairs();
-            if (!TryGetDateTimeQueryParameterValue(queryNameValuePairs, CreatedTimeFromParameter, out DateTime createdTimeFrom))
+            string createdTimeFromValue = queryNameValuePairs[CreatedTimeFromParameter];
+            bool hasBareCreatedTimeFrom = queryNameValuePairs.GetValues(string.Empty)?
+                .Any(value => string.Equals(value, CreatedTimeFromParameter, StringComparison.OrdinalIgnoreCase)) == true;
+            DateTime createdTimeFrom;
+            if (createdTimeFromValue == null && !hasBareCreatedTimeFrom)
+            {
+                createdTimeFrom = DateTime.MinValue;
+            }
+            else if (!TryGetDateTimeQueryParameterValue(queryNameValuePairs, CreatedTimeFromParameter, out createdTimeFrom))
             {
                 var badRequestResponse = request.CreateResponse(
                     HttpStatusCode.BadRequest,
@@ -790,17 +798,21 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         {
             string value = queryStringNameValueCollection[queryParameterName];
             int yearSeparatorIndex = value?.IndexOf('-') ?? -1;
-            if (yearSeparatorIndex > 0 &&
+            if (value != null &&
+                yearSeparatorIndex > 0 &&
                 yearSeparatorIndex < 4 &&
                 value.Take(yearSeparatorIndex).All(char.IsDigit))
             {
                 // Python's strftime can omit leading zeroes from years before 1000 on Linux.
                 string paddedValue = value.PadLeft(value.Length + 4 - yearSeparatorIndex, '0');
-                return DateTime.TryParse(
-                    paddedValue,
-                    CultureInfo.InvariantCulture,
-                    DateTimeStyles.RoundtripKind,
-                    out dateTimeValue);
+                if (DateTime.TryParse(
+                        paddedValue,
+                        CultureInfo.InvariantCulture,
+                        DateTimeStyles.RoundtripKind,
+                        out dateTimeValue))
+                {
+                    return true;
+                }
             }
 
             return DateTime.TryParse(value, out dateTimeValue);

--- a/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
+++ b/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Diagnostics;
+using System.Globalization;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -788,6 +789,20 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         private static bool TryGetDateTimeQueryParameterValue(NameValueCollection queryStringNameValueCollection, string queryParameterName, out DateTime dateTimeValue)
         {
             string value = queryStringNameValueCollection[queryParameterName];
+            int yearSeparatorIndex = value?.IndexOf('-') ?? -1;
+            if (yearSeparatorIndex > 0 &&
+                yearSeparatorIndex < 4 &&
+                value.Take(yearSeparatorIndex).All(char.IsDigit))
+            {
+                // Python's strftime can omit leading zeroes from years before 1000 on Linux.
+                string paddedValue = value.PadLeft(value.Length + 4 - yearSeparatorIndex, '0');
+                return DateTime.TryParse(
+                    paddedValue,
+                    CultureInfo.InvariantCulture,
+                    DateTimeStyles.RoundtripKind,
+                    out dateTimeValue);
+            }
+
             return DateTime.TryParse(value, out dateTimeValue);
         }
 

--- a/test/FunctionsV2/Tests/Unit/HttpApiHandlerTests.cs
+++ b/test/FunctionsV2/Tests/Unit/HttpApiHandlerTests.cs
@@ -851,6 +851,42 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             Assert.Equal(instanceId, actual.InstanceId);
         }
 
+        [Theory]
+        [InlineData("1-01-01T00:00:00.000000Z", 1)]
+        [InlineData("100-01-01T00:00:00.000000Z", 100)]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public async Task PurgeHistoryWithShortYearDate_Succeeds(string createdTimeFrom, int expectedYear)
+        {
+            DateTime actualCreatedTimeFrom = default;
+            var clientMock = new Mock<IDurableClient>();
+            clientMock
+                .Setup(x => x.PurgeInstanceHistoryAsync(
+                    It.IsAny<DateTime>(),
+                    It.IsAny<DateTime?>(),
+                    It.IsAny<IEnumerable<OrchestrationStatus>>()))
+                .Callback((DateTime createdTimeFrom, DateTime? createdTimeTo, IEnumerable<OrchestrationStatus> runtimeStatus) =>
+                {
+                    actualCreatedTimeFrom = createdTimeFrom;
+                })
+                .Returns(Task.FromResult(new PurgeHistoryResult(1)));
+
+            var purgeRequestUriBuilder = new UriBuilder(TestConstants.NotificationUrl);
+            purgeRequestUriBuilder.Path += "/Instances/";
+            purgeRequestUriBuilder.Query = $"createdTimeFrom={createdTimeFrom}";
+
+            var httpApiHandler = new ExtendedHttpApiHandler(clientMock.Object);
+            HttpResponseMessage responseMessage = await httpApiHandler.HandleRequestAsync(
+                new HttpRequestMessage
+                {
+                    Method = HttpMethod.Delete,
+                    RequestUri = purgeRequestUriBuilder.Uri,
+                },
+                CancellationToken.None);
+
+            Assert.Equal(HttpStatusCode.OK, responseMessage.StatusCode);
+            Assert.Equal(new DateTime(expectedYear, 1, 1), actualCreatedTimeFrom);
+        }
+
         [Fact]
         [Trait("Category", PlatformSpecificHelpers.TestCategory)]
         public async Task TerminateInstanceWebhook()

--- a/test/FunctionsV2/Tests/Unit/HttpApiHandlerTests.cs
+++ b/test/FunctionsV2/Tests/Unit/HttpApiHandlerTests.cs
@@ -889,21 +889,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
         [Fact]
         [Trait("Category", PlatformSpecificHelpers.TestCategory)]
-        public async Task PurgeHistoryWithoutCreatedTimeFrom_UsesMinimumDate()
+        public async Task PurgeHistoryWithoutCreatedTimeFrom_ReturnsBadRequest()
         {
-            DateTime actualCreatedTimeFrom = default;
-            var clientMock = new Mock<IDurableClient>();
-            clientMock
-                .Setup(x => x.PurgeInstanceHistoryAsync(
-                    It.IsAny<DateTime>(),
-                    It.IsAny<DateTime?>(),
-                    It.IsAny<IEnumerable<OrchestrationStatus>>()))
-                .Callback((DateTime createdTimeFrom, DateTime? createdTimeTo, IEnumerable<OrchestrationStatus> runtimeStatus) =>
-                {
-                    actualCreatedTimeFrom = createdTimeFrom;
-                })
-                .Returns(Task.FromResult(new PurgeHistoryResult(1)));
-
+            var clientMock = new Mock<IDurableClient>(MockBehavior.Strict);
             var purgeRequestUriBuilder = new UriBuilder(TestConstants.NotificationUrl);
             purgeRequestUriBuilder.Path += "/Instances/";
 
@@ -916,8 +904,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 },
                 CancellationToken.None);
 
-            Assert.Equal(HttpStatusCode.OK, responseMessage.StatusCode);
-            Assert.Equal(DateTime.MinValue, actualCreatedTimeFrom);
+            Assert.Equal(HttpStatusCode.BadRequest, responseMessage.StatusCode);
         }
 
         [Fact]
@@ -960,6 +947,40 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 CancellationToken.None);
 
             Assert.Equal(HttpStatusCode.BadRequest, responseMessage.StatusCode);
+        }
+
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public async Task PurgeHistoryWithLegacyShortDate_PreservesExistingParsing()
+        {
+            DateTime actualCreatedTimeFrom = default;
+            var clientMock = new Mock<IDurableClient>();
+            clientMock
+                .Setup(x => x.PurgeInstanceHistoryAsync(
+                    It.IsAny<DateTime>(),
+                    It.IsAny<DateTime?>(),
+                    It.IsAny<IEnumerable<OrchestrationStatus>>()))
+                .Callback((DateTime createdTimeFrom, DateTime? createdTimeTo, IEnumerable<OrchestrationStatus> runtimeStatus) =>
+                {
+                    actualCreatedTimeFrom = createdTimeFrom;
+                })
+                .Returns(Task.FromResult(new PurgeHistoryResult(1)));
+
+            var purgeRequestUriBuilder = new UriBuilder(TestConstants.NotificationUrl);
+            purgeRequestUriBuilder.Path += "/Instances/";
+            purgeRequestUriBuilder.Query = "createdTimeFrom=12-11-10";
+
+            var httpApiHandler = new ExtendedHttpApiHandler(clientMock.Object);
+            HttpResponseMessage responseMessage = await httpApiHandler.HandleRequestAsync(
+                new HttpRequestMessage
+                {
+                    Method = HttpMethod.Delete,
+                    RequestUri = purgeRequestUriBuilder.Uri,
+                },
+                CancellationToken.None);
+
+            Assert.Equal(HttpStatusCode.OK, responseMessage.StatusCode);
+            Assert.Equal(DateTime.Parse("12-11-10"), actualCreatedTimeFrom);
         }
 
         [Fact]

--- a/test/FunctionsV2/Tests/Unit/HttpApiHandlerTests.cs
+++ b/test/FunctionsV2/Tests/Unit/HttpApiHandlerTests.cs
@@ -872,7 +872,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
             var purgeRequestUriBuilder = new UriBuilder(TestConstants.NotificationUrl);
             purgeRequestUriBuilder.Path += "/Instances/";
-            purgeRequestUriBuilder.Query = $"createdTimeFrom={createdTimeFrom}";
+            purgeRequestUriBuilder.Query = $"createdTimeFrom={WebUtility.UrlEncode(createdTimeFrom)}";
 
             var httpApiHandler = new ExtendedHttpApiHandler(clientMock.Object);
             HttpResponseMessage responseMessage = await httpApiHandler.HandleRequestAsync(
@@ -885,6 +885,81 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
             Assert.Equal(HttpStatusCode.OK, responseMessage.StatusCode);
             Assert.Equal(new DateTime(expectedYear, 1, 1), actualCreatedTimeFrom);
+        }
+
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public async Task PurgeHistoryWithoutCreatedTimeFrom_UsesMinimumDate()
+        {
+            DateTime actualCreatedTimeFrom = default;
+            var clientMock = new Mock<IDurableClient>();
+            clientMock
+                .Setup(x => x.PurgeInstanceHistoryAsync(
+                    It.IsAny<DateTime>(),
+                    It.IsAny<DateTime?>(),
+                    It.IsAny<IEnumerable<OrchestrationStatus>>()))
+                .Callback((DateTime createdTimeFrom, DateTime? createdTimeTo, IEnumerable<OrchestrationStatus> runtimeStatus) =>
+                {
+                    actualCreatedTimeFrom = createdTimeFrom;
+                })
+                .Returns(Task.FromResult(new PurgeHistoryResult(1)));
+
+            var purgeRequestUriBuilder = new UriBuilder(TestConstants.NotificationUrl);
+            purgeRequestUriBuilder.Path += "/Instances/";
+
+            var httpApiHandler = new ExtendedHttpApiHandler(clientMock.Object);
+            HttpResponseMessage responseMessage = await httpApiHandler.HandleRequestAsync(
+                new HttpRequestMessage
+                {
+                    Method = HttpMethod.Delete,
+                    RequestUri = purgeRequestUriBuilder.Uri,
+                },
+                CancellationToken.None);
+
+            Assert.Equal(HttpStatusCode.OK, responseMessage.StatusCode);
+            Assert.Equal(DateTime.MinValue, actualCreatedTimeFrom);
+        }
+
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public async Task PurgeHistoryWithInvalidCreatedTimeFrom_ReturnsBadRequest()
+        {
+            var clientMock = new Mock<IDurableClient>(MockBehavior.Strict);
+            var purgeRequestUriBuilder = new UriBuilder(TestConstants.NotificationUrl);
+            purgeRequestUriBuilder.Path += "/Instances/";
+            purgeRequestUriBuilder.Query = "createdTimeFrom=invalid";
+
+            var httpApiHandler = new ExtendedHttpApiHandler(clientMock.Object);
+            HttpResponseMessage responseMessage = await httpApiHandler.HandleRequestAsync(
+                new HttpRequestMessage
+                {
+                    Method = HttpMethod.Delete,
+                    RequestUri = purgeRequestUriBuilder.Uri,
+                },
+                CancellationToken.None);
+
+            Assert.Equal(HttpStatusCode.BadRequest, responseMessage.StatusCode);
+        }
+
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public async Task PurgeHistoryWithBareCreatedTimeFrom_ReturnsBadRequest()
+        {
+            var clientMock = new Mock<IDurableClient>(MockBehavior.Strict);
+            var purgeRequestUriBuilder = new UriBuilder(TestConstants.NotificationUrl);
+            purgeRequestUriBuilder.Path += "/Instances/";
+            purgeRequestUriBuilder.Query = "createdTimeFrom";
+
+            var httpApiHandler = new ExtendedHttpApiHandler(clientMock.Object);
+            HttpResponseMessage responseMessage = await httpApiHandler.HandleRequestAsync(
+                new HttpRequestMessage
+                {
+                    Method = HttpMethod.Delete,
+                    RequestUri = purgeRequestUriBuilder.Uri,
+                },
+                CancellationToken.None);
+
+            Assert.Equal(HttpStatusCode.BadRequest, responseMessage.StatusCode);
         }
 
         [Fact]

--- a/test/FunctionsV2/Tests/Unit/HttpApiHandlerTests.cs
+++ b/test/FunctionsV2/Tests/Unit/HttpApiHandlerTests.cs
@@ -853,7 +853,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
         [Theory]
         [InlineData("1-01-01T00:00:00.000000Z", 1)]
-        [InlineData("100-01-01T00:00:00.000000Z", 100)]
+        [InlineData("12-01-01T00:00:00.000000Z", 12)]
         [Trait("Category", PlatformSpecificHelpers.TestCategory)]
         public async Task PurgeHistoryWithShortYearDate_Succeeds(string createdTimeFrom, int expectedYear)
         {
@@ -981,6 +981,41 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
             Assert.Equal(HttpStatusCode.OK, responseMessage.StatusCode);
             Assert.Equal(DateTime.Parse("12-11-10"), actualCreatedTimeFrom);
+        }
+
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public async Task PurgeHistoryWithPreviouslyAcceptedThreeDigitYear_PreservesExistingParsing()
+        {
+            const string createdTimeFrom = "100-01-01T00:00:00.000000Z";
+            DateTime actualCreatedTimeFrom = default;
+            var clientMock = new Mock<IDurableClient>();
+            clientMock
+                .Setup(x => x.PurgeInstanceHistoryAsync(
+                    It.IsAny<DateTime>(),
+                    It.IsAny<DateTime?>(),
+                    It.IsAny<IEnumerable<OrchestrationStatus>>()))
+                .Callback((DateTime parsedCreatedTimeFrom, DateTime? createdTimeTo, IEnumerable<OrchestrationStatus> runtimeStatus) =>
+                {
+                    actualCreatedTimeFrom = parsedCreatedTimeFrom;
+                })
+                .Returns(Task.FromResult(new PurgeHistoryResult(1)));
+
+            var purgeRequestUriBuilder = new UriBuilder(TestConstants.NotificationUrl);
+            purgeRequestUriBuilder.Path += "/Instances/";
+            purgeRequestUriBuilder.Query = $"createdTimeFrom={WebUtility.UrlEncode(createdTimeFrom)}";
+
+            var httpApiHandler = new ExtendedHttpApiHandler(clientMock.Object);
+            HttpResponseMessage responseMessage = await httpApiHandler.HandleRequestAsync(
+                new HttpRequestMessage
+                {
+                    Method = HttpMethod.Delete,
+                    RequestUri = purgeRequestUriBuilder.Uri,
+                },
+                CancellationToken.None);
+
+            Assert.Equal(HttpStatusCode.OK, responseMessage.StatusCode);
+            Assert.Equal(DateTime.Parse(createdTimeFrom), actualCreatedTimeFrom);
         }
 
         [Fact]


### PR DESCRIPTION
## Summary
- accept one- to three-digit years in Durable HTTP date filters
- preserve UTC semantics while normalizing Python/Linux short-year timestamps
- cover filtered purge requests using datetime.min-style values

Fixes #2531