### PR TITLE
Fix Durable App Insights auth for distributed tracing

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/Correlation/TelemetryActivator.cs
+++ b/src/WebJobs.Extensions.DurableTask/Correlation/TelemetryActivator.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
+using System.Linq;
 using System.Threading.Tasks;
 using DurableTask.ApplicationInsights;
 using DurableTask.Core;
@@ -21,6 +22,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Correlation
     {
         private readonly DurableTaskOptions options;
         private readonly INameResolver nameResolver;
+        private readonly TelemetryConfiguration hostTelemetryConfiguration;
         private EndToEndTraceHelper endToEndTraceHelper;
         private TelemetryClient telemetryClient;
 
@@ -29,10 +31,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Correlation
         /// </summary>
         /// <param name="options">DurableTask options.</param>
         /// <param name="nameResolver">Name resolver used for environment variables.</param>
-        public TelemetryActivator(IOptions<DurableTaskOptions> options, INameResolver nameResolver)
+        /// <param name="telemetryConfiguration">Host telemetry configuration, when available.</param>
+        public TelemetryActivator(IOptions<DurableTaskOptions> options, INameResolver nameResolver, TelemetryConfiguration telemetryConfiguration = null)
         {
             this.options = options.Value;
             this.nameResolver = nameResolver;
+            this.hostTelemetryConfiguration = telemetryConfiguration;
         }
 
         /// <summary>
@@ -180,13 +184,26 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Correlation
 
         private TelemetryConfiguration SetupTelemetryConfiguration()
         {
-            TelemetryConfiguration config = TelemetryConfiguration.CreateDefault();
             if (this.OnSend != null)
             {
+                TelemetryConfiguration config = this.CreateStandaloneTelemetryConfiguration();
                 config.TelemetryChannel = new NoOpTelemetryChannel { OnSend = this.OnSend };
+                return config;
             }
 
-            config.TelemetryInitializers.Add(new DurableTaskInstanceIdTelemetryInitializer(this.options.Tracing.IncludeInstanceIdInOperationName));
+            if (this.hostTelemetryConfiguration != null)
+            {
+                this.EnsureDurableTelemetryInitializers(this.hostTelemetryConfiguration);
+                return this.hostTelemetryConfiguration;
+            }
+
+            return this.CreateStandaloneTelemetryConfiguration();
+        }
+
+        private TelemetryConfiguration CreateStandaloneTelemetryConfiguration()
+        {
+            TelemetryConfiguration config = TelemetryConfiguration.CreateDefault();
+            this.EnsureDurableTelemetryInitializers(config);
 
             string resolvedInstrumentationKey = this.nameResolver.Resolve("APPINSIGHTS_INSTRUMENTATIONKEY");
             string resolvedConnectionString = this.nameResolver.Resolve("APPLICATIONINSIGHTS_CONNECTION_STRING");
@@ -239,6 +256,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Correlation
             }
 
             return config;
+        }
+
+        private void EnsureDurableTelemetryInitializers(TelemetryConfiguration config)
+        {
+            if (!config.TelemetryInitializers.OfType<DurableTaskInstanceIdTelemetryInitializer>().Any())
+            {
+                config.TelemetryInitializers.Add(
+                    new DurableTaskInstanceIdTelemetryInitializer(this.options.Tracing.IncludeInstanceIdInOperationName));
+            }
         }
     }
 }

--- a/src/WebJobs.Extensions.DurableTask/Correlation/TelemetryActivator.cs
+++ b/src/WebJobs.Extensions.DurableTask/Correlation/TelemetryActivator.cs
@@ -31,8 +31,18 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Correlation
         /// </summary>
         /// <param name="options">DurableTask options.</param>
         /// <param name="nameResolver">Name resolver used for environment variables.</param>
