### PR TITLE
Forward Durable settings to gRPC workers

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/Bindings/BindingHelper.cs
+++ b/src/WebJobs.Extensions.DurableTask/Bindings/BindingHelper.cs
@@ -52,6 +52,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     RpcBaseUrl = localRpcAddress,
                     RequiredQueryStringParameters = this.config.HttpApiHandler.GetUniversalQueryStrings(),
                     HttpBaseUrl = this.config.HttpApiHandler.GetBaseUrl(),
+                    UseForwardedHost = this.config.Options.HttpSettings.UseForwardedHost,
                     MaxGrpcMessageSizeInBytes = this.config.Options.MaxGrpcMessageSizeInBytes,
                     GrpcHttpClientTimeout = JsonConvert.SerializeObject(this.config.Options.GrpcHttpClientTimeout),
                 });
@@ -149,6 +150,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             /// </summary>
             [JsonProperty("httpBaseUrl")]
             public string? HttpBaseUrl { get; set; }
+
+            /// <summary>
+            /// Gets or sets a value indicating whether workers should use forwarded headers for URL construction.
+            /// </summary>
+            [JsonProperty("useForwardedHost", NullValueHandling = NullValueHandling.Ignore)]
+            public bool? UseForwardedHost { get; set; }
 
             /// <summary>
             /// Optional setting that specifies the maximum gRPC receive message size (in bytes) for the DurableTaskClient.

--- a/src/WebJobs.Extensions.DurableTask/Bindings/BindingHelper.cs
+++ b/src/WebJobs.Extensions.DurableTask/Bindings/BindingHelper.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     RpcBaseUrl = localRpcAddress,
                     RequiredQueryStringParameters = this.config.HttpApiHandler.GetUniversalQueryStrings(),
                     HttpBaseUrl = this.config.HttpApiHandler.GetBaseUrl(),
-                    UseForwardedHost = this.config.Options.HttpSettings.UseForwardedHost,
+                    UseForwardedHost = this.config.Options.HttpSettings?.UseForwardedHost ?? false,
                     MaxGrpcMessageSizeInBytes = this.config.Options.MaxGrpcMessageSizeInBytes,
                     GrpcHttpClientTimeout = JsonConvert.SerializeObject(this.config.Options.GrpcHttpClientTimeout),
                 });

