### PR TITLE
 Expose orchestration version in HTTP status responses 

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableClient.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableClient.cs
@@ -1209,6 +1209,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             return new DurableOrchestrationStatus
             {
                 Name = orchestrationState.Name,
+                Version = orchestrationState.Version,
                 InstanceId = orchestrationState.OrchestrationInstance.InstanceId,
                 ParentInstanceId = orchestrationState.ParentInstance?.OrchestrationInstance?.InstanceId,
                 CreatedTime = orchestrationState.CreatedTime,

--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableClient.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableClient.cs
@@ -1209,7 +1209,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             return new DurableOrchestrationStatus
             {
                 Name = orchestrationState.Name,
-                Version = orchestrationState.Version,
+                Version = string.IsNullOrEmpty(orchestrationState.Version) ? null : orchestrationState.Version,
                 InstanceId = orchestrationState.OrchestrationInstance.InstanceId,
                 ParentInstanceId = orchestrationState.ParentInstance?.OrchestrationInstance?.InstanceId,
                 CreatedTime = orchestrationState.CreatedTime,

--- a/src/WebJobs.Extensions.DurableTask/DurableOrchestrationStatus.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableOrchestrationStatus.cs
@@ -24,6 +24,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         public string Name { get; set; }
 
         /// <summary>
+        /// Gets the version assigned to the queried orchestration instance.
+        /// </summary>
+        /// <value>
+        /// The orchestration version, or <c>null</c> if no version was assigned.
+        /// </value>
+        public string Version { get; set; }
+
+        /// <summary>
         /// Gets the ID of the queried orchestration instance.
         /// </summary>
         /// <remarks>

--- a/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
+++ b/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
@@ -747,6 +747,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             return new StatusResponsePayload
             {
                 Name = status.Name,
+                Version = status.Version,
                 InstanceId = status.InstanceId,
                 ParentInstanceId = status.ParentInstanceId,
                 RuntimeStatus = status.RuntimeStatus.ToString(),

--- a/src/WebJobs.Extensions.DurableTask/StatusResponsePayload.cs
+++ b/src/WebJobs.Extensions.DurableTask/StatusResponsePayload.cs
@@ -19,6 +19,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         public string Name { get; set; }
 
         /// <summary>
+        /// Orchestration version.
+        /// </summary>
+        [DataMember(Name = "version", EmitDefaultValue = false)]
+        public string Version { get; set; }
+
+        /// <summary>
         /// InstanceId.
         /// </summary>
         [DataMember(Name = "instanceId")]

--- a/test/FunctionsV2/Tests/Unit/DurableClientBaseTests.cs
+++ b/test/FunctionsV2/Tests/Unit/DurableClientBaseTests.cs
@@ -591,19 +591,21 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             Assert.Equal(ParentInstanceId, status.ParentInstanceId);
         }
 
-        [Fact]
+        [Theory]
+        [InlineData("2.0", "2.0")]
+        [InlineData("", null)]
+        [InlineData(null, null)]
         [Trait("Category", PlatformSpecificHelpers.TestCategory)]
-        public async Task GetStatusAsync_IncludesVersion()
+        public async Task GetStatusAsync_NormalizesVersion(string orchestrationVersion, string expectedVersion)
         {
-            const string Version = "2.0";
             var orchestrationServiceClientMock = new Mock<IOrchestrationServiceClient>();
             orchestrationServiceClientMock.Setup(x => x.GetOrchestrationStateAsync(It.IsAny<string>(), It.IsAny<bool>()))
-                .ReturnsAsync(GetInstanceState(OrchestrationStatus.Running, version: Version));
+                .ReturnsAsync(GetInstanceState(OrchestrationStatus.Running, version: orchestrationVersion));
 
             var durableOrchestrationClient = this.GetDurableClient(orchestrationServiceClientMock.Object);
             DurableOrchestrationStatus status = await durableOrchestrationClient.GetStatusAsync("testInstanceId");
 
-            Assert.Equal(Version, status.Version);
+            Assert.Equal(expectedVersion, status.Version);
         }
 
         [Fact]

--- a/test/FunctionsV2/Tests/Unit/DurableClientBaseTests.cs
+++ b/test/FunctionsV2/Tests/Unit/DurableClientBaseTests.cs
@@ -593,6 +593,21 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
         [Fact]
         [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public async Task GetStatusAsync_IncludesVersion()
+        {
+            const string Version = "2.0";
+            var orchestrationServiceClientMock = new Mock<IOrchestrationServiceClient>();
+            orchestrationServiceClientMock.Setup(x => x.GetOrchestrationStateAsync(It.IsAny<string>(), It.IsAny<bool>()))
+                .ReturnsAsync(GetInstanceState(OrchestrationStatus.Running, version: Version));
+
+            var durableOrchestrationClient = this.GetDurableClient(orchestrationServiceClientMock.Object);
+            DurableOrchestrationStatus status = await durableOrchestrationClient.GetStatusAsync("testInstanceId");
+
+            Assert.Equal(Version, status.Version);
+        }
+
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
         public async Task DurableClient_ExternalApp_TerminateAsync_TerminateEventPlaced()
         {
             var orchestrationServiceClientMock = new Mock<IOrchestrationServiceClient>();
@@ -784,12 +799,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             return null;
         }
 
-        private static List<OrchestrationState> GetInstanceState(OrchestrationStatus status, string parentInstanceId = null)
+        private static List<OrchestrationState> GetInstanceState(
+            OrchestrationStatus status,
+            string parentInstanceId = null,
+            string version = null)
         {
             return new List<OrchestrationState>()
             {
                 new OrchestrationState()
                 {
+                    Version = version,
                     OrchestrationInstance = new OrchestrationInstance
                     {
                         InstanceId = "valid_instance_id",

--- a/test/FunctionsV2/Tests/Unit/HttpApiHandlerTests.cs
+++ b/test/FunctionsV2/Tests/Unit/HttpApiHandlerTests.cs
@@ -508,12 +508,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                     new DurableOrchestrationStatus
                     {
                         Name = "DoThis",
+                        Version = "1.0",
                         InstanceId = "01",
                         RuntimeStatus = OrchestrationRuntimeStatus.Running,
                     },
                     new DurableOrchestrationStatus
                     {
                         Name = "DoThat",
+                        Version = "2.0",
                         InstanceId = "02",
                         RuntimeStatus = OrchestrationRuntimeStatus.Completed,
                     },
@@ -541,9 +543,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             var actual = JsonConvert.DeserializeObject<IList<StatusResponsePayload>>(await responseMessage.Content.ReadAsStringAsync());
 
             Assert.Equal("DoThis", actual[0].Name);
+            Assert.Equal("1.0", actual[0].Version);
             Assert.Equal("01", actual[0].InstanceId);
             Assert.Equal("Running", actual[0].RuntimeStatus);
             Assert.Equal("DoThat", actual[1].Name);
+            Assert.Equal("2.0", actual[1].Version);
             Assert.Equal("02", actual[1].InstanceId);
             Assert.Equal("Completed", actual[1].RuntimeStatus);
         }
@@ -871,6 +875,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 new DurableOrchestrationStatus
                 {
                     Name = "DoThis",
+                    Version = "2.0",
                     InstanceId = instanceId,
                     RuntimeStatus = OrchestrationRuntimeStatus.Completed,
                 },
@@ -896,6 +901,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             var actual = JsonConvert.DeserializeObject<StatusResponsePayload>(await responseMessage.Content.ReadAsStringAsync());
             Assert.Equal(HttpStatusCode.OK, responseMessage.StatusCode);
             Assert.Equal(instanceId, actual.InstanceId);
+            Assert.Equal("2.0", actual.Version);
         }
 
         [Theory]

--- a/test/FunctionsV2/Tests/Unit/HttpApiHandlerTests.cs
+++ b/test/FunctionsV2/Tests/Unit/HttpApiHandlerTests.cs
@@ -519,6 +519,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                         InstanceId = "02",
                         RuntimeStatus = OrchestrationRuntimeStatus.Completed,
                     },
+                    new DurableOrchestrationStatus
+                    {
+                        Name = "DoOther",
+                        InstanceId = "03",
+                        RuntimeStatus = OrchestrationRuntimeStatus.Pending,
+                    },
                 },
             };
 
@@ -540,7 +546,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 CancellationToken.None);
             Assert.Equal(HttpStatusCode.OK, responseMessage.StatusCode);
             Assert.Equal(string.Empty, responseMessage.Headers.GetValues("x-ms-continuation-token").FirstOrDefault());
-            var actual = JsonConvert.DeserializeObject<IList<StatusResponsePayload>>(await responseMessage.Content.ReadAsStringAsync());
+            string responseContent = await responseMessage.Content.ReadAsStringAsync();
+            var actual = JsonConvert.DeserializeObject<IList<StatusResponsePayload>>(responseContent);
+            JArray responsePayload = JArray.Parse(responseContent);
 
             Assert.Equal("DoThis", actual[0].Name);
             Assert.Equal("1.0", actual[0].Version);
@@ -550,6 +558,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             Assert.Equal("2.0", actual[1].Version);
             Assert.Equal("02", actual[1].InstanceId);
             Assert.Equal("Completed", actual[1].RuntimeStatus);
+            Assert.Null(((JObject)responsePayload[2]).Property("version"));
         }
 
         [Fact]

