### PR TITLE
Hide stale output for in-progress orchestrations

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableClient.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableClient.cs
@@ -1217,9 +1217,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 RuntimeStatus = (OrchestrationRuntimeStatus)orchestrationState.OrchestrationStatus,
                 CustomStatus = ParseToJToken(orchestrationState.Status),
                 Input = ParseToJToken(orchestrationState.Input),
-                Output = ParseToJToken(orchestrationState.Output),
+                Output = ParseToJToken(GetVisibleOrchestrationOutput(orchestrationState)),
                 History = historyArray,
             };
+        }
+
+        internal static string GetVisibleOrchestrationOutput(OrchestrationState orchestrationState)
+        {
+            return IsOrchestrationRunning(orchestrationState)
+                ? null
+                : orchestrationState.Output;
         }
 
         internal static JToken ParseToJToken(string value)

--- a/src/WebJobs.Extensions.DurableTask/ProtobufUtils.cs
+++ b/src/WebJobs.Extensions.DurableTask/ProtobufUtils.cs
@@ -530,7 +530,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                     Version = state.Version,
                     ParentInstanceId = state.ParentInstance?.OrchestrationInstance?.InstanceId,
                     Input = state.Input,
-                    Output = state.Output,
+                    Output = DurableClient.GetVisibleOrchestrationOutput(state),
                     ScheduledStartTimestamp = state.ScheduledStartTime == null ? null : Timestamp.FromDateTime(state.ScheduledStartTime.Value),
                     CreatedTimestamp = Timestamp.FromDateTime(state.CreatedTime),
                     LastUpdatedTimestamp = Timestamp.FromDateTime(state.LastUpdatedTime),

--- a/src/WebJobs.Extensions.DurableTask/TaskHubGrpcServer.cs
+++ b/src/WebJobs.Extensions.DurableTask/TaskHubGrpcServer.cs
@@ -564,7 +564,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 CreatedTimestamp = Timestamp.FromDateTime(state.CreatedTime),
                 LastUpdatedTimestamp = Timestamp.FromDateTime(state.LastUpdatedTime),
                 Input = request.GetInputsAndOutputs ? state.Input : null,
-                Output = request.GetInputsAndOutputs ? state.Output : null,
+                Output = request.GetInputsAndOutputs ? DurableClient.GetVisibleOrchestrationOutput(state) : null,
                 CustomStatus = request.GetInputsAndOutputs ? state.Status : null,
                 FailureDetails = request.GetInputsAndOutputs ? GetFailureDetails(state.FailureDetails) : null,
             };

--- a/test/FunctionsV2/Tests/E2E/OrchestrationLifecycleTests.cs
+++ b/test/FunctionsV2/Tests/E2E/OrchestrationLifecycleTests.cs
@@ -390,6 +390,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         [MemberData(nameof(TestDataGenerator.GetFullFeaturedStorageProviderOptions), MemberType = typeof(TestDataGenerator))]
         public async Task RewindOrchestration(string storageProvider)
         {
+            TestOrchestrations.SayHelloWithActivityForRewindShouldFail = true;
+
             string[] orchestratorFunctionNames =
             {
                 nameof(TestOrchestrations.SayHelloWithActivityForRewind),
@@ -436,6 +438,41 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                         orchestratorFunctionNames,
                         activityFunctionName);
                 }
+            }
+        }
+
+        [Theory]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        [MemberData(nameof(TestDataGenerator.GetFullFeaturedStorageProviderOptions), MemberType = typeof(TestDataGenerator))]
+        public async Task RewindOrchestration_ClearsFailureOutput(string storageProvider)
+        {
+            TestOrchestrations.SayHelloWithActivityForRewindShouldFail = true;
+
+            using (ITestHost host = TestHelpers.GetJobHost(
+                this.loggerProvider,
+                nameof(this.RewindOrchestration_ClearsFailureOutput),
+                enableExtendedSessions: false,
+                storageProviderType: storageProvider))
+            {
+                await host.StartAsync();
+
+                TestDurableClient client = await host.StartOrchestratorAsync(
+                    nameof(TestOrchestrations.SayHelloWithActivityForRewind),
+                    "Catherine",
+                    this.output);
+
+                DurableOrchestrationStatus failedStatus = await client.WaitForCompletionAsync(this.output);
+                Assert.Equal(OrchestrationRuntimeStatus.Failed, failedStatus.RuntimeStatus);
+                Assert.NotEqual(JTokenType.Null, failedStatus.Output.Type);
+
+                await host.StopAsync();
+                await client.RewindAsync("rewind!");
+
+                DurableOrchestrationStatus rewoundStatus = await client.GetStatusAsync();
+                Assert.Equal(OrchestrationRuntimeStatus.Pending, rewoundStatus.RuntimeStatus);
+                Assert.Equal(JTokenType.Null, rewoundStatus.Output.Type);
+
+                TestOrchestrations.SayHelloWithActivityForRewindShouldFail = false;
             }
         }
 

