### PR TITLE
Warn on truncated default task hub names

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/AzureStorageDurabilityProviderFactory.cs
+++ b/src/WebJobs.Extensions.DurableTask/AzureStorageDurabilityProviderFactory.cs
@@ -14,10 +14,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
     internal class AzureStorageDurabilityProviderFactory : IDurabilityProviderFactory
     {
         private const string LoggerName = "Host.Triggers.DurableTask.AzureStorage";
-        private const string TaskHubNamesDocumentationUrl =
-            "https://docs.azure.cn/en-us/durable-task/common/durable-task-hubs" +
-            "?tabs=csharp%2Cportal&pivots=durable-functions#task-hub-names";
-
+        private const string TaskHubNamesDocumentationUrl = "https://go.microsoft.com/fwlink/?LinkId=2377701";
         private const string UseLegacyPartitionManagementSettingName = "useLegacyPartitionManagement";
         private const string UseTablePartitionManagementSettingName = "useTablePartitionManagement";
         internal const string ProviderName = "AzureStorage";

--- a/src/WebJobs.Extensions.DurableTask/AzureStorageDurabilityProviderFactory.cs
+++ b/src/WebJobs.Extensions.DurableTask/AzureStorageDurabilityProviderFactory.cs
@@ -14,6 +14,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
     internal class AzureStorageDurabilityProviderFactory : IDurabilityProviderFactory
     {
         private const string LoggerName = "Host.Triggers.DurableTask.AzureStorage";
+        private const string TaskHubNamesDocumentationUrl =
+            "https://docs.azure.cn/en-us/durable-task/common/durable-task-hubs" +
+            "?tabs=csharp%2Cportal&pivots=durable-functions#task-hub-names";
+
         private const string UseLegacyPartitionManagementSettingName = "useLegacyPartitionManagement";
         private const string UseTablePartitionManagementSettingName = "useTablePartitionManagement";
         internal const string ProviderName = "AzureStorage";
@@ -141,8 +145,22 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 {
                     this.azureStorageOptions.ValidateHubName(this.options.HubName);
                 }
-                else if (!this.azureStorageOptions.IsSanitizedHubName(this.options.HubName, out string sanitizedHubName))
+                else if (!this.azureStorageOptions.IsSanitizedHubName(this.options.HubName, out string sanitizedHubName, out bool wasTruncated))
                 {
+                    if (wasTruncated)
+                    {
+                        ILogger logger = this.loggerFactory.CreateLogger(LoggerName);
+                        logger.LogWarning(
+                            "The default task hub name '{UnsanitizedHubName}' exceeds the 45-character limit and was truncated " +
+                            "to '{SanitizedHubName}'. " +
+                            "This may cause task hub collisions when multiple function apps use the same storage account. " +
+                            "Check the generated task hub name and configure a unique `hubName` in `host.json`. " +
+                            "For more information, see {TaskHubNamesDocumentationUrl}.",
+                            this.options.HubName,
+                            sanitizedHubName,
+                            TaskHubNamesDocumentationUrl);
+                    }
+
                     this.options.SetDefaultHubName(sanitizedHubName);
                 }
 

--- a/src/WebJobs.Extensions.DurableTask/IErrorSerializerSettingsFactory.cs
+++ b/src/WebJobs.Extensions.DurableTask/IErrorSerializerSettingsFactory.cs
@@ -13,6 +13,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// <summary>
         /// Creates or retrieves <see cref="JsonSerializerSettings"/> to be used throughout the extension for error serialization.
         /// </summary>
+        /// <remarks>
+        /// For more information about Durable Functions serialization and deserialization, see
+        /// <see href="https://go.microsoft.com/fwlink/?LinkId=2377701">the documentation</see>.
+        /// </remarks>
         /// <returns><see cref="JsonSerializerSettings"/> to be used by the Durable Task Extension for error serialization.</returns>
         JsonSerializerSettings CreateJsonSerializerSettings();
     }

--- a/src/WebJobs.Extensions.DurableTask/IMessageSerializerSettingsFactory.cs
+++ b/src/WebJobs.Extensions.DurableTask/IMessageSerializerSettingsFactory.cs
@@ -13,6 +13,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// <summary>
         /// Creates or retrieves <see cref="JsonSerializerSettings"/> to be used throughout the extension for message serialization.
         /// </summary>
+        /// <remarks>
+        /// For more information about Durable Functions serialization and deserialization, see
+        /// <see href="https://go.microsoft.com/fwlink/?LinkId=2377701">the documentation</see>.
+        /// </remarks>
         /// <returns><see cref="JsonSerializerSettings"/> to be used by the Durable Task Extension for message serialization.</returns>
         JsonSerializerSettings CreateJsonSerializerSettings();
     }