--- a/test/e2e/Apps/BasicNode/src/functions/VersionedOrchestration.ts
+++ b/test/e2e/Apps/BasicNode/src/functions/VersionedOrchestration.ts
@@ -1,0 +1,32 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+import { app, HttpHandler, HttpRequest, HttpResponse, InvocationContext } from "@azure/functions";
+import * as df from "durable-functions";
+import { OrchestrationContext, OrchestrationHandler } from "durable-functions";
+
+const VersionedOrchestration: OrchestrationHandler = function* (
+    context: OrchestrationContext
+) {
+    return `Version: '${context.df.version}'`;
+};
+df.app.orchestration("VersionedOrchestration", VersionedOrchestration);
+
+const HttpStart: HttpHandler = async (
+    request: HttpRequest,
+    context: InvocationContext
+): Promise<HttpResponse> => {
+    const client = df.getClient(context);
+    const version = request.query.get("version") ?? undefined;
+    const instanceId = await client.startNew("VersionedOrchestration", { version });
+
+    context.log(`Started orchestration with ID = '${instanceId}' and Version = '${version}'.`);
+
+    return client.createCheckStatusResponse(request, instanceId);
+};
+
+app.http("OrchestrationVersion_HttpStart", {
+    route: "OrchestrationVersion_HttpStart",
+    extraInputs: [df.input.durableClient()],
+    handler: HttpStart,
+});

