### PR TITLE
Bind the local gRPC listener to a dynamic port

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -28,6 +28,7 @@
 - Fixed a poison loop where dispatching a disabled-but-still-deployed activity or entity function caused in-flight orchestrations to retry indefinitely (e.g. throwing `ArgumentNullException('executor')` on the activity dispatch path) instead of failing gracefully. Such registered-but-inactive functions are now treated as unavailable and fail deterministically. (#3471)
 - Fixed the Event Grid `Terminated` lifecycle notification never being published when an orchestration is terminated. It is now raised from the orchestration dispatch middleware, which covers both the in-process/legacy out-of-proc path and the middleware-passthrough path. Previously no notification was sent at all on the former, and the latter incorrectly published a `Completed` notification. (#286)
 - Fixed empty Application Insights operation names for Distributed Tracing V2 orchestration and activity telemetry when instance ID suffixes are disabled. (#3156)
+- Fixed the local gRPC listener failing to start when the port it had probed for became unavailable between the probe and the actual bind. Kestrel now requests a dynamic port (`0`) so the OS assigns it as part of the bind itself, closing the race window; the bound address is still discovered through `IServerAddressesFeature`. Previously this surfaced as a `FunctionListenerException` wrapping a `SocketException` and left the Durable trigger listener unable to start.
 
 ### Breaking Changes
 

--- a/src/WebJobs.Extensions.DurableTask/Grpc/AspNetCoreLocalGrpcListener.cs
+++ b/src/WebJobs.Extensions.DurableTask/Grpc/AspNetCoreLocalGrpcListener.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Linq;
 using System.Net;
-using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
@@ -130,13 +129,17 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Grpc
 
         private async Task StartInternalAsync(CancellationToken cancellationToken)
         {
-            int port = GetFreeTcpPort();
             IHost newHost = new HostBuilder().ConfigureWebHost(
                 builder =>
                 {
+                    // Bind to port 0 and let the OS pick a free port as part of the bind itself.
+                    // Probing for a free port in a separate socket and then binding it here leaves a
+                    // window where the port can be taken (or become unbindable) in between, which
+                    // surfaces as an unrecoverable SocketException. The port that was actually bound
+                    // is read back from IServerAddressesFeature below.
                     builder.UseKestrel(o => o.Listen(
                         IPAddress.Parse(HostName),
-                        port,
+                        0,
                         listenOptions => listenOptions.Protocols = HttpProtocols.Http2));
 
                     builder.ConfigureServices(services =>
@@ -177,14 +180,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Grpc
             IServerAddressesFeature? addressFeature = server?.Features.Get<IServerAddressesFeature>();
             this.ListenAddress = addressFeature?.Addresses.SingleOrDefault();
 
-            var expected = new Uri($"http://{HostName}:{port}");
-            if (!Uri.TryCreate(this.ListenAddress, UriKind.Absolute, out Uri? uri) || expected != uri)
+            if (!Uri.TryCreate(this.ListenAddress, UriKind.Absolute, out Uri? uri) || uri.Port == 0)
             {
                 this.extension.TraceHelper.ExtensionWarningEvent(
                     this.extension.Options.HubName,
                     instanceId: string.Empty,
                     functionName: string.Empty,
-                    message: $"Configured Uri ({expected}) does not match actual Uri ({uri}).");
+                    message: $"Unexpected listen address reported by the server: {this.ListenAddress ?? "null"}.");
             }
 
             this.extension.TraceHelper.ExtensionInformationalEvent(
@@ -265,20 +267,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Grpc
                 this.host = null;
                 this.ListenAddress = null;
                 this.addressReady = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
-            }
-        }
-
-        private static int GetFreeTcpPort()
-        {
-            var listener = new TcpListener(IPAddress.Loopback, 0);
-            try
-            {
-                listener.Start();
-                return ((IPEndPoint)listener.LocalEndpoint).Port;
-            }
-            finally
-            {
-                listener.Stop();
             }
         }
     }


### PR DESCRIPTION
# Summary
## What changed?
- `AspNetCoreLocalGrpcListener` now lets Kestrel bind a dynamic port (`o.Listen(IPAddress.Parse(HostName), 0, ...)`) instead of probing for a free port with a temporary `TcpListener` and then binding that port number in a separate call.
- Removed `GetFreeTcpPort()`, and the `System.Net.Sockets` using directive that only existed for it.
- The post-start sanity check no longer compares against a pre-computed URI. It now warns when the address reported by the server does not parse or resolves to port `0`.
- `ListenAddress` is still read from `IServerAddressesFeature`, so the value handed to out-of-proc workers is unchanged (`http://127.0.0.1:<port>`).

## Why is this change needed?
`GetFreeTcpPort()` closes its probe socket before Kestrel binds, so there is a window in which the port can be taken by another socket or otherwise become unbindable. There is no retry or exception handling around `newHost.StartAsync(...)`, and `DurableTaskExtension.InitializeTaskHubWorker` starts the listener synchronously, so a single failed bind fails the entire Durable trigger listener:

```
Microsoft.Azure.WebJobs.Host.Listeners.FunctionListenerException:
System.Net.Sockets.SocketException:
   at System.Net.Sockets.Socket.DoBind
   at Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.SocketTransportOptions.CreateDefaultBoundListenSocket
   at Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.SocketConnectionListener.Bind
   ...
   at ...DurableTask.Grpc.AspNetCoreLocalGrpcListener+<StartInternalAsync>d__10.MoveNext (AspNetCoreLocalGrpcListener.cs:95)
   at ...DurableTask.Grpc.AspNetCoreLocalGrpcListener+<StartAsync>d__9.MoveNext (AspNetCoreLocalGrpcListener.cs:49)
   at ...DurableTask.DurableTaskExtension.InitializeTaskHubWorker (DurableTaskExtension.cs:247)
   at Microsoft.Azure.WebJobs.Host.Listeners.FunctionListener+<StartAsync>d__13.MoveNext (FunctionListener.cs:68)
```

Note that the inner exception is a raw `SocketException`, not "address already in use": Kestrel converts only `SocketError.AddressAlreadyInUse` into `AddressInUseException` / `IOException` ([SocketConnectionListener.cs#L46](https://github.com/dotnet/aspnetcore/blob/release/10.0/src/Servers/Kestrel/Transport.Sockets/src/SocketConnectionListener.cs#L46), [AddressBinder.cs#L92](https://github.com/dotnet/aspnetcore/blob/release/10.0/src/Servers/Kestrel/Core/src/Internal/AddressBinder.cs#L92)), so this failure was a different socket error (for example `WSAEACCES`, when the chosen port falls inside a range the OS refuses to bind). Letting the OS assign the port as part of `bind` addresses both variants: the race window disappears, and the OS only hands out ports it is willing to bind.

### Why binding port `0` is safe for this endpoint
- Documented behavior: "When port number `0` is specified, Kestrel dynamically binds to an available port", with `IServerAddressesFeature` as the documented way to discover the bound port ([docs](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/servers/kestrel/endpoints)).
- Neither documented limitation applies here: this endpoint uses `Listen(IPAddress, ...)` rather than `ListenLocalhost` (whose XML docs state that "Requesting a dynamic port by specifying 0 is not supported for this type of endpoint"), and it enables `HttpProtocols.Http2` only, so there is no TCP + QUIC/HTTP-3 combination.
- The resolved port reaches `IServerAddressesFeature` because `SocketConnectionListener.Bind()` replaces its `EndPoint` with `listenSocket.LocalEndPoint`, `TransportManager.BindAsync` returns that endpoint, `KestrelServerImpl.OnBind` assigns it to `options.EndPoint`, and only afterwards does `ListenOptions.BindAsync` add `GetDisplayName()` to `context.Addresses`.

## Issues / work items
- Related #3058

---

# Project checklist
- [x] Documentation changes are not required
  - [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
- [ ] Release notes are not required for the next release
  - [x] Otherwise: Notes added to `release_notes.md`
- [x] Backport is not required
  - [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
- [x] All required tests have been added/updated (unit tests, E2E tests)
- [x] No extra work is required to be leveraged by OutOfProc SDKs
  - [ ] Otherwise: Work tracked here: #issue_or_pr_in_each_sdk
- [x] No change to the version of the `WebJobs.Extensions.DurableTask` package
  - [ ] Otherwise: Major/minor updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
- [x] No EventIds were added to `EventSource` logs
  - [ ] Otherwise: Ensure EventIds are within the supported range in the existing Windows infrastructure
- [ ] This change should be added to the `v2.x` branch
  - [x] Otherwise: This change applies exclusively to `WebJobs.Extensions.DurableTask` v3.x and will be retained only in the `dev` and `main` branches
- [ ] Breaking change?
  - [ ] If yes:
    - Impact:
    - Migration guidance:

`AspNetCoreLocalGrpcListener` does not exist on `v2.x`, so there is nothing to backport. The listen address format is unchanged, so no OutOfProc SDK work is required.

---

# AI-assisted code disclosure (required)
## Was an AI tool used? (select one)
- [ ] No
- [ ] Yes, AI helped write parts of this PR (e.g., GitHub Copilot)
- [x] Yes, an AI agent generated most of this PR

If AI was used:
- Tool(s): Claude Code (Opus 5)
- AI-assisted areas/files: `src/WebJobs.Extensions.DurableTask/Grpc/AspNetCoreLocalGrpcListener.cs`, `release_notes.md`, and this PR description
- What you changed after AI output:

AI verification (required if AI was used):
- [x] I understand the code and can explain it
- [x] I verified referenced APIs/types exist and are correct
- [x] I reviewed edge cases/failure paths (timeouts, retries, cancellation, exceptions)
- [x] I reviewed concurrency/async behavior
- [x] I checked for unintended breaking or behavior changes

---

# Testing
## Automated tests
- Result: Passed
  - `dotnet build src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj` -> net8.0 and net10.0, 0 warnings, 0 errors
  - `dotnet test test/FunctionsV2/WebJobs.Extensions.DurableTask.Tests.V2.csproj --filter "FullyQualifiedName~LocalGrpcListenerTests"` -> 44 passed / 0 failed, on both net8.0 and net10.0

The existing `LocalGrpcListenerTests` already exercise the affected path: they connect over gRPC using `listener.ListenAddress`, assert that it parses as an absolute URI, and assert that two concurrently running listeners report different addresses. No test assumes a specific port number.

## Manual validation (only if runtime/behavior changed)
- Environment (OS, .NET version, components): Windows 11, .NET SDK 10.0.400, Kestrel from the .NET 10 shared framework
- Steps + observed results:
  1. Built a standalone host with the same configuration as `StartInternalAsync`: `HostBuilder().ConfigureWebHost(... UseKestrel(o => o.Listen(IPAddress.Parse("127.0.0.1"), 0, lo => lo.Protocols = HttpProtocols.Http2)) ...)`.
  2. Started and stopped it three times, reading `IServerAddressesFeature.Addresses` after each start.
  3. Each run reported a distinct, non-zero port, and the address parsed as an absolute URI.
- Evidence (optional):

```
[1] ListenAddress = http://127.0.0.1:55757 / Uri.TryCreate = True, Port = 55757
[2] ListenAddress = http://127.0.0.1:55758 / Uri.TryCreate = True, Port = 55758
[3] ListenAddress = http://127.0.0.1:55759 / Uri.TryCreate = True, Port = 55759
```

---

# Notes for reviewers
Alternatives considered and rejected:
- `ListenLocalhost(0)`: dynamic ports are explicitly unsupported for that endpoint type, and it binds both `::1` and `127.0.0.1`, which would make `Addresses.SingleOrDefault()` throw.
- `ListenHandle(...)` with a pre-bound socket: the endpoint becomes a `FileHandleEndPoint`, so `GetDisplayName()` returns `http://<file handle>` and `ListenAddress` would no longer be a usable URI.
- Unix domain sockets: this would remove TCP ports entirely, but the address string is consumed by out-of-proc workers, so it requires a coordinated change in the worker SDKs and breaks old-worker / new-extension combinations.

Deliberately left out of this PR, and worth follow-ups:
- There is still no retry around the bind, so transient failures (for example ephemeral port exhaustion) rely on the WebJobs `FunctionListener` retry loop.
- When `newHost.StartAsync(...)` throws, the partially built `IHost` is not disposed, so every failed start leaks its service provider while that retry loop runs.