--- a/src/WebJobs.Extensions.DurableTask/Options/AzureStorageOptions.cs
+++ b/src/WebJobs.Extensions.DurableTask/Options/AzureStorageOptions.cs
@@ -285,7 +285,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             return $"Task hub name '{hubName}' should contain only alphanumeric characters, start with a letter, and have length between {MinTaskHubNameSize} and {MaxTaskHubNameSize}.";
         }
 
-        internal bool IsSanitizedHubName(string hubName, out string sanitizedHubName)
+        internal bool IsSanitizedHubName(string hubName, out string sanitizedHubName, out bool wasTruncated)
         {
             // Only alphanumeric characters are valid.
             var validHubNameCharacters = hubName.ToCharArray().Where(char.IsLetterOrDigit);
@@ -293,6 +293,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             if (!validHubNameCharacters.Any())
             {
                 sanitizedHubName = "DefaultTaskHub";
+                wasTruncated = false;
                 return false;
             }
 
@@ -304,6 +305,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 ((List<char>)validHubNameCharacters).Insert(0, 't');
             }
 
+            wasTruncated = validHubNameCharacters.Skip(MaxTaskHubNameSize).Any();
             sanitizedHubName = new string(validHubNameCharacters
                                 .Take(MaxTaskHubNameSize)
                                 .ToArray());

--- a/test/FunctionsV2/Tests/Unit/AzureStorageDurabilityProviderFactoryTests.cs
+++ b/test/FunctionsV2/Tests/Unit/AzureStorageDurabilityProviderFactoryTests.cs
@@ -371,7 +371,7 @@ namespace WebJobs.Extensions.DurableTask.Tests.V2
                 Assert.Contains("was truncated", warning.FormattedMessage);
                 Assert.Contains("task hub collisions", warning.FormattedMessage);
                 Assert.Contains(
-                    "https://docs.azure.cn/en-us/durable-task/common/durable-task-hubs?tabs=csharp%2Cportal&pivots=durable-functions#task-hub-names",
+                    "https://go.microsoft.com/fwlink/?LinkId=2377701",
                     warning.FormattedMessage);
             }
             finally

--- a/test/FunctionsV2/Tests/Unit/AzureStorageDurabilityProviderFactoryTests.cs
+++ b/test/FunctionsV2/Tests/Unit/AzureStorageDurabilityProviderFactoryTests.cs
@@ -334,6 +334,93 @@ namespace WebJobs.Extensions.DurableTask.Tests.V2
             Assert.Equal("Storage", provider.ConnectionName);
         }
 