--- a/test/e2e/Tests/Helpers/DurableHelpers.cs
+++ b/test/e2e/Tests/Helpers/DurableHelpers.cs
@@ -19,6 +19,7 @@ internal class DurableHelpers
     internal class OrchestrationStatusDetails
     {
         public string InstanceId { get; set; } = string.Empty;
+        public string Version { get; set; } = string.Empty;
         public string RuntimeStatus { get; set; } = string.Empty;
         public string Input { get; set; } = string.Empty;
         public string Output { get; set; } = string.Empty;
@@ -36,6 +37,7 @@ internal class DurableHelpers
                 return;
             }
             this.InstanceId = statusQueryJsonNode["instanceId"]?.GetValue<string>() ?? string.Empty;
+            this.Version = statusQueryJsonNode["version"]?.GetValue<string>() ?? string.Empty;
             this.RuntimeStatus = statusQueryJsonNode["runtimeStatus"]?.GetValue<string>() ?? string.Empty;
             this.Input = statusQueryJsonNode["input"]?.ToString() ?? string.Empty;
             this.Output = statusQueryJsonNode["output"]?.ToString() ?? string.Empty;

--- a/test/e2e/Tests/Tests/VersioningTests.cs
+++ b/test/e2e/Tests/Tests/VersioningTests.cs
@@ -54,6 +54,28 @@ public class VersioningTests
         }
     }
 
+    [Fact]
+    [Trait("Dotnet", "Skip")] // This scenario validates the JavaScript client and BasicNode app.
+    [Trait("PowerShell", "Skip")] // See notes on TestVersionedOrchestration_OKWithMatchingVersion
+    [Trait("Python", "Skip")] // See notes on TestVersionedOrchestration_OKWithMatchingVersion
+    [Trait("Java", "Skip")] // See notes on TestVersionedOrchestration_OKWithMatchingVersion
+    public async Task TestVersionedOrchestration_StatusResponseIncludesVersion()
+    {
+        const string Version = "1.0";
+        using HttpResponseMessage response = await HttpHelpers.InvokeHttpTrigger(
+            "OrchestrationVersion_HttpStart",
+            $"?version={Version}");
+
+        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
+        string statusQueryGetUri = await DurableHelpers.ParseStatusQueryGetUriAsync(response);
+        await DurableHelpers.WaitForOrchestrationStateAsync(statusQueryGetUri, "Completed", 30);
+
+        DurableHelpers.OrchestrationStatusDetails orchestrationDetails =
+            await DurableHelpers.GetRunningOrchestrationDetailsAsync(statusQueryGetUri);
+
+        Assert.Equal(Version, orchestrationDetails.Version);
+    }
+
     [Theory]
     [InlineData(null)] // Represents a non-versioned case.
     [InlineData("")] // Non-versioned/empty-versioned case.


