### PR TITLE
Fix WorkerExtensions restore in isolated smoke tests

### DIFF
--- a/.github/workflows/smoketest-dotnet-isolated-v4.yml
+++ b/.github/workflows/smoketest-dotnet-isolated-v4.yml
@@ -66,7 +66,8 @@ jobs:
         mkdir "$HOME/packages"
         dotnet nuget push ./bin/Release/Microsoft.Azure.WebJobs.Extensions.DurableTask.*.nupkg --source "$HOME/packages"
         cd "$env:GITHUB_WORKSPACE"
-        $configPath = Join-Path $env:RUNNER_TEMP "NuGet.config"
+        # The Worker SDK restores WorkerExtensions.csproj during build, so its config must be discoverable from obj/.
+        $configPath = Join-Path $env:GITHUB_WORKSPACE "test/SmokeTests/OOProcSmokeTests/DotNetIsolated/NuGet.config"
         ./eng/cfs/New-LocalNuGetConfig.ps1 `
           -DestinationPath $configPath `
           -LocalSourcePath "$HOME/packages" `
@@ -77,7 +78,7 @@ jobs:
       shell: pwsh
       run: |
         cd ./test/SmokeTests/OOProcSmokeTests/DotNetIsolated
-        $configPath = Join-Path $env:RUNNER_TEMP "NuGet.config"
+        $configPath = Join-Path (Get-Location) "NuGet.config"
         dotnet restore --configfile "$configPath" --verbosity normal -p:TargetFramework=${{ matrix.targetFramework }}
         dotnet build -c Release -f ${{ matrix.targetFramework }} --no-restore
 

--- a/test/SmokeTests/OOProcSmokeTests/DotNetIsolated/Dockerfile
+++ b/test/SmokeTests/OOProcSmokeTests/DotNetIsolated/Dockerfile
@@ -19,9 +19,9 @@ RUN cd /root/src/WebJobs.Extensions.DurableTask && \
     dotnet restore "WebJobs.Extensions.DurableTask.csproj" && \
     dotnet build -c Release -f "$TARGET_FRAMEWORK" "WebJobs.Extensions.DurableTask.csproj" --no-restore && \
     dotnet nuget push "bin/Release/Microsoft.Azure.WebJobs.Extensions.DurableTask.*.nupkg" --source "/packages" && \
-    cp "/root/nuget.config" "/tmp/NuGet.config" && \
-    dotnet nuget add source "/packages" --name "local-packages" --configfile "/tmp/NuGet.config" && \
-    sed -i '/<\/packageSourceMapping>/i\    <packageSource key="local-packages">\n      <package pattern="Microsoft.Azure.WebJobs.Extensions.DurableTask" />\n    </packageSource>' "/tmp/NuGet.config"
+    cp "/root/nuget.config" "/root/test/SmokeTests/OOProcSmokeTests/DotNetIsolated/NuGet.config" && \
+    dotnet nuget add source "/packages" --name "local-packages" --configfile "/root/test/SmokeTests/OOProcSmokeTests/DotNetIsolated/NuGet.config" && \
+    sed -i '/<\/packageSourceMapping>/i\    <packageSource key="local-packages">\n      <package pattern="Microsoft.Azure.WebJobs.Extensions.DurableTask" />\n    </packageSource>' "/root/test/SmokeTests/OOProcSmokeTests/DotNetIsolated/NuGet.config"
 
 # Step 2: Build the sample app, which references the locally built extension from Step 1
 #         IMPORTANT: restore seems to need to be done separately to ensure the correct
@@ -30,7 +30,7 @@ RUN cd /root/src/WebJobs.Extensions.DurableTask && \
 #         be an issue with the Azure Functions Worker SDK build process.
 RUN cd /root/test/SmokeTests/OOProcSmokeTests/DotNetIsolated && \
     mkdir -p /home/site/wwwroot && \
-    dotnet restore "DotNetIsolated.csproj" --configfile "/tmp/NuGet.config" --verbosity normal -p:TargetFramework="$TARGET_FRAMEWORK" && \
+    dotnet restore "DotNetIsolated.csproj" --configfile "NuGet.config" --verbosity normal -p:TargetFramework="$TARGET_FRAMEWORK" && \
     dotnet build "DotNetIsolated.csproj" -c Release -f "$TARGET_FRAMEWORK" --no-restore && \
     dotnet publish "DotNetIsolated.csproj" -c Release -f "$TARGET_FRAMEWORK" --no-build --no-restore --output "/home/site/wwwroot" && \
     cp "/root/src/WebJobs.Extensions.DurableTask/bin/Release/$TARGET_FRAMEWORK/Microsoft.Azure.WebJobs.Extensions.DurableTask.dll" "/home/site/wwwroot/.azurefunctions/" && \


### PR DESCRIPTION
## Summary
- generate the isolated smoke test's NuGet config inside the function app directory
- allow the Worker SDK's nested `WorkerExtensions.csproj` restore to discover the local WebJobs package source
- apply the same fix to the Docker smoke-test build

## Validation
- built the isolated `net8.0` smoke app with an isolated NuGet package cache
- confirmed `Microsoft.Azure.WebJobs.Extensions.DurableTask` was restored from the locally built package feed