### PR TITLE
Include sub-orchestration instance IDs in history

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableClient.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableClient.cs
@@ -1050,7 +1050,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
         private static void TrackNameAndScheduledTime(JObject historyItem, EventType eventType, int index, Dictionary<string, EventIndexDateMapping> eventMapper)
         {
-            eventMapper.Add($"{eventType}_{historyItem["EventId"]}", new EventIndexDateMapping { Index = index, Name = (string)historyItem["Name"], Date = (DateTime)historyItem["Timestamp"], Input = (string)historyItem["Input"] });
+            eventMapper.Add($"{eventType}_{historyItem["EventId"]}", new EventIndexDateMapping { Index = index, Name = (string)historyItem["Name"], Date = (DateTime)historyItem["Timestamp"], Input = (string)historyItem["Input"], InstanceId = (string)historyItem["InstanceId"] });
         }
 
         private static void AddScheduledEventDataAndAggregate(ref Dictionary<string, EventIndexDateMapping> eventMapper, string prefix, JToken historyItem, int[] eventsToRemove, bool showInput)
@@ -1059,6 +1059,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             {
                 historyItem["ScheduledTime"] = taskScheduledData.Date;
                 historyItem["FunctionName"] = taskScheduledData.Name;
+                if (taskScheduledData.InstanceId != null)
+                {
+                    historyItem["InstanceId"] = taskScheduledData.InstanceId;
+                }
+
                 if (showInput)
                 {
                     historyItem["Input"] = taskScheduledData.Input;
@@ -1367,6 +1372,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             public string Name { get; set; }
 
             public string Input { get; set; }
+
+            public string InstanceId { get; set; }
         }
     }
 }

--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableClient.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableClient.cs
@@ -1059,7 +1059,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             {
                 historyItem["ScheduledTime"] = taskScheduledData.Date;
                 historyItem["FunctionName"] = taskScheduledData.Name;
-                if (taskScheduledData.InstanceId != null)
+                if (!string.IsNullOrEmpty(taskScheduledData.InstanceId))
                 {
                     historyItem["InstanceId"] = taskScheduledData.InstanceId;
                 }

--- a/test/FunctionsV2/Tests/Unit/DurableClientHistoryTests.cs
+++ b/test/FunctionsV2/Tests/Unit/DurableClientHistoryTests.cs
@@ -24,6 +24,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         private const string ChildInput = "{\"child\":1}";
         private const string FailedChildInput = "{\"child\":2}";
         private const string InFlightChildInput = "{\"child\":3}";
+        private const string CompletedChildInstanceId = "completed-child-instance";
+        private const string FailedChildInstanceId = "failed-child-instance";
+        private const string InFlightChildInstanceId = "in-flight-child-instance";
         private const string StringResult = "\"activity-result\"";
         private const string FailureResult = "\"failure-result\"";
         private const string ObjectResult = "{\"ok\":true}";
@@ -61,7 +64,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         [Theory]
         [MemberData(nameof(HistoryProjectionOptions))]
         [Trait("Category", PlatformSpecificHelpers.TestCategory)]
-        public async Task GetStatusAsync_ProjectsSubOrchestrationHistoryWithoutChangingPublicShape(bool showInput, bool showHistoryOutput)
+        public async Task GetStatusAsync_ProjectsSubOrchestrationHistoryWithInstanceIds(bool showInput, bool showHistoryOutput)
         {
             JArray actual = await GetProjectedHistoryAsync(CreateSubOrchestrationHistory(), showInput, showHistoryOutput);
 
@@ -390,6 +393,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                     40,
                     StartTime,
                     new JProperty("Name", "RepeatedChild"),
+                    new JProperty("InstanceId", CompletedChildInstanceId),
                     new JProperty("Input", ChildInput),
                     new JProperty("Version", "v1")),
                 CreateEvent(
@@ -404,6 +408,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                     50,
                     StartTime.AddSeconds(2),
                     new JProperty("Name", "RepeatedChild"),
+                    new JProperty("InstanceId", FailedChildInstanceId),
                     new JProperty("Input", FailedChildInput),
                     new JProperty("Version", "v2")),
                 CreateEvent(
@@ -420,6 +425,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                     60,
                     StartTime.AddSeconds(4),
                     new JProperty("Name", "InFlightChild"),
+                    new JProperty("InstanceId", InFlightChildInstanceId),
                     new JProperty("Input", InFlightChildInput),
                     new JProperty("Version", "v3"),
                     new JProperty("Extension", "in-flight-child-extension"))).ToString(Formatting.None);
