### PR TITLE
Fix dependency submission CI failure by removing abandoned TaskBuilder.fs dependency

### DIFF
--- a/samples/Directory.Packages.props
+++ b/samples/Directory.Packages.props
@@ -9,6 +9,7 @@
   <!-- Dependencies only required for samples -->
   <ItemGroup>
     <PackageVersion Include="EntityFramework" Version="6.5.1" />
+    <PackageVersion Include="FSharp.Core" Version="6.0.0" />
     <PackageVersion Include="Microsoft.AspNet.WebApi.Client" Version="5.2.7" />
     <PackageVersion Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
     <PackageVersion Include="Microsoft.Azure.WebJobs.Extensions.Twilio" Version="3.0.2" />
@@ -17,7 +18,6 @@
     <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="3.1.3" />
     <PackageVersion Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.1.2" />
     <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="5.7.0" />
-    <PackageVersion Include="TaskBuilder.fs" Version="1.0.0" />
   </ItemGroup>
 
   <!-- Dependencies pinned for samples -->

--- a/samples/fsharp/BackupSiteContent.fs
+++ b/samples/fsharp/BackupSiteContent.fs
@@ -10,7 +10,6 @@ open Microsoft.Azure.WebJobs
 open Microsoft.Azure.WebJobs.Extensions.DurableTask
 open Microsoft.Extensions.Logging
 open Microsoft.WindowsAzure.Storage.Blob
-open FSharp.Control.Tasks
 
 module BackupSiteContent =
 

--- a/samples/fsharp/DurableFSharp.fsproj
+++ b/samples/fsharp/DurableFSharp.fsproj
@@ -2,14 +2,13 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <FSharpCoreImplicitPackageVersion>4.2.3</FSharpCoreImplicitPackageVersion>
     <AzureFunctionsVersion>v2</AzureFunctionsVersion>
   </PropertyGroup>
 
   <!-- We use central package management. For version details, refer to `samples/Directory.packages.props`. -->
   <!-- To specify a version in the package reference below, simply add `Version = ""`. -->
   <ItemGroup>
-    <PackageReference Include="TaskBuilder.fs" />
+    <PackageReference Include="FSharp.Core" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Http" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" />

--- a/samples/fsharp/HelloSequence.fs
+++ b/samples/fsharp/HelloSequence.fs
@@ -5,7 +5,6 @@ namespace VSSample
 
 open Microsoft.Azure.WebJobs
 open Microsoft.Azure.WebJobs.Extensions.DurableTask
-open FSharp.Control.Tasks
 
 module HelloSequence =
 

--- a/samples/fsharp/HttpStart.fs
+++ b/samples/fsharp/HttpStart.fs
@@ -10,7 +10,6 @@ open Microsoft.Azure.WebJobs
 open Microsoft.Azure.WebJobs.Extensions.DurableTask
 open Microsoft.Azure.WebJobs.Extensions.Http
 open Microsoft.Extensions.Logging
-open FSharp.Control.Tasks
 
 module HttpStart = 
 

--- a/samples/fsharp/HttpSyncStart.fs
+++ b/samples/fsharp/HttpSyncStart.fs
@@ -9,7 +9,6 @@ open Microsoft.Azure.WebJobs
 open Microsoft.Azure.WebJobs.Extensions.DurableTask
 open Microsoft.Azure.WebJobs.Extensions.Http
 open Microsoft.Extensions.Logging
-open FSharp.Control.Tasks
 
 module HttpSyncStart = 
 

--- a/samples/fsharp/Monitor.fs
+++ b/samples/fsharp/Monitor.fs
@@ -12,7 +12,6 @@ open Microsoft.Extensions.Logging
 open Newtonsoft.Json.Linq
 open Twilio.Rest.Api.V2010.Account
 open Twilio.Types
-open FSharp.Control.Tasks
 
 type WeatherCondition =  Other | Clear | Precipitation
 

--- a/samples/fsharp/PhoneVerification.fs
+++ b/samples/fsharp/PhoneVerification.fs
@@ -11,7 +11,6 @@ open Microsoft.Azure.WebJobs.Extensions.DurableTask
 open Microsoft.Extensions.Logging
 open Twilio.Rest.Api.V2010.Account
 open Twilio.Types
-open FSharp.Control.Tasks
 
 module PhoneVerification =
 


### PR DESCRIPTION
## Symptom

The `submit-nuget` check is currently failing on essentially **every open PR** in this repo.

## Which job is this?

It belongs to GitHub's auto-generated workflow **"Automatic Dependency Submission (NuGet)"** (run path `dynamic/dependency-graph/auto-submission`, event `dynamic`). This workflow is GitHub-managed and **cannot be edited from this repository**.

What it does: it discovers project files with

```
find . -type f \( -name '*.csproj' -o -name '*.sln' -o -name '*.vbproj' -o -name '*.vcxproj' -o -name '*.fsproj' \) \
  | grep -v /obj/ | grep -v /bin/ | head -20
```

