### PR TITLE
Fix Durable client current-app detection

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/AzureStorageDurabilityProvider.cs
+++ b/src/WebJobs.Extensions.DurableTask/AzureStorageDurabilityProvider.cs
@@ -73,6 +73,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
         public override string EventSourceName { get; set; } = "DurableTask-AzureStorage";
 
+        internal override bool TaskHubNameMatches(string taskHubName, string otherTaskHubName)
+        {
+            return string.Equals(taskHubName, otherTaskHubName, StringComparison.OrdinalIgnoreCase);
+        }
+
         /// <inheritdoc/>
         public async override Task<IList<OrchestrationState>> GetAllOrchestrationStates(CancellationToken cancellationToken)
         {

--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableClient.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableClient.cs
@@ -358,7 +358,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
         private bool ClientReferencesCurrentApp(DurableClient client)
         {
-            return !client.attribute.ExternalClient &&
+            return this.config != null &&
+                !client.attribute.ExternalClient &&
                 this.TaskHubMatchesCurrentApp(client) &&
                 this.ConnectionNameMatchesCurrentApp(client);
         }
@@ -374,12 +375,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         private bool TaskHubMatchesCurrentApp(DurableClient client)
         {
             var taskHubName = this.durableTaskOptions.HubName;
-            return client.TaskHubName.Equals(taskHubName);
+            return this.config.DefaultDurabilityProvider.TaskHubNameMatches(client.TaskHubName, taskHubName);
         }
 
         private bool ConnectionNameMatchesCurrentApp(DurableClient client)
         {
-            return this.DurabilityProvider.ConnectionNameMatches(client.DurabilityProvider);
+            return this.config.DefaultDurabilityProvider.ConnectionNameMatches(client.DurabilityProvider);
         }
 
         /// <inheritdoc />

--- a/src/WebJobs.Extensions.DurableTask/DurabilityProvider.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurabilityProvider.cs
@@ -617,6 +617,17 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         }
 
         /// <summary>
+        /// Returns true if two task hub names identify the same task hub for this durability provider.
+        /// </summary>
+        /// <param name="taskHubName">The first task hub name.</param>
+        /// <param name="otherTaskHubName">The second task hub name.</param>
+        /// <returns>A boolean indicating whether the task hub names match.</returns>
+        internal virtual bool TaskHubNameMatches(string taskHubName, string otherTaskHubName)
+        {
+            return string.Equals(taskHubName, otherTaskHubName, StringComparison.Ordinal);
+        }
+
+        /// <summary>
         /// Tries to obtain a scale monitor for autoscaling.
         /// </summary>
         /// <param name="functionId">Function id.</param>

--- a/test/FunctionsV2/Tests/Unit/DurableClientBaseTests.cs
+++ b/test/FunctionsV2/Tests/Unit/DurableClientBaseTests.cs
@@ -82,10 +82,69 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
         [Fact]
         [Trait("Category", PlatformSpecificHelpers.TestCategory)]