+        public TelemetryActivator(IOptions<DurableTaskOptions> options, INameResolver nameResolver)
+            : this(options, nameResolver, null)
+        {
+        }
+
+        /// <summary>
+        /// Constructor for initializing Distributed Tracing with a host telemetry configuration.
+        /// </summary>
+        /// <param name="options">DurableTask options.</param>
+        /// <param name="nameResolver">Name resolver used for environment variables.</param>
         /// <param name="telemetryConfiguration">Host telemetry configuration, when available.</param>
-        public TelemetryActivator(IOptions<DurableTaskOptions> options, INameResolver nameResolver, TelemetryConfiguration telemetryConfiguration = null)
+        public TelemetryActivator(IOptions<DurableTaskOptions> options, INameResolver nameResolver, TelemetryConfiguration telemetryConfiguration)
         {
             this.options = options.Value;
             this.nameResolver = nameResolver;

--- a/test/FunctionsV2/Tests/Unit/TelemetryActivatorTests.cs
+++ b/test/FunctionsV2/Tests/Unit/TelemetryActivatorTests.cs
@@ -6,13 +6,16 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Reflection;
 using Microsoft.ApplicationInsights.Channel;
 using Microsoft.ApplicationInsights.DataContracts;
 using Microsoft.ApplicationInsights.Extensibility;
+using Microsoft.Azure.WebJobs;
 using Microsoft.Azure.WebJobs.Extensions.DurableTask;
 using Microsoft.Azure.WebJobs.Extensions.DurableTask.Correlation;
 using Microsoft.Azure.WebJobs.Extensions.DurableTask.Options;
 using Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Xunit;
@@ -27,14 +30,39 @@ namespace WebJobs.Extensions.DurableTask.Tests.V2
 
         [Fact]
         [Trait("Category", PlatformSpecificHelpers.TestCategory)]
-        public void Initialize_UsesProvidedHostTelemetryConfiguration_ForV2()
+        public void Constructors_PreserveLegacySignature_AndRequireExplicitHostConfiguration()
+        {
+            ConstructorInfo legacyConstructor = typeof(TelemetryActivator).GetConstructor(new[]
+            {
+                typeof(IOptions<DurableTaskOptions>),
+                typeof(INameResolver),
+            });
+            ConstructorInfo hostConfigurationConstructor = typeof(TelemetryActivator).GetConstructor(new[]
+            {
+                typeof(IOptions<DurableTaskOptions>),
+                typeof(INameResolver),
+                typeof(TelemetryConfiguration),
+            });
+
+            Assert.NotNull(legacyConstructor);
+            Assert.NotNull(hostConfigurationConstructor);
+            Assert.False(hostConfigurationConstructor.GetParameters()[2].IsOptional);
+        }
+
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public void ResolveFromDi_UsesRegisteredTelemetryConfiguration()
         {
             var channel = new CollectingTelemetryChannel();
             var hostTelemetryConfiguration = TelemetryConfiguration.CreateDefault();
             hostTelemetryConfiguration.TelemetryChannel = channel;
 
-            using TelemetryActivator activator = CreateTelemetryActivator(hostTelemetryConfiguration);
+            using ServiceProvider serviceProvider = CreateServiceProvider(hostTelemetryConfiguration);
+            var activator = Assert.IsType<TelemetryActivator>(serviceProvider.GetRequiredService<ITelemetryActivator>());
 
+            Assert.Same(hostTelemetryConfiguration, GetHostTelemetryConfiguration(activator));
+
+            activator.Initialize(NullLogger.Instance);
             EmitDurableActivity("orchestration:host-config", ActivityKind.Server, "orchestration");
             EmitDurableActivity("activity:host-config", ActivityKind.Internal, "activity");
 
@@ -45,39 +73,48 @@ namespace WebJobs.Extensions.DurableTask.Tests.V2
 
         [Fact]
         [Trait("Category", PlatformSpecificHelpers.TestCategory)]
-        public void Initialize_PrefersOnSendTestHook_OverProvidedHostTelemetryConfiguration()
+        public void ResolveFromDi_FallsBackToLegacyConstructor_WhenTelemetryConfigurationMissing()
+        {
+            var sentItems = new ConcurrentQueue<ITelemetry>();
+
+            using ServiceProvider serviceProvider = CreateServiceProvider();
+            var activator = Assert.IsType<TelemetryActivator>(serviceProvider.GetRequiredService<ITelemetryActivator>());
+
+            Assert.Null(GetHostTelemetryConfiguration(activator));
+
+            activator.OnSend = telemetry => sentItems.Enqueue(telemetry);
+            activator.Initialize(NullLogger.Instance);
+            EmitDurableActivity("orchestration:di-fallback", ActivityKind.Server, "orchestration");
+            EmitDurableActivity("activity:di-fallback", ActivityKind.Internal, "activity");
+
+            Assert.Contains(sentItems.OfType<RequestTelemetry>(), telemetry => telemetry.Name == "orchestration:di-fallback");
+            Assert.Contains(sentItems.OfType<DependencyTelemetry>(), telemetry => telemetry.Name == "activity:di-fallback");
+        }
+
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public void Initialize_PrefersOnSendTestHook_OverRegisteredTelemetryConfiguration()
         {
             var channel = new CollectingTelemetryChannel();
             var hostTelemetryConfiguration = TelemetryConfiguration.CreateDefault();
             hostTelemetryConfiguration.TelemetryChannel = channel;
             var sentItems = new ConcurrentQueue<ITelemetry>();
 
-            using TelemetryActivator activator = CreateTelemetryActivator(hostTelemetryConfiguration, telemetry => sentItems.Enqueue(telemetry));
+            using var activator = new TelemetryActivator(CreateOptions(), CreateNameResolver(), hostTelemetryConfiguration)
+            {
+                OnSend = telemetry => sentItems.Enqueue(telemetry),
+            };
 
+            activator.Initialize(NullLogger.Instance);
             EmitDurableActivity("orchestration:on-send", ActivityKind.Server, "orchestration");
 
             Assert.Contains(sentItems.OfType<RequestTelemetry>(), telemetry => telemetry.Name == "orchestration:on-send");
             Assert.Empty(channel.Items);
         }
 
-        [Fact]
-        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
-        public void Initialize_StandaloneTelemetryConfiguration_PreservesOnSendBehavior()
+        private static IOptions<DurableTaskOptions> CreateOptions()
         {
-            var sentItems = new ConcurrentQueue<ITelemetry>();
-
-            using TelemetryActivator activator = CreateTelemetryActivator(onSend: telemetry => sentItems.Enqueue(telemetry));
-
-            EmitDurableActivity("orchestration:standalone", ActivityKind.Server, "orchestration");
-            EmitDurableActivity("activity:standalone", ActivityKind.Internal, "activity");
-
-            Assert.Contains(sentItems.OfType<RequestTelemetry>(), telemetry => telemetry.Name == "orchestration:standalone");
-            Assert.Contains(sentItems.OfType<DependencyTelemetry>(), telemetry => telemetry.Name == "activity:standalone");
-        }
-
-        private static TelemetryActivator CreateTelemetryActivator(TelemetryConfiguration telemetryConfiguration = null, Action<ITelemetry> onSend = null)
-        {
-            var options = Options.Create(new DurableTaskOptions
+            return Options.Create(new DurableTaskOptions
             {
                 Tracing = new Microsoft.Azure.WebJobs.Extensions.DurableTask.TraceOptions
                 {
@@ -85,19 +122,35 @@ namespace WebJobs.Extensions.DurableTask.Tests.V2
                     Version = DurableDistributedTracingVersion.V2,
                 },
             });
+        }
 
-            var nameResolver = new SimpleNameResolver(new Dictionary<string, string>
+        private static INameResolver CreateNameResolver()
+        {
+            return new SimpleNameResolver(new Dictionary<string, string>
             {
                 ["APPLICATIONINSIGHTS_CONNECTION_STRING"] = ConnectionString,
             });
+        }
 
-            var activator = new TelemetryActivator(options, nameResolver, telemetryConfiguration)
+        private static ServiceProvider CreateServiceProvider(TelemetryConfiguration telemetryConfiguration = null)
+        {
+            var services = new ServiceCollection();
+            services.AddSingleton(CreateOptions());
+            services.AddSingleton(CreateNameResolver());
+
+            if (telemetryConfiguration != null)
             {
-                OnSend = onSend,
-            };
+                services.AddSingleton(telemetryConfiguration);
+            }
 
-            activator.Initialize(NullLogger.Instance);
-            return activator;
+            services.AddSingleton<ITelemetryActivator, TelemetryActivator>();
+            return services.BuildServiceProvider();
+        }
+
+        private static TelemetryConfiguration GetHostTelemetryConfiguration(TelemetryActivator activator)
+        {
+            FieldInfo field = typeof(TelemetryActivator).GetField("hostTelemetryConfiguration", BindingFlags.Instance | BindingFlags.NonPublic);
+            return field?.GetValue(activator) as TelemetryConfiguration;
         }
 
         private static void EmitDurableActivity(string name, ActivityKind kind, string durableTaskType)

--- a/test/FunctionsV2/Tests/Unit/TelemetryActivatorTests.cs
+++ b/test/FunctionsV2/Tests/Unit/TelemetryActivatorTests.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
+using Microsoft.ApplicationInsights;
 using Microsoft.ApplicationInsights.Channel;
 using Microsoft.ApplicationInsights.DataContracts;
 using Microsoft.ApplicationInsights.Extensibility;
@@ -51,7 +52,7 @@ namespace WebJobs.Extensions.DurableTask.Tests.V2
 
         [Fact]
         [Trait("Category", PlatformSpecificHelpers.TestCategory)]
-        public void ResolveFromDi_UsesRegisteredTelemetryConfiguration()
+        public void ResolveFromDi_UsesRegisteredTelemetryConfiguration_ForV2()
         {
             var channel = new CollectingTelemetryChannel();
             var hostTelemetryConfiguration = TelemetryConfiguration.CreateDefault();
@@ -69,6 +70,28 @@ namespace WebJobs.Extensions.DurableTask.Tests.V2
             Assert.Contains(channel.Items.OfType<RequestTelemetry>(), telemetry => telemetry.Name == "orchestration:host-config");
             Assert.Contains(channel.Items.OfType<DependencyTelemetry>(), telemetry => telemetry.Name == "activity:host-config");
             Assert.Single(hostTelemetryConfiguration.TelemetryInitializers.OfType<DurableTaskInstanceIdTelemetryInitializer>());
+        }
+
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public void ResolveFromDi_UsesRegisteredTelemetryConfiguration_ForV1()
+        {
+            var channel = new CollectingTelemetryChannel();
+            var hostTelemetryConfiguration = TelemetryConfiguration.CreateDefault();
+            hostTelemetryConfiguration.TelemetryChannel = channel;
+
+            using ServiceProvider serviceProvider = CreateServiceProvider(
+                telemetryConfiguration: hostTelemetryConfiguration,
+                version: DurableDistributedTracingVersion.V1);
+            var activator = Assert.IsType<TelemetryActivator>(serviceProvider.GetRequiredService<ITelemetryActivator>());
+
+            Assert.Same(hostTelemetryConfiguration, GetHostTelemetryConfiguration(activator));
+
+            activator.Initialize(NullLogger.Instance);
+            TelemetryClient telemetryClient = GetTelemetryClient(activator);
+            telemetryClient.TrackRequest(new RequestTelemetry { Name = "v1-host-config" });
+
+            Assert.Contains(channel.Items.OfType<RequestTelemetry>(), telemetry => telemetry.Name == "v1-host-config");
         }
 
         [Fact]
@@ -112,14 +135,14 @@ namespace WebJobs.Extensions.DurableTask.Tests.V2
             Assert.Empty(channel.Items);
         }
 
-        private static IOptions<DurableTaskOptions> CreateOptions()
+        private static IOptions<DurableTaskOptions> CreateOptions(DurableDistributedTracingVersion version = DurableDistributedTracingVersion.V2)
         {
             return Options.Create(new DurableTaskOptions
             {
                 Tracing = new Microsoft.Azure.WebJobs.Extensions.DurableTask.TraceOptions
                 {
                     DistributedTracingEnabled = true,
-                    Version = DurableDistributedTracingVersion.V2,
+                    Version = version,
                 },
             });
         }
@@ -132,10 +155,12 @@ namespace WebJobs.Extensions.DurableTask.Tests.V2
             });
         }
 
