### PR TITLE
Restore npm/pip from public registries in GitHub Actions

### DIFF
--- a/.github/workflows/E2ETest.yml
+++ b/.github/workflows/E2ETest.yml
@@ -4,8 +4,8 @@ permissions:
 
 env:
   CORE_TOOLS_VERSION: '4.8.0'
-  NPM_CONFIG_USERCONFIG: ${{ github.workspace }}/eng/cfs/.npmrc
-  PIP_INDEX_URL: https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/pypi/simple/
+  NPM_CONFIG_REGISTRY: https://registry.npmjs.org/
+  PIP_INDEX_URL: https://pypi.org/simple/
 
 on:
   workflow_dispatch:

--- a/.github/workflows/dep-version-validation.yml
+++ b/.github/workflows/dep-version-validation.yml
@@ -25,7 +25,7 @@ permissions:
   contents: read
 
 env:
-  NPM_CONFIG_USERCONFIG: ${{ github.workspace }}/eng/cfs/.npmrc
+  NPM_CONFIG_REGISTRY: https://registry.npmjs.org/
 
 jobs:
   # ====================================================================================

--- a/.github/workflows/smoketest-dotnet-isolated-v4.yml
+++ b/.github/workflows/smoketest-dotnet-isolated-v4.yml
@@ -17,7 +17,7 @@ on:
       - 'test/SmokeTests/OOProcSmokeTests/DotNetIsolated/**'
 
 env:
-  NPM_CONFIG_USERCONFIG: ${{ github.workspace }}/eng/cfs/.npmrc
+  NPM_CONFIG_REGISTRY: https://registry.npmjs.org/
 
 jobs:
   build:

--- a/.github/workflows/validate-build-analyzer.yml
+++ b/.github/workflows/validate-build-analyzer.yml
@@ -17,7 +17,7 @@ on:
 env:
   config: Release
   AzureWebJobsStorage: UseDevelopmentStorage=true
-  NPM_CONFIG_USERCONFIG: ${{ github.workspace }}/eng/cfs/.npmrc
+  NPM_CONFIG_REGISTRY: https://registry.npmjs.org/
 
 jobs:
   build:

--- a/.github/workflows/validate-build-e2e.yml
+++ b/.github/workflows/validate-build-e2e.yml
@@ -17,7 +17,7 @@ on:
 env:
   config: Release
   AzureWebJobsStorage: UseDevelopmentStorage=true
-  NPM_CONFIG_USERCONFIG: ${{ github.workspace }}/eng/cfs/.npmrc
+  NPM_CONFIG_REGISTRY: https://registry.npmjs.org/
 
 jobs:
   build:

--- a/.github/workflows/validate-build-scale.yml
+++ b/.github/workflows/validate-build-scale.yml
@@ -16,7 +16,7 @@ on:
 env:
   config: Release
   AzureWebJobsStorage: UseDevelopmentStorage=true
-  NPM_CONFIG_USERCONFIG: ${{ github.workspace }}/eng/cfs/.npmrc
+  NPM_CONFIG_REGISTRY: https://registry.npmjs.org/
 
 jobs:
   azure-storage:

--- a/src/WebJobs.Extensions.DurableTask/AzureStorageDurabilityProviderFactory.cs
+++ b/src/WebJobs.Extensions.DurableTask/AzureStorageDurabilityProviderFactory.cs
@@ -87,7 +87,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 this.useSeparateQueueForEntityWorkItems = true;
             }
 
-            // The following defaults are only applied if the customer did not explicitely set them on `host.json`
+            // The following defaults are only applied if the customer did not explicitly set them on `host.json`
             this.options.MaxConcurrentOrchestratorFunctions = this.options.MaxConcurrentOrchestratorFunctions ?? maxConcurrentOrchestratorsDefault;
             this.options.MaxConcurrentActivityFunctions = this.options.MaxConcurrentActivityFunctions ?? maxConcurrentActivitiesDefault;
             this.options.MaxConcurrentEntityFunctions = this.options.MaxConcurrentEntityFunctions ?? maxConcurrentEntitiesDefault;