-        public async Task StartNewAsync_DifferentConnection_MissingOrchestrator_ThrowsException()
+        public async Task StartNewAsync_DifferentConnection_MissingOrchestrator_SchedulesInstance()
         {
             (DurableClient durableClient, Mock<IOrchestrationServiceClient> serviceClient, _) =
                 CreateClient();
+
+            await ((IDurableOrchestrationClient)durableClient).StartNewAsync("MissingOrchestrator");
+
+            serviceClient.Verify(
+                x => x.CreateTaskOrchestrationAsync(It.IsAny<TaskMessage>(), It.IsAny<OrchestrationStatus[]>()),
+                Times.Once());
+        }
+
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public async Task StartNewAsync_UsesHostProviderConnectionMatching()
+        {
+            var serviceClient = new Mock<IOrchestrationServiceClient>();
+            serviceClient
+                .Setup(x => x.CreateTaskOrchestrationAsync(It.IsAny<TaskMessage>(), It.IsAny<OrchestrationStatus[]>()))
+                .Returns(Task.CompletedTask);
+            var targetProvider = new DurabilityProvider(
+                "targetProvider",
+                new Mock<IOrchestrationService>().Object,
+                serviceClient.Object,
+                TestConstants.ConnectionName);
+            var defaultProvider = new Mock<Microsoft.Azure.WebJobs.Extensions.DurableTask.DurabilityProvider>(
+                "defaultProvider",
+                new Mock<IOrchestrationService>().Object,
+                new Mock<IOrchestrationServiceClient>().Object,
+                TestConstants.ConnectionName)
+            {
+                CallBase = true,
+            };
+            defaultProvider
+                .Setup(provider => provider.ConnectionNameMatches(targetProvider))
+                .Returns(false);
+            DurableTaskExtension extension = GetDurableTaskConfig(defaultProvider.Object);
+            var client = (IDurableOrchestrationClient)new DurableClient(
+                targetProvider,
+                extension,
+                extension.HttpApiHandler,
+                new DurableClientAttribute
+                {
+                    TaskHub = "DurableTaskHub",
+                    ConnectionName = TestConstants.ConnectionName,
+                });
+
+            await client.StartNewAsync("MissingOrchestrator");
+
+            defaultProvider.Verify(
+                provider => provider.ConnectionNameMatches(targetProvider),
+                Times.Exactly(2));
+            serviceClient.Verify(
+                x => x.CreateTaskOrchestrationAsync(It.IsAny<TaskMessage>(), It.IsAny<OrchestrationStatus[]>()),
+                Times.Once());
+        }
+
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public async Task StartNewAsync_AzureStorageCaseVariantTaskHub_MissingOrchestrator_ThrowsException()
+        {
+            (DurableClient durableClient, Mock<IOrchestrationServiceClient> serviceClient, _) =
+                CreateClient(taskHub: "durabletaskhub", connectionName: TestConstants.ConnectionName);
 
             ArgumentException exception = await Assert.ThrowsAsync<ArgumentException>(
                 () => ((IDurableOrchestrationClient)durableClient).StartNewAsync("MissingOrchestrator"));
@@ -98,10 +157,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
         [Fact]
         [Trait("Category", PlatformSpecificHelpers.TestCategory)]
-        public async Task StartNewAsync_CaseVariantTaskHub_MissingOrchestrator_SchedulesInstance()
+        public async Task StartNewAsync_ExactCaseProviderCaseVariantTaskHub_MissingOrchestrator_SchedulesInstance()
         {
             (DurableClient durableClient, Mock<IOrchestrationServiceClient> serviceClient, _) =
-                CreateClient(taskHub: "durabletaskhub", connectionName: TestConstants.ConnectionName);
+                CreateClient(
+                    taskHub: "durabletaskhub",
+                    connectionName: TestConstants.ConnectionName,
+                    useExactCaseDefaultProvider: true);
 
             await ((IDurableOrchestrationClient)durableClient).StartNewAsync("MissingOrchestrator");
 
@@ -113,9 +175,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         [Theory]
         [InlineData(null, true)]
         [InlineData("DurableTaskHub", true)]
-        [InlineData("durabletaskhub", false)]
+        [InlineData("durabletaskhub", true)]
         [Trait("Category", PlatformSpecificHelpers.TestCategory)]
-        public async Task StartNewAsync_DisabledOrchestrator_UsesLegacyTaskHubMatching(
+        public async Task StartNewAsync_DisabledOrchestrator_UsesAzureStorageTaskHubMatching(
             string taskHub,
             bool rejectStart)
         {
@@ -154,27 +216,26 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
         [Fact]
         [Trait("Category", PlatformSpecificHelpers.TestCategory)]
-        public async Task StartNewAsync_DifferentConnection_DisabledOrchestrator_ThrowsException()
+        public async Task StartNewAsync_DifferentConnection_DisabledOrchestrator_SchedulesInstance()
         {
             const string FunctionName = "DisabledOrchestrator";
             (DurableClient durableClient, Mock<IOrchestrationServiceClient> serviceClient, DurableTaskExtension extension) =
                 CreateClient();
             extension.RegisterOrchestrator(new FunctionName(FunctionName), orchestratorInfo: null);
 
-            await Assert.ThrowsAsync<OrchestratorFunctionUnavailableException>(
-                () => ((IDurableOrchestrationClient)durableClient).StartNewAsync(FunctionName));
+            await ((IDurableOrchestrationClient)durableClient).StartNewAsync(FunctionName);
 
             serviceClient.Verify(
                 x => x.CreateTaskOrchestrationAsync(It.IsAny<TaskMessage>(), It.IsAny<OrchestrationStatus[]>()),
-                Times.Never());
+                Times.Once());
         }
 
         [Theory]
         [InlineData(null, true)]
         [InlineData("DurableTaskHub", true)]
-        [InlineData("durabletaskhub", false)]
+        [InlineData("durabletaskhub", true)]
         [Trait("Category", PlatformSpecificHelpers.TestCategory)]
-        public async Task RestartAsync_DisabledOrchestrator_UsesLegacyTaskHubMatching(
+        public async Task RestartAsync_DisabledOrchestrator_UsesAzureStorageTaskHubMatching(
             string taskHub,
             bool rejectRestart)
         {
@@ -228,7 +289,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
         [Fact]
         [Trait("Category", PlatformSpecificHelpers.TestCategory)]
-        public async Task RestartAsync_DifferentConnection_DisabledOrchestrator_ThrowsException()
+        public async Task RestartAsync_DifferentConnection_DisabledOrchestrator_SchedulesInstance()
         {
             const string InstanceId = "completed-instance";
             const string FunctionName = "DisabledOrchestrator";
@@ -249,14 +310,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                     });
             extension.RegisterOrchestrator(new FunctionName(FunctionName), orchestratorInfo: null);
 
-            await Assert.ThrowsAsync<OrchestratorFunctionUnavailableException>(
-                () => ((IDurableOrchestrationClient)durableClient).RestartAsync(
-                    InstanceId,
-                    restartWithNewInstanceId: false));
+            await ((IDurableOrchestrationClient)durableClient).RestartAsync(
+                InstanceId,
+                restartWithNewInstanceId: false);
 
             serviceClient.Verify(
                 x => x.CreateTaskOrchestrationAsync(It.IsAny<TaskMessage>(), It.IsAny<OrchestrationStatus[]>()),
-                Times.Never());
+                Times.Once());
         }
 
         [Theory]
@@ -377,10 +437,27 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
         [Fact]
         [Trait("Category", PlatformSpecificHelpers.TestCategory)]
-        public async Task SignalEntityAsync_DifferentConnection_MissingEntity_ThrowsException()
+        public async Task SignalEntityAsync_DifferentConnection_MissingEntity_SendsMessage()
         {
             (DurableClient durableClient, Mock<IOrchestrationServiceClient> serviceClient, _) =
                 CreateClient();
+
+            await ((IDurableEntityClient)durableClient).SignalEntityAsync(
+                new EntityId("MissingEntity", "entity-key"),
+                "operation",
+                new { Value = 1 });
+
+            serviceClient.Verify(
+                x => x.SendTaskOrchestrationMessageAsync(It.IsAny<TaskMessage>()),
+                Times.Once());
+        }
+
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public async Task SignalEntityAsync_AzureStorageCaseVariantTaskHub_MissingEntity_ThrowsException()
+        {
+            (DurableClient durableClient, Mock<IOrchestrationServiceClient> serviceClient, _) =
+                CreateClient(taskHub: "durabletaskhub", connectionName: TestConstants.ConnectionName);
 
             ArgumentException exception = await Assert.ThrowsAsync<ArgumentException>(
                 () => ((IDurableEntityClient)durableClient).SignalEntityAsync(
@@ -392,23 +469,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             serviceClient.Verify(
                 x => x.SendTaskOrchestrationMessageAsync(It.IsAny<TaskMessage>()),
                 Times.Never());
-        }
-
-        [Fact]
-        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
-        public async Task SignalEntityAsync_CaseVariantTaskHub_MissingEntity_SendsMessage()
-        {
-            (DurableClient durableClient, Mock<IOrchestrationServiceClient> serviceClient, _) =
-                CreateClient(taskHub: "durabletaskhub", connectionName: TestConstants.ConnectionName);
-
-            await ((IDurableEntityClient)durableClient).SignalEntityAsync(
-                new EntityId("MissingEntity", "entity-key"),
-                "operation",
-                new { Value = 1 });
-
-            serviceClient.Verify(
-                x => x.SendTaskOrchestrationMessageAsync(It.IsAny<TaskMessage>()),
-                Times.Once());
         }
 
         [Theory]
@@ -681,7 +741,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             DurableTaskExtension Extension) CreateClient(
             string taskHub = "DurableTaskHub",
             string connectionName = "TargetStorage",
-            bool externalClient = false)
+            bool externalClient = false,
+            bool useExactCaseDefaultProvider = false)
         {
             var serviceClient = new Mock<IOrchestrationServiceClient>();
             serviceClient
@@ -695,7 +756,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 new Mock<IOrchestrationService>().Object,
                 serviceClient.Object,
                 connectionName);
-            var durableExtension = GetDurableTaskConfig();
+            DurableTaskExtension durableExtension = useExactCaseDefaultProvider
+                ? GetDurableTaskConfig(
+                    new DurabilityProvider(
+                        "azureManaged",
+                        new Mock<IOrchestrationService>().Object,
+                        new Mock<IOrchestrationServiceClient>().Object,
+                        TestConstants.ConnectionName))
+                : GetDurableTaskConfig();
             var attribute = new DurableClientAttribute
             {
                 TaskHub = taskHub,
@@ -808,7 +876,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             };
         }
 
-        private static DurableTaskExtension GetDurableTaskConfig()
+        private static DurableTaskExtension GetDurableTaskConfig(
+            Microsoft.Azure.WebJobs.Extensions.DurableTask.DurabilityProvider defaultProvider = null)
         {
             var options = new DurableTaskOptions();
             options.HubName = "DurableTaskHub";
@@ -817,12 +886,27 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             var nameResolver = TestHelpers.GetTestNameResolver();
             var clientProviderFactory = new TestStorageServiceClientProviderFactory();
             var platformInformationService = TestHelpers.GetMockPlatformInformationService();
-            var serviceFactory = new AzureStorageDurabilityProviderFactory(
-                wrappedOptions,
-                clientProviderFactory,
-                nameResolver,
-                NullLoggerFactory.Instance,
-                platformInformationService);
+            IDurabilityProviderFactory serviceFactory;
+            if (defaultProvider == null)
+            {
+                serviceFactory = new AzureStorageDurabilityProviderFactory(
+                    wrappedOptions,
+                    clientProviderFactory,
+                    nameResolver,
+                    NullLoggerFactory.Instance,
+                    platformInformationService);
+            }
+            else
+            {
+                var serviceFactoryMock = new Mock<IDurabilityProviderFactory>();
+                serviceFactoryMock.SetupGet(factory => factory.Name).Returns(AzureStorageDurabilityProviderFactory.ProviderName);
+                serviceFactoryMock.Setup(factory => factory.GetDurabilityProvider()).Returns(defaultProvider);
+                serviceFactoryMock
+                    .Setup(factory => factory.GetDurabilityProvider(It.IsAny<DurableClientAttribute>()))
+                    .Returns(defaultProvider);
+                serviceFactory = serviceFactoryMock.Object;
+            }
+
             return new DurableTaskExtension(
                 wrappedOptions,
                 new LoggerFactory(),

--- a/test/FunctionsV2/Tests/Unit/HttpApiHandlerTests.cs
+++ b/test/FunctionsV2/Tests/Unit/HttpApiHandlerTests.cs
@@ -2124,11 +2124,53 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
         [Fact]
         [Trait("Category", PlatformSpecificHelpers.TestCategory)]
-        public async Task StartNewInstance_CaseVariantTaskHub_DoesNotRejectLocallyDisabledFunction()
+        public async Task StartNewInstance_DifferentConnection_DoesNotRejectLocallyDisabledFunction()
+        {
+            const string FunctionName = "DisabledOrchestrator";
+            const string TargetConnectionName = "TargetStorage";
+            var requestUri = new Uri(
+                $"http://localhost/runtime/webhooks/durabletask/orchestrators/{FunctionName}" +
+                $"?taskHub={TestConstants.TaskHub}&connection={TargetConnectionName}");
+            var orchestrationServiceMock = new Mock<IOrchestrationService>(MockBehavior.Strict);
+            var orchestrationServiceClientMock = new Mock<IOrchestrationServiceClient>();
+            orchestrationServiceClientMock
+                .Setup(p => p.CreateTaskOrchestrationAsync(
+                    It.IsAny<TaskMessage>(),
+                    It.IsAny<OrchestrationStatus[]>()))
+                .Returns(Task.CompletedTask);
+            var durabilityProvider = new DurabilityProvider(
+                "storageProviderName",
+                orchestrationServiceMock.Object,
+                orchestrationServiceClientMock.Object,
+                TargetConnectionName);
+            var options = new DurableTaskOptions
+            {
+                WebhookUriProviderOverride = () => new Uri("http://localhost/runtime/webhooks/durabletask"),
+                HubName = TestConstants.TaskHub,
+            };
+            var extension = TestDurableTaskExtension.CreateWithProvider(options, durabilityProvider);
+            extension.RegisterOrchestrator(new FunctionName(FunctionName), orchestratorInfo: null);
+            var handler = new HttpApiHandler(extension, NullLogger.Instance);
+
+            HttpResponseMessage response = await handler.HandleRequestAsync(
+                new HttpRequestMessage(HttpMethod.Post, requestUri),
+                CancellationToken.None);
+
+            Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
+            orchestrationServiceClientMock.Verify(
+                p => p.CreateTaskOrchestrationAsync(
+                    It.IsAny<TaskMessage>(),
+                    It.IsAny<OrchestrationStatus[]>()),
+                Times.Once);
+        }
+
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public async Task StartNewInstance_AzureStorageCaseVariantTaskHub_RejectsLocallyDisabledFunction()
         {
             const string FunctionName = "DisabledOrchestrator";
             var requestUri = new Uri(
-                $"http://localhost/runtime/webhooks/durabletask/orchestrators/{FunctionName}?taskHub=testhubname");
+                $"http://localhost/runtime/webhooks/durabletask/orchestrators/{FunctionName}?taskHub=samplehubvs");
             var orchestrationServiceMock = new Mock<IOrchestrationService>(MockBehavior.Strict);
             var orchestrationServiceClientMock = new Mock<IOrchestrationServiceClient>();
             orchestrationServiceClientMock
@@ -2154,12 +2196,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 new HttpRequestMessage(HttpMethod.Post, requestUri),
                 CancellationToken.None);
 
-            Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
             orchestrationServiceClientMock.Verify(
                 p => p.CreateTaskOrchestrationAsync(
                     It.IsAny<TaskMessage>(),
                     It.IsAny<OrchestrationStatus[]>()),
-                Times.Once);
+                Times.Never);
         }
 
         private static DurableTaskExtension GetTestExtension()