### PR DESCRIPTION
# Summary
## What changed?
- Added orchestration version metadata to Durable Functions status models and HTTP status responses.
- `DurableOrchestrationStatus.Version` is now populated from the persisted orchestration state.
- HTTP single-instance and collection status responses now include an optional `version` field.
- Added unit coverage and a Node E2E scenario for versioned orchestration status responses.

## Why is this change needed?
- This lets applications and operators verify which orchestration version an instance is running without duplicating version information in input, inspecting history, or manually storing it in a custom status.

## Example

The HTTP GET orchestration status response now includes the effective orchestration version:

```json
{
  "name": "processOrder",
  "instanceId": "order-123",
  "version": "2.0",
  "runtimeStatus": "Running",
  "createdTime": "2026-08-27T17:00:00Z",
  "lastUpdatedTime": "2026-08-27T17:00:05Z",
  "input": {},
  "customStatus": null,
  "output": null
}
```

If version information is unavailable, the `version` field is omitted.

# Project checklist
- [ ] Documentation changes are not required
  - [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
- [ ] Release notes are not required for the next release
  - [ ] Otherwise: Notes added to `release_notes.md`
- [x] Backport is not required
  - [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
- [x] All required tests have been added/updated (unit tests, E2E tests)
- [ ] No extra work is required to be leveraged by OutOfProc SDKs
  - [x] Otherwise: Work tracked here: companion JavaScript SDK PR #
- [x] No change to the version of the `WebJobs.Extensions.DurableTask` package
  - [ ] Otherwise: Major/minor updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
- [x] No EventIds were added to `EventSource` logs
  - [ ] Otherwise: Ensure EventIds are within the supported range in the existing Windows infrastructure (validate via deployed telemetry). If needed, extend the range via a PR such as https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files
- [ ] This change should be added to the `v2.x` branch
  - [x] Otherwise: This change applies exclusively to `WebJobs.Extensions.DurableTask` v3.x and will be retained only in the `dev` and `main` branches
- [ ] Breaking change?
  - [ ] If yes:
    - Impact:
    - Migration guidance:
---

# AI-assisted code disclosure (required)
## Was an AI tool used? (select one)
- [ ] No
- [ ] Yes, AI helped write parts of this PR (e.g., GitHub Copilot)
- [x] Yes, an AI agent generated most of this PR

If AI was used:
- Tool(s): GitHub Copilot CLI
- AI-assisted areas/files:
  - `src/WebJobs.Extensions.DurableTask/DurableOrchestrationStatus.cs`
  - `src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableClient.cs`
  - `src/WebJobs.Extensions.DurableTask/StatusResponsePayload.cs`
  - `src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs`
  - `test/FunctionsV2/Tests/Unit/DurableClientBaseTests.cs`
  - `test/FunctionsV2/Tests/Unit/HttpApiHandlerTests.cs`
  - `test/e2e/Tests/Helpers/DurableHelpers.cs`
  - `test/e2e/Tests/Tests/VersioningTests.cs`
  - `test/e2e/Apps/BasicNode/src/functions/VersionedOrchestration.ts`
- What you changed after AI output: Reviewed the implementation, ran targeted validation, and committed the final changes.

AI verification (required if AI was used):
- [x] I understand the code and can explain it
- [x] I verified referenced APIs/types exist and are correct
- [x] I reviewed edge cases/failure paths (timeouts, retries, cancellation, exceptions)
- [x] I reviewed concurrency/async behavior
- [x] I checked for unintended breaking or behavior changes

---

# Testing
## Automated tests
- Result: Passed

## Manual validation (only if runtime/behavior changed)
- Environment: Windows, Durable Functions extension E2E test app, Docker Azurite, locally packed JavaScript SDK package.
- Steps + observed results:
  1. Started Azurite in Docker.
  2. Ran the focused BasicNode E2E scenario for a versioned orchestration.
  3. Confirmed the HTTP status response included the expected `version` value.

---

# Notes for reviewers
- This is the extension side of the orchestration version status feature.
- Companion JavaScript SDK PR: #
- The `version` field is optional and omitted when no version metadata is available.