--- a/test/FunctionsV2/Tests/E2E/OrchestrationLifecycleTests.cs
+++ b/test/FunctionsV2/Tests/E2E/OrchestrationLifecycleTests.cs
@@ -444,13 +444,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         [Theory]
         [Trait("Category", PlatformSpecificHelpers.TestCategory)]
         [MemberData(nameof(TestDataGenerator.GetFullFeaturedStorageProviderOptions), MemberType = typeof(TestDataGenerator))]
-        public async Task RewindOrchestration_ClearsFailureOutput(string storageProvider)
+        public async Task RewindOrchestration_HidesFailureOutput(string storageProvider)
         {
             TestOrchestrations.SayHelloWithActivityForRewindShouldFail = true;
 
             using (ITestHost host = TestHelpers.GetJobHost(
                 this.loggerProvider,
-                nameof(this.RewindOrchestration_ClearsFailureOutput),
+                nameof(this.RewindOrchestration_HidesFailureOutput),
                 enableExtendedSessions: false,
                 storageProviderType: storageProvider))
             {

--- a/test/FunctionsV2/Tests/Unit/DurableClientBaseTests.cs
+++ b/test/FunctionsV2/Tests/Unit/DurableClientBaseTests.cs
@@ -16,6 +16,7 @@ using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Primitives;
 using Moq;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using Xunit;
 using Xunit.Abstractions;
 using static Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests.HttpApiHandlerTests;
@@ -576,6 +577,26 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             Assert.Equal(OrchestrationRuntimeStatus.Running, status.RuntimeStatus);
         }
 
+        [Theory]
+        [InlineData(OrchestrationStatus.Running)]
+        [InlineData(OrchestrationStatus.ContinuedAsNew)]
+        [InlineData(OrchestrationStatus.Pending)]
+        [InlineData(OrchestrationStatus.Suspended)]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public async Task GetStatusAsync_InProgressInstanceWithStoredOutput_ReturnsNullOutput(
+            OrchestrationStatus orchestrationStatus)
+        {
+            var orchestrationServiceClientMock = new Mock<IOrchestrationServiceClient>();
+            orchestrationServiceClientMock.Setup(x => x.GetOrchestrationStateAsync(It.IsAny<string>(), It.IsAny<bool>()))
+                .ReturnsAsync(GetInstanceState(orchestrationStatus, output: "\"stale output\""));
+
+            IDurableOrchestrationClient durableOrchestrationClient = this.GetDurableClient(orchestrationServiceClientMock.Object);
+
+            DurableOrchestrationStatus status = await durableOrchestrationClient.GetStatusAsync("testInstanceId");
+
+            Assert.Equal(JTokenType.Null, status.Output.Type);
+        }
+
         [Fact]
         [Trait("Category", PlatformSpecificHelpers.TestCategory)]
         public async Task GetStatusAsync_IncludesParentInstanceId()
@@ -804,7 +825,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
         private static List<OrchestrationState> GetInstanceState(
             OrchestrationStatus status,
             string parentInstanceId = null,
-            string version = null)
+            string version = null,
+            string output = null)
         {
             return new List<OrchestrationState>()
             {
@@ -825,6 +847,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
                             },
                         },
                     OrchestrationStatus = status,
+                    Output = output,
                 },
             };
         }

--- a/test/FunctionsV2/Tests/Unit/LocalGrpcListenerTests.cs
+++ b/test/FunctionsV2/Tests/Unit/LocalGrpcListenerTests.cs
@@ -151,6 +151,57 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             }
         }
 
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public async Task TestGrpcListener_GetInProgressInstanceOmitsStoredOutput()
+        {
+            const string InstanceId = "rewound-instance";
+            var orchestrationState = new OrchestrationState
+            {
+                Name = "RewoundOrchestration",
+                OrchestrationInstance = new OrchestrationInstance
+                {
+                    InstanceId = InstanceId,
+                    ExecutionId = "rewound-execution",
+                },
+                CreatedTime = DateTime.UtcNow,
+                LastUpdatedTime = DateTime.UtcNow,
+                OrchestrationStatus = OrchestrationStatus.Pending,
+                Output = "\"stale output\"",
+            };
+            var orchestrationServiceClient = new Mock<IOrchestrationServiceClient>();
+            orchestrationServiceClient
+                .Setup(client => client.GetOrchestrationStateAsync(InstanceId, (string)null))
+                .ReturnsAsync(orchestrationState);
+            DurabilityProvider durabilityProvider = CreateDurabilityProvider(
+                new Mock<IOrchestrationService>().Object,
+                orchestrationServiceClient.Object);
+            using DurableTaskExtension extension = this.CreateExtension(
+                "GetInProgressInstanceOmitsStoredOutput",
+                durabilityProvider);
+            ILocalGrpcListener listener = LocalGrpcListener.Create(extension, LocalGrpcListenerMode.AspNetCore);
+
+            try
+            {
+                await listener.StartAsync(default);
+                using GrpcChannel channel = GrpcChannel.ForAddress(listener.ListenAddress);
+                var client = new P.TaskHubSidecarService.TaskHubSidecarServiceClient(channel);
+
+                P.GetInstanceResponse response = await client.GetInstanceAsync(
+                    new P.GetInstanceRequest
+                    {
+                        InstanceId = InstanceId,
+                        GetInputsAndOutputs = true,
+                    }).ResponseAsync;
+
+                Assert.Null(response.OrchestrationState.Output);
+            }
+            finally
+            {
+                await listener.StopAsync(default);
+            }
+        }
+
         [Theory]
         [InlineData("AttributionOtherHub", "AttributionOtherHub")]
         [InlineData(null, AttributionDefaultHubName)]