### PR DESCRIPTION
# Summary
## What changed?
- Repointed npm restores from the CFS feed to the public npm registry in the six CFS-consuming GitHub Actions workflows: replaced `NPM_CONFIG_USERCONFIG: ${{ github.workspace }}/eng/cfs/.npmrc` with `NPM_CONFIG_REGISTRY: https://registry.npmjs.org/`.
- Repointed pip restores to public PyPI in `E2ETest.yml`: `PIP_INDEX_URL` now `https://pypi.org/simple/`.
- Files touched: `.github/workflows/validate-build-e2e.yml`, `validate-build-scale.yml`, `validate-build-analyzer.yml`, `E2ETest.yml`, `dep-version-validation.yml`, `smoketest-dotnet-isolated-v4.yml`.
- The committed CFS configs (`nuget.config`, `eng/cfs/.npmrc`, test-app `.npmrc`/`nuget.config`) are intentionally left unchanged so the official/release build still restores through CFS.

## Why is this change needed?
- GitHub-hosted runners access the CFS-routed feed anonymously. Anonymous callers can download already-cached packages but cannot trigger upstream saves for versions not yet in the feed, which returns 401 on npm (Azurite) and pip restores and fails the CI checks.
- Setting `NPM_CONFIG_REGISTRY` / `PIP_INDEX_URL` as workflow env vars takes precedence over both the committed `.npmrc`/`nuget.config` and the emulator scripts' "set-if-unset" CFS fallback, so the runners reliably use public feeds.

---

# Project checklist
- [x] Documentation changes are not required
  - [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
- [x] Release notes are not required for the next release
  - [ ] Otherwise: Notes added to `release_notes.md`
- [x] Backport is not required
  - [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
- [x] All required tests have been added/updated (unit tests, E2E tests)
  - CI-configuration-only change; no test additions apply.
- [x] No extra work is required to be leveraged by OutOfProc SDKs
  - [ ] Otherwise: Work tracked here: #issue_or_pr_in_each_sdk
- [x] No change to the version of the `WebJobs.Extensions.DurableTask` package
  - [ ] Otherwise: Major/minor updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
- [x] No EventIds were added to `EventSource` logs
  - [ ] Otherwise: Ensure EventIds are within the supported range in the existing Windows infrastructure (validate via deployed telemetry). If needed, extend the range via a PR such as https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files
- [ ] This change should be added to the `v2.x` branch
  - [x] Otherwise: This change applies exclusively to `WebJobs.Extensions.DurableTask` v3.x and will be retained only in the `dev` and `main` branches
  - NOTE: confirm whether `v2.x` carries the same CFS-routed workflows; if so, the same env change should be applied there.
- [ ] Breaking change?
  - [ ] If yes:
    - Impact:
    - Migration guidance:
---

# AI-assisted code disclosure (required)
## Was an AI tool used? (select one)
- [ ] No
- [ ] Yes, AI helped write parts of this PR (e.g., GitHub Copilot)
- [x] Yes, an AI agent generated most of this PR

If AI was used:
- Tool(s): GitHub Copilot
- AI-assisted areas/files: the env-var edits in the six workflow YAML files listed above.
- What you changed after AI output:

AI verification (required if AI was used):
- [x] I understand the code and can explain it
- [x] I verified referenced APIs/types exist and are correct (public registry endpoints `https://registry.npmjs.org/` and `https://pypi.org/simple/`; env vars `NPM_CONFIG_REGISTRY` / `PIP_INDEX_URL`)
- [x] I reviewed edge cases/failure paths (env-var precedence over committed `.npmrc`/`nuget.config` and over the scripts' set-if-unset CFS fallback)
- [x] I reviewed concurrency/async behavior (N/A — CI configuration only)
- [x] I checked for unintended breaking or behavior changes (ADO official build untouched; nuget restore behavior unchanged)

---

# Testing
## Automated tests

## Manual validation (only if runtime/behavior changed)
- N/A — CI configuration change only; no product runtime/behavior change.

---

# Notes for reviewers
- Committed CFS configs are intentionally unchanged so the ADO official/release build keeps restoring through CFS.
- nuget restores in GitHub Actions still use the committed CFS `nuget.config`