### PR TITLE
Fix ArgumentException from GetStatusAsync(showHistory: true) after a rewind

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -24,6 +24,7 @@
 
 ### Bug Fixes
 
+- Fixed `GetStatusAsync(showHistory: true)` throwing `ArgumentException: An item with the same key has already been added` for orchestrations that had been rewound, since rewound history legitimately contains repeated scheduled-event IDs. (#874)
 - Fixed a poison loop where dispatching a disabled-but-still-deployed activity or entity function caused in-flight orchestrations to retry indefinitely (e.g. throwing `ArgumentNullException('executor')` on the activity dispatch path) instead of failing gracefully. Such registered-but-inactive functions are now treated as unavailable and fail deterministically. (#3471)
 - Fixed empty Application Insights operation names for Distributed Tracing V2 orchestration and activity telemetry when instance ID suffixes are disabled. (#3156)
 

--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableClient.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableClient.cs
@@ -1048,7 +1048,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
         private static void TrackNameAndScheduledTime(JObject historyItem, EventType eventType, int index, Dictionary<string, EventIndexDateMapping> eventMapper)
         {
-            eventMapper.Add($"{eventType}_{historyItem["EventId"]}", new EventIndexDateMapping { Index = index, Name = (string)historyItem["Name"], Date = (DateTime)historyItem["Timestamp"], Input = (string)historyItem["Input"] });
+            eventMapper[$"{eventType}_{historyItem["EventId"]}"] = new EventIndexDateMapping { Index = index, Name = (string)historyItem["Name"], Date = (DateTime)historyItem["Timestamp"], Input = (string)historyItem["Input"] };
         }
 
         private static void AddScheduledEventDataAndAggregate(ref Dictionary<string, EventIndexDateMapping> eventMapper, string prefix, JToken historyItem, int[] eventsToRemove, bool showInput)

--- a/test/FunctionsV2/Tests/Unit/DurableClientHistoryTests.cs
+++ b/test/FunctionsV2/Tests/Unit/DurableClientHistoryTests.cs
@@ -39,6 +39,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             { true, true },
         };
 
+        public static TheoryData<EventType, EventType> RewindDuplicateScheduledEventIdCases => new TheoryData<EventType, EventType>
+        {
+            { EventType.TaskScheduled, EventType.TaskCompleted },
+            { EventType.SubOrchestrationInstanceCreated, EventType.SubOrchestrationInstanceCompleted },
+        };
+
         public static TheoryData<int[]> HistoryRemovalCases => new TheoryData<int[]>
         {
             new[] { 0, 0, 0 },
@@ -199,6 +205,67 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             };
             AssertJsonEqual(
                 new JArray(retainedUnknownEvent, expectedCompletion1, expectedCompletion2),
+                actual);
+        }
+
+        [Theory]
+        [MemberData(nameof(RewindDuplicateScheduledEventIdCases))]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public async Task GetStatusAsync_DuplicateScheduledEventIdsFromRewindDoNotThrow(EventType scheduledType, EventType completedType)
+        {
+            // A rewind replays work items, so history can legitimately contain two scheduled events
+            // sharing the same EventId. Each completion must resolve to the most recent preceding
+            // scheduled event, and both scheduled events must still be compacted away.
+            string history = new JArray(
+                CreateEvent(
+                    scheduledType,
+                    40,
+                    StartTime,
+                    new JProperty("Name", "PreRewindWork"),
+                    new JProperty("Input", ActivityInput),
+                    new JProperty("Version", "v1")),
+                CreateEvent(
+                    completedType,
+                    41,
+                    StartTime.AddSeconds(1),
+                    new JProperty("TaskScheduledId", 40),
+                    new JProperty("Result", StringResult)),
+                CreateEvent(
+                    scheduledType,
+                    40,
+                    StartTime.AddSeconds(2),
+                    new JProperty("Name", "PostRewindWork"),
+                    new JProperty("Input", FailedActivityInput),
+                    new JProperty("Version", "v2")),
+                CreateEvent(
+                    completedType,
+                    42,
+                    StartTime.AddSeconds(3),
+                    new JProperty("TaskScheduledId", 40),
+                    new JProperty("Result", ObjectResult))).ToString(Formatting.None);
+
+            JArray actual = await GetProjectedHistoryAsync(history, showInput: true, showHistoryOutput: true);
+
+            var expectedPreRewindCompletion = new JObject
+            {
+                ["EventType"] = completedType.ToString(),
+                ["Timestamp"] = StartTime.AddSeconds(1),
+                ["Result"] = "activity-result",
+                ["ScheduledTime"] = StartTime.ToLocalTime(),
+                ["FunctionName"] = "PreRewindWork",
+                ["Input"] = ActivityInput,
+            };
+            var expectedPostRewindCompletion = new JObject
+            {
+                ["EventType"] = completedType.ToString(),
+                ["Timestamp"] = StartTime.AddSeconds(3),
+                ["Result"] = new JObject { ["ok"] = true },
+                ["ScheduledTime"] = StartTime.AddSeconds(2).ToLocalTime(),
+                ["FunctionName"] = "PostRewindWork",
+                ["Input"] = FailedActivityInput,
+            };
+            AssertJsonEqual(
+                new JArray(expectedPreRewindCompletion, expectedPostRewindCompletion),
                 actual);
         }
 


### PR DESCRIPTION
# Summary
## What changed?
- Make the client-side history projection tolerate duplicate scheduled `EventId`s instead of throwing.
- Add unit coverage for both affected event pairs (`TaskScheduled`/`TaskCompleted` and `SubOrchestrationInstanceCreated`/`SubOrchestrationInstanceCompleted`).
- Add a release note for the user-visible bug fix.

## Why is this change needed?
- `DurableClient.TrackNameAndScheduledTime` built its lookup with `eventMapper.Add(key, ...)`, which throws when the same key is inserted twice.
- Rewind replays a failed region of an orchestration, so a history can legitimately contain a second `TaskScheduled` (or `SubOrchestrationInstanceCreated`) event reusing an earlier `EventId`.
- The result was that `GetStatusAsync(instanceId, showHistory: true)` threw `ArgumentException: An item with the same key has already been added. Key: TaskScheduled_40` for any instance that had been rewound, making status-with-history permanently unreadable for that instance.
- Switching to an indexer assignment (`eventMapper[key] = ...`) gives last-write-wins, so the most recent scheduling attempt is the one projected onto the corresponding completion event — which is the attempt the completion actually belongs to.

## Issues / work items
- Resolves #874

---

# Project checklist
- [x] Documentation changes are not required
  - [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
- [ ] Release notes are not required for the next release
  - [x] Otherwise: Notes added to `release_notes.md`
- [x] Backport is not required
  - [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
- [x] All required tests have been added/updated (unit tests, E2E tests)
- [x] No extra work is required to be leveraged by OutOfProc SDKs
  - [ ] Otherwise: Work tracked here: #issue_or_pr_in_each_sdk
- [x] No change to the version of the `WebJobs.Extensions.DurableTask` package
  - [ ] Otherwise: Major/minor updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
- [x] No EventIds were added to `EventSource` logs
  - [ ] Otherwise: Ensure EventIds are within the supported range in the existing Windows infrastructure (validate via deployed telemetry).
- [ ] This change should be added to the `v2.x` branch
  - [x] Otherwise: This change applies exclusively to `WebJobs.Extensions.DurableTask` v3.x and will be retained only in the `dev` and `main` branches
- [ ] Breaking change?
  - [ ] If yes:
    - Impact:
    - Migration guidance:

---

# AI-assisted code disclosure (required)
## Was an AI tool used? (select one)
- [ ] No
- [ ] Yes, AI helped write parts of this PR (e.g., GitHub Copilot)
- [x] Yes, an AI agent generated most of this PR

If AI was used:
- Tool(s): GitHub Copilot CLI
- AI-assisted areas/files: `DurableClient.TrackNameAndScheduledTime` fix, `DurableClientHistoryTests` regression theory, and the release note.
- What you changed after AI output: The generated test originally only asserted that no exception was thrown, which would have passed under either duplicate-handling strategy. It was reworked to assert the full projected history array, and then validated by temporarily substituting a first-write-wins `ContainsKey` guard — the test correctly failed, confirming the assertions actually pin last-write-wins semantics rather than merely the absence of a throw. The variant was reverted.

AI verification (required if AI was used):
- [x] I understand the code and can explain it
- [x] I verified referenced APIs/types exist and are correct
- [x] I reviewed edge cases/failure paths (timeouts, retries, cancellation, exceptions)
- [x] I reviewed concurrency/async behavior
- [x] I checked for unintended breaking or behavior changes

---

# Testing
## Automated tests
- Result: Passed
  - `DurableClientHistoryTests`: 20/20 on .NET 8 and 20/20 on .NET 10
  - Full unit suite: no regressions
- Red/green evidence for the new regression:
  - Before the fix: 2 failed / 18 passed, failing with the exact exception from the issue — `System.ArgumentException : An item with the same key has already been added. Key: TaskScheduled_40` (and `Key: SubOrchestrationInstanceCreated_40`), thrown from `DurableClient.cs:1051`.
  - After the fix: 20/20.

## Manual validation (only if runtime/behavior changed)
- Not required — the change is a pure in-memory history projection fix and is fully covered by the unit regression, which reproduces the reported exception directly from a rewound history fixture.
- The fixture models the rewind shape reported in the issue: scheduled `EventId=40` -> completion -> scheduled `EventId=40` again -> completion.

---

# Notes for reviewers
- `TrackNameAndScheduledTime` is the shared helper behind both affected call sites (`TaskScheduled` and `SubOrchestrationInstanceCreated`), so the single-line change fixes both event families; the test is a `[Theory]` covering both.
- Last-write-wins was chosen deliberately over first-write-wins: after a rewind, the later scheduling entry is the one the subsequent completion event corresponds to, so projecting the newer name/timestamp is the semantically correct pairing.
- Worth confirming during review whether the same projection code exists on the `v2.x` branch; if it does, this is likely a backport candidate. The checklist is marked "no backport" only because I could not confirm that from the `dev` branch alone.
