### PR TITLE
Add CFS-authenticated public Azure DevOps CI

### DIFF
--- a/eng/ci/public.yml
+++ b/eng/ci/public.yml
@@ -34,6 +34,8 @@ resources:
       ref: refs/tags/release
 
 variables:
+  - name: AZURITE_VERSION
+    value: 3.35.0
   - name: CORE_TOOLS_VERSION
     value: 4.8.0
   - name: NPM_CONFIG_USERCONFIG
@@ -75,7 +77,7 @@ extends:
         dependsOn: []
         pool:
           name: 1es-pool-azfunc-public
-          image: 1es-ubuntu-24.04-min
+          image: 1es-ubuntu-22.04
           os: linux
         jobs:
           - template: /eng/ci/templates/public/dependency-validation.yml@self
@@ -99,7 +101,7 @@ extends:
         dependsOn: []
         pool:
           name: 1es-pool-azfunc-public
-          image: 1es-ubuntu-24.04-min
+          image: 1es-ubuntu-22.04
           os: linux
         jobs:
           - template: /eng/ci/templates/public/language-e2e.yml@self

--- a/eng/ci/public.yml
+++ b/eng/ci/public.yml
@@ -1,0 +1,107 @@
+trigger:
+  batch: true
+  branches:
+    include:
+      - main
+      - dev
+  paths:
+    exclude:
+      - '**/*.md'
+
+pr:
+  autoCancel: true
+  branches:
+    include:
+      - main
+      - dev
+  paths:
+    exclude:
+      - '**/*.md'
+
+schedules:
+  - cron: '0 0 * * 1'
+    displayName: Weekly security build
+    branches:
+      include:
+        - dev
+    always: true
+
+resources:
+  repositories:
+    - repository: 1es
+      type: git
+      name: 1ESPipelineTemplates/1ESPipelineTemplates
+      ref: refs/tags/release
+
+variables:
+  - name: CORE_TOOLS_VERSION
+    value: 4.8.0
+  - name: NPM_CONFIG_USERCONFIG
+    value: $(Build.SourcesDirectory)/eng/cfs/.npmrc
+  - name: DOTNET_CLI_TELEMETRY_OPTOUT
+    value: 1
+
+extends:
+  template: v1/1ES.Unofficial.PipelineTemplate.yml@1es
+  parameters:
+    pool:
+      name: 1es-pool-azfunc-public
+      image: 1es-windows-2022
+      os: windows
+
+    sdl:
+      codeql:
+        compiled:
+          enabled: true
+        runSourceLanguagesInSourceAnalysis: true
+
+    settings:
+      # Fork PRs cannot set the informational build tags added by 1ES.
+      skipBuildTagsForGitHubPullRequests: ${{ variables['System.PullRequest.IsFork'] }}
+
+    stages:
+      - stage: WindowsValidation
+        displayName: Windows validation
+        dependsOn: []
+        pool:
+          name: 1es-pool-azfunc-public
+          image: 1es-windows-2022
+          os: windows
+        jobs:
+          - template: /eng/ci/templates/public/windows-validation.yml@self
+
+      - stage: LinuxValidation
+        displayName: Linux validation
+        dependsOn: []
+        pool:
+          name: 1es-pool-azfunc-public
+          image: 1es-ubuntu-24.04-min
+          os: linux
+        jobs:
+          - template: /eng/ci/templates/public/dependency-validation.yml@self
+          - template: /eng/ci/templates/public/smoke-tests.yml@self
+          - template: /eng/ci/templates/public/scale-tests.yml@self
+
+      - stage: WindowsLanguageE2E
+        displayName: Windows language E2E
+        dependsOn: []
+        pool:
+          name: 1es-pool-azfunc-public
+          image: 1es-windows-2022
+          os: windows
+        jobs:
+          - template: /eng/ci/templates/public/language-e2e.yml@self
+            parameters:
+              platform: windows
+
+      - stage: LinuxLanguageE2E
+        displayName: Linux language E2E
+        dependsOn: []
+        pool:
+          name: 1es-pool-azfunc-public
+          image: 1es-ubuntu-24.04-min
+          os: linux
+        jobs:
+          - template: /eng/ci/templates/public/language-e2e.yml@self
+            parameters:
+              platform: linux

--- a/eng/ci/templates/public/cfs-authentication.yml
+++ b/eng/ci/templates/public/cfs-authentication.yml
@@ -1,0 +1,139 @@
+steps:
+  - task: NuGetAuthenticate@1
+    displayName: Authenticate NuGet with CFS
+
+  - task: npmAuthenticate@0
+    displayName: Authenticate npm with CFS
+    inputs:
+      workingFile: eng/cfs/.npmrc
+
+  - task: PipAuthenticate@1
+    displayName: Authenticate pip with CFS
+    inputs:
+      artifactFeeds: public/upstream-public
+      onlyAddExtraIndex: false
+
+  - task: MavenAuthenticate@0
+    displayName: Authenticate Maven with CFS
+    inputs:
+      artifactsFeeds: upstream-public
+
+  - pwsh: |
+      $ErrorActionPreference = 'Stop'
+      $feedUrl = 'https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/maven/v1'
+
+      $settingsPath = Join-Path $HOME '.m2/settings.xml'
+      [xml] $settings = Get-Content -LiteralPath $settingsPath -Raw
+      $namespace = $settings.DocumentElement.NamespaceURI
+      $mirrors = $settings.DocumentElement.SelectSingleNode(
+        "*[local-name()='mirrors']")
+      if ($null -eq $mirrors) {
+        $mirrors = $settings.CreateElement('mirrors', $namespace)
+        [void] $settings.DocumentElement.AppendChild($mirrors)
+      }
+
+      $mirror = $settings.CreateElement('mirror', $namespace)
+      foreach ($entry in @{
+        id = 'upstream-public'
+        name = 'Azure Functions CFS'
+        url = $feedUrl
+        mirrorOf = '*'
+      }.GetEnumerator()) {
+        $element = $settings.CreateElement($entry.Key, $namespace)
+        $element.InnerText = $entry.Value
+        [void] $mirror.AppendChild($element)
+      }
+      [void] $mirrors.AppendChild($mirror)
+      $settings.Save($settingsPath)
+
+      $gradleInitDirectory = Join-Path $HOME '.gradle/init.d'
+      New-Item -ItemType Directory -Path $gradleInitDirectory -Force | Out-Null
+      @"
+      settingsEvaluated { settings ->
+          settings.pluginManagement.repositories.clear()
+          settings.pluginManagement.repositories.gradlePluginPortal()
+          settings.pluginManagement.repositories.maven {
+              url = uri('$feedUrl')
+              credentials {
+                  username = 'AzureDevOps'
+                  password = System.getenv('VSS_NUGET_ACCESSTOKEN')
+              }
+          }
+      }
+      allprojects {
+          buildscript.repositories {
+              clear()
+              maven {
+                  url = uri('$feedUrl')
+                  credentials {
+                      username = 'AzureDevOps'
+                      password = System.getenv('VSS_NUGET_ACCESSTOKEN')
+                  }
+              }
+          }
+          repositories {
+              clear()
+              maven {
+                  url = uri('$feedUrl')
+                  credentials {
+                      username = 'AzureDevOps'
+                      password = System.getenv('VSS_NUGET_ACCESSTOKEN')
+                  }
+              }
+          }
+      }
+      "@ | Set-Content -LiteralPath (Join-Path $gradleInitDirectory 'cfs.gradle')
+    displayName: Route Maven and Gradle through CFS
+
+  - pwsh: |
+      $ErrorActionPreference = 'Stop'
+      $outputDirectory = Join-Path $env:AGENT_TEMPDIRECTORY 'cfs-docker'
+      New-Item -ItemType Directory -Path $outputDirectory -Force | Out-Null
+
+      $npmConfigPath = Join-Path $outputDirectory '.npmrc'
+      Copy-Item -LiteralPath 'eng/cfs/.npmrc' -Destination $npmConfigPath -Force
+      if ((Get-Content -LiteralPath $npmConfigPath -Raw) -notmatch ':(_authToken|_password)=') {
+        throw 'npmAuthenticate did not add credentials to the CFS npm configuration.'
+      }
+
+      if ([string]::IsNullOrWhiteSpace($env:PIP_INDEX_URL)) {
+        throw 'PipAuthenticate did not set PIP_INDEX_URL.'
+      }
+      $pipIndexPath = Join-Path $outputDirectory 'pip-index-url'
+      [System.IO.File]::WriteAllText(
+        $pipIndexPath,
+        $env:PIP_INDEX_URL,
+        [System.Text.UTF8Encoding]::new($false))
+
+      if ([string]::IsNullOrWhiteSpace($env:VSS_NUGET_ACCESSTOKEN)) {
+        throw 'NuGetAuthenticate did not set VSS_NUGET_ACCESSTOKEN.'
+      }
+      [xml] $nugetConfig = Get-Content -LiteralPath 'nuget.config' -Raw
+      $credentials = $nugetConfig.CreateElement('packageSourceCredentials')
+      $source = $nugetConfig.CreateElement('upstream-public')
+      foreach ($entry in @{
+        Username = 'AzureDevOps'
+        ClearTextPassword = $env:VSS_NUGET_ACCESSTOKEN
+      }.GetEnumerator()) {
+        $add = $nugetConfig.CreateElement('add')
+        $add.SetAttribute('key', $entry.Key)
+        $add.SetAttribute('value', $entry.Value)
+        [void] $source.AppendChild($add)
+      }
+      [void] $credentials.AppendChild($source)
+      [void] $nugetConfig.configuration.AppendChild($credentials)
+      $nugetConfigPath = Join-Path $outputDirectory 'NuGet.config'
+      $writerSettings = [System.Xml.XmlWriterSettings]::new()
+      $writerSettings.Indent = $true
+      $writerSettings.Encoding = [System.Text.UTF8Encoding]::new($false)
+      $writer = [System.Xml.XmlWriter]::Create($nugetConfigPath, $writerSettings)
+      try {
+        $nugetConfig.Save($writer)
+      } finally {
+        $writer.Dispose()
+      }
+
+      Write-Host "##vso[task.setvariable variable=CFS_NPM_CONFIG]$npmConfigPath"
+      Write-Host "##vso[task.setvariable variable=CFS_PIP_INDEX]$pipIndexPath"
+      Write-Host "##vso[task.setvariable variable=CFS_NUGET_CONFIG]$nugetConfigPath"
+    displayName: Prepare authenticated CFS Docker configuration

--- a/eng/ci/templates/public/cfs-authentication.yml
+++ b/eng/ci/templates/public/cfs-authentication.yml
@@ -20,6 +20,26 @@ steps:
 
   - pwsh: |
       $ErrorActionPreference = 'Stop'
+      $repository = @{
+        Name = 'upstream-public'
+        SourceLocation = 'https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/nuget/v2'
+        InstallationPolicy = 'Trusted'
+        Credential = [PSCredential]::new(
+          'AzurePipelines',
+          (ConvertTo-SecureString $env:SYSTEM_ACCESSTOKEN -AsPlainText -Force))
+      }
+
+      if (Get-PSRepository -Name $repository.Name -ErrorAction SilentlyContinue) {
+        Set-PSRepository @repository
+      } else {
+        Register-PSRepository @repository
+      }
+    displayName: Authenticate PowerShell Gallery with CFS
+    env:
+      SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+
+  - pwsh: |
+      $ErrorActionPreference = 'Stop'
       $feedUrl = 'https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/maven/v1'
 
       $settingsPath = Join-Path $HOME '.m2/settings.xml'