and then runs `dotnet restore` on each result, failing the job if any single restore fails.

## Root cause

Commit 87e1972b ("Route dependency restores through CFS") moved **all** NuGet restores through the Azure DevOps Central Feed Service feed `upstream-public`, using `<clear />` plus a `packageSourceMapping` of `*` → `upstream-public`. This matches Azure/durabletask and microsoft/durabletask-dotnet and is a deliberate org compliance decision.

That CFS feed only serves package versions that have already been **saved into** it when the caller is anonymous. For a version never pulled through the feed, an anonymous caller gets **HTTP 401**:

> No local versions of package X; please provide authentication to access versions from upstream that have not yet been saved to your feed

GitHub Actions runs anonymously against that feed.

`samples/fsharp/DurableFSharp.fsproj` referenced **`TaskBuilder.fs` 1.0.0** — an abandoned package (last released 2018). That project is in **no solution** and is built by **no pipeline** (neither GitHub Actions nor Azure DevOps), so no authenticated build ever warmed `TaskBuilder.fs` into CFS. But the dynamic dependency-submission workflow *does* restore it. Result:

```
##[error]Failed to restore project: ./samples/fsharp/DurableFSharp.fsproj
```

…and `submit-nuget` fails on every PR.

> **If you try to reproduce the 401 today, you may not see it.** `TaskBuilder.fs` 1.0.0 has since been saved into `upstream-public` (an anonymous probe now returns HTTP 200), most likely warmed by an authenticated restore during investigation. The 401 above describes the state at the time of the failures. The case for this change does not rest on that transient feed state: the sample depends on a package abandoned since 2018 that nothing in the repo builds, which is exactly the kind of dependency that silently breaks anonymous restore — removing it eliminates the failure class regardless of what happens to be cached.

## The fix

`TaskBuilder.fs` existed only to provide the `task { }` computation expression, which has been **built into FSharp.Core since 6.0.0**. So this PR drops the abandoned package and uses the built-in `task` CE instead:

- Removed the `TaskBuilder.fs` `PackageReference` / `PackageVersion`.
- Removed `open FSharp.Control.Tasks` (that namespace came from TaskBuilder.fs) from all six F# sample files.
- Removed the now-obsolete `<FSharpCoreImplicitPackageVersion>4.2.3</FSharpCoreImplicitPackageVersion>` property.
- **Added an explicit `FSharp.Core` 6.0.0 pin.** This repo uses Central Package Management, which sets `DisableImplicitFSharpCoreReference=true`, and FSharp.Core previously only arrived *transitively* via TaskBuilder.fs. Without an explicit reference it would silently disappear from the dependency graph.

The `task { ... }` bodies are unchanged — FSharp.Core 6.0.0 provides an API-compatible `task` builder.

## Validation

- `dotnet restore samples/fsharp/DurableFSharp.fsproj` (the exact command the failing CI job runs) now **succeeds**.
- Re-verified with an isolated `NUGET_PACKAGES` directory and `--no-cache --force`, so every package was genuinely downloaded from the CFS feed rather than served from a local cache — restore succeeded, `fsharp.core` was pulled, `taskbuilder.fs` was not.
- Confirmed anonymously (no credentials) that `FSharp.Core` 6.0.0 returns **HTTP 200** from `upstream-public`, so this change introduces no new 401 risk for the anonymous CI caller.
- `dotnet build samples/fsharp/DurableFSharp.fsproj -c Release` produces **zero `error FS…` F# compiler errors**. 
- This change **newly introduces 2 `warning FS3511`** (`Monitor.fs`, `PhoneVerification.fs`); the baseline produces none. FSharp.Core's `task` CE is implemented with resumable-code state machines, and the `let rec` inside those two orchestrators prevents static compilation, so a slower dynamic implementation is used. TaskBuilder.fs did not use resumable code, hence no such warning before. Benign for sample code; suppressible later if desired.

- No references to `TaskBuilder` or `FSharp.Control.Tasks` remain anywhere in tracked source.

> **Note on the sample's build:** this sample has a known, pre-existing failure from the ancient Functions v2 metadata generator (`Mono.Cecil.AssemblyResolutionException` / `Metadata generation failed`) that is unrelated to this change and reproduces identically on the unmodified baseline — verified on a fresh clone of `dev` (SDK 10.0.303, clean working tree, no prior build output), where baseline and this change fail that step in exactly the same way. It is out of scope here and is **not** a regression introduced by this PR. (This step's outcome is sensitive to local NuGet package-cache state: across the environments we tested it both failed and succeeded. In **every** configuration tested, however, the unmodified baseline and this change behaved identically — which is the only property that matters for reviewing this diff.)

## Note on `nuget.config`

`nuget.config` was **deliberately left untouched**. Adding nuget.org back would have "fixed" the restore but would revert the CFS migration and break the org compliance posture. CFS compliance is fully preserved by this PR.