--- a/test/FunctionsV2/Tests/Unit/LocalGrpcListenerTests.cs
+++ b/test/FunctionsV2/Tests/Unit/LocalGrpcListenerTests.cs
@@ -50,6 +50,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
     public class LocalGrpcListenerTests
     {
+        private const string ConnectionNameMetadataKey = "Durable-ConnectionName";
         private const string TaskHubMetadataKey = "Durable-TaskHub";
 
         // Host's configured hub for the task hub attribution test. Must be a constant so it can be
@@ -315,7 +316,64 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
         [Fact]
         [Trait("Category", PlatformSpecificHelpers.TestCategory)]
-        public async Task TestGrpcListener_CaseVariantTaskHub_DoesNotRejectLocallyDisabledFunction()
+        public async Task TestGrpcListener_DifferentConnection_DoesNotRejectLocallyDisabledFunction()
+        {
+            const string FunctionName = "DisabledOrchestrator";
+            const string HubName = "CurrentHub";
+            const string TargetConnectionName = "TargetConnection";
+            Mock<DurabilityProvider> targetProvider = CreateDurabilityProviderMock(
+                new Mock<IOrchestrationService>().Object,
+                new Mock<IOrchestrationServiceClient>().Object,
+                TargetConnectionName);
+            targetProvider
+                .Setup(provider => provider.CreateTaskOrchestrationAsync(
+                    It.IsAny<TaskMessage>(),
+                    It.IsAny<OrchestrationStatus[]>(),
+                    It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+            DurabilityProvider defaultProvider = CreateDurabilityProvider(
+                new Mock<IOrchestrationService>().Object,
+                new Mock<IOrchestrationServiceClient>().Object);
+            using DurableTaskExtension extension = this.CreateExtension(
+                HubName,
+                targetProvider.Object,
+                defaultProvider);
+            extension.RegisterOrchestrator(new FunctionName(FunctionName), orchestratorInfo: null);
+            ILocalGrpcListener listener = LocalGrpcListener.Create(
+                extension,
+                LocalGrpcListenerMode.AspNetCore);
+
+            try
+            {
+                await listener.StartAsync(default);
+                using GrpcChannel channel = GrpcChannel.ForAddress(listener.ListenAddress);
+                var client = new P.TaskHubSidecarService.TaskHubSidecarServiceClient(channel);
+                var headers = new Metadata
+                {
+                    { TaskHubMetadataKey, HubName },
+                    { ConnectionNameMetadataKey, TargetConnectionName },
+                };
+
+                await client.StartInstanceAsync(
+                    new P.CreateInstanceRequest { Name = FunctionName },
+                    headers).ResponseAsync;
+            }
+            finally
+            {
+                await listener.StopAsync(default);
+            }
+
+            targetProvider.Verify(
+                provider => provider.CreateTaskOrchestrationAsync(
+                    It.IsAny<TaskMessage>(),
+                    It.IsAny<OrchestrationStatus[]>(),
+                    It.IsAny<CancellationToken>()),
+                Times.Once);
+        }
+
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public async Task TestGrpcListener_ExactCaseProviderCaseVariantTaskHub_DoesNotRejectLocallyDisabledFunction()
         {
             const string FunctionName = "RemoteOrchestrator";
             Mock<DurabilityProvider> durabilityProvider = CreateDurabilityProviderMock(


### PR DESCRIPTION
## Summary

Fixes #3523.

This compatibility correction builds on merged PR #3514 (`477a92915cbeb46423fe55ceb36c036b845b00b0`). It keeps the single shared `DurableClient.ClientReferencesCurrentApp` gate introduced there, but compares a target client with the host's actual default durability provider instead of comparing the target provider with itself.

## Before / after

| Scenario | Before | After |
|---|---|---|
| Same exact TaskHub, different connection, missing orchestrator | Rejected by local metadata; target provider not called | Local validation skipped; target provider receives the start |
| Same exact TaskHub, different connection, missing entity | Rejected by local metadata; message not sent | Local validation skipped; entity signal is sent |
| Same exact TaskHub, different connection, locally startup-disabled orchestrator start/restart | Rejected locally | Local validation skipped; target backend receives start/restart |
| Azure Storage case-only TaskHub difference | Classified as remote | Classified as current app because Azure Storage hub identity is case-insensitive |
| Azure Managed / exact-case provider case-only TaskHub difference | Classified as remote | Remains classified as remote |
| `ExternalClient = true` | Bypasses local validation | Unchanged |
| Unknown registry key / disabled null entry / active or deregistered listener | #3514 behavior | Unchanged; only current-app classification is corrected |

## Design rationale

- `ClientReferencesCurrentApp` remains the only predicate used by missing-orchestrator, missing-entity, and startup-disabled-orchestrator validation.
- Connection identity is evaluated by virtual dispatch on `DurableTaskExtension.DefaultDurabilityProvider`, passing the target provider. This preserves provider-specific connection matching direction.
- TaskHub identity is an internal durability-provider semantic. The base implementation uses ordinal matching (including Azure Managed's shipped exact-case semantics), while Azure Storage overrides it with ordinal-ignore-case matching to reflect its lowercased storage resources.
- No provider-name string switches, public API additions, entity dispatch changes, or HTTP/gRPC error-mapping changes are introduced.

## Compatibility

The intentional behavior change is limited to local metadata validation at corrected current/remote boundaries. Cross-connection operations now reach their configured backend; Azure Storage case variants now receive current-app validation. Exact-case providers, the explicit external-client bypass, replay, and deregistered listener drain behavior remain unchanged.

## Tests

TDD RED evidence on `net8.0` before production changes:
- `DurableClientBaseTests`: 8 expected failures covering cross-connection missing/disabled orchestrator start, restart, entity signal, and Azure Storage case-only matching.
- HTTP cross-connection disabled start: expected `Accepted`, observed `BadRequest`.
- gRPC cross-connection disabled start: observed the expected pre-fix `InvalidArgument` local rejection.

GREEN results:
- Focused `DurableClientBaseTests`: 50/50 passed on `net8.0`; 50/50 passed on `net10.0`.
- Focused HTTP current/remote/missing/disabled tests: 4/4 passed on each TFM.
- Focused gRPC current/remote/unknown/disabled/restart tests: 5/5 passed on each TFM.
- Complete relevant classes (`DurableClientBaseTests`, `DisabledFunctionDispatchTests`, `HttpApiHandlerTests`, `LocalGrpcListenerTests`): 187/187 passed on `net8.0`; 187/187 passed on `net10.0`.
- `git -c core.whitespace=cr-at-eol diff --check`: passed.

A principal-level review found no critical or important findings.