--- a/test/FunctionsV2/Tests/Unit/ProtobufUtilsTests.cs
+++ b/test/FunctionsV2/Tests/Unit/ProtobufUtilsTests.cs
@@ -430,6 +430,20 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
 
         [Fact]
         [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public void CreateQueryInstancesResponse_InProgressInstanceWithStoredOutput_OmitsOutput()
+        {
+            OrchestrationState state = CreateOrchestrationState("parent-instance");
+            state.Output = "\"stale output\"";
+            var result = new OrchestrationQueryResult(new[] { state }, continuationToken: null);
+
+            P.QueryInstancesResponse response =
+                ProtobufUtils.CreateQueryInstancesResponse(result, new P.QueryInstancesRequest());
+
+            Assert.Null(Assert.Single(response.OrchestrationState).Output);
+        }
+
+        [Fact]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
         public void ToHistoryEventProto_HistoryStateIncludesParentInstanceId()
         {
             const string ParentInstanceId = "parent-instance";


### PR DESCRIPTION
# Summary
## What changed?
- Return a null orchestration output while an instance is pending, running, suspended, or continuing as new.
- Apply the same projection rule to the classic client status API and the isolated-worker gRPC single-instance and query APIs.
- Add unit regressions and an Azurite-backed E2E test that observes the pending state immediately after rewind.

## Why is this change needed?
- Rewinding a failed Azure Storage orchestration changes its runtime status to `Pending` but can retain the previous failure output in storage. Status APIs then expose a terminal failure value for an instance that is running again, contrary to the status API contract.

## Issues / work items
- Resolves #968
- Related: N/A

---

# Project checklist
- [x] Documentation changes are not required
  - [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
- [x] Release notes are not required for the next release
  - [ ] Otherwise: Notes added to `release_notes.md`
- [ ] Backport is not required
  - [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
- [x] All required tests have been added/updated (unit tests, E2E tests)
- [x] No extra work is required to be leveraged by OutOfProc SDKs
  - [ ] Otherwise: Work tracked here: #issue_or_pr_in_each_sdk
- [x] No change to the version of the `WebJobs.Extensions.DurableTask` package
  - [ ] Otherwise: Major/minor updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
- [x] No EventIds were added to `EventSource` logs
  - [ ] Otherwise: Ensure EventIds are within the supported range in the existing Windows infrastructure (validate via deployed telemetry). If needed, extend the range via a PR such as https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files
- [x] This change should be added to the `v2.x` branch
  - [ ] Otherwise: This change applies exclusively to `WebJobs.Extensions.DurableTask` v3.x and will be retained only in the `dev` and `main` branches
- [ ] Breaking change? No
  - [ ] If yes:
    - Impact: N/A
    - Migration guidance: N/A
---

# AI-assisted code disclosure (required)
## Was an AI tool used? (select one)
- [ ] No
- [ ] Yes, AI helped write parts of this PR (e.g., GitHub Copilot)
- [x] Yes, an AI agent generated most of this PR

If AI was used:
- Tool(s): GitHub Copilot CLI
- AI-assisted areas/files: Status projection logic and unit/E2E regression tests
- What you changed after AI output: N/A (agent-authored draft)

AI verification (required if AI was used):
- [ ] I understand the code and can explain it
- [x] I verified referenced APIs/types exist and are correct
- [x] I reviewed edge cases/failure paths (timeouts, retries, cancellation, exceptions)
- [x] I reviewed concurrency/async behavior
- [x] I checked for unintended breaking or behavior changes

---

# Testing
## Automated tests
- Result: Passed
- 132 affected unit tests on .NET 8
- 2 Azurite-backed rewind E2E tests on .NET 8

## Manual validation (only if runtime/behavior changed)
- Environment (OS, .NET version, components): Windows, .NET 8, Azurite 3.36.0
- Steps + observed results:
  1. Failed an orchestration and confirmed that its failure output was present.
  2. Stopped the worker and rewound the failed instance so it remained observable as `Pending`.
  3. Queried status and observed a null output; the normal rewind flow still completed with `"Hello, Catherine!"`.
- Evidence (optional): Automated E2E regression in `OrchestrationLifecycleTests`.

---

# Notes for reviewers
- The Azure Storage row can still retain the old terminal output during rewind. This change enforces the public status API contract by suppressing stored output for all in-progress runtime statuses across both classic and isolated-worker status surfaces.