--- a/eng/ci/templates/public/cfs-authentication.yml
+++ b/eng/ci/templates/public/cfs-authentication.yml
@@ -21,7 +21,7 @@ steps:
   - pwsh: |
       $ErrorActionPreference = 'Stop'
       $repository = @{
-        Name = 'upstream-public'
+        Name = 'cfs-powershell-gallery'
         SourceLocation = 'https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/nuget/v2'
         InstallationPolicy = 'Trusted'
         Credential = [PSCredential]::new(

--- a/eng/ci/templates/public/dependency-validation.yml
+++ b/eng/ci/templates/public/dependency-validation.yml
@@ -76,7 +76,7 @@ jobs:
 
       - bash: |
           set -euo pipefail
-          npm install -g azurite
+          npm install -g azurite@$(AZURITE_VERSION)
           nohup azurite --silent --skipApiVersionCheck \
             --blobPort 10000 --queuePort 10001 --tablePort 10002 \
             > /tmp/azurite.log 2>&1 &
@@ -202,7 +202,7 @@ jobs:
 
       - bash: |
           set -euo pipefail
-          npm install -g azurite
+          npm install -g azurite@$(AZURITE_VERSION)
           nohup azurite --silent --skipApiVersionCheck \
             --blobPort 10000 --queuePort 10001 --tablePort 10002 \
             > /tmp/azurite.log 2>&1 &

--- a/eng/ci/templates/public/dependency-validation.yml
+++ b/eng/ci/templates/public/dependency-validation.yml
@@ -1,0 +1,261 @@
+jobs:
+  - job: IsolatedDependencyValidation
+    displayName: Dependency validation - .NET isolated
+    timeoutInMinutes: 30
+    steps:
+      - checkout: self
+        clean: true
+
+      - template: cfs-authentication.yml
+
+      - task: UseDotNet@2
+        displayName: Install .NET SDK from global.json
+        inputs:
+          packageType: sdk
+          useGlobalJson: true
+
+      - task: UseDotNet@2
+        displayName: Install .NET 8 SDK
+        inputs:
+          packageType: sdk
+          version: 8.0.x
+
+      - task: NodeTool@0
+        displayName: Install Node.js 22
+        inputs:
+          versionSpec: 22.x
+
+      - bash: npm install -g azure-functions-core-tools@4 --unsafe-perm true
+        displayName: Install Azure Functions Core Tools
+
+      - bash: |
+          set -euo pipefail
+          csproj='src/Worker.Extensions.DurableTask/Worker.Extensions.DurableTask.csproj'
+          prefix=$(grep -oP '<VersionPrefix>\K[^<]+' "$csproj")
+          suffix=$(grep -oP '<VersionSuffix>\K[^<]+' "$csproj" || true)
+          IFS='.' read -r major minor patch <<< "$prefix"
+          patch=$((patch + 1))
+          version="${major}.${minor}.${patch}"
+          if [ -n "$suffix" ]; then version="${version}-${suffix}"; fi
+          sed -i "s|<VersionPrefix>${prefix}</VersionPrefix>|<VersionPrefix>${major}.${minor}.${patch}</VersionPrefix>|" "$csproj"
+          grep -q "<VersionPrefix>${major}.${minor}.${patch}</VersionPrefix>" "$csproj"
+          echo "##vso[task.setvariable variable=extensionVersion]${version}"
+        displayName: Bump Worker extension test version
+
+      - bash: |
+          set -euo pipefail
+          package_dir='test/SmokeTests/DepValidation/Isolated/local-packages'
+          mkdir -p "$package_dir"
+          pushd src/Worker.Extensions.DurableTask
+          dotnet build -c Release
+          cp bin/Release/*.nupkg "../../$package_dir/"
+          popd
+          pushd src/WebJobs.Extensions.DurableTask
+          dotnet build -c Release
+          find bin/Release -name '*.nupkg' -exec cp {} "../../$package_dir/" \;
+        displayName: Pack local extensions
+
+      - pwsh: |
+          ./eng/cfs/New-LocalNuGetConfig.ps1 `
+            -DestinationPath 'test/SmokeTests/DepValidation/Isolated/NuGet.config' `
+            -LocalSourcePath './local-packages' `
+            -PackagePatterns @(
+              'Microsoft.Azure.Functions.Worker.Extensions.DurableTask',
+              'Microsoft.Azure.WebJobs.Extensions.DurableTask'
+            )
+        displayName: Generate NuGet configuration
+
+      - bash: |
+          set -euo pipefail
+          dotnet build test/SmokeTests/DepValidation/Isolated/DepValidationApp.csproj \
+            -c Release \
+            -p:SmokeTestExtVersion=$(extensionVersion)
+          key="Microsoft.Azure.Functions.Worker.Extensions.DurableTask/$(extensionVersion)"
+          grep -qi "$key" test/SmokeTests/DepValidation/Isolated/obj/project.assets.json
+        displayName: Build and verify smoke test application
+
+      - bash: |
+          set -euo pipefail
+          npm install -g azurite
+          nohup azurite --silent --skipApiVersionCheck \
+            --blobPort 10000 --queuePort 10001 --tablePort 10002 \
+            > /tmp/azurite.log 2>&1 &
+          for i in $(seq 1 30); do
+            timeout 1 bash -c 'echo>/dev/tcp/127.0.0.1/10000' 2>/dev/null &&
+              timeout 1 bash -c 'echo>/dev/tcp/127.0.0.1/10001' 2>/dev/null &&
+              timeout 1 bash -c 'echo>/dev/tcp/127.0.0.1/10002' 2>/dev/null && exit 0
+            if [ "$i" -eq 30 ]; then cat /tmp/azurite.log; exit 1; fi
+            sleep 1
+          done
+        displayName: Start Azurite
+
+      - bash: |
+          set -euo pipefail
+          port=7071
+          timeout=120
+          export AzureWebJobsStorage='UseDevelopmentStorage=true'
+          export FUNCTIONS_WORKER_RUNTIME='dotnet-isolated'
+          cd test/SmokeTests/DepValidation/Isolated/bin/Release/net8.0
+          func host start --port "$port" > /tmp/func.log 2>&1 &
+          pid=$!
+          for i in $(seq 1 45); do
+            curl -s -o /dev/null -w '%{http_code}' "http://localhost:$port/admin/host/ping" | grep -q 200 && break
+            kill -0 "$pid" 2>/dev/null || { cat /tmp/func.log; exit 1; }
+            if [ "$i" -eq 45 ]; then cat /tmp/func.log; exit 1; fi
+            sleep 2
+          done
+          code=$(curl -s -o /tmp/start.json -w '%{http_code}' -X POST \
+            "http://localhost:$port/api/HelloCitiesOrchestration_HttpStart")
+          [ "$code" = 200 ] || [ "$code" = 202 ] || { cat /tmp/func.log; exit 1; }
+          url=$(python3 -c "import json; d=json.load(open('/tmp/start.json')); print(d.get('statusQueryGetUri') or d.get('StatusQueryGetUri'))")
+          elapsed=0
+          while [ "$elapsed" -lt "$timeout" ]; do
+            sleep 2
+            elapsed=$((elapsed + 2))
+            status=$(curl -s "$url" | python3 -c "import sys,json; print(json.load(sys.stdin).get('runtimeStatus',''))")
+            if [ "$status" = Completed ]; then
+              output=$(curl -s "$url" | python3 -c "import sys,json; print(json.load(sys.stdin).get('output',''))")
+              echo "$output" | grep -q 'Hello, Tokyo!'
+              echo "$output" | grep -q 'Hello, Seattle!'
+              version=$(curl -s "http://localhost:$port/api/SdkVersionCheck" | \
+                python3 -c "import sys,json; print(json.load(sys.stdin).get('Microsoft.Azure.Functions.Worker.Extensions.DurableTask',''))")
+              [ "$version" = '$(extensionVersion)' ]
+              kill "$pid" 2>/dev/null || true
+              exit 0
+            fi
+            [ "$status" != Failed ] && [ "$status" != Terminated ] || exit 1
+          done
+          echo 'Orchestration timed out'
+          exit 1
+        displayName: Run .NET isolated dependency smoke test
+
+      - bash: tail -50 /tmp/func.log 2>/dev/null || true
+        displayName: Print Functions host log
+        condition: failed()
+
+  - job: InProcessDependencyValidation
+    displayName: Dependency validation - .NET in-process
+    timeoutInMinutes: 30
+    steps:
+      - checkout: self
+        clean: true
+
+      - template: cfs-authentication.yml
+
+      - task: UseDotNet@2
+        displayName: Install .NET SDK from global.json
+        inputs:
+          packageType: sdk
+          useGlobalJson: true
+
+      - task: UseDotNet@2
+        displayName: Install .NET 8 SDK
+        inputs:
+          packageType: sdk
+          version: 8.0.x
+
+      - task: NodeTool@0
+        displayName: Install Node.js 22
+        inputs:
+          versionSpec: 22.x
+
+      - bash: npm install -g azure-functions-core-tools@4 --unsafe-perm true
+        displayName: Install Azure Functions Core Tools
+
+      - bash: |
+          set -euo pipefail
+          csproj='src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj'
+          major=$(grep -oP '<MajorVersion>\K[^<]+' "$csproj")
+          minor=$(grep -oP '<MinorVersion>\K[^<]+' "$csproj")
+          patch=$(grep -oP '<PatchVersion>\K[^<]+' "$csproj")
+          next_patch=$((patch + 1))
+          sed -i "s|<PatchVersion>${patch}</PatchVersion>|<PatchVersion>${next_patch}</PatchVersion>|" "$csproj"
+          grep -q "<PatchVersion>${next_patch}</PatchVersion>" "$csproj"
+          echo "##vso[task.setvariable variable=extensionVersion]${major}.${minor}.${next_patch}"
+        displayName: Bump WebJobs extension test version
+
+      - bash: |
+          set -euo pipefail
+          package_dir='test/SmokeTests/DepValidation/InProcess/local-packages'
+          mkdir -p "$package_dir"
+          pushd src/WebJobs.Extensions.DurableTask
+          dotnet build -c Release
+          find bin/Release -name '*.nupkg' -exec cp {} "../../$package_dir/" \;
+          ls -la "../../$package_dir/"
+        displayName: Pack local WebJobs extension
+
+      - pwsh: |
+          ./eng/cfs/New-LocalNuGetConfig.ps1 `
+            -DestinationPath 'test/SmokeTests/DepValidation/InProcess/NuGet.config' `
+            -LocalSourcePath './local-packages' `
+            -PackagePatterns 'Microsoft.Azure.WebJobs.Extensions.DurableTask'
+        displayName: Generate NuGet configuration
+
+      - bash: |
+          set -euo pipefail
+          dotnet build test/SmokeTests/DepValidation/InProcess/InProcessSmokeTest.csproj \
+            -c Release \
+            -p:SmokeTestWebJobsVersion=$(extensionVersion)
+          key="Microsoft.Azure.WebJobs.Extensions.DurableTask/$(extensionVersion)"
+          grep -qi "$key" test/SmokeTests/DepValidation/InProcess/obj/project.assets.json
+        displayName: Build and verify smoke test application
+
+      - bash: |
+          set -euo pipefail
+          npm install -g azurite
+          nohup azurite --silent --skipApiVersionCheck \
+            --blobPort 10000 --queuePort 10001 --tablePort 10002 \
+            > /tmp/azurite.log 2>&1 &
+          for i in $(seq 1 30); do
+            timeout 1 bash -c 'echo>/dev/tcp/127.0.0.1/10000' 2>/dev/null &&
+              timeout 1 bash -c 'echo>/dev/tcp/127.0.0.1/10001' 2>/dev/null &&
+              timeout 1 bash -c 'echo>/dev/tcp/127.0.0.1/10002' 2>/dev/null && exit 0
+            if [ "$i" -eq 30 ]; then cat /tmp/azurite.log; exit 1; fi
+            sleep 1
+          done
+        displayName: Start Azurite
+
+      - bash: |
+          set -euo pipefail
+          port=7072
+          timeout=120
+          export AzureWebJobsStorage='UseDevelopmentStorage=true'
+          export FUNCTIONS_WORKER_RUNTIME='dotnet'
+          export FUNCTIONS_INPROC_NET8_ENABLED='1'
+          cd test/SmokeTests/DepValidation/InProcess/bin/Release/net8.0
+          func host start --port "$port" > /tmp/func.log 2>&1 &
+          pid=$!
+          for i in $(seq 1 45); do
+            curl -s -o /dev/null -w '%{http_code}' "http://localhost:$port/admin/host/ping" | grep -q 200 && break
+            kill -0 "$pid" 2>/dev/null || { cat /tmp/func.log; exit 1; }
+            if [ "$i" -eq 45 ]; then cat /tmp/func.log; exit 1; fi
+            sleep 2
+          done
+          code=$(curl -s -o /tmp/start.json -w '%{http_code}' -X POST \
+            "http://localhost:$port/api/HelloCitiesOrchestration_HttpStart")
+          [ "$code" = 200 ] || [ "$code" = 202 ] || { cat /tmp/func.log; exit 1; }
+          url=$(python3 -c "import json; d=json.load(open('/tmp/start.json')); print(d.get('statusQueryGetUri') or d.get('StatusQueryGetUri'))")
+          elapsed=0
+          while [ "$elapsed" -lt "$timeout" ]; do
+            sleep 2
+            elapsed=$((elapsed + 2))
+            status=$(curl -s "$url" | python3 -c "import sys,json; print(json.load(sys.stdin).get('runtimeStatus',''))")
+            if [ "$status" = Completed ]; then
+              output=$(curl -s "$url" | python3 -c "import sys,json; print(json.load(sys.stdin).get('output',''))")
+              echo "$output" | grep -q 'Hello, Tokyo!'
+              echo "$output" | grep -q 'Hello, Seattle!'
+              version=$(curl -s "http://localhost:$port/api/SdkVersionCheck" | \
+                python3 -c "import sys,json; print(json.load(sys.stdin).get('Microsoft.Azure.WebJobs.Extensions.DurableTask',''))")
+              [ "$version" = '$(extensionVersion)' ]
+              kill "$pid" 2>/dev/null || true
+              exit 0
+            fi
+            [ "$status" != Failed ] && [ "$status" != Terminated ] || exit 1
+          done
+          echo 'Orchestration timed out'
+          exit 1
+        displayName: Run .NET in-process dependency smoke test
+
+      - bash: tail -50 /tmp/func.log 2>/dev/null || true
+        displayName: Print Functions host log
+        condition: failed()

--- a/eng/ci/templates/public/language-e2e.yml
+++ b/eng/ci/templates/public/language-e2e.yml
@@ -58,7 +58,7 @@ jobs:
             (ConvertTo-SecureString $env:SYSTEM_ACCESSTOKEN -AsPlainText -Force))
           $module = Find-Module `
             -Name AzureFunctions.PowerShell.Durable.SDK `
-            -Repository upstream-public `
+            -Repository cfs-powershell-gallery `
             -AllVersions `
             -Credential $credential |
             Where-Object { ([version] $_.Version).Major -eq 2 } |
@@ -72,7 +72,7 @@ jobs:
           Save-Module `
             -Name $module.Name `
             -RequiredVersion $module.Version `
-            -Repository upstream-public `
+            -Repository cfs-powershell-gallery `
             -Path "$app/Modules" `
             -Credential $credential `
             -Force

--- a/eng/ci/templates/public/language-e2e.yml
+++ b/eng/ci/templates/public/language-e2e.yml
@@ -86,7 +86,7 @@ jobs:
           Push-Location .azurite
           try {
             '{"name":"azurite-local","private":true}' | Set-Content package.json
-            npm install azurite
+            npm install azurite@$(AZURITE_VERSION)
             if ($LASTEXITCODE) { exit $LASTEXITCODE }
           } finally {
             Pop-Location

--- a/eng/ci/templates/public/language-e2e.yml
+++ b/eng/ci/templates/public/language-e2e.yml
@@ -51,20 +51,35 @@ jobs:
 
       - template: cfs-authentication.yml
 
-      # TODO: Use the gallery SDK again when PSGallery is available through CFS.
       - pwsh: |
           $ErrorActionPreference = 'Stop'
+          $credential = [PSCredential]::new(
+            'AzurePipelines',
+            (ConvertTo-SecureString $env:SYSTEM_ACCESSTOKEN -AsPlainText -Force))
+          $module = Find-Module `
+            -Name AzureFunctions.PowerShell.Durable.SDK `
+            -Repository upstream-public `
+            -AllVersions `
+            -Credential $credential |
+            Where-Object { ([version] $_.Version).Major -eq 2 } |
+            Sort-Object Version -Descending |
+            Select-Object -First 1
+          if (!$module) {
+            throw 'AzureFunctions.PowerShell.Durable.SDK 2.x was not found in CFS.'
+          }
+
           $app = './test/e2e/Apps/BasicPowerShell'
+          Save-Module `
+            -Name $module.Name `
+            -RequiredVersion $module.Version `
+            -Repository upstream-public `
+            -Path "$app/Modules" `
+            -Credential $credential `
+            -Force
           Remove-Item "$app/requirements.psd1" -Force
-          (Get-Content "$app/profile.ps1") |
-            Where-Object { $_ -notmatch 'AzureFunctions\.PowerShell\.Durable\.SDK' } |
-            Set-Content "$app/profile.ps1"
-          $settingsPath = "$app/local.settings.json"
-          $settings = Get-Content $settingsPath -Raw | ConvertFrom-Json
-          $settings.Values.ExternalDurablePowerShellSDK = 'false'
-          $settings | ConvertTo-Json -Depth 10 | Set-Content $settingsPath
-          Write-Host '##vso[task.setvariable variable=ExternalDurablePowerShellSDK]false'
-        displayName: Use built-in PowerShell Durable SDK
+        displayName: Restore PowerShell Durable SDK from CFS
+        env:
+          SYSTEM_ACCESSTOKEN: $(System.AccessToken)
 
       - task: UseDotNet@2
         displayName: Install .NET SDK from global.json
@@ -178,13 +193,6 @@ jobs:
             $env:TEST_APP_NAME = $case.App
             $backendFilter = '$(backendFilter)'
             $filter = "$($backendFilter)!=Skip&$($case.Filter)!=Skip&$($case.Filter)-$($backendFilter)!=Skip"
-            if ($case.Name -eq 'powershell') {
-              # The built-in SDK does not support these external-SDK behaviors.
-              $filter += '&FullyQualifiedName!~ErrorHandlingTests.OrchestratorWithCaughtActivityException_ShouldSucceed'
-              $filter += '&FullyQualifiedName!~IsReplayingTests.IsReplayingFanOutFanIn_ReportsReplayStateAroundParallelTasks'
-              $filter += '&FullyQualifiedName!~SuspendResumeTests'
-              $filter += '&FullyQualifiedName!~DedupeStatusesTests.CanStartOrchestration_WithSameId_ForAllStatuses_ForEmptyDedupeStatuses'
-            }
             dotnet test $testProject `
               -f $(testTargetFramework) `
               --no-build `

--- a/eng/ci/templates/public/language-e2e.yml
+++ b/eng/ci/templates/public/language-e2e.yml
@@ -178,6 +178,13 @@ jobs:
             $env:TEST_APP_NAME = $case.App
             $backendFilter = '$(backendFilter)'
             $filter = "$($backendFilter)!=Skip&$($case.Filter)!=Skip&$($case.Filter)-$($backendFilter)!=Skip"
+            if ($case.Name -eq 'powershell') {
+              # The built-in SDK does not support these external-SDK behaviors.
+              $filter += '&FullyQualifiedName!~ErrorHandlingTests.OrchestratorWithCaughtActivityException_ShouldSucceed'
+              $filter += '&FullyQualifiedName!~IsReplayingTests.IsReplayingFanOutFanIn_ReportsReplayStateAroundParallelTasks'
+              $filter += '&FullyQualifiedName!~SuspendResumeTests'
+              $filter += '&FullyQualifiedName!~DedupeStatusesTests.CanStartOrchestration_WithSameId_ForAllStatuses_ForEmptyDedupeStatuses'
+            }
             dotnet test $testProject `
               -f $(testTargetFramework) `
               --no-build `

--- a/eng/ci/templates/public/language-e2e.yml
+++ b/eng/ci/templates/public/language-e2e.yml
@@ -76,7 +76,10 @@ jobs:
             -Path "$app/Modules" `
             -Credential $credential `
             -Force
-          Remove-Item "$app/requirements.psd1" -Force
+          $hostConfigPath = "$app/host.json"
+          $hostConfig = Get-Content $hostConfigPath -Raw | ConvertFrom-Json
+          $hostConfig.managedDependency.enabled = $false
+          $hostConfig | ConvertTo-Json -Depth 10 | Set-Content $hostConfigPath
         displayName: Restore PowerShell Durable SDK from CFS
         env:
           SYSTEM_ACCESSTOKEN: $(System.AccessToken)

--- a/eng/ci/templates/public/language-e2e.yml
+++ b/eng/ci/templates/public/language-e2e.yml
@@ -51,27 +51,20 @@ jobs:
 
       - template: cfs-authentication.yml
 
+      # TODO: Use the gallery SDK again when PSGallery is available through CFS.
       - pwsh: |
           $ErrorActionPreference = 'Stop'
-          if ([string]::IsNullOrWhiteSpace($env:VSS_NUGET_ACCESSTOKEN)) {
-            throw 'NuGetAuthenticate did not provide a CFS access token.'
-          }
-
-          $version = '2.3.0'
-          $package = "azurefunctions.powershell.durable.sdk.$version.nupkg"
-          $url = "https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/nuget/v3/flat2/azurefunctions.powershell.durable.sdk/$version/$package"
-          $archive = Join-Path $env:AGENT_TEMPDIRECTORY "$package.zip"
-          $modulePath = "./test/e2e/Apps/BasicPowerShell/Modules/AzureFunctions.PowerShell.Durable.SDK/$version"
-          $credentials = [Convert]::ToBase64String(
-            [Text.Encoding]::ASCII.GetBytes("AzureDevOps:$env:VSS_NUGET_ACCESSTOKEN"))
-
-          Invoke-WebRequest `
-            -Uri $url `
-            -Headers @{ Authorization = "Basic $credentials" } `
-            -OutFile $archive
-          Expand-Archive -LiteralPath $archive -DestinationPath $modulePath -Force
-          Remove-Item ./test/e2e/Apps/BasicPowerShell/requirements.psd1 -Force
-        displayName: Install PowerShell E2E module from CFS
+          $app = './test/e2e/Apps/BasicPowerShell'
+          Remove-Item "$app/requirements.psd1" -Force
+          (Get-Content "$app/profile.ps1") |
+            Where-Object { $_ -notmatch 'AzureFunctions\.PowerShell\.Durable\.SDK' } |
+            Set-Content "$app/profile.ps1"
+          $settingsPath = "$app/local.settings.json"
+          $settings = Get-Content $settingsPath -Raw | ConvertFrom-Json
+          $settings.Values.ExternalDurablePowerShellSDK = 'false'
+          $settings | ConvertTo-Json -Depth 10 | Set-Content $settingsPath
+          Write-Host '##vso[task.setvariable variable=ExternalDurablePowerShellSDK]false'
+        displayName: Use built-in PowerShell Durable SDK
 
       - task: UseDotNet@2
         displayName: Install .NET SDK from global.json

--- a/eng/ci/templates/public/language-e2e.yml
+++ b/eng/ci/templates/public/language-e2e.yml
@@ -7,7 +7,7 @@ parameters:
 
 jobs:
   - job: LanguageE2E
-    displayName: $(backendName) ($(targetFramework))
+    displayName: $(backendName) ($(testTargetFramework))
     timeoutInMinutes: 180
     strategy:
       matrix:
@@ -15,36 +15,36 @@ jobs:
           AzureStorageNet8:
             backendName: AzureStorage
             backendFilter: AzureStorage
-            targetFramework: net8.0
+            testTargetFramework: net8.0
           AzureStorageNet10:
             backendName: AzureStorage
             backendFilter: AzureStorage
-            targetFramework: net10.0
+            testTargetFramework: net10.0
         ${{ if eq(parameters.platform, 'linux') }}:
           AzureStorageNet8:
             backendName: AzureStorage
             backendFilter: AzureStorage
-            targetFramework: net8.0
+            testTargetFramework: net8.0
           AzureStorageNet10:
             backendName: AzureStorage
             backendFilter: AzureStorage
-            targetFramework: net10.0
+            testTargetFramework: net10.0
           DTSNet8:
             backendName: DTS
             backendFilter: DTS
-            targetFramework: net8.0
+            testTargetFramework: net8.0
           DTSNet10:
             backendName: DTS
             backendFilter: DTS
-            targetFramework: net10.0
+            testTargetFramework: net10.0
           MSSQLNet8:
             backendName: MSSQL
             backendFilter: MSSQL
-            targetFramework: net8.0
+            testTargetFramework: net8.0
           MSSQLNet10:
             backendName: MSSQL
             backendFilter: MSSQL
-            targetFramework: net10.0
+            testTargetFramework: net10.0
     steps:
       - checkout: self
         clean: true
@@ -114,7 +114,7 @@ jobs:
       - pwsh: |
           $ErrorActionPreference = 'Stop'
           $arguments = @{
-            TargetFramework = '$(targetFramework)'
+            TargetFramework = '$(testTargetFramework)'
             SkipStorageEmulator = $true
           }
 
@@ -150,7 +150,7 @@ jobs:
           )
 
           $testProject = './test/e2e/Tests'
-          dotnet build $testProject -f $(targetFramework)
+          dotnet build $testProject -f $(testTargetFramework)
           if ($LASTEXITCODE) { exit $LASTEXITCODE }
 
           foreach ($case in $cases) {
@@ -159,10 +159,10 @@ jobs:
             $backendFilter = '$(backendFilter)'
             $filter = "$($backendFilter)!=Skip&$($case.Filter)!=Skip&$($case.Filter)-$($backendFilter)!=Skip"
             dotnet test $testProject `
-              -f $(targetFramework) `
+              -f $(testTargetFramework) `
               --no-build `
               --filter $filter `
-              --logger "trx;LogFileName=language-e2e-$(backendName)-$(targetFramework)-$($case.Name).trx" `
+              --logger "trx;LogFileName=language-e2e-$(backendName)-$(testTargetFramework)-$($case.Name).trx" `
               --results-directory "$env:AGENT_TEMPDIRECTORY/TestResults"
             if ($LASTEXITCODE) { exit $LASTEXITCODE }
           }

--- a/eng/ci/templates/public/language-e2e.yml
+++ b/eng/ci/templates/public/language-e2e.yml
@@ -51,6 +51,28 @@ jobs:
 
       - template: cfs-authentication.yml
 
+      - pwsh: |
+          $ErrorActionPreference = 'Stop'
+          if ([string]::IsNullOrWhiteSpace($env:VSS_NUGET_ACCESSTOKEN)) {
+            throw 'NuGetAuthenticate did not provide a CFS access token.'
+          }
+
+          $version = '2.3.0'
+          $package = "azurefunctions.powershell.durable.sdk.$version.nupkg"
+          $url = "https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/nuget/v3/flat2/azurefunctions.powershell.durable.sdk/$version/$package"
+          $archive = Join-Path $env:AGENT_TEMPDIRECTORY "$package.zip"
+          $modulePath = "./test/e2e/Apps/BasicPowerShell/Modules/AzureFunctions.PowerShell.Durable.SDK/$version"
+          $credentials = [Convert]::ToBase64String(
+            [Text.Encoding]::ASCII.GetBytes("AzureDevOps:$env:VSS_NUGET_ACCESSTOKEN"))
+
+          Invoke-WebRequest `
+            -Uri $url `
+            -Headers @{ Authorization = "Basic $credentials" } `
+            -OutFile $archive
+          Expand-Archive -LiteralPath $archive -DestinationPath $modulePath -Force
+          Remove-Item ./test/e2e/Apps/BasicPowerShell/requirements.psd1 -Force
+        displayName: Install PowerShell E2E module from CFS
+
       - task: UseDotNet@2
         displayName: Install .NET SDK from global.json
         inputs:

--- a/eng/ci/templates/public/language-e2e.yml
+++ b/eng/ci/templates/public/language-e2e.yml
@@ -97,7 +97,12 @@ jobs:
           } else {
             $azurite = Resolve-Path '.azurite/node_modules/.bin/azurite'
           }
-          Start-Process $azurite -ArgumentList '--silent','--skipApiVersionCheck','--inMemoryPersistence','--blobPort','10000','--queuePort','10001','--tablePort','10002'
+          $azuriteOut = Join-Path $env:AGENT_TEMPDIRECTORY 'azurite.stdout.log'
+          $azuriteErr = Join-Path $env:AGENT_TEMPDIRECTORY 'azurite.stderr.log'
+          Start-Process $azurite `
+            -ArgumentList '--silent','--skipApiVersionCheck','--inMemoryPersistence','--blobPort','10000','--queuePort','10001','--tablePort','10002' `
+            -RedirectStandardOutput $azuriteOut `
+            -RedirectStandardError $azuriteErr
           for ($i = 1; $i -le 30; $i++) {
             try {
               $tcp = [System.Net.Sockets.TcpClient]::new('127.0.0.1', 10000)

--- a/eng/ci/templates/public/language-e2e.yml
+++ b/eng/ci/templates/public/language-e2e.yml
@@ -1,0 +1,174 @@
+parameters:
+  - name: platform
+    type: string
+    values:
+      - windows
+      - linux
+
+jobs:
+  - job: LanguageE2E
+    displayName: $(backendName) ($(targetFramework))
+    timeoutInMinutes: 180
+    strategy:
+      matrix:
+        ${{ if eq(parameters.platform, 'windows') }}:
+          AzureStorageNet8:
+            backendName: AzureStorage
+            backendFilter: AzureStorage
+            targetFramework: net8.0
+          AzureStorageNet10:
+            backendName: AzureStorage
+            backendFilter: AzureStorage
+            targetFramework: net10.0
+        ${{ if eq(parameters.platform, 'linux') }}:
+          AzureStorageNet8:
+            backendName: AzureStorage
+            backendFilter: AzureStorage
+            targetFramework: net8.0
+          AzureStorageNet10:
+            backendName: AzureStorage
+            backendFilter: AzureStorage
+            targetFramework: net10.0
+          DTSNet8:
+            backendName: DTS
+            backendFilter: DTS
+            targetFramework: net8.0
+          DTSNet10:
+            backendName: DTS
+            backendFilter: DTS
+            targetFramework: net10.0
+          MSSQLNet8:
+            backendName: MSSQL
+            backendFilter: MSSQL
+            targetFramework: net8.0
+          MSSQLNet10:
+            backendName: MSSQL
+            backendFilter: MSSQL
+            targetFramework: net10.0
+    steps:
+      - checkout: self
+        clean: true
+
+      - template: cfs-authentication.yml
+
+      - task: UseDotNet@2
+        displayName: Install .NET SDK from global.json
+        inputs:
+          packageType: sdk
+          useGlobalJson: true
+
+      - task: UseDotNet@2
+        displayName: Install .NET 8 SDK
+        inputs:
+          packageType: sdk
+          version: 8.0.x
+
+      - task: NodeTool@0
+        displayName: Install Node.js 22
+        inputs:
+          versionSpec: 22.x
+
+      - task: UsePythonVersion@0
+        displayName: Install Python 3.13
+        inputs:
+          versionSpec: 3.13
+
+      - task: JavaToolInstaller@0
+        displayName: Install JDK 17
+        inputs:
+          versionSpec: 17
+          jdkArchitectureOption: x64
+          jdkSourceOption: PreInstalled
+
+      - pwsh: |
+          $ErrorActionPreference = 'Stop'
+          New-Item -ItemType Directory -Path .azurite -Force | Out-Null
+          Push-Location .azurite
+          try {
+            '{"name":"azurite-local","private":true}' | Set-Content package.json
+            npm install azurite
+            if ($LASTEXITCODE) { exit $LASTEXITCODE }
+          } finally {
+            Pop-Location
+          }
+
+          if ($IsWindows) {
+            $azurite = Resolve-Path '.azurite/node_modules/.bin/azurite.cmd'
+          } else {
+            $azurite = Resolve-Path '.azurite/node_modules/.bin/azurite'
+          }
+          Start-Process $azurite -ArgumentList '--silent','--skipApiVersionCheck','--inMemoryPersistence','--blobPort','10000','--queuePort','10001','--tablePort','10002'
+          for ($i = 1; $i -le 30; $i++) {
+            try {
+              $tcp = [System.Net.Sockets.TcpClient]::new('127.0.0.1', 10000)
+              $tcp.Dispose()
+              Write-Host 'Azurite is ready'
+              break
+            } catch {
+              if ($i -eq 30) { throw 'Azurite did not start within 30 seconds' }
+              Start-Sleep -Seconds 1
+            }
+          }
+        displayName: Start Azurite
+
+      - pwsh: |
+          $ErrorActionPreference = 'Stop'
+          $arguments = @{
+            TargetFramework = '$(targetFramework)'
+            SkipStorageEmulator = $true
+          }
+
+          switch ('$(backendName)') {
+            'DTS' {
+              $arguments.StartDTSContainer = $true
+              $backend = 'azureManaged'
+            }
+            'MSSQL' {
+              $password = "TEST12_$([guid]::NewGuid().ToString('N').Substring(0, 12))!"
+              $arguments.StartMSSqlContainer = $true
+              $arguments.MSSQLpwd = $password
+              $backend = 'MSSQL'
+              Write-Host "##vso[task.setvariable variable=MSSQL_SA_PASSWORD;issecret=true]$password"
+            }
+            default {
+              $backend = 'AzureStorage'
+            }
+          }
+
+          Write-Host "##vso[task.setvariable variable=E2E_TEST_DURABLE_BACKEND]$backend"
+          ./test/e2e/Tests/build-e2e-test.ps1 @arguments
+        displayName: Build E2E applications and start emulators
+
+      - pwsh: |
+          $ErrorActionPreference = 'Stop'
+          $cases = @(
+            @{ Name = 'dotnet-isolated'; App = 'BasicDotNetIsolated'; Filter = 'Dotnet' }
+            @{ Name = 'powershell'; App = 'BasicPowerShell'; Filter = 'PowerShell' }
+            @{ Name = 'python'; App = 'BasicPython'; Filter = 'Python' }
+            @{ Name = 'node'; App = 'BasicNode'; Filter = 'Node' }
+            @{ Name = 'java'; App = 'BasicJava'; Filter = 'Java' }
+          )
+
+          $testProject = './test/e2e/Tests'
+          dotnet build $testProject -f $(targetFramework)
+          if ($LASTEXITCODE) { exit $LASTEXITCODE }
+
+          foreach ($case in $cases) {
+            $env:E2E_TEST_FUNCTIONS_LANGUAGE = $case.Name
+            $env:TEST_APP_NAME = $case.App
+            $backendFilter = '$(backendFilter)'
+            $filter = "$($backendFilter)!=Skip&$($case.Filter)!=Skip&$($case.Filter)-$($backendFilter)!=Skip"
+            dotnet test $testProject `
+              -f $(targetFramework) `
+              --no-build `
+              --filter $filter `
+              --logger "trx;LogFileName=language-e2e-$(backendName)-$(targetFramework)-$($case.Name).trx" `
+              --results-directory "$env:AGENT_TEMPDIRECTORY/TestResults"
+            if ($LASTEXITCODE) { exit $LASTEXITCODE }
+          }
+        displayName: Run language E2E tests
+        env:
+          E2E_TEST_DURABLE_BACKEND: $(E2E_TEST_DURABLE_BACKEND)
+          MSSQL_SA_PASSWORD: $(MSSQL_SA_PASSWORD)
+
+      - template: publish-test-results.yml

--- a/eng/ci/templates/public/publish-test-results.yml
+++ b/eng/ci/templates/public/publish-test-results.yml
@@ -1,0 +1,10 @@
+steps:
+  - task: PublishTestResults@2
+    displayName: Publish test results
+    condition: succeededOrFailed()
+    inputs:
+      testResultsFormat: VSTest
+      testResultsFiles: '**/*.trx'
+      searchFolder: $(Agent.TempDirectory)/TestResults
+      failTaskOnFailedTests: true
+      failTaskOnMissingResultsFile: false

--- a/eng/ci/templates/public/scale-tests.yml
+++ b/eng/ci/templates/public/scale-tests.yml
@@ -26,7 +26,7 @@ jobs:
           mkdir -p .azurite
           pushd .azurite
           echo '{"name":"azurite-local","private":true}' > package.json
-          npm install azurite
+          npm install azurite@$(AZURITE_VERSION)
           popd
           ./.azurite/node_modules/.bin/azurite --silent --skipApiVersionCheck \
             --blobPort 10000 --queuePort 10001 --tablePort 10002 &
@@ -69,7 +69,7 @@ jobs:
           versionSpec: 22.x
       - bash: |
           set -euo pipefail
-          npm install -g azurite
+          npm install -g azurite@$(AZURITE_VERSION)
           azurite --silent --skipApiVersionCheck \
             --blobPort 10000 --queuePort 10001 --tablePort 10002 &
           for i in $(seq 1 30); do
@@ -134,7 +134,7 @@ jobs:
           versionSpec: 22.x
       - bash: |
           set -euo pipefail
-          npm install -g azurite
+          npm install -g azurite@$(AZURITE_VERSION)
           azurite --silent --skipApiVersionCheck \
             --blobPort 10000 --queuePort 10001 --tablePort 10002 &
           for i in $(seq 1 30); do
@@ -204,7 +204,7 @@ jobs:
           versionSpec: 22.x
       - bash: |
           set -euo pipefail
-          npm install -g azurite
+          npm install -g azurite@$(AZURITE_VERSION)
           azurite --silent --skipApiVersionCheck \
             --blobPort 10000 --queuePort 10001 --tablePort 10002 &
           for i in $(seq 1 30); do

--- a/eng/ci/templates/public/scale-tests.yml
+++ b/eng/ci/templates/public/scale-tests.yml
@@ -121,6 +121,8 @@ jobs:
             --logger 'trx;LogFileName=scale-netherite.trx' \
             --results-directory '$(Agent.TempDirectory)/TestResults'
         displayName: Run Netherite scale tests
+        env:
+          EventHubsConnection: $(EventHubsConnection)
       - template: publish-test-results.yml
 
   - job: MSSQLScale

--- a/eng/ci/templates/public/scale-tests.yml
+++ b/eng/ci/templates/public/scale-tests.yml
@@ -1,0 +1,242 @@
+jobs:
+  - job: AzureStorageScale
+    displayName: Scale tests - Azure Storage
+    timeoutInMinutes: 60
+    variables:
+      AzureWebJobsStorage: UseDevelopmentStorage=true
+    steps:
+      - checkout: self
+        clean: true
+        submodules: true
+      - template: cfs-authentication.yml
+      - task: UseDotNet@2
+        displayName: Install .NET SDK from global.json
+        inputs:
+          packageType: sdk
+          useGlobalJson: true
+      - task: NodeTool@0
+        displayName: Install Node.js 22
+        inputs:
+          versionSpec: 22.x
+      - bash: |
+          set -euo pipefail
+          project='./test/ScaleTests/Microsoft.Azure.WebJobs.Extensions.DurableTask.FunctionsScale.Tests.csproj'
+          dotnet restore "$project"
+          dotnet build "$project" -c Release --no-restore
+          mkdir -p .azurite
+          pushd .azurite
+          echo '{"name":"azurite-local","private":true}' > package.json
+          npm install azurite
+          popd
+          ./.azurite/node_modules/.bin/azurite --silent --skipApiVersionCheck \
+            --blobPort 10000 --queuePort 10001 --tablePort 10002 &
+          azurite_pid=$!
+          trap 'kill $azurite_pid || true' EXIT
+          for i in $(seq 1 30); do
+            timeout 1 bash -c 'echo>/dev/tcp/127.0.0.1/10000' 2>/dev/null && break
+            if [ "$i" -eq 30 ]; then echo 'Azurite did not start'; exit 1; fi
+            sleep 1
+          done
+          dotnet test "$project" \
+            -c Release \
+            --no-build \
+            --verbosity normal \
+            --filter 'FullyQualifiedName!~AzureManaged&FullyQualifiedName!~Netherite&FullyQualifiedName!~Sql' \
+            --logger 'trx;LogFileName=scale-azure-storage.trx' \
+            --results-directory '$(Agent.TempDirectory)/TestResults'
+        displayName: Run Azure Storage scale tests
+      - template: publish-test-results.yml
+
+  - job: NetheriteScale
+    displayName: Scale tests - Netherite
+    timeoutInMinutes: 75
+    variables:
+      AzureWebJobsStorage: UseDevelopmentStorage=true
+      EventHubsConnection: Endpoint=sb://localhost;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;
+    steps:
+      - checkout: self
+        clean: true
+        submodules: true
+      - template: cfs-authentication.yml
+      - task: UseDotNet@2
+        displayName: Install .NET SDK from global.json
+        inputs:
+          packageType: sdk
+          useGlobalJson: true
+      - task: NodeTool@0
+        displayName: Install Node.js 22
+        inputs:
+          versionSpec: 22.x
+      - bash: |
+          set -euo pipefail
+          npm install -g azurite
+          azurite --silent --skipApiVersionCheck \
+            --blobPort 10000 --queuePort 10001 --tablePort 10002 &
+          for i in $(seq 1 30); do
+            timeout 1 bash -c 'echo>/dev/tcp/127.0.0.1/10000' 2>/dev/null && break
+            if [ "$i" -eq 30 ]; then echo 'Azurite did not start'; exit 1; fi
+            sleep 1
+          done
+        displayName: Start Azurite
+      - bash: |
+          set -euo pipefail
+          docker info
+          docker run -d \
+            --name eventhubs-emulator \
+            -p 5672:5672 \
+            -e ACCEPT_EULA=Y \
+            -e BLOB_SERVER=host.docker.internal \
+            -e METADATA_SERVER=host.docker.internal \
+            -v '$(Build.SourcesDirectory)/test/ScaleTests/Netherite/eventhubs-emulator-config.json:/Emulator/ConfigFiles/Config.json' \
+            --add-host host.docker.internal:host-gateway \
+            mcr.microsoft.com/azure-messaging/eventhubs-emulator:latest
+          for i in $(seq 1 60); do
+            timeout 1 bash -c 'echo>/dev/tcp/127.0.0.1/5672' 2>/dev/null && exit 0
+            if [ "$i" -eq 60 ]; then
+              docker logs eventhubs-emulator
+              exit 1
+            fi
+            sleep 2
+          done
+        displayName: Start Event Hubs emulator
+      - bash: |
+          set -euo pipefail
+          project='./test/ScaleTests/Microsoft.Azure.WebJobs.Extensions.DurableTask.FunctionsScale.Tests.csproj'
+          dotnet build "$project" -c Release
+          dotnet test "$project" \
+            -c Release \
+            --no-build \
+            --verbosity normal \
+            --filter 'FullyQualifiedName~Netherite' \
+            --logger 'trx;LogFileName=scale-netherite.trx' \
+            --results-directory '$(Agent.TempDirectory)/TestResults'
+        displayName: Run Netherite scale tests
+      - template: publish-test-results.yml
+
+  - job: MSSQLScale
+    displayName: Scale tests - MSSQL
+    timeoutInMinutes: 75
+    variables:
+      AzureWebJobsStorage: UseDevelopmentStorage=true
+    steps:
+      - checkout: self
+        clean: true
+        submodules: true
+      - template: cfs-authentication.yml
+      - task: UseDotNet@2
+        displayName: Install .NET SDK from global.json
+        inputs:
+          packageType: sdk
+          useGlobalJson: true
+      - task: NodeTool@0
+        displayName: Install Node.js 22
+        inputs:
+          versionSpec: 22.x
+      - bash: |
+          set -euo pipefail
+          npm install -g azurite
+          azurite --silent --skipApiVersionCheck \
+            --blobPort 10000 --queuePort 10001 --tablePort 10002 &
+          for i in $(seq 1 30); do
+            timeout 1 bash -c 'echo>/dev/tcp/127.0.0.1/10000' 2>/dev/null && break
+            if [ "$i" -eq 30 ]; then echo 'Azurite did not start'; exit 1; fi
+            sleep 1
+          done
+        displayName: Start Azurite
+      - bash: |
+          set -euo pipefail
+          password="TEST12_${RANDOM}_${RANDOM}!"
+          echo "##vso[task.setvariable variable=MSSQL_SA_PASSWORD;issecret=true]${password}"
+        displayName: Generate SQL Server password
+      - bash: |
+          set -euo pipefail
+          docker info
+          docker pull mcr.microsoft.com/mssql/server:2022-latest
+          docker run --name mssql-server \
+            -e ACCEPT_EULA=Y \
+            -e "MSSQL_SA_PASSWORD=$MSSQL_SA_PASSWORD" \
+            -e MSSQL_PID=Express \
+            -p 1433:1433 \
+            -d mcr.microsoft.com/mssql/server:2022-latest
+          for i in $(seq 1 60); do
+            timeout 1 bash -c 'echo>/dev/tcp/127.0.0.1/1433' 2>/dev/null && exit 0
+            if [ "$i" -eq 60 ]; then docker logs mssql-server; exit 1; fi
+            sleep 2
+          done
+        displayName: Start SQL Server
+        env:
+          MSSQL_SA_PASSWORD: $(MSSQL_SA_PASSWORD)
+      - bash: |
+          set -euo pipefail
+          cd test/ScaleTests
+          dotnet build --configuration Release
+          dotnet test \
+            --configuration Release \
+            --no-build \
+            --verbosity normal \
+            --filter 'FullyQualifiedName~SqlServer' \
+            --logger 'trx;LogFileName=scale-mssql.trx' \
+            --results-directory '$(Agent.TempDirectory)/TestResults'
+        displayName: Run SQL Server scale tests
+        env:
+          SQLDB_Connection: Server=localhost,1433;Database=DurableDB;User Id=sa;Password=$(MSSQL_SA_PASSWORD);TrustServerCertificate=True;Encrypt=False;
+      - template: publish-test-results.yml
+
+  - job: DTSScale
+    displayName: Scale tests - Durable Task Scheduler
+    timeoutInMinutes: 75
+    variables:
+      AzureWebJobsStorage: UseDevelopmentStorage=true
+      DURABLE_TASK_SCHEDULER_CONNECTION_STRING: Endpoint=http://localhost:8080;Authentication=None
+    steps:
+      - checkout: self
+        clean: true
+        submodules: true
+      - template: cfs-authentication.yml
+      - task: UseDotNet@2
+        displayName: Install .NET SDK from global.json
+        inputs:
+          packageType: sdk
+          useGlobalJson: true
+      - task: NodeTool@0
+        displayName: Install Node.js 22
+        inputs:
+          versionSpec: 22.x
+      - bash: |
+          set -euo pipefail
+          npm install -g azurite
+          azurite --silent --skipApiVersionCheck \
+            --blobPort 10000 --queuePort 10001 --tablePort 10002 &
+          for i in $(seq 1 30); do
+            timeout 1 bash -c 'echo>/dev/tcp/127.0.0.1/10000' 2>/dev/null && break
+            if [ "$i" -eq 30 ]; then echo 'Azurite did not start'; exit 1; fi
+            sleep 1
+          done
+        displayName: Start Azurite
+      - bash: |
+          set -euo pipefail
+          docker info
+          docker pull mcr.microsoft.com/dts/dts-emulator:latest
+          docker run -i \
+            -p 8080:8080 \
+            -p 8082:8082 \
+            -d mcr.microsoft.com/dts/dts-emulator:latest
+          for i in $(seq 1 30); do
+            timeout 1 bash -c 'echo>/dev/tcp/127.0.0.1/8080' 2>/dev/null && exit 0
+            if [ "$i" -eq 30 ]; then echo 'DTS emulator did not start'; exit 1; fi
+            sleep 1
+          done
+        displayName: Start Durable Task Scheduler emulator
+      - bash: |
+          set -euo pipefail
+          cd test/ScaleTests
+          dotnet build --configuration Release
+          dotnet test \
+            --configuration Release \
+            --no-build \
+            --verbosity normal \
+            --filter 'FullyQualifiedName~AzureManaged' \
+            --logger 'trx;LogFileName=scale-dts.trx' \
+            --results-directory '$(Agent.TempDirectory)/TestResults'
+        displayName: Run Durable Task Scheduler scale tests
+      - template: publish-test-results.yml

--- a/eng/ci/templates/public/scale-tests.yml
+++ b/eng/ci/templates/public/scale-tests.yml
@@ -14,6 +14,11 @@ jobs:
         inputs:
           packageType: sdk
           useGlobalJson: true
+      - task: UseDotNet@2
+        displayName: Install .NET 8 SDK
+        inputs:
+          packageType: sdk
+          version: 8.x
       - task: NodeTool@0
         displayName: Install Node.js 22
         inputs:
@@ -63,6 +68,11 @@ jobs:
         inputs:
           packageType: sdk
           useGlobalJson: true
+      - task: UseDotNet@2
+        displayName: Install .NET 8 SDK
+        inputs:
+          packageType: sdk
+          version: 8.x
       - task: NodeTool@0
         displayName: Install Node.js 22
         inputs:
@@ -128,6 +138,11 @@ jobs:
         inputs:
           packageType: sdk
           useGlobalJson: true
+      - task: UseDotNet@2
+        displayName: Install .NET 8 SDK
+        inputs:
+          packageType: sdk
+          version: 8.x
       - task: NodeTool@0
         displayName: Install Node.js 22
         inputs:
@@ -198,6 +213,11 @@ jobs:
         inputs:
           packageType: sdk
           useGlobalJson: true
+      - task: UseDotNet@2
+        displayName: Install .NET 8 SDK
+        inputs:
+          packageType: sdk
+          version: 8.x
       - task: NodeTool@0
         displayName: Install Node.js 22
         inputs:

--- a/eng/ci/templates/public/smoke-tests.yml
+++ b/eng/ci/templates/public/smoke-tests.yml
@@ -163,16 +163,16 @@ jobs:
           }
           dotnet nuget push $packages[0].FullName --source "$HOME/packages"
           if ($LASTEXITCODE) { exit $LASTEXITCODE }
-          $configPath = Join-Path $env:AGENT_TEMPDIRECTORY 'NuGet.config'
+          $configPath = Join-Path (Resolve-Path './test/SmokeTests/OOProcSmokeTests/DotNetIsolated') 'NuGet.config'
           ./eng/cfs/New-LocalNuGetConfig.ps1 `
             -DestinationPath $configPath `
             -LocalSourcePath "$HOME/packages" `
             -PackagePatterns 'Microsoft.Azure.WebJobs.Extensions.DurableTask'
         displayName: Build and pack WebJobs extension
       - pwsh: |
-          $configPath = Join-Path $env:AGENT_TEMPDIRECTORY 'NuGet.config'
           Push-Location ./test/SmokeTests/OOProcSmokeTests/DotNetIsolated
           try {
+            $configPath = Join-Path (Get-Location) 'NuGet.config'
             dotnet restore --configfile $configPath --verbosity normal -p:TargetFramework=$(testTargetFramework)
             dotnet build -c Release -f $(testTargetFramework) --no-restore
           } finally {

--- a/eng/ci/templates/public/smoke-tests.yml
+++ b/eng/ci/templates/public/smoke-tests.yml
@@ -1,0 +1,214 @@
+jobs:
+  - job: NodeSmoke
+    displayName: Smoke test - Node 20
+    timeoutInMinutes: 60
+    steps:
+      - checkout: self
+        clean: true
+      - template: cfs-authentication.yml
+      - pwsh: >
+          ./test/SmokeTests/e2e-test.ps1
+          -DockerfilePath test/SmokeTests/OOProcSmokeTests/durableJS/Dockerfile
+          -HttpStartPath api/DurableFunctionsHttpStart
+          -TargetFramework net8.0
+          -DotnetSdkTag 10.0
+          -ContainerName nodeApp
+          -TestWithCustomInstanceId
+        displayName: Run Node 20 smoke test
+
+  - job: PythonSmoke
+    displayName: Smoke test - Python 3.11
+    timeoutInMinutes: 60
+    steps:
+      - checkout: self
+        clean: true
+      - template: cfs-authentication.yml
+      - pwsh: >
+          ./test/SmokeTests/e2e-test.ps1
+          -DockerfilePath test/SmokeTests/OOProcSmokeTests/durablePy/Dockerfile
+          -HttpStartPath api/DurableFunctionsHttpStart
+          -TargetFramework net8.0
+          -DotnetSdkTag 10.0
+          -ContainerName pyApp
+          -TestWithCustomInstanceId
+        displayName: Run Python 3.11 smoke test
+
+  - job: NetheriteSmoke
+    displayName: Smoke test - .NET in-process with Netherite
+    timeoutInMinutes: 60
+    variables:
+      FUNCTIONS_INPROC_NET8_ENABLED: 1
+    steps:
+      - checkout: self
+        clean: true
+      - template: cfs-authentication.yml
+      - pwsh: >
+          ./test/SmokeTests/e2e-test.ps1
+          -DockerfilePath test/SmokeTests/BackendSmokeTests/Netherite/Dockerfile
+          -HttpStartPath api/DurableFunctionsHttpStart
+          -ContainerName NetheriteApp
+        displayName: Run Netherite smoke test
+
+  - job: MSSQLSmoke
+    displayName: Smoke test - .NET in-process with MSSQL
+    timeoutInMinutes: 75
+    variables:
+      FUNCTIONS_INPROC_NET8_ENABLED: 1
+    steps:
+      - checkout: self
+        clean: true
+      - template: cfs-authentication.yml
+      - pwsh: |
+          $password = "TEST12_$([guid]::NewGuid().ToString('N').Substring(0, 12))!"
+          Write-Host "##vso[task.setvariable variable=MSSQL_SA_PASSWORD;issecret=true]$password"
+        displayName: Generate SQL Server password
+      - pwsh: >
+          ./test/SmokeTests/e2e-test.ps1
+          -DockerfilePath test/SmokeTests/BackendSmokeTests/MSSQL/Dockerfile
+          -HttpStartPath api/DurableFunctionsHttpStart
+          -ContainerName MSSQLApp
+          -SetupSQLServer
+        displayName: Run MSSQL smoke test
+        env:
+          SA_PASSWORD: $(MSSQL_SA_PASSWORD)
+
+  - job: JavaSmoke
+    displayName: Smoke test - Java 8
+    timeoutInMinutes: 75
+    steps:
+      - checkout: self
+        clean: true
+      - template: cfs-authentication.yml
+      - task: JavaToolInstaller@0
+        displayName: Install JDK 8
+        inputs:
+          versionSpec: 8
+          jdkArchitectureOption: x64
+          jdkSourceOption: PreInstalled
+      - pwsh: |
+          $archive = Join-Path $env:AGENT_TEMPDIRECTORY 'gradle.zip'
+          Invoke-WebRequest `
+            -Uri 'https://services.gradle.org/distributions/gradle-6.9.4-bin.zip' `
+            -OutFile $archive
+          Expand-Archive -LiteralPath $archive -DestinationPath $env:AGENT_TEMPDIRECTORY
+          Write-Host "##vso[task.prependpath]$env:AGENT_TEMPDIRECTORY/gradle-6.9.4/bin"
+        displayName: Install Gradle 6.9.4
+      - bash: gradle azureFunctionsPackage -p test/SmokeTests/OOProcSmokeTests/durableJava/
+        displayName: Build Java Functions sample
+        continueOnError: true
+      - bash: |
+          set -euo pipefail
+          destination='test/SmokeTests/OOProcSmokeTests/durableJava/build/azure-functions/durableJava/lib'
+          mkdir -p "$destination"
+          curl -fsSL -u "AzureDevOps:$VSS_NUGET_ACCESSTOKEN" \
+            'https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/maven/v1/com/microsoft/azure/functions/azure-functions-java-library/2.0.1/azure-functions-java-library-2.0.1.jar' \
+            -o "$destination/azure-functions-java-library-2.0.1.jar"
+        displayName: Download Azure Functions Java library from CFS
+      - pwsh: >
+          ./test/SmokeTests/e2e-test.ps1
+          -DockerfilePath test/SmokeTests/OOProcSmokeTests/durableJava/Dockerfile
+          -HttpStartPath api/StartOrchestration
+          -TargetFramework net8.0
+          -DotnetSdkTag 10.0
+          -TestWithCustomInstanceId
+        displayName: Run Java 8 smoke test
+
+  - job: DotNetIsolatedSmoke
+    displayName: Smoke test - .NET isolated ($(targetFramework))
+    timeoutInMinutes: 90
+    strategy:
+      matrix:
+        Net8:
+          targetFramework: net8.0
+        Net10:
+          targetFramework: net10.0
+    steps:
+      - checkout: self
+        clean: true
+      - template: cfs-authentication.yml
+      - task: UseDotNet@2
+        displayName: Install .NET 2.1 SDK
+        inputs:
+          packageType: sdk
+          version: 2.1.x
+      - task: UseDotNet@2
+        displayName: Install .NET 3.1 SDK
+        inputs:
+          packageType: sdk
+          version: 3.1.x
+      - task: UseDotNet@2
+        displayName: Install .NET 6 SDK
+        inputs:
+          packageType: sdk
+          version: 6.x
+      - task: UseDotNet@2
+        displayName: Install .NET 8 SDK
+        inputs:
+          packageType: sdk
+          version: 8.x
+      - task: UseDotNet@2
+        displayName: Install .NET 10 SDK
+        inputs:
+          packageType: sdk
+          version: 10.0.x
+      - task: NodeTool@0
+        displayName: Install Node.js 22
+        inputs:
+          versionSpec: 22.x
+      - pwsh: |
+          dotnet restore ./WebJobs.Extensions.DurableTask.sln
+          dotnet build -c Release ./src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
+          if ($LASTEXITCODE) { exit $LASTEXITCODE }
+          New-Item -ItemType Directory -Path "$HOME/packages" -Force | Out-Null
+          dotnet nuget push ./src/WebJobs.Extensions.DurableTask/bin/Release/Microsoft.Azure.WebJobs.Extensions.DurableTask.*.nupkg `
+            --source "$HOME/packages"
+          $configPath = Join-Path $env:AGENT_TEMPDIRECTORY 'NuGet.config'
+          ./eng/cfs/New-LocalNuGetConfig.ps1 `
+            -DestinationPath $configPath `
+            -LocalSourcePath "$HOME/packages" `
+            -PackagePatterns 'Microsoft.Azure.WebJobs.Extensions.DurableTask'
+        displayName: Build and pack WebJobs extension
+      - pwsh: |
+          $configPath = Join-Path $env:AGENT_TEMPDIRECTORY 'NuGet.config'
+          Push-Location ./test/SmokeTests/OOProcSmokeTests/DotNetIsolated
+          try {
+            dotnet restore --configfile $configPath --verbosity normal -p:TargetFramework=$(targetFramework)
+            dotnet build -c Release -f $(targetFramework) --no-restore
+          } finally {
+            Pop-Location
+          }
+        displayName: Build .NET isolated smoke application
+      - bash: npm install -g azure-functions-core-tools@4 --unsafe-perm true
+        displayName: Install Azure Functions Core Tools
+      - pwsh: |
+          New-Item -ItemType Directory -Path .azurite -Force | Out-Null
+          Push-Location .azurite
+          try {
+            '{"name":"azurite-local","private":true}' | Set-Content package.json
+            npm install azurite
+          } finally {
+            Pop-Location
+          }
+          $azurite = Resolve-Path '.azurite/node_modules/.bin/azurite'
+          Start-Process $azurite -ArgumentList '--silent','--skipApiVersionCheck','--blobPort','10000','--queuePort','10001','--tablePort','10002'
+          for ($i = 1; $i -le 30; $i++) {
+            try {
+              $tcp = [System.Net.Sockets.TcpClient]::new('127.0.0.1', 10000)
+              $tcp.Dispose()
+              break
+            } catch {
+              if ($i -eq 30) { throw 'Azurite did not start within 30 seconds' }
+              Start-Sleep -Seconds 1
+            }
+          }
+        displayName: Start Azurite
+      - pwsh: |
+          $script = './test/SmokeTests/OOProcSmokeTests/DotNetIsolated/run-smoke-tests.ps1'
+          & $script -HttpStartPath api/StartHelloCitiesTyped
+          & $script -HttpStartPath api/StartHelloCitiesUntyped
+          & $script -HttpStartPath api/StartHelloCitiesUntyped -TestWithCustomInstanceId
+          & $script -HttpStartPath api/durable_HttpStartProcessExitOrchestrator
+          & $script -HttpStartPath api/durable_HttpStartTimeoutOrchestrator
+          & $script -HttpStartPath api/durable_HttpStartOOMOrchestrator
+          & $script -HttpStartPath api/StartEntityOrchestration
+        displayName: Run .NET isolated smoke tests

--- a/eng/ci/templates/public/smoke-tests.yml
+++ b/eng/ci/templates/public/smoke-tests.yml
@@ -80,30 +80,22 @@ jobs:
         clean: true
       - template: cfs-authentication.yml
       - task: JavaToolInstaller@0
-        displayName: Install JDK 8
+        displayName: Install JDK 17
         inputs:
-          versionSpec: 8
+          versionSpec: 17
           jdkArchitectureOption: x64
           jdkSourceOption: PreInstalled
       - pwsh: |
-          $archive = Join-Path $env:AGENT_TEMPDIRECTORY 'gradle.zip'
-          Invoke-WebRequest `
-            -Uri 'https://services.gradle.org/distributions/gradle-6.9.4-bin.zip' `
-            -OutFile $archive
-          Expand-Archive -LiteralPath $archive -DestinationPath $env:AGENT_TEMPDIRECTORY
-          Write-Host "##vso[task.prependpath]$env:AGENT_TEMPDIRECTORY/gradle-6.9.4/bin"
-        displayName: Install Gradle 6.9.4
-      - bash: gradle azureFunctionsPackage -p test/SmokeTests/OOProcSmokeTests/durableJava/
+          $project = './test/SmokeTests/OOProcSmokeTests/durableJava/pom.xml'
+          mvn --batch-mode --file $project clean package
+          if ($LASTEXITCODE) { exit $LASTEXITCODE }
+
+          $appDirectory = Split-Path -Parent $project
+          $mavenOutput = Join-Path $appDirectory 'target/azure-functions/durableJava'
+          $dockerOutput = Join-Path $appDirectory 'build/azure-functions/durableJava'
+          New-Item -ItemType Directory -Path (Split-Path -Parent $dockerOutput) -Force | Out-Null
+          Copy-Item -LiteralPath $mavenOutput -Destination $dockerOutput -Recurse -Force
         displayName: Build Java Functions sample
-        continueOnError: true
-      - bash: |
-          set -euo pipefail
-          destination='test/SmokeTests/OOProcSmokeTests/durableJava/build/azure-functions/durableJava/lib'
-          mkdir -p "$destination"
-          curl -fsSL -u "AzureDevOps:$VSS_NUGET_ACCESSTOKEN" \
-            'https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/maven/v1/com/microsoft/azure/functions/azure-functions-java-library/2.0.1/azure-functions-java-library-2.0.1.jar' \
-            -o "$destination/azure-functions-java-library-2.0.1.jar"
-        displayName: Download Azure Functions Java library from CFS
       - pwsh: >
           ./test/SmokeTests/e2e-test.ps1
           -DockerfilePath test/SmokeTests/OOProcSmokeTests/durableJava/Dockerfile
@@ -114,14 +106,14 @@ jobs:
         displayName: Run Java 8 smoke test
 
   - job: DotNetIsolatedSmoke
-    displayName: Smoke test - .NET isolated ($(targetFramework))
+    displayName: Smoke test - .NET isolated ($(testTargetFramework))
     timeoutInMinutes: 90
     strategy:
       matrix:
         Net8:
-          targetFramework: net8.0
+          testTargetFramework: net8.0
         Net10:
-          targetFramework: net10.0
+          testTargetFramework: net10.0
     steps:
       - checkout: self
         clean: true
@@ -181,8 +173,8 @@ jobs:
           $configPath = Join-Path $env:AGENT_TEMPDIRECTORY 'NuGet.config'
           Push-Location ./test/SmokeTests/OOProcSmokeTests/DotNetIsolated
           try {
-            dotnet restore --configfile $configPath --verbosity normal -p:TargetFramework=$(targetFramework)
-            dotnet build -c Release -f $(targetFramework) --no-restore
+            dotnet restore --configfile $configPath --verbosity normal -p:TargetFramework=$(testTargetFramework)
+            dotnet build -c Release -f $(testTargetFramework) --no-restore
           } finally {
             Pop-Location
           }

--- a/eng/ci/templates/public/smoke-tests.yml
+++ b/eng/ci/templates/public/smoke-tests.yml
@@ -159,9 +159,18 @@ jobs:
           dotnet restore ./WebJobs.Extensions.DurableTask.sln
           dotnet build -c Release ./src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
           if ($LASTEXITCODE) { exit $LASTEXITCODE }
+          dotnet pack -c Release --no-build ./src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj
+          if ($LASTEXITCODE) { exit $LASTEXITCODE }
           New-Item -ItemType Directory -Path "$HOME/packages" -Force | Out-Null
-          dotnet nuget push ./src/WebJobs.Extensions.DurableTask/bin/Release/Microsoft.Azure.WebJobs.Extensions.DurableTask.*.nupkg `
-            --source "$HOME/packages"
+          $packages = @(
+            Get-ChildItem ./src/WebJobs.Extensions.DurableTask/bin/Release `
+              -Filter 'Microsoft.Azure.WebJobs.Extensions.DurableTask.*.nupkg' |
+              Where-Object Name -NotLike '*.symbols.nupkg')
+          if ($packages.Count -ne 1) {
+            throw "Expected one Durable Task extension package, found $($packages.Count)."
+          }
+          dotnet nuget push $packages[0].FullName --source "$HOME/packages"
+          if ($LASTEXITCODE) { exit $LASTEXITCODE }
           $configPath = Join-Path $env:AGENT_TEMPDIRECTORY 'NuGet.config'
           ./eng/cfs/New-LocalNuGetConfig.ps1 `
             -DestinationPath $configPath `
@@ -185,7 +194,7 @@ jobs:
           Push-Location .azurite
           try {
             '{"name":"azurite-local","private":true}' | Set-Content package.json
-            npm install azurite
+            npm install azurite@$(AZURITE_VERSION)
           } finally {
             Pop-Location
           }

--- a/eng/ci/templates/public/smoke-tests.yml
+++ b/eng/ci/templates/public/smoke-tests.yml
@@ -191,7 +191,12 @@ jobs:
             Pop-Location
           }
           $azurite = Resolve-Path '.azurite/node_modules/.bin/azurite'
-          Start-Process $azurite -ArgumentList '--silent','--skipApiVersionCheck','--blobPort','10000','--queuePort','10001','--tablePort','10002'
+          $azuriteOut = Join-Path $env:AGENT_TEMPDIRECTORY 'azurite.stdout.log'
+          $azuriteErr = Join-Path $env:AGENT_TEMPDIRECTORY 'azurite.stderr.log'
+          Start-Process $azurite `
+            -ArgumentList '--silent','--skipApiVersionCheck','--blobPort','10000','--queuePort','10001','--tablePort','10002' `
+            -RedirectStandardOutput $azuriteOut `
+            -RedirectStandardError $azuriteErr
           for ($i = 1; $i -le 30; $i++) {
             try {
               $tcp = [System.Net.Sockets.TcpClient]::new('127.0.0.1', 10000)

--- a/eng/ci/templates/public/windows-validation.yml
+++ b/eng/ci/templates/public/windows-validation.yml
@@ -148,14 +148,14 @@ jobs:
       - template: publish-test-results.yml
 
   - job: FunctionsV2E2E
-    displayName: Functions V2 E2E ($(targetFramework))
+    displayName: Functions V2 E2E ($(testTargetFramework))
     timeoutInMinutes: 90
     strategy:
       matrix:
         Net8:
-          targetFramework: net8.0
+          testTargetFramework: net8.0
         Net10:
-          targetFramework: net10.0
+          testTargetFramework: net10.0
     variables:
       AzureWebJobsStorage: UseDevelopmentStorage=true
     steps:
@@ -211,10 +211,10 @@ jobs:
 
       - pwsh: |
           dotnet test ./test/FunctionsV2/WebJobs.Extensions.DurableTask.Tests.V2.csproj `
-            --framework $(targetFramework) `
+            --framework $(testTargetFramework) `
             --no-build `
             --filter 'TestType=E2E' `
-            --logger 'trx;LogFileName=functions-v2-e2e-$(targetFramework).trx' `
+            --logger 'trx;LogFileName=functions-v2-e2e-$(testTargetFramework).trx' `
             --results-directory "$env:AGENT_TEMPDIRECTORY/TestResults" `
             -- xunit.maxParallelThreads=1
         displayName: Run Functions V2 E2E tests

--- a/eng/ci/templates/public/windows-validation.yml
+++ b/eng/ci/templates/public/windows-validation.yml
@@ -1,0 +1,222 @@
+jobs:
+  - job: CodeQLBuild
+    displayName: Build solution for CodeQL
+    timeoutInMinutes: 60
+    steps:
+      - checkout: self
+        clean: true
+        submodules: true
+
+      - template: cfs-authentication.yml
+
+      - task: UseDotNet@2
+        displayName: Install .NET SDK from global.json
+        inputs:
+          packageType: sdk
+          useGlobalJson: true
+
+      - task: UseDotNet@2
+        displayName: Install .NET 2.1 SDK
+        inputs:
+          packageType: sdk
+          version: 2.1.x
+
+      - task: UseDotNet@2
+        displayName: Install .NET 3.1 SDK
+        inputs:
+          packageType: sdk
+          version: 3.1.x
+
+      - pwsh: |
+          dotnet restore ./WebJobs.Extensions.DurableTask.sln
+          dotnet build ./WebJobs.Extensions.DurableTask.sln --no-restore
+        displayName: Build solution
+
+  - job: UnitTests
+    displayName: Validate build and unit tests
+    timeoutInMinutes: 60
+    steps:
+      - checkout: self
+        clean: true
+        submodules: true
+
+      - template: cfs-authentication.yml
+
+      - task: UseDotNet@2
+        displayName: Install .NET SDK from global.json
+        inputs:
+          packageType: sdk
+          useGlobalJson: true
+
+      - task: UseDotNet@2
+        displayName: Install .NET 8 SDK
+        inputs:
+          packageType: sdk
+          version: 8.0.x
+
+      - pwsh: |
+          dotnet restore ./test/FunctionsV2/WebJobs.Extensions.DurableTask.Tests.V2.csproj
+          if ($LASTEXITCODE) { exit $LASTEXITCODE }
+          dotnet restore ./test/Worker.Extensions.DurableTask.Tests/Worker.Extensions.DurableTask.Tests.csproj
+        displayName: Restore dependencies
+
+      - pwsh: |
+          dotnet build ./test/FunctionsV2/WebJobs.Extensions.DurableTask.Tests.V2.csproj --no-restore
+          if ($LASTEXITCODE) { exit $LASTEXITCODE }
+          dotnet build ./test/Worker.Extensions.DurableTask.Tests/Worker.Extensions.DurableTask.Tests.csproj --no-restore
+        displayName: Build
+
+      - pwsh: |
+          $results = Join-Path $env:AGENT_TEMPDIRECTORY 'TestResults'
+          dotnet test ./test/FunctionsV2/WebJobs.Extensions.DurableTask.Tests.V2.csproj `
+            --no-build `
+            --filter 'TestType!=E2E' `
+            --logger 'trx;LogFileName=functions-v2-unit.trx' `
+            --results-directory $results
+          if ($LASTEXITCODE) { exit $LASTEXITCODE }
+          dotnet test ./test/Worker.Extensions.DurableTask.Tests/Worker.Extensions.DurableTask.Tests.csproj `
+            --no-build `
+            --logger 'trx;LogFileName=worker-extension-unit.trx' `
+            --results-directory $results
+        displayName: Run unit tests
+
+      - template: publish-test-results.yml
+
+  - job: AnalyzerTests
+    displayName: Validate analyzer
+    timeoutInMinutes: 60
+    variables:
+      AzureWebJobsStorage: UseDevelopmentStorage=true
+    steps:
+      - checkout: self
+        clean: true
+        submodules: true
+
+      - template: cfs-authentication.yml
+
+      - task: UseDotNet@2
+        displayName: Install .NET SDK from global.json
+        inputs:
+          packageType: sdk
+          useGlobalJson: true
+
+      - task: UseDotNet@2
+        displayName: Install .NET 8 SDK
+        inputs:
+          packageType: sdk
+          version: 8.0.x
+
+      - task: NodeTool@0
+        displayName: Install Node.js 22
+        inputs:
+          versionSpec: 22.x
+
+      - pwsh: |
+          dotnet restore ./test/WebJobs.Extensions.DurableTask.Analyzers.Test/WebJobs.Extensions.DurableTask.Analyzers.Test.csproj
+          dotnet build ./test/WebJobs.Extensions.DurableTask.Analyzers.Test/WebJobs.Extensions.DurableTask.Analyzers.Test.csproj --no-restore
+        displayName: Build analyzer tests
+
+      - pwsh: |
+          New-Item -ItemType Directory -Path .azurite -Force | Out-Null
+          Set-Location .azurite
+          '{"name":"azurite-local","private":true}' | Set-Content package.json
+          npm install azurite
+          if ($LASTEXITCODE) { exit $LASTEXITCODE }
+
+          $azurite = Resolve-Path 'node_modules/.bin/azurite.cmd'
+          Start-Process $azurite -ArgumentList '--silent','--skipApiVersionCheck','--blobPort','10000','--queuePort','10001','--tablePort','10002'
+          for ($i = 1; $i -le 30; $i++) {
+            try {
+              $tcp = [System.Net.Sockets.TcpClient]::new('127.0.0.1', 10000)
+              $tcp.Dispose()
+              Write-Host 'Azurite is ready'
+              break
+            } catch {
+              if ($i -eq 30) { throw 'Azurite did not start within 30 seconds' }
+              Start-Sleep -Seconds 1
+            }
+          }
+        displayName: Start Azurite
+
+      - pwsh: |
+          dotnet test ./test/WebJobs.Extensions.DurableTask.Analyzers.Test/WebJobs.Extensions.DurableTask.Analyzers.Test.csproj `
+            --no-build `
+            --logger 'trx;LogFileName=analyzer.trx' `
+            --results-directory "$env:AGENT_TEMPDIRECTORY/TestResults"
+        displayName: Run analyzer tests
+
+      - template: publish-test-results.yml
+
+  - job: FunctionsV2E2E
+    displayName: Functions V2 E2E ($(targetFramework))
+    timeoutInMinutes: 90
+    strategy:
+      matrix:
+        Net8:
+          targetFramework: net8.0
+        Net10:
+          targetFramework: net10.0
+    variables:
+      AzureWebJobsStorage: UseDevelopmentStorage=true
+    steps:
+      - checkout: self
+        clean: true
+        submodules: true
+
+      - template: cfs-authentication.yml
+
+      - task: UseDotNet@2
+        displayName: Install .NET SDK from global.json
+        inputs:
+          packageType: sdk
+          useGlobalJson: true
+
+      - task: UseDotNet@2
+        displayName: Install .NET 8 SDK
+        inputs:
+          packageType: sdk
+          version: 8.0.x
+
+      - task: NodeTool@0
+        displayName: Install Node.js 22
+        inputs:
+          versionSpec: 22.x
+
+      - pwsh: |
+          dotnet restore ./test/FunctionsV2/WebJobs.Extensions.DurableTask.Tests.V2.csproj
+          dotnet build ./test/FunctionsV2/WebJobs.Extensions.DurableTask.Tests.V2.csproj --no-restore
+        displayName: Build E2E tests
+
+      - pwsh: |
+          New-Item -ItemType Directory -Path .azurite -Force | Out-Null
+          Set-Location .azurite
+          '{"name":"azurite-local","private":true}' | Set-Content package.json
+          npm install azurite
+          if ($LASTEXITCODE) { exit $LASTEXITCODE }
+
+          $azurite = Resolve-Path 'node_modules/.bin/azurite.cmd'
+          Start-Process $azurite -ArgumentList '--silent','--skipApiVersionCheck','--blobPort','10000','--queuePort','10001','--tablePort','10002'
+          for ($i = 1; $i -le 30; $i++) {
+            try {
+              $tcp = [System.Net.Sockets.TcpClient]::new('127.0.0.1', 10000)
+              $tcp.Dispose()
+              Write-Host 'Azurite is ready'
+              break
+            } catch {
+              if ($i -eq 30) { throw 'Azurite did not start within 30 seconds' }
+              Start-Sleep -Seconds 1
+            }
+          }
+        displayName: Start Azurite
+
+      - pwsh: |
+          dotnet test ./test/FunctionsV2/WebJobs.Extensions.DurableTask.Tests.V2.csproj `
+            --framework $(targetFramework) `
+            --no-build `
+            --filter 'TestType=E2E' `
+            --logger 'trx;LogFileName=functions-v2-e2e-$(targetFramework).trx' `
+            --results-directory "$env:AGENT_TEMPDIRECTORY/TestResults" `
+            -- xunit.maxParallelThreads=1
+        displayName: Run Functions V2 E2E tests
+
+      - template: publish-test-results.yml

--- a/eng/ci/templates/public/windows-validation.yml
+++ b/eng/ci/templates/public/windows-validation.yml
@@ -120,7 +120,7 @@ jobs:
           New-Item -ItemType Directory -Path .azurite -Force | Out-Null
           Set-Location .azurite
           '{"name":"azurite-local","private":true}' | Set-Content package.json
-          npm install azurite
+          npm install azurite@$(AZURITE_VERSION)
           if ($LASTEXITCODE) { exit $LASTEXITCODE }
 
           $azurite = Resolve-Path 'node_modules/.bin/azurite.cmd'
@@ -191,7 +191,7 @@ jobs:
           New-Item -ItemType Directory -Path .azurite -Force | Out-Null
           Set-Location .azurite
           '{"name":"azurite-local","private":true}' | Set-Content package.json
-          npm install azurite
+          npm install azurite@$(AZURITE_VERSION)
           if ($LASTEXITCODE) { exit $LASTEXITCODE }
 
           $azurite = Resolve-Path 'node_modules/.bin/azurite.cmd'

--- a/test/SmokeTests/BackendSmokeTests/MSSQL/Dockerfile
+++ b/test/SmokeTests/BackendSmokeTests/MSSQL/Dockerfile
@@ -1,5 +1,3 @@
-﻿# syntax=docker/dockerfile:1.7
-
 # Copyright (c) .NET Foundation. All rights reserved.
 # Licensed under the MIT License. See LICENSE in the project root for license information.
 

--- a/test/SmokeTests/BackendSmokeTests/MSSQL/Dockerfile
+++ b/test/SmokeTests/BackendSmokeTests/MSSQL/Dockerfile
@@ -1,4 +1,6 @@
-﻿# Copyright (c) .NET Foundation. All rights reserved.
+﻿# syntax=docker/dockerfile:1.7
+
+# Copyright (c) .NET Foundation. All rights reserved.
 # Licensed under the MIT License. See LICENSE in the project root for license information.
 
 ARG DOTNET_SDK_TAG=10.0
@@ -8,9 +10,15 @@ ARG TARGET_FRAMEWORK
 
 # Build the DF MSSQL app
 COPY . /root
-RUN cd /root/test/SmokeTests/BackendSmokeTests/MSSQL && \
+RUN --mount=type=secret,id=nuget_config,required=false \
+    cd /root/test/SmokeTests/BackendSmokeTests/MSSQL && \
     mkdir -p /home/site/wwwroot && \
-    dotnet publish -c Release -f $TARGET_FRAMEWORK --output /home/site/wwwroot
+    if [ -f /run/secrets/nuget_config ]; then \
+      dotnet restore -p:TargetFramework=$TARGET_FRAMEWORK --configfile /run/secrets/nuget_config; \
+    else \
+      dotnet restore -p:TargetFramework=$TARGET_FRAMEWORK; \
+    fi && \
+    dotnet publish -c Release -f $TARGET_FRAMEWORK --no-restore --output /home/site/wwwroot
 
 # Deploy the app
 FROM mcr.microsoft.com/azure-functions/dotnet:4-dotnet8

--- a/test/SmokeTests/BackendSmokeTests/Netherite/Dockerfile
+++ b/test/SmokeTests/BackendSmokeTests/Netherite/Dockerfile
@@ -1,5 +1,3 @@
-﻿# syntax=docker/dockerfile:1.7
-
 # Copyright (c) .NET Foundation. All rights reserved.
 # Licensed under the MIT License. See LICENSE in the project root for license information.
 

--- a/test/SmokeTests/BackendSmokeTests/Netherite/Dockerfile
+++ b/test/SmokeTests/BackendSmokeTests/Netherite/Dockerfile
@@ -1,4 +1,6 @@
-﻿# Copyright (c) .NET Foundation. All rights reserved.
+﻿# syntax=docker/dockerfile:1.7
+
+# Copyright (c) .NET Foundation. All rights reserved.
 # Licensed under the MIT License. See LICENSE in the project root for license information.
 
 ARG DOTNET_SDK_TAG=10.0
@@ -8,9 +10,15 @@ ARG TARGET_FRAMEWORK
 
 # Build the app
 COPY . /root
-RUN cd /root/test/SmokeTests/BackendSmokeTests/Netherite && \
+RUN --mount=type=secret,id=nuget_config,required=false \
+    cd /root/test/SmokeTests/BackendSmokeTests/Netherite && \
     mkdir -p /home/site/wwwroot && \
-    dotnet publish -c Release -f $TARGET_FRAMEWORK --output /home/site/wwwroot
+    if [ -f /run/secrets/nuget_config ]; then \
+      dotnet restore -p:TargetFramework=$TARGET_FRAMEWORK --configfile /run/secrets/nuget_config; \
+    else \
+      dotnet restore -p:TargetFramework=$TARGET_FRAMEWORK; \
+    fi && \
+    dotnet publish -c Release -f $TARGET_FRAMEWORK --no-restore --output /home/site/wwwroot
 
 # Deploy the app
 FROM mcr.microsoft.com/azure-functions/dotnet:4-dotnet8.0

--- a/test/SmokeTests/OOProcSmokeTests/DotNetIsolated/run-smoke-tests.ps1
+++ b/test/SmokeTests/OOProcSmokeTests/DotNetIsolated/run-smoke-tests.ps1
@@ -16,6 +16,9 @@ $retryCount = 0;
 $statusUrl = $null;
 $success = $false;
 $haveManuallyRestartedHost = $false;
+$funcLogId = [guid]::NewGuid().ToString("N")
+$funcStandardOutput = Join-Path ([IO.Path]::GetTempPath()) "func-$funcLogId.stdout.log"
+$funcStandardError = Join-Path ([IO.Path]::GetTempPath()) "func-$funcLogId.stderr.log"
 
 # Get the directory where this script is located (the DotNetIsolated folder)
 $scriptDir = $PSScriptRoot
@@ -38,9 +41,12 @@ Do {
         Write-Host "Starting the Functions host..." -ForegroundColor Yellow
         Write-Host "Working directory: $scriptDir" -ForegroundColor Cyan
 
-        # Start the Functions host as a background process using Start-Process
-        # This runs func in the correct directory with proper environment
-        Start-Process -FilePath "func" -ArgumentList "host", "start", "--port", "7071" -WorkingDirectory $scriptDir -NoNewWindow
+        Start-Process `
+            -FilePath "func" `
+            -ArgumentList "host", "start", "--port", "7071" `
+            -WorkingDirectory $scriptDir `
+            -RedirectStandardOutput $funcStandardOutput `
+            -RedirectStandardError $funcStandardError
 
         Write-Host "Waiting for the Functions host to start up..." -ForegroundColor Yellow
         Start-Sleep -Seconds 60
@@ -115,6 +121,8 @@ Do {
         # - The host is running but not healthy (OOMs may cause this), so it needs to be forcibly restarted
         Write-Host "An error occurred:" -ForegroundColor Red
         Write-Host $_ -ForegroundColor Red
+        Get-Content $funcStandardOutput -Tail 100 -ErrorAction SilentlyContinue
+        Get-Content $funcStandardError -Tail 100 -ErrorAction SilentlyContinue
 
         # When testing for platform errors, we want to make sure the Functions host is healthy and ready to take requests.
         # The Host can get into bad states (for example, in an OOM-inducing test) where it does not self-heal.

--- a/test/SmokeTests/OOProcSmokeTests/durableJS/Dockerfile
+++ b/test/SmokeTests/OOProcSmokeTests/durableJS/Dockerfile
@@ -1,5 +1,3 @@
-# syntax=docker/dockerfile:1.7
-
 # Copyright (c) .NET Foundation. All rights reserved.
 # Licensed under the MIT License. See LICENSE in the project root for license information.
 

--- a/test/SmokeTests/OOProcSmokeTests/durableJS/Dockerfile
+++ b/test/SmokeTests/OOProcSmokeTests/durableJS/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1.7
+
 # Copyright (c) .NET Foundation. All rights reserved.
 # Licensed under the MIT License. See LICENSE in the project root for license information.
 
@@ -8,8 +10,14 @@ ARG TARGET_FRAMEWORK=net8.0
 FROM mcr.microsoft.com/dotnet/sdk:${DOTNET_SDK_TAG} AS build-env
 ARG TARGET_FRAMEWORK
 COPY . /root
-RUN cd /root/test/SmokeTests/OOProcSmokeTests/durableJS && \
-    dotnet build -o bin -f $TARGET_FRAMEWORK
+RUN --mount=type=secret,id=nuget_config,required=false \
+    cd /root/test/SmokeTests/OOProcSmokeTests/durableJS && \
+    if [ -f /run/secrets/nuget_config ]; then \
+      dotnet restore -p:TargetFramework=$TARGET_FRAMEWORK --configfile /run/secrets/nuget_config; \
+    else \
+      dotnet restore -p:TargetFramework=$TARGET_FRAMEWORK; \
+    fi && \
+    dotnet build -o bin -f $TARGET_FRAMEWORK --no-restore
 
 # Step 2: Deploy and run npm install to get the Durable Functions SDK
 FROM mcr.microsoft.com/azure-functions/node:4-node20
@@ -17,7 +25,8 @@ ARG NPM_REGISTRY=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-pu
 COPY --from=build-env /root/test/SmokeTests/OOProcSmokeTests/durableJS /home/site/wwwroot
 ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     AzureFunctionsJobHost__Logging__Console__IsEnabled=true
-RUN cd /home/site/wwwroot && \
+RUN --mount=type=secret,id=npmrc,target=/root/.npmrc,required=false \
+    cd /home/site/wwwroot && \
     npm install --registry="$NPM_REGISTRY" \
       --@azure:registry="$NPM_REGISTRY" \
       --@opentelemetry:registry="$NPM_REGISTRY"

--- a/test/SmokeTests/OOProcSmokeTests/durableJava/.gitignore
+++ b/test/SmokeTests/OOProcSmokeTests/durableJava/.gitignore
@@ -1,1 +1,2 @@
 build/*
+target/*

--- a/test/SmokeTests/OOProcSmokeTests/durableJava/Dockerfile
+++ b/test/SmokeTests/OOProcSmokeTests/durableJava/Dockerfile
@@ -1,5 +1,3 @@
-# syntax=docker/dockerfile:1.7
-
 ARG DOTNET_SDK_TAG=10.0
 ARG TARGET_FRAMEWORK=net8.0
 FROM mcr.microsoft.com/dotnet/sdk:${DOTNET_SDK_TAG} AS build-env

--- a/test/SmokeTests/OOProcSmokeTests/durableJava/Dockerfile
+++ b/test/SmokeTests/OOProcSmokeTests/durableJava/Dockerfile
@@ -1,10 +1,18 @@
+# syntax=docker/dockerfile:1.7
+
 ARG DOTNET_SDK_TAG=10.0
 ARG TARGET_FRAMEWORK=net8.0
 FROM mcr.microsoft.com/dotnet/sdk:${DOTNET_SDK_TAG} AS build-env
 ARG TARGET_FRAMEWORK
 COPY . /root
-RUN cd /root/test/SmokeTests/OOProcSmokeTests/durableJava && \
-    dotnet build -o bin -f $TARGET_FRAMEWORK
+RUN --mount=type=secret,id=nuget_config,required=false \
+    cd /root/test/SmokeTests/OOProcSmokeTests/durableJava && \
+    if [ -f /run/secrets/nuget_config ]; then \
+      dotnet restore -p:TargetFramework=$TARGET_FRAMEWORK --configfile /run/secrets/nuget_config; \
+    else \
+      dotnet restore -p:TargetFramework=$TARGET_FRAMEWORK; \
+    fi && \
+    dotnet build -o bin -f $TARGET_FRAMEWORK --no-restore
 
 FROM mcr.microsoft.com/azure-functions/java:4-java8
 # Copy the bin folder generated at /root/test/SmokeTests/OOProcSmokeTests/durableJava

--- a/test/SmokeTests/OOProcSmokeTests/durableJava/pom.xml
+++ b/test/SmokeTests/OOProcSmokeTests/durableJava/pom.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.functions</groupId>
+  <artifactId>durableJava</artifactId>
+  <version>0.1.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.release>8</maven.compiler.release>
+    <azure.functions.maven.plugin.version>1.37.0</azure.functions.maven.plugin.version>
+    <functionAppName>durableJava</functionAppName>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.microsoft</groupId>
+      <artifactId>durabletask-azure-functions</artifactId>
+      <version>1.0.0-beta.1</version>
+    </dependency>
+    <dependency>
+      <groupId>com.microsoft.azure.functions</groupId>
+      <artifactId>azure-functions-java-library</artifactId>
+      <version>2.0.1</version>
+    </dependency>
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-netty-shaded</artifactId>
+      <version>1.38.0</version>
+      <scope>runtime</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.14.1</version>
+      </plugin>
+      <plugin>
+        <groupId>com.microsoft.azure</groupId>
+        <artifactId>azure-functions-maven-plugin</artifactId>
+        <version>${azure.functions.maven.plugin.version}</version>
+        <configuration>
+          <appName>${functionAppName}</appName>
+          <resourceGroup>java-functions-group</resourceGroup>
+          <region>westus</region>
+          <runtime>
+            <os>windows</os>
+            <javaVersion>8</javaVersion>
+          </runtime>
+          <appSettings>
+            <property>
+              <name>FUNCTIONS_EXTENSION_VERSION</name>
+              <value>~4</value>
+            </property>
+          </appSettings>
+        </configuration>
+        <executions>
+          <execution>
+            <id>package-functions</id>
+            <goals>
+              <goal>package</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/test/SmokeTests/OOProcSmokeTests/durableJava/pom.xml
+++ b/test/SmokeTests/OOProcSmokeTests/durableJava/pom.xml
@@ -48,6 +48,7 @@
         <version>${azure.functions.maven.plugin.version}</version>
         <configuration>
           <appName>${functionAppName}</appName>
+          <skipInstallExtensions>true</skipInstallExtensions>
           <resourceGroup>java-functions-group</resourceGroup>
           <region>westus</region>
           <runtime>

--- a/test/SmokeTests/OOProcSmokeTests/durablePy/Dockerfile
+++ b/test/SmokeTests/OOProcSmokeTests/durablePy/Dockerfile
@@ -1,5 +1,3 @@
-# syntax=docker/dockerfile:1.7
-
 # Copyright (c) .NET Foundation. All rights reserved.
 # Licensed under the MIT License. See LICENSE in the project root for license information.
 

--- a/test/SmokeTests/OOProcSmokeTests/durablePy/Dockerfile
+++ b/test/SmokeTests/OOProcSmokeTests/durablePy/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1.7
+
 # Copyright (c) .NET Foundation. All rights reserved.
 # Licensed under the MIT License. See LICENSE in the project root for license information.
 
@@ -8,8 +10,14 @@ ARG TARGET_FRAMEWORK=net8.0
 FROM mcr.microsoft.com/dotnet/sdk:${DOTNET_SDK_TAG} AS build-env
 ARG TARGET_FRAMEWORK
 COPY . /root
-RUN cd /root/test/SmokeTests/OOProcSmokeTests/durablePy && \
-    dotnet build -o bin -f $TARGET_FRAMEWORK
+RUN --mount=type=secret,id=nuget_config,required=false \
+    cd /root/test/SmokeTests/OOProcSmokeTests/durablePy && \
+    if [ -f /run/secrets/nuget_config ]; then \
+      dotnet restore -p:TargetFramework=$TARGET_FRAMEWORK --configfile /run/secrets/nuget_config; \
+    else \
+      dotnet restore -p:TargetFramework=$TARGET_FRAMEWORK; \
+    fi && \
+    dotnet build -o bin -f $TARGET_FRAMEWORK --no-restore
 
 # Step 2: Deploy and run pip install to get the Durable Functions SDK
 FROM mcr.microsoft.com/azure-functions/python:4-python3.11
@@ -18,5 +26,9 @@ COPY --from=build-env /root/test/SmokeTests/OOProcSmokeTests/durablePy /home/sit
 ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     AzureFunctionsJobHost__Logging__Console__IsEnabled=true
 
-RUN cd /home/site/wwwroot && \
+RUN --mount=type=secret,id=pip_index_url,required=false \
+    cd /home/site/wwwroot && \
+    if [ -f /run/secrets/pip_index_url ]; then \
+      PIP_INDEX_URL="$(cat /run/secrets/pip_index_url)"; \
+    fi && \
     PIP_INDEX_URL="$PIP_INDEX_URL" pip install --requirement requirements.txt

--- a/test/SmokeTests/e2e-test.ps1
+++ b/test/SmokeTests/e2e-test.ps1
@@ -91,6 +91,21 @@ if ($NoSetup -eq $false) {
 		$buildArgs += "--build-arg"
 		$buildArgs += "DOTNET_ISOLATED_TAG=$DotnetIsolatedTag"
 	}
+	$dockerSecrets = @{
+		"nuget_config" = $env:CFS_NUGET_CONFIG
+		"npmrc" = $env:CFS_NPM_CONFIG
+		"pip_index_url" = $env:CFS_PIP_INDEX
+	}
+	foreach ($secret in $dockerSecrets.GetEnumerator()) {
+		if ($secret.Value) {
+			if (!(Test-Path -LiteralPath $secret.Value)) {
+				throw "Docker secret '$($secret.Key)' does not exist at '$($secret.Value)'."
+			}
+			$buildArgs += "--secret"
+			$buildArgs += "id=$($secret.Key),src=$($secret.Value)"
+		}
+	}
+	$env:DOCKER_BUILDKIT = "1"
 	docker build --pull -f $DockerfilePath -t $ImageName --progress plain @buildArgs $PSScriptRoot/../../
 	Exit-OnError
 


### PR DESCRIPTION
# Summary
## What changed?
- Added `eng/ci/public.yml`, an additive public `azfunc` 1ES pipeline covering the repository's existing Windows validation, Linux validation, smoke, scale, dependency-validation, language E2E, and CodeQL jobs.
- Added reusable templates with centralized CFS authentication for NuGet, npm, pip, Maven, Gradle, Docker BuildKit, and PowerShell Gallery restores.
- Added authenticated BuildKit secrets for containerized NuGet, npm, and pip restores without persisting credentials in image layers.
- Kept all existing GitHub Actions workflows enabled for parallel rollout and comparison.

## Why is this change needed?
GitHub-hosted workflows cannot authenticate every restore through Azure Functions Central Feed Services (CFS). The public Azure DevOps organization can use standard Azure Artifacts authentication while preserving public PR visibility and supporting network-isolated 1ES agents.

## Findings from validating the public pipeline
The public definition is `durable-extension.public` (definition 1787). Getting a complete network-isolated run passing exposed several portability requirements now handled by these templates:

- Dockerfile frontend directives can contact Docker Hub before the build starts, so smoke Dockerfiles use the bundled frontend and authenticated BuildKit restore secrets.
- Azurite is pinned to `3.35.0`, whose complete dependency graph is available in CFS. Linux Azurite and Functions host processes redirect output so detached processes do not retain ADO task handles and hang jobs.
- Minimal 1ES images require explicit .NET and JDK setup. Matrix variables use `testTargetFramework` so ADO does not export `TARGETFRAMEWORK` and unintentionally override MSBuild globally.
- The Azure Functions Gradle plugin marker is not currently available through CFS, so the Java smoke app uses the CFS-available Maven plugin and suppresses extension installation during packaging.
- Smoke tests explicitly build and resolve their local extension package rather than relying on an implicit package location. Netherite jobs explicitly pass the case-sensitive `EventHubsConnection` variable.
- PowerShell Gallery packages are available through the authenticated public CFS NuGet v2 endpoint. CI registers a uniquely named PowerShell repository, stages the latest external `AzureFunctions.PowerShell.Durable.SDK` 2.x module, and disables managed dependencies in the job-local app configuration because the current PowerShell worker performs managed-dependency discovery against a hardcoded direct PSGallery URL.

## Issues / work items
- Resolves #
- Related #

---

# Project checklist
- [x] Documentation changes are not required
  - [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
- [x] Release notes are not required for the next release
  - [ ] Otherwise: Notes added to `release_notes.md`
- [x] Backport is not required
  - [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
- [x] All required tests have been added/updated (unit tests, E2E tests)
- [x] No extra work is required to be leveraged by OutOfProc SDKs
  - [ ] Otherwise: Work tracked here: #issue_or_pr_in_each_sdk
- [x] No change to the version of the `WebJobs.Extensions.DurableTask` package
  - [ ] Otherwise: Major/minor updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
- [x] No EventIds were added to `EventSource` logs
  - [ ] Otherwise: Ensure EventIds are within the supported range in the existing Windows infrastructure (validate via deployed telemetry). If needed, extend the range via a PR such as https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files
- [ ] This change should be added to the `v2.x` branch
  - [x] Otherwise: This change applies exclusively to `WebJobs.Extensions.DurableTask` v3.x and will be retained only in the `dev` and `main` branches
- [ ] Breaking change?
  - [ ] If yes:
    - Impact:
    - Migration guidance:
---

# AI-assisted code disclosure (required)
## Was an AI tool used? (select one)
- [ ] No
- [ ] Yes, AI helped write parts of this PR (e.g., GitHub Copilot)
- [x] Yes, an AI agent generated most of this PR

If AI was used:
- Tool(s): GitHub Copilot
- AI-assisted areas/files: Public Azure Pipelines YAML/templates, CFS authentication, Docker restore changes, Java smoke packaging, and isolated-process handling
- What you changed after AI output: Reviewed public `azfunc` pipeline precedents, validated against network-isolated 1ES agents, corrected runtime and package-source behavior, and incorporated independent code reviews

AI verification (required if AI was used):
- [x] I understand the code and can explain it
- [x] I verified referenced APIs/types exist and are correct
- [x] I reviewed edge cases/failure paths (timeouts, retries, cancellation, exceptions)
- [x] I reviewed concurrency/async behavior
- [x] I checked for unintended breaking or behavior changes

---

# Testing
## Automated tests
- Result: Passed — public ADO run 299097 completed successfully across all 27 validation jobs.

## Manual validation (only if runtime/behavior changed)
- Environment: Public `azfunc` 1ES Windows and Ubuntu agents with CFS-only dependency access
- Steps + observed results:
  1. Created public definition 1787 against `eng/ci/public.yml` using the GitHub service connection.
  2. Validated authenticated restores for NuGet, npm, pip, Maven, Docker, and PowerShell Gallery packages through CFS.
  3. Ran the full Windows, Linux, smoke, scale, dependency, language E2E, and SDL matrix successfully.
  4. Locally confirmed the authenticated PowerShell Gallery endpoint discovers, installs, imports, and resolves commands from `AzureFunctions.PowerShell.Durable.SDK` 2.3.0.

---

# Notes for reviewers
- GitHub Actions remain enabled during rollout. After merge, definition 1787 should use `dev` as its default branch.
- The GitHub net10 isolated smoke check that failed on the latest push exited during worker startup because `System.Diagnostics.DiagnosticSource, Version=10.0.0.0` was unavailable. The equivalent ADO net10 smoke job passed; the failed GitHub job has been rerun to confirm it is an environment/workflow flake rather than a CFS pipeline regression.