+        // Tests that an unset hub name derived from a site name over 45 characters is truncated
+        // and logs a warning about possible collisions.
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public void DefaultHubNameDerivedFromLongSiteName_LogsCollisionWarning()
+        {
+            string originalSiteName = Environment.GetEnvironmentVariable("WEBSITE_SITE_NAME");
+            string siteName = new string('a', 47);
+            string expectedHubName = new string('a', 45);
+
+            try
+            {
+                Environment.SetEnvironmentVariable("WEBSITE_SITE_NAME", siteName);
+
+                // Leave HubName unset so DurableTaskOptions derives its default from WEBSITE_SITE_NAME.
+                var options = new DurableTaskOptions();
+                var loggerProvider = new TestLoggerProvider(null);
+                using var loggerFactory = new LoggerFactory();
+                loggerFactory.AddProvider(loggerProvider);
+                var factory = new AzureStorageDurabilityProviderFactory(
+                    new OptionsWrapper<DurableTaskOptions>(options),
+                    new TestStorageServiceClientProviderFactory(),
+                    new Mock<INameResolver>().Object,
+                    loggerFactory,
+                    TestHelpers.GetMockPlatformInformationService());
+
+                factory.GetDurabilityProvider();
+
+                Assert.Equal(expectedHubName, options.HubName);
+                var warning = Assert.Single(
+                    loggerProvider.GetAllLogMessages(),
+                    message =>
+                        message.Level == LogLevel.Warning &&
+                        message.FormattedMessage.Contains("The default task hub name"));
+                Assert.Contains("was truncated", warning.FormattedMessage);
+                Assert.Contains("task hub collisions", warning.FormattedMessage);
+                Assert.Contains(
+                    "https://docs.azure.cn/en-us/durable-task/common/durable-task-hubs?tabs=csharp%2Cportal&pivots=durable-functions#task-hub-names",
+                    warning.FormattedMessage);
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("WEBSITE_SITE_NAME", originalSiteName);
+            }
+        }
+
+        // Tests that an unset hub name derived from a 45-character site name remains unchanged
+        // and does not log a collision warning.
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public void DefaultHubNameDerivedFromSiteNameAtLimit_DoesNotLogCollisionWarning()
+        {
+            string originalSiteName = Environment.GetEnvironmentVariable("WEBSITE_SITE_NAME");
+            string siteName = new string('a', 45);
+
+            try
+            {
+                Environment.SetEnvironmentVariable("WEBSITE_SITE_NAME", siteName);
+
+                // Leave HubName unset so DurableTaskOptions derives its default from WEBSITE_SITE_NAME.
+                var options = new DurableTaskOptions();
+                var loggerProvider = new TestLoggerProvider(null);
+                using var loggerFactory = new LoggerFactory();
+                loggerFactory.AddProvider(loggerProvider);
+                var factory = new AzureStorageDurabilityProviderFactory(
+                    new OptionsWrapper<DurableTaskOptions>(options),
+                    new TestStorageServiceClientProviderFactory(),
+                    new Mock<INameResolver>().Object,
+                    loggerFactory,
+                    TestHelpers.GetMockPlatformInformationService());
+
+                factory.GetDurabilityProvider();
+
+                // A site name at the limit remains unchanged and does not produce a warning.
+                Assert.Equal(siteName, options.HubName);
+                Assert.DoesNotContain(
+                    loggerProvider.GetAllLogMessages(),
+                    message =>
+                        message.Level == LogLevel.Warning &&
+                        message.FormattedMessage.Contains("task hub collisions"));
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("WEBSITE_SITE_NAME", originalSiteName);
+            }
+        }
+
         private static DurableTaskOptions BindDurableTaskOptions(
             IDictionary<string, string> storageProviderSettings)
         {


### PR DESCRIPTION
When hubName is not configured and the Azure Storage backend is used, the default task hub name is derived from the Functions app name and truncated to 45 characters when exceeds the limit. This PR adds a warning when the default task hub name is truncated to 45 characters, as this may result in collisions between apps with same storage account. The warning recommends configuring a unique hubName and provides a link to the relevant documentation. This PR also adds tests covering app names at and above the 45-character limit.

---

# Project checklist
- [ ] Documentation changes are not required
  - [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
- [ ] Release notes are not required for the next release
  - [ ] Otherwise: Notes added to `release_notes.md`
- [ ] Backport is not required
  - [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
- [ ] All required tests have been added/updated (unit tests, E2E tests)
- [ ] No extra work is required to be leveraged by OutOfProc SDKs
  - [ ] Otherwise: Work tracked here: #issue_or_pr_in_each_sdk
- [ ] No change to the version of the `WebJobs.Extensions.DurableTask` package
  - [ ] Otherwise: Major/minor updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
- [ ] No EventIds were added to `EventSource` logs
  - [ ] Otherwise: Ensure EventIds are within the supported range in the existing Windows infrastructure (validate via deployed telemetry). If needed, extend the range via a PR such as https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files
- [ ] This change should be added to the `v2.x` branch
  - [ ] Otherwise: This change applies exclusively to `WebJobs.Extensions.DurableTask` v3.x and will be retained only in the `dev` and `main` branches
- [ ] Breaking change?
  - [ ] If yes:
    - Impact:
    - Migration guidance:
---

# AI-assisted code disclosure (required)
## Was an AI tool used? (select one)
- [ ] No
- [ ] Yes, AI helped write parts of this PR (e.g., GitHub Copilot)
- [ ] Yes, an AI agent generated most of this PR

If AI was used:
- Tool(s):
- AI-assisted areas/files:
- What you changed after AI output:

AI verification (required if AI was used):
- [ ] I understand the code and can explain it
- [ ] I verified referenced APIs/types exist and are correct
- [ ] I reviewed edge cases/failure paths (timeouts, retries, cancellation, exceptions)
- [ ] I reviewed concurrency/async behavior
- [ ] I checked for unintended breaking or behavior changes

---

# Testing
## Automated tests
- Result: Passed / Failed (link logs if failed)

## Manual validation (only if runtime/behavior changed)
- Environment (OS, .NET version, components):
- Steps + observed results:
  1.
  2.
  3.
- Evidence (optional):

---

# Notes for reviewers
- N/A