--- a/src/WebJobs.Extensions.DurableTask/Bindings/EntityTriggerAttributeBindingProvider.cs
+++ b/src/WebJobs.Extensions.DurableTask/Bindings/EntityTriggerAttributeBindingProvider.cs
@@ -139,7 +139,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 {
                     // Generate a byte array which is the serialized protobuf payload
                     // https://developers.google.com/protocol-buffers/docs/csharptutorial#parsing_and_serialization
-                    var entityBatchRequest = remoteContext.Request.ToEntityBatchRequest(remoteContext.Configurations);
+                    var entityBatchRequest = remoteContext.Request.ToEntityBatchRequest(
+                        remoteContext.Configurations,
+                        remoteContext.RollbackEntityOperationsOnExceptions);
 
                     // We convert the binary payload into a base64 string because that seems to be the most commonly supported
                     // format for Azure Functions language workers. Attempts to send unencoded byte[] payloads were unsuccessful.

--- a/src/WebJobs.Extensions.DurableTask/Bindings/EntityTriggerAttributeBindingProvider.cs
+++ b/src/WebJobs.Extensions.DurableTask/Bindings/EntityTriggerAttributeBindingProvider.cs
@@ -139,9 +139,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 {
                     // Generate a byte array which is the serialized protobuf payload
                     // https://developers.google.com/protocol-buffers/docs/csharptutorial#parsing_and_serialization
-                    var entityBatchRequest = remoteContext.Request.ToEntityBatchRequest(
-                        remoteContext.Configurations,
-                        remoteContext.RollbackEntityOperationsOnExceptions);
+                    var entityBatchRequest = remoteContext.Request.ToEntityBatchRequest(remoteContext.Configurations);
 
                     // We convert the binary payload into a base64 string because that seems to be the most commonly supported
                     // format for Azure Functions language workers. Attempts to send unencoded byte[] payloads were unsuccessful.

--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/RemoteEntityContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/RemoteEntityContext.cs
@@ -14,15 +14,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         public RemoteEntityContext(EntityBatchRequest batchRequest, DurableTaskOptions options, bool isExtendedSession, bool includeEntityState)
         {
             this.Request = batchRequest;
-            this.RollbackEntityOperationsOnExceptions = options.RollbackEntityOperationsOnExceptions;
+            this.Configurations = new RemoteInstanceConfiguration
+            {
+                RollbackEntityOperationsOnExceptions = options.RollbackEntityOperationsOnExceptions,
+            };
+
             if (options.ExtendedSessionsEnabled)
             {
-                this.Configurations = new RemoteInstanceConfiguration
-                {
-                    IsExtendedSession = isExtendedSession,
-                    IncludeState = includeEntityState,
-                    ExtendedSessionIdleTimeoutInSeconds = options.ExtendedSessionIdleTimeoutInSeconds,
-                };
+                this.Configurations.IsExtendedSession = isExtendedSession;
+                this.Configurations.IncludeState = includeEntityState;
+                this.Configurations.ExtendedSessionIdleTimeoutInSeconds = options.ExtendedSessionIdleTimeoutInSeconds;
             }
         }
 
@@ -30,10 +31,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         internal EntityBatchRequest Request { get; private set; }
 
         [JsonProperty("configurations")]
-        public RemoteInstanceConfiguration? Configurations { get; }
-
-        [JsonIgnore]
-        internal bool RollbackEntityOperationsOnExceptions { get; }
+        public RemoteInstanceConfiguration Configurations { get; }
 
         [JsonIgnore]
         internal EntityBatchResult? Result { get; set; }

--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/RemoteEntityContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/RemoteEntityContext.cs
@@ -14,16 +14,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         public RemoteEntityContext(EntityBatchRequest batchRequest, DurableTaskOptions options, bool isExtendedSession, bool includeEntityState)
         {
             this.Request = batchRequest;
-            this.Configurations = new RemoteInstanceConfiguration
-            {
-                RollbackEntityOperationsOnExceptions = options.RollbackEntityOperationsOnExceptions,
-            };
-
+            this.RollbackEntityOperationsOnExceptions = options.RollbackEntityOperationsOnExceptions;
             if (options.ExtendedSessionsEnabled)
             {
-                this.Configurations.IsExtendedSession = isExtendedSession;
-                this.Configurations.IncludeState = includeEntityState;
-                this.Configurations.ExtendedSessionIdleTimeoutInSeconds = options.ExtendedSessionIdleTimeoutInSeconds;
+                this.Configurations = new RemoteInstanceConfiguration
+                {
+                    IsExtendedSession = isExtendedSession,
+                    IncludeState = includeEntityState,
+                    ExtendedSessionIdleTimeoutInSeconds = options.ExtendedSessionIdleTimeoutInSeconds,
+                };
             }
         }
 
@@ -31,7 +30,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         internal EntityBatchRequest Request { get; private set; }
 
         [JsonProperty("configurations")]
-        public RemoteInstanceConfiguration Configurations { get; }
+        public RemoteInstanceConfiguration? Configurations { get; }
+
+        [JsonIgnore]
+        internal bool RollbackEntityOperationsOnExceptions { get; }
 
         [JsonIgnore]
         internal EntityBatchResult? Result { get; set; }

--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/RemoteEntityContext.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/RemoteEntityContext.cs
@@ -14,6 +14,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         public RemoteEntityContext(EntityBatchRequest batchRequest, DurableTaskOptions options, bool isExtendedSession, bool includeEntityState)
         {
             this.Request = batchRequest;
+            this.RollbackEntityOperationsOnExceptions = options.RollbackEntityOperationsOnExceptions;
             if (options.ExtendedSessionsEnabled)
             {
                 this.Configurations = new RemoteInstanceConfiguration
@@ -30,6 +31,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
         [JsonProperty("configurations")]
         public RemoteInstanceConfiguration? Configurations { get; }
+
+        [JsonIgnore]
+        internal bool RollbackEntityOperationsOnExceptions { get; }
 
         [JsonIgnore]
         internal EntityBatchResult? Result { get; set; }

--- a/src/WebJobs.Extensions.DurableTask/ProtobufUtils.cs
+++ b/src/WebJobs.Extensions.DurableTask/ProtobufUtils.cs
@@ -604,13 +604,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// </summary>
         /// <param name="entityBatchRequest">The operation request to convert.</param>
         /// <param name="configurations">The remote instance configuration options for this batch request.</param>
-        /// <param name="rollbackEntityOperationsOnExceptions">Whether failed entity operations should be rolled back.</param>
         /// <returns>The converted operation request.</returns>
         [return: NotNullIfNotNull("entityBatchRequest")]
-        internal static P.EntityBatchRequest? ToEntityBatchRequest(
-            this EntityBatchRequest? entityBatchRequest,
-            RemoteInstanceConfiguration? configurations,
-            bool? rollbackEntityOperationsOnExceptions = null)
+        internal static P.EntityBatchRequest? ToEntityBatchRequest(this EntityBatchRequest? entityBatchRequest, RemoteInstanceConfiguration? configurations)
         {
             if (entityBatchRequest == null)
             {
@@ -624,11 +620,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             };
 
             batchRequest.Properties.Add(ProtobufUtils.ConvertPocoToProtoMap(configurations));
-            if (rollbackEntityOperationsOnExceptions.HasValue)
-            {
-                batchRequest.Properties[nameof(DurableTaskOptions.RollbackEntityOperationsOnExceptions)] =
-                    Value.ForBool(rollbackEntityOperationsOnExceptions.Value);
-            }
 
             foreach (var operation in entityBatchRequest.Operations ?? Enumerable.Empty<OperationRequest>())
             {

--- a/src/WebJobs.Extensions.DurableTask/ProtobufUtils.cs
+++ b/src/WebJobs.Extensions.DurableTask/ProtobufUtils.cs
@@ -604,9 +604,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// </summary>
         /// <param name="entityBatchRequest">The operation request to convert.</param>
         /// <param name="configurations">The remote instance configuration options for this batch request.</param>
+        /// <param name="rollbackEntityOperationsOnExceptions">Whether failed entity operations should be rolled back.</param>
         /// <returns>The converted operation request.</returns>
         [return: NotNullIfNotNull("entityBatchRequest")]
-        internal static P.EntityBatchRequest? ToEntityBatchRequest(this EntityBatchRequest? entityBatchRequest, RemoteInstanceConfiguration? configurations)
+        internal static P.EntityBatchRequest? ToEntityBatchRequest(
+            this EntityBatchRequest? entityBatchRequest,
+            RemoteInstanceConfiguration? configurations,
+            bool? rollbackEntityOperationsOnExceptions = null)
         {
             if (entityBatchRequest == null)
             {
@@ -620,6 +624,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             };
 
             batchRequest.Properties.Add(ProtobufUtils.ConvertPocoToProtoMap(configurations));
+            if (rollbackEntityOperationsOnExceptions.HasValue)
+            {
+                batchRequest.Properties[nameof(DurableTaskOptions.RollbackEntityOperationsOnExceptions)] =
+                    Value.ForBool(rollbackEntityOperationsOnExceptions.Value);
+            }
 
             foreach (var operation in entityBatchRequest.Operations ?? Enumerable.Empty<OperationRequest>())
             {

--- a/src/WebJobs.Extensions.DurableTask/ProtobufUtils.cs
+++ b/src/WebJobs.Extensions.DurableTask/ProtobufUtils.cs
@@ -27,6 +27,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 {
     internal static class ProtobufUtils
     {
+        internal const string RollbackEntityOperationsOnExceptionsPropertyName = "RollbackEntityOperationsOnExceptions";
+
         public static P.HistoryEvent ToHistoryEventProto(HistoryEvent e)
         {
             var payload = new P.HistoryEvent()
@@ -604,9 +606,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// </summary>
         /// <param name="entityBatchRequest">The operation request to convert.</param>
         /// <param name="configurations">The remote instance configuration options for this batch request.</param>
+        /// <param name="rollbackEntityOperationsOnExceptions">Whether failed entity operations should be rolled back.</param>
         /// <returns>The converted operation request.</returns>
         [return: NotNullIfNotNull("entityBatchRequest")]
-        internal static P.EntityBatchRequest? ToEntityBatchRequest(this EntityBatchRequest? entityBatchRequest, RemoteInstanceConfiguration? configurations)
+        internal static P.EntityBatchRequest? ToEntityBatchRequest(
+            this EntityBatchRequest? entityBatchRequest,
+            RemoteInstanceConfiguration? configurations,
+            bool? rollbackEntityOperationsOnExceptions = null)
         {
             if (entityBatchRequest == null)
             {
@@ -620,6 +626,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             };
 
             batchRequest.Properties.Add(ProtobufUtils.ConvertPocoToProtoMap(configurations));
+            if (rollbackEntityOperationsOnExceptions.HasValue)
+            {
+                batchRequest.Properties[RollbackEntityOperationsOnExceptionsPropertyName] =
+                    Value.ForBool(rollbackEntityOperationsOnExceptions.Value);
+            }
 
             foreach (var operation in entityBatchRequest.Operations ?? Enumerable.Empty<OperationRequest>())
             {

--- a/src/WebJobs.Extensions.DurableTask/RemoteInstanceConfiguration.cs
+++ b/src/WebJobs.Extensions.DurableTask/RemoteInstanceConfiguration.cs
@@ -30,10 +30,5 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// Gets or sets the amount of time in seconds before an idle extended session times out.
         /// </summary>
         internal int ExtendedSessionIdleTimeoutInSeconds { get; set; }
-
-        /// <summary>
-        /// Gets or sets whether an uncaught exception should roll back the effects of an entity operation.
-        /// </summary>
-        internal bool RollbackEntityOperationsOnExceptions { get; set; } = true;
     }
 }

--- a/src/WebJobs.Extensions.DurableTask/RemoteInstanceConfiguration.cs
+++ b/src/WebJobs.Extensions.DurableTask/RemoteInstanceConfiguration.cs
@@ -30,5 +30,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// Gets or sets the amount of time in seconds before an idle extended session times out.
         /// </summary>
         internal int ExtendedSessionIdleTimeoutInSeconds { get; set; }
+
+        /// <summary>
+        /// Gets or sets whether an uncaught exception should roll back the effects of an entity operation.
+        /// </summary>
+        internal bool RollbackEntityOperationsOnExceptions { get; set; } = true;
     }
 }

--- a/test/FunctionsV2/Tests/Unit/LocalGrpcListenerTests.cs
+++ b/test/FunctionsV2/Tests/Unit/LocalGrpcListenerTests.cs
@@ -19,6 +19,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Moq;
+using Newtonsoft.Json.Linq;
 using Xunit;
 using Xunit.Abstractions;
 using P = Microsoft.DurableTask.Protobuf;
@@ -833,6 +834,59 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             Assert.Contains("transient", ex.Message);
         }
 
+        [Theory]
+        [InlineData(null, false)]
+        [InlineData(true, true)]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public void TestBindingHelper_SerializesUseForwardedHost(bool? configuredValue, bool expectedValue)
+        {
+            var options = new DurableTaskOptions
+            {
+                HubName = "UseForwardedHost",
+                WebhookUriProviderOverride = () => new Uri("https://durable.test/runtime/webhooks/durabletask"),
+            };
+            if (configuredValue.HasValue)
+            {
+                options.HttpSettings.UseForwardedHost = configuredValue.Value;
+            }
+
+            using DurableTaskExtension extension = this.CreateExtension(options, WorkerRuntimeType.DotNetIsolated);
+            extension.EnsureTaskHubWorker();
+
+            var bindingHelper = new BindingHelper(extension);
+            var client = new Mock<IDurableOrchestrationClient>();
+            client.Setup(c => c.TaskHubName).Returns(options.HubName);
+
+            string payload = bindingHelper.DurableOrchestrationClientToString(
+                client.Object,
+                new DurableClientAttribute());
+
+            Assert.Equal(expectedValue, JObject.Parse(payload).Value<bool>("useForwardedHost"));
+        }
+
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public void TestBindingHelper_OmitsUseForwardedHostFromLegacyPayload()
+        {
+            var options = new DurableTaskOptions
+            {
+                HubName = "LegacyUseForwardedHost",
+                WebhookUriProviderOverride = () => new Uri("https://durable.test/runtime/webhooks/durabletask"),
+            };
+            options.HttpSettings.UseForwardedHost = true;
+            using DurableTaskExtension extension = this.CreateExtension(options, WorkerRuntimeType.DotNet);
+
+            var bindingHelper = new BindingHelper(extension);
+            var client = new Mock<IDurableOrchestrationClient>();
+            client.Setup(c => c.TaskHubName).Returns(options.HubName);
+
+            string payload = bindingHelper.DurableOrchestrationClientToString(
+                client.Object,
+                new DurableClientAttribute());
+
+            Assert.False(JObject.Parse(payload).ContainsKey("useForwardedHost"));
+        }
+
         /// <summary>
         /// Verifies that the native worker runtimes (the Go worker reports either "native" or,
         /// defensively, "golang") select the gRPC protocol (MiddlewarePassthrough) at extension
@@ -896,7 +950,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
         private DurableTaskExtension CreateExtension(string hubName, WorkerRuntimeType runtimeType)
         {
-            var options = new DurableTaskOptions { HubName = hubName };
+            return this.CreateExtension(new DurableTaskOptions { HubName = hubName }, runtimeType);
+        }
+
+        private DurableTaskExtension CreateExtension(DurableTaskOptions options, WorkerRuntimeType runtimeType)
+        {
             var wrappedOptions = new OptionsWrapper<DurableTaskOptions>(options);
             var nameResolver = TestHelpers.GetTestNameResolver();
             var serviceFactory = new AzureStorageDurabilityProviderFactory(

--- a/test/FunctionsV2/Tests/Unit/LocalGrpcListenerTests.cs
+++ b/test/FunctionsV2/Tests/Unit/LocalGrpcListenerTests.cs
@@ -835,17 +835,26 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         }
 
         [Theory]
-        [InlineData(null, false)]
-        [InlineData(true, true)]
+        [InlineData(null, false, false)]
+        [InlineData(false, false, false)]
+        [InlineData(true, true, false)]
+        [InlineData(null, false, true)]
         [Trait("Category", PlatformSpecificHelpers.TestCategory)]
-        public void TestBindingHelper_SerializesUseForwardedHost(bool? configuredValue, bool expectedValue)
+        public void TestBindingHelper_SerializesUseForwardedHost(
+            bool? configuredValue,
+            bool expectedValue,
+            bool nullHttpSettings)
         {
             var options = new DurableTaskOptions
             {
                 HubName = "UseForwardedHost",
                 WebhookUriProviderOverride = () => new Uri("https://durable.test/runtime/webhooks/durabletask"),
             };
-            if (configuredValue.HasValue)
+            if (nullHttpSettings)
+            {
+                options.HttpSettings = null;
+            }
+            else if (configuredValue.HasValue)
             {
                 options.HttpSettings.UseForwardedHost = configuredValue.Value;
             }

--- a/test/FunctionsV2/Tests/Unit/ProtobufUtilsTests.cs
+++ b/test/FunctionsV2/Tests/Unit/ProtobufUtilsTests.cs
@@ -109,13 +109,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             Assert.Equal(defaultVersion, action.Version);
         }
 
-        [Theory]
-        [InlineData(null, true)]
-        [InlineData(false, false)]
+        [Fact]
         [Trait("Category", PlatformSpecificHelpers.TestCategory)]
-        public void ToEntityBatchRequest_IncludesRollbackEntityOperationsOnExceptions(
-            bool? configuredValue,
-            bool expectedValue)
+        public void ToEntityBatchRequest_IncludesDefaultRollbackEntityOperationsOnExceptions()
         {
             var request = new EntityBatchRequest
             {
@@ -126,10 +122,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             {
                 ExtendedSessionsEnabled = false,
             };
-            if (configuredValue.HasValue)
-            {
-                options.RollbackEntityOperationsOnExceptions = configuredValue.Value;
-            }
 
             var context = new RemoteEntityContext(
                 request,
@@ -137,13 +129,35 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 isExtendedSession: false,
                 includeEntityState: true);
 
-            P.EntityBatchRequest result = context.Request.ToEntityBatchRequest(
-                context.Configurations,
-                context.RollbackEntityOperationsOnExceptions);
+            P.EntityBatchRequest result = context.Request.ToEntityBatchRequest(context.Configurations);
 
-            Assert.Null(context.Configurations);
-            Assert.Equal(
-                expectedValue,
+            Assert.True(
+                result.Properties[nameof(DurableTaskOptions.RollbackEntityOperationsOnExceptions)].BoolValue);
+        }
+
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public void ToEntityBatchRequest_IncludesDisabledRollbackEntityOperationsOnExceptions()
+        {
+            var request = new EntityBatchRequest
+            {
+                InstanceId = "@TestEntity@test-key",
+                Operations = new List<OperationRequest>(),
+            };
+            var options = new DurableTaskOptions
+            {
+                ExtendedSessionsEnabled = false,
+                RollbackEntityOperationsOnExceptions = false,
+            };
+            var context = new RemoteEntityContext(
+                request,
+                options,
+                isExtendedSession: false,
+                includeEntityState: true);
+
+            P.EntityBatchRequest result = context.Request.ToEntityBatchRequest(context.Configurations);
+
+            Assert.False(
                 result.Properties[nameof(DurableTaskOptions.RollbackEntityOperationsOnExceptions)].BoolValue);
         }
 

--- a/test/FunctionsV2/Tests/Unit/ProtobufUtilsTests.cs
+++ b/test/FunctionsV2/Tests/Unit/ProtobufUtilsTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using DurableTask.Core.Entities.OperationFormat;
 using Google.Protobuf.WellKnownTypes;
 using Xunit;
@@ -109,9 +110,17 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             Assert.Equal(defaultVersion, action.Version);
         }
 
-        [Fact]
+        [Theory]
+        [InlineData(false, null, true)]
+        [InlineData(false, true, true)]
+        [InlineData(false, false, false)]
+        [InlineData(true, true, true)]
+        [InlineData(true, false, false)]
         [Trait("Category", PlatformSpecificHelpers.TestCategory)]
-        public void ToEntityBatchRequest_IncludesDefaultRollbackEntityOperationsOnExceptions()
+        public void ToEntityBatchRequest_IncludesExpectedProperties(
+            bool extendedSessionsEnabled,
+            bool? configuredRollback,
+            bool expectedRollback)
         {
             var request = new EntityBatchRequest
             {
@@ -120,45 +129,38 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             };
             var options = new DurableTaskOptions
             {
-                ExtendedSessionsEnabled = false,
+                ExtendedSessionsEnabled = extendedSessionsEnabled,
             };
+            if (configuredRollback.HasValue)
+            {
+                options.RollbackEntityOperationsOnExceptions = configuredRollback.Value;
+            }
 
             var context = new RemoteEntityContext(
                 request,
                 options,
-                isExtendedSession: false,
-                includeEntityState: true);
+                isExtendedSession: true,
+                includeEntityState: false);
 
-            P.EntityBatchRequest result = context.Request.ToEntityBatchRequest(context.Configurations);
+            P.EntityBatchRequest result = context.Request.ToEntityBatchRequest(
+                context.Configurations,
+                context.RollbackEntityOperationsOnExceptions);
 
+            string[] expectedKeys = extendedSessionsEnabled
+                ? new[]
+                {
+                    "ExtendedSessionIdleTimeoutInSeconds",
+                    "HttpDefaultAsyncRequestSleepTimeMilliseconds",
+                    "IncludeState",
+                    "IsExtendedSession",
+                    "RollbackEntityOperationsOnExceptions",
+                }
+                : new[] { "RollbackEntityOperationsOnExceptions" };
+            Assert.Equal(expectedKeys, result.Properties.Keys.OrderBy(key => key));
+            bool actualRollback = result.Properties["RollbackEntityOperationsOnExceptions"].BoolValue;
             Assert.True(
-                result.Properties[nameof(DurableTaskOptions.RollbackEntityOperationsOnExceptions)].BoolValue);
-        }
-
-        [Fact]
-        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
-        public void ToEntityBatchRequest_IncludesDisabledRollbackEntityOperationsOnExceptions()
-        {
-            var request = new EntityBatchRequest
-            {
-                InstanceId = "@TestEntity@test-key",
-                Operations = new List<OperationRequest>(),
-            };
-            var options = new DurableTaskOptions
-            {
-                ExtendedSessionsEnabled = false,
-                RollbackEntityOperationsOnExceptions = false,
-            };
-            var context = new RemoteEntityContext(
-                request,
-                options,
-                isExtendedSession: false,
-                includeEntityState: true);
-
-            P.EntityBatchRequest result = context.Request.ToEntityBatchRequest(context.Configurations);
-
-            Assert.False(
-                result.Properties[nameof(DurableTaskOptions.RollbackEntityOperationsOnExceptions)].BoolValue);
+                actualRollback == expectedRollback,
+                $"Expected rollback to be {expectedRollback}, but it was {actualRollback}.");
         }
 
         /// <summary>

--- a/test/FunctionsV2/Tests/Unit/ProtobufUtilsTests.cs
+++ b/test/FunctionsV2/Tests/Unit/ProtobufUtilsTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using DurableTask.Core.Entities.OperationFormat;
 using Google.Protobuf.WellKnownTypes;
 using Xunit;
@@ -106,6 +107,44 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             Assert.Single(result.Actions);
             var action = Assert.IsType<StartNewOrchestrationOperationAction>(result.Actions[0]);
             Assert.Equal(defaultVersion, action.Version);
+        }
+
+        [Theory]
+        [InlineData(null, true)]
+        [InlineData(false, false)]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public void ToEntityBatchRequest_IncludesRollbackEntityOperationsOnExceptions(
+            bool? configuredValue,
+            bool expectedValue)
+        {
+            var request = new EntityBatchRequest
+            {
+                InstanceId = "@TestEntity@test-key",
+                Operations = new List<OperationRequest>(),
+            };
+            var options = new DurableTaskOptions
+            {
+                ExtendedSessionsEnabled = false,
+            };
+            if (configuredValue.HasValue)
+            {
+                options.RollbackEntityOperationsOnExceptions = configuredValue.Value;
+            }
+
+            var context = new RemoteEntityContext(
+                request,
+                options,
+                isExtendedSession: false,
+                includeEntityState: true);
+
+            P.EntityBatchRequest result = context.Request.ToEntityBatchRequest(
+                context.Configurations,
+                context.RollbackEntityOperationsOnExceptions);
+
+            Assert.Null(context.Configurations);
+            Assert.Equal(
+                expectedValue,
+                result.Properties[nameof(DurableTaskOptions.RollbackEntityOperationsOnExceptions)].BoolValue);
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary

- expose `httpSettings.useForwardedHost` in middleware-passthrough durable-client binding payloads while leaving legacy payloads unchanged
- expose `rollbackEntityOperationsOnExceptions` in the existing entity batch protobuf properties map
- preserve backward compatibility so older workers can ignore the new settings

## Testing

- `dotnet test test\FunctionsV2\WebJobs.Extensions.DurableTask.Tests.V2.csproj --framework net8.0 --no-restore --filter "FullyQualifiedName~ProtobufUtilsTests|FullyQualifiedName~TestBindingHelper_"`

Fixes #3503