-        private static ServiceProvider CreateServiceProvider(TelemetryConfiguration telemetryConfiguration = null)
+        private static ServiceProvider CreateServiceProvider(
+            TelemetryConfiguration telemetryConfiguration = null,
+            DurableDistributedTracingVersion version = DurableDistributedTracingVersion.V2)
         {
             var services = new ServiceCollection();
-            services.AddSingleton(CreateOptions());
+            services.AddSingleton(CreateOptions(version));
             services.AddSingleton(CreateNameResolver());
 
             if (telemetryConfiguration != null)
@@ -151,6 +176,12 @@ namespace WebJobs.Extensions.DurableTask.Tests.V2
         {
             FieldInfo field = typeof(TelemetryActivator).GetField("hostTelemetryConfiguration", BindingFlags.Instance | BindingFlags.NonPublic);
             return field?.GetValue(activator) as TelemetryConfiguration;
+        }
+
+        private static TelemetryClient GetTelemetryClient(TelemetryActivator activator)
+        {
+            FieldInfo field = typeof(TelemetryActivator).GetField("telemetryClient", BindingFlags.Instance | BindingFlags.NonPublic);
+            return Assert.IsType<TelemetryClient>(field?.GetValue(activator));
         }
 
         private static void EmitDurableActivity(string name, ActivityKind kind, string durableTaskType)

--- a/test/FunctionsV2/Tests/Unit/TelemetryActivatorTests.cs
+++ b/test/FunctionsV2/Tests/Unit/TelemetryActivatorTests.cs
@@ -1,0 +1,136 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using Microsoft.ApplicationInsights.Channel;
+using Microsoft.ApplicationInsights.DataContracts;
+using Microsoft.ApplicationInsights.Extensibility;
+using Microsoft.Azure.WebJobs.Extensions.DurableTask;
+using Microsoft.Azure.WebJobs.Extensions.DurableTask.Correlation;
+using Microsoft.Azure.WebJobs.Extensions.DurableTask.Options;
+using Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace WebJobs.Extensions.DurableTask.Tests.V2
+{
+    [Collection("Non-Parallel Collection")]
+    public class TelemetryActivatorTests
+    {
+        private const string ConnectionString = "InstrumentationKey=00000000-0000-0000-0000-000000000000;IngestionEndpoint=https://westus2-0.in.applicationinsights.azure.com/";
+        private static readonly ActivitySource TestActivitySource = new ActivitySource("WebJobs.Extensions.DurableTask.Tests");
+
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public void Initialize_UsesProvidedHostTelemetryConfiguration_ForV2()
+        {
+            var channel = new CollectingTelemetryChannel();
+            var hostTelemetryConfiguration = TelemetryConfiguration.CreateDefault();
+            hostTelemetryConfiguration.TelemetryChannel = channel;
+
+            using TelemetryActivator activator = CreateTelemetryActivator(hostTelemetryConfiguration);
+
+            EmitDurableActivity("orchestration:host-config", ActivityKind.Server, "orchestration");
+            EmitDurableActivity("activity:host-config", ActivityKind.Internal, "activity");
+
+            Assert.Contains(channel.Items.OfType<RequestTelemetry>(), telemetry => telemetry.Name == "orchestration:host-config");
+            Assert.Contains(channel.Items.OfType<DependencyTelemetry>(), telemetry => telemetry.Name == "activity:host-config");
+            Assert.Single(hostTelemetryConfiguration.TelemetryInitializers.OfType<DurableTaskInstanceIdTelemetryInitializer>());
+        }
+
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public void Initialize_PrefersOnSendTestHook_OverProvidedHostTelemetryConfiguration()
+        {
+            var channel = new CollectingTelemetryChannel();
+            var hostTelemetryConfiguration = TelemetryConfiguration.CreateDefault();
+            hostTelemetryConfiguration.TelemetryChannel = channel;
+            var sentItems = new ConcurrentQueue<ITelemetry>();
+
+            using TelemetryActivator activator = CreateTelemetryActivator(hostTelemetryConfiguration, telemetry => sentItems.Enqueue(telemetry));
+
+            EmitDurableActivity("orchestration:on-send", ActivityKind.Server, "orchestration");
+
+            Assert.Contains(sentItems.OfType<RequestTelemetry>(), telemetry => telemetry.Name == "orchestration:on-send");
+            Assert.Empty(channel.Items);
+        }
+
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public void Initialize_StandaloneTelemetryConfiguration_PreservesOnSendBehavior()
+        {
+            var sentItems = new ConcurrentQueue<ITelemetry>();
+
+            using TelemetryActivator activator = CreateTelemetryActivator(onSend: telemetry => sentItems.Enqueue(telemetry));
+
+            EmitDurableActivity("orchestration:standalone", ActivityKind.Server, "orchestration");
+            EmitDurableActivity("activity:standalone", ActivityKind.Internal, "activity");
+
+            Assert.Contains(sentItems.OfType<RequestTelemetry>(), telemetry => telemetry.Name == "orchestration:standalone");
+            Assert.Contains(sentItems.OfType<DependencyTelemetry>(), telemetry => telemetry.Name == "activity:standalone");
+        }
+
+        private static TelemetryActivator CreateTelemetryActivator(TelemetryConfiguration telemetryConfiguration = null, Action<ITelemetry> onSend = null)
+        {
+            var options = Options.Create(new DurableTaskOptions
+            {
+                Tracing = new Microsoft.Azure.WebJobs.Extensions.DurableTask.TraceOptions
+                {
+                    DistributedTracingEnabled = true,
+                    Version = DurableDistributedTracingVersion.V2,
+                },
+            });
+
+            var nameResolver = new SimpleNameResolver(new Dictionary<string, string>
+            {
+                ["APPLICATIONINSIGHTS_CONNECTION_STRING"] = ConnectionString,
+            });
+
+            var activator = new TelemetryActivator(options, nameResolver, telemetryConfiguration)
+            {
+                OnSend = onSend,
+            };
+
+            activator.Initialize(NullLogger.Instance);
+            return activator;
+        }
+
+        private static void EmitDurableActivity(string name, ActivityKind kind, string durableTaskType)
+        {
+            Activity.DefaultIdFormat = ActivityIdFormat.W3C;
+            Activity.ForceDefaultIdFormat = true;
+
+            using Activity activity = TestActivitySource.StartActivity(name, kind);
+            activity?.SetTag("durabletask.type", durableTaskType);
+            activity?.SetTag("durabletask.task.operation", $"test_{durableTaskType}");
+            activity?.SetTag("durabletask.task.instance_id", "test-instance");
+        }
+
+        private sealed class CollectingTelemetryChannel : ITelemetryChannel
+        {
+            public ConcurrentQueue<ITelemetry> Items { get; } = new ConcurrentQueue<ITelemetry>();
+
+            public bool? DeveloperMode { get; set; }
+
+            public string EndpointAddress { get; set; }
+
+            public void Send(ITelemetry item)
+            {
+                this.Items.Enqueue(item);
+            }
+
+            public void Flush()
+            {
+            }
+
+            public void Dispose()
+            {
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- reuse a host-provided `TelemetryConfiguration` in `TelemetryActivator` when one is available
- preserve binary/source compatibility by restoring `TelemetryActivator(IOptions<DurableTaskOptions>, INameResolver)` and keeping the host-config constructor as an explicit 3-argument overload for DI selection
- V1 and V2 reuse the host `TelemetryConfiguration` when available; the standalone path remains only when no host configuration is registered or when `OnSend` overrides it for tests
- add focused regression coverage for DI constructor selection, V1/V2 host-config reuse, and the `OnSend` fallback behavior

Fixes #3497.

## Root cause

`TelemetryActivator.SetupTelemetryConfiguration()` always built a fresh `TelemetryConfiguration` and only copied `APPINSIGHTS_INSTRUMENTATIONKEY` / `APPLICATIONINSIGHTS_CONNECTION_STRING`. That meant Durable distributed tracing never inherited the host's authenticated Application Insights pipeline, so an Entra-only component (`DisableLocalAuth=true`) dropped Durable Request/Dependency telemetry even while the Functions host could still emit its own telemetry.

## Why #3009 was reverted by #3053

#3009 moved Durable tracing onto a host `TelemetryConfiguration`, which solved the auth gap, but it also stopped initializing `WebJobsTelemetryModule` and removed the standalone/`OnSend` path. That caused missing V2 spans and led to the revert in #3053. This PR keeps the host-config auth fix while preserving the older public constructor and the standalone/test path where it is actually needed.

## Behavior note

When Durable telemetry reuses the host `TelemetryConfiguration`, it also inherits the host's telemetry processor policy. That includes adaptive sampling and any other configured processors, so Durable dependencies can be sampled unless the host sampling settings explicitly exclude them.

## Validation

- `dotnet test test\FunctionsV2\WebJobs.Extensions.DurableTask.Tests.V2.csproj --filter "FullyQualifiedName~TelemetryActivatorTests" -v minimal`
  - net8.0: 5 passed
  - net10.0: 5 passed
- `dotnet build src\WebJobs.Extensions.DurableTask\WebJobs.Extensions.DurableTask.csproj -c Debug -v minimal`
  - succeeded with 0 warnings and 0 errors
- existing branch validation retained:
  - `dotnet test test\FunctionsV2\WebJobs.Extensions.DurableTask.Tests.V2.csproj --filter "FullyQualifiedName~CorrelationEndToEndTests" -v minimal`
    - net8.0: 29 passed
    - net10.0: 29 passed

### Real Azure proof

Against a temporary Application Insights resource with local auth disabled and Entra-authenticated ingestion:

- **Pre-fix** harness run `prefix-harness-002`
  - ingested `control:prefix-harness-002` at `2026-08-05T23:28:14.1336742Z`
  - ingested **zero** Durable `orchestration:` / `activity:` Request/Dependency rows
- **Post-fix** harness run `postfix-harness-002`
  - ingested `control:postfix-harness-002` at `2026-08-05T23:36:43.6056342Z`
  - ingested `AppRequests` row `orchestration:postfix-harness-002` at `2026-08-05T23:36:46.9925016Z`
  - ingested `AppDependencies` row `activity:postfix-harness-002` at `2026-08-05T23:36:47.0526819Z`

A true local Functions Core Tools sample was attempted first, but in this environment it produced no ingested telemetry at all against the Entra-only component, so the final repro/validation used the smallest production-code harness with `AzureCliCredential`.

### Cleanup

The temporary Azure resource groups used for validation and correlation follow-up tests were deleted and verified gone. Detailed sanitized Azure CLI provisioning, query, and deletion transcript is captured in the external evidence artifact.

### Unrelated current CI failure

The inspected `Smoke Test - Python 3.11 on Functions V4` failure is unrelated to this PR's code and comes from a Docker build hitting an Azure DevOps pip feed credential prompt (`User for pkgs.dev.azure.com`) followed by `EOFError: EOF when reading a line`.