@@ -440,6 +446,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             completed["Extension"] = "completed-child-extension";
             completed["ScheduledTime"] = StartTime.ToLocalTime();
             completed["FunctionName"] = "RepeatedChild";
+            completed["InstanceId"] = CompletedChildInstanceId;
             if (showInput)
             {
                 completed["Input"] = ChildInput;
@@ -455,6 +462,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 ["Extension"] = "failed-child-extension",
                 ["ScheduledTime"] = StartTime.AddSeconds(2).ToLocalTime(),
                 ["FunctionName"] = "RepeatedChild",
+                ["InstanceId"] = FailedChildInstanceId,
             };
             if (showInput)
             {
@@ -466,6 +474,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 ["EventType"] = "SubOrchestrationInstanceCreated",
                 ["Timestamp"] = StartTime.AddSeconds(4),
                 ["Name"] = "InFlightChild",
+                ["InstanceId"] = InFlightChildInstanceId,
             };
             if (showInput)
             {

--- a/test/e2e/Tests/Tests/GetOrchestrationHistoryTests.cs
+++ b/test/e2e/Tests/Tests/GetOrchestrationHistoryTests.cs
@@ -7,6 +7,7 @@ using DurableTask.Core.History;
 using Microsoft.Azure.WebJobs.Extensions.DurableTask;
 using Microsoft.DurableTask.Entities;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -33,6 +34,36 @@ public class GetOrchestrationHistoryTests
         this.fixture = fixture;
         this.fixture.TestLogs.UseTestLogger(testOutputHelper);
         this.output = testOutputHelper;
+    }
+
+    [Fact]
+    [Trait("Java", "Skip")] // GetOrchestrationHistory_HttpStart is only defined in the .NET isolated test app
+    [Trait("Python", "Skip")] // GetOrchestrationHistory_HttpStart is only defined in the .NET isolated test app
+    [Trait("PowerShell", "Skip")] // GetOrchestrationHistory_HttpStart is only defined in the .NET isolated test app
+    [Trait("Node", "Skip")] // GetOrchestrationHistory_HttpStart is only defined in the .NET isolated test app
+    [Trait("MSSQL", "Skip")] // MSSQL does not include InstanceId in SubOrchestrationInstanceCreated events
+    public async Task GetStatusHistory_CompletedSubOrchestrationIncludesInstanceId()
+    {
+        string subOrchestrationInstanceId = Guid.NewGuid().ToString();
+
+        using HttpResponseMessage response = await HttpHelpers.InvokeHttpTrigger(
+            "GetOrchestrationHistory_HttpStart",
+            $"?orchestrationType=succeed&subOrchestrationInstanceId={subOrchestrationInstanceId}&outputSize=16&callEntities=false&tagsKey={TagsKey}&tagsValue={TagsValue}");
+        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
+
+        string statusQueryGetUri = await DurableHelpers.ParseStatusQueryGetUriAsync(response);
+        await DurableHelpers.WaitForOrchestrationStateAsync(statusQueryGetUri, "Completed", 30);
+
+        string separator = statusQueryGetUri.Contains('?') ? "&" : "?";
+        using var httpClient = new HttpClient();
+        string statusJson = await httpClient.GetStringAsync($"{statusQueryGetUri}{separator}showHistory=true");
+        JObject status = JObject.Parse(statusJson);
+        JArray historyEvents = Assert.IsType<JArray>(status["historyEvents"]);
+        JObject completedEvent = Assert.Single(
+            historyEvents.OfType<JObject>(),
+            historyEvent => (string?)historyEvent["EventType"] == nameof(EventType.SubOrchestrationInstanceCompleted));
+
+        Assert.Equal(subOrchestrationInstanceId, (string?)completedEvent["InstanceId"]);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- preserve the child orchestration `InstanceId` when compacting `SubOrchestrationInstanceCreated` into completed or failed history entries
- keep activity history unchanged by only projecting the property when the scheduling event contains an instance ID
- cover completed, failed, and in-flight sub-orchestration history across input/output projection options
- add a .NET isolated E2E test that queries the generated management status URI with `showHistory=true` and verifies the completed sub-orchestration ID

Fixes #854.

## Testing
- `DurableClientHistoryTests` on `net8.0` and `net10.0`
- `GetStatusHistory_CompletedSubOrchestrationIncludesInstanceId` on `net8.0` with Azure Storage/Azurite
- confirmed the E2E test fails on the parent commit with `Actual: null` and passes with this fix