### PR TITLE
Return HTTP 400 when makeprimary app lease is disabled

### DIFF
--- a/pending_docs.md
+++ b/pending_docs.md
@@ -1,2 +1,4 @@
 <!-- Please include a link to your pending docs PR below. https://docs.microsoft.com/en-us/azure/azure-functions/durable ([private docs repo for Microsoft employees](http://github.com/MicrosoftDocs/azure-docs-pr)). 
 Your code PR should not be merged until your docs PR has been approved. Wait to #sign-off until release. -->
+
+https://github.com/MicrosoftDocs/azure-docs-pr/pull/320038

--- a/release_notes.md
+++ b/release_notes.md
@@ -25,6 +25,7 @@
 
 ### Bug Fixes
 
+- The `/makeprimary` HTTP API now returns HTTP 400 with an actionable error when app leases are disabled, instead of returning HTTP 500. (#3534)
 - Fixed a poison loop where dispatching a disabled-but-still-deployed activity or entity function caused in-flight orchestrations to retry indefinitely (e.g. throwing `ArgumentNullException('executor')` on the activity dispatch path) instead of failing gracefully. Such registered-but-inactive functions are now treated as unavailable and fail deterministically. (#3471)
 - Fixed the Event Grid `Terminated` lifecycle notification never being published when an orchestration is terminated. It is now raised from the orchestration dispatch middleware, which covers both the in-process/legacy out-of-proc path and the middleware-passthrough path. Previously no notification was sent at all on the former, and the latter incorrectly published a `Completed` notification. (#286)
 - Fixed empty Application Insights operation names for Distributed Tracing V2 orchestration and activity telemetry when instance ID suffixes are disabled. (#3156)

--- a/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
+++ b/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
@@ -735,6 +735,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
         private async Task<HttpResponseMessage> HandleMakePrimaryRequestAsync(HttpRequestMessage request)
         {
+            if (!this.durableTaskOptions.UseAppLease)
+            {
+                return request.CreateErrorResponse(
+                    HttpStatusCode.BadRequest,
+                    "Cannot make current app primary. This app is not using the AppLease feature.");
+            }
+
             IDurableOrchestrationClient client = this.GetClient(request);
 
             await client.MakeCurrentAppPrimaryAsync();

--- a/test/FunctionsV2/Tests/Unit/HttpApiHandlerTests.cs
+++ b/test/FunctionsV2/Tests/Unit/HttpApiHandlerTests.cs
@@ -2162,6 +2162,97 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                 Times.Once);
         }
 
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public async Task MakePrimary_Returns_HTTP_400_When_AppLease_Is_Disabled()
+        {
+            (HttpApiHandler handler, Mock<DurabilityProvider> provider) =
+                CreateMakePrimaryHandler(useAppLease: false);
+            provider
+                .Setup(p => p.MakeCurrentAppPrimaryAsync())
+                .Returns(Task.CompletedTask);
+
+            HttpResponseMessage response = await handler.HandleRequestAsync(
+                new HttpRequestMessage(
+                    HttpMethod.Post,
+                    "http://localhost/runtime/webhooks/durabletask/makeprimary"),
+                CancellationToken.None);
+
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+            string content = await response.Content.ReadAsStringAsync();
+            var error = JsonConvert.DeserializeObject<JObject>(content);
+            Assert.Equal(
+                "Cannot make current app primary. This app is not using the AppLease feature.",
+                error["Message"].ToString());
+            provider.Verify(p => p.MakeCurrentAppPrimaryAsync(), Times.Never);
+        }
+
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public async Task MakePrimary_Returns_HTTP_200_When_AppLease_Is_Enabled()
+        {
+            (HttpApiHandler handler, Mock<DurabilityProvider> provider) =
+                CreateMakePrimaryHandler(useAppLease: true);
+            provider
+                .Setup(p => p.MakeCurrentAppPrimaryAsync())
+                .Returns(Task.CompletedTask);
+
+            HttpResponseMessage response = await handler.HandleRequestAsync(
+                new HttpRequestMessage(
+                    HttpMethod.Post,
+                    "http://localhost/runtime/webhooks/durabletask/makeprimary"),
+                CancellationToken.None);
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Empty(await response.Content.ReadAsByteArrayAsync());
+            provider.Verify(p => p.MakeCurrentAppPrimaryAsync(), Times.Once);
+        }
+
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public async Task MakePrimary_Returns_HTTP_500_When_Provider_Fails()
+        {
+            (HttpApiHandler handler, Mock<DurabilityProvider> provider) =
+                CreateMakePrimaryHandler(useAppLease: true);
+            provider
+                .Setup(p => p.MakeCurrentAppPrimaryAsync())
+                .ThrowsAsync(new InvalidOperationException("Provider failure."));
+
+            HttpResponseMessage response = await handler.HandleRequestAsync(
+                new HttpRequestMessage(
+                    HttpMethod.Post,
+                    "http://localhost/runtime/webhooks/durabletask/makeprimary"),
+                CancellationToken.None);
+
+            Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
+            string content = await response.Content.ReadAsStringAsync();
+            var error = JsonConvert.DeserializeObject<JObject>(content);
+            Assert.Equal("Something went wrong while processing your request", error["Message"].ToString());
+            provider.Verify(p => p.MakeCurrentAppPrimaryAsync(), Times.Once);
+        }
+
+        private static (HttpApiHandler Handler, Mock<DurabilityProvider> Provider) CreateMakePrimaryHandler(
+            bool useAppLease)
+        {
+            var orchestrationService = new Mock<IOrchestrationService>();
+            var orchestrationServiceClient = new Mock<IOrchestrationServiceClient>();
+            var provider = new Mock<DurabilityProvider>(
+                "storageProviderName",
+                orchestrationService.Object,
+                orchestrationServiceClient.Object,
+                TestConstants.ConnectionName);
+            var options = new DurableTaskOptions
+            {
+                UseAppLease = useAppLease,
+                WebhookUriProviderOverride = () =>
+                    new Uri("http://localhost/runtime/webhooks/durabletask"),
+                HubName = TestConstants.TaskHub,
+            };
+            var extension = TestDurableTaskExtension.CreateWithProvider(options, provider.Object);
+
+            return (new HttpApiHandler(extension, NullLogger.Instance), provider);
+        }
+
         private static DurableTaskExtension GetTestExtension()
         {
             var options = new DurableTaskOptions();


### PR DESCRIPTION
Fixes #3534

## Problem

Calling `POST /runtime/webhooks/durabletask/makeprimary` with app leases disabled currently throws `InvalidOperationException`, which the HTTP handler maps to a generic HTTP 500 response. This is a deterministic configuration error and should be reported as a bad request.

## Change

- Return HTTP 400 with the existing actionable app-lease message before creating the durable client when `useAppLease` is disabled.
- Preserve HTTP 200 and provider invocation when app leases are enabled.
- Preserve HTTP 500 for provider and operation failures.
- Add the fix to the release notes.

## Tests

- `HttpApiHandlerTests`: 86 passed on net8.0
- `HttpApiHandlerTests`: 86 passed on net10.0

## Documentation

Companion docs PR: https://github.com/MicrosoftDocs/azure-docs-pr/pull/320038