### PR TITLE
Support orchestration restart with an explicit instance ID and version

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableClient.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableClient.cs
@@ -1271,13 +1271,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
         async Task<string> IDurableOrchestrationClient.RestartAsync(string instanceId, bool restartWithNewInstanceId)
         {
-            // GetOrchestrationInstanceStateAsync will throw ArgumentException if the provided instanceid is not found.
-            OrchestrationState state = await this.GetOrchestrationInstanceStateAsync(instanceId);
-
-            this.ThrowIfOrchestratorFunctionIsDisabled(state.Name);
-
-            JToken input = ParseToJToken(state.Input);
-
             string newInstanceId = null;
 
             if (restartWithNewInstanceId)
@@ -1285,12 +1278,57 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 newInstanceId = Guid.NewGuid().ToString("N");
             }
 
+            return await this.RestartCoreAsync(
+                sourceInstanceId: instanceId,
+                newInstanceId: restartWithNewInstanceId ? newInstanceId : instanceId,
+                version: null);
+        }
+
+        internal Task<string> RestartWithOptionsAsync(string sourceInstanceId, string newInstanceId, string version)
+        {
+            ValidateRestartTargetInstanceId(newInstanceId);
+            return this.RestartCoreAsync(sourceInstanceId, newInstanceId, version);
+        }
+
+        private async Task<string> RestartCoreAsync(string sourceInstanceId, string newInstanceId, string version)
+        {
+            // GetOrchestrationInstanceStateAsync will throw ArgumentException if the provided instance ID is not found.
+            OrchestrationState state = await this.GetOrchestrationInstanceStateAsync(sourceInstanceId);
+
+            this.ThrowIfOrchestratorFunctionIsDisabled(state.Name);
+
+            JToken input = ParseToJToken(state.Input);
+
             return await this.CreateOrchestrationInstanceAndTraceAsync(
                 orchestratorFunctionName: state.Name,
-                instanceId: restartWithNewInstanceId ? newInstanceId : instanceId,
+                instanceId: newInstanceId,
                 input: input,
                 tags: state.Tags,
-                reason: "RestartInstance");
+                reason: "RestartInstance",
+                version: version);
+        }
+
+        private static void ValidateRestartTargetInstanceId(string newInstanceId)
+        {
+            if (string.IsNullOrEmpty(newInstanceId))
+            {
+                throw new ArgumentException("A new orchestration instance ID must be provided.", nameof(newInstanceId));
+            }
+
+            if (newInstanceId.StartsWith("@"))
+            {
+                throw new ArgumentException("Orchestration instance IDs must not start with @.", nameof(newInstanceId));
+            }
+
+            if (newInstanceId.Any(IsInvalidCharacter))
+            {
+                throw new ArgumentException("Orchestration instance IDs must not contain /, \\, #, ?, or control characters.", nameof(newInstanceId));
+            }
+
+            if (newInstanceId.Length > MaxInstanceIdLength)
+            {
+                throw new ArgumentException($"Instance ID lengths must not exceed {MaxInstanceIdLength} characters.", nameof(newInstanceId));
+            }
         }
 
         /// <inheritdoc/>
@@ -1353,12 +1391,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             string instanceId,
             object input,
             IDictionary<string, string> tags,
-            string reason)
+            string reason,
+            string version = null)
         {
             OrchestrationStatus[] dedupeStatuses = this.GetStatusesNotToOverride();
             Task<OrchestrationInstance> createTask = this.client.CreateOrchestrationInstanceAsync(
                 orchestratorFunctionName,
-                this.durableTaskOptions.DefaultVersion,
+                version ?? this.durableTaskOptions.DefaultVersion,
                 instanceId,
                 input,
                 tags,

--- a/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
+++ b/src/WebJobs.Extensions.DurableTask/HttpApiHandler.cs
@@ -47,6 +47,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         private const string TerminateOperation = "terminate";
         private const string RewindOperation = "rewind";
         private const string RestartOperation = "restart";
+        private const string RestartWithOptionsOperation = "restartWithOptions";
         private const string ShowHistoryParameter = "showHistory";
         private const string ShowHistoryOutputParameter = "showHistoryOutput";
         private const string ShowInputParameter = "showInput";
@@ -60,6 +61,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         private const string LastOperationTimeFrom = "lastOperationTimeFrom";
         private const string LastOperationTimeTo = "lastOperationTimeTo";
         private const string RestartWithNewInstanceId = "restartWithNewInstanceId";
+        private const string NewInstanceIdParameter = "newInstanceId";
         private const string TimeoutParameter = "timeout";
         private const string PollingInterval = "pollingInterval";
         private const string SuspendOperation = "suspend";
@@ -220,12 +222,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
             DurableOrchestrationStatus status = null;
 
-            if (client is DurableClient durableClient && durableClient.DurabilityProvider.SupportsPollFreeWait)
+            if (client is DurableClient pollingClient && pollingClient.DurabilityProvider.SupportsPollFreeWait)
             {
                 // For durability providers that support long polling, WaitForOrchestrationAsync is more efficient than GetStatusAsync
                 // so we ignore the retryInterval argument and instead wait for the entire timeout duration
 
-                var state = await durableClient.DurabilityProvider.WaitForOrchestrationAsync(instanceId, null, timeout, CancellationToken.None);
+                var state = await pollingClient.DurabilityProvider.WaitForOrchestrationAsync(instanceId, null, timeout, CancellationToken.None);
                 if (state != null)
                 {
                     status = DurableClient.ConvertOrchestrationStateToStatus(state);
@@ -404,7 +406,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                         }
                         else if (string.Equals(operation, RestartOperation, StringComparison.OrdinalIgnoreCase))
                         {
-                            return await this.HandleRestartInstanceRequestAsync(request, instanceId);
+                            return await this.HandleRestartInstanceRequestAsync(request, instanceId, useOptions: false);
+                        }
+                        else if (string.Equals(operation, RestartWithOptionsOperation, StringComparison.OrdinalIgnoreCase))
+                        {
+                            return await this.HandleRestartInstanceRequestAsync(request, instanceId, useOptions: true);
                         }
                         else if (string.Equals(operation, SuspendOperation, StringComparison.OrdinalIgnoreCase))
                         {
@@ -1066,7 +1072,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 
         private async Task<HttpResponseMessage> HandleRestartInstanceRequestAsync(
             HttpRequestMessage request,
-            string instanceId)
+            string instanceId,
+            bool useOptions)
         {
             this.LogClientOperationReceived(request, "Restart", instanceId);
 
@@ -1077,7 +1084,23 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 var queryNameValuePairs = request.GetQueryNameValuePairs();
 
                 string newInstanceId;
-                if (TryGetBooleanQueryParameterValue(queryNameValuePairs, RestartWithNewInstanceId, out bool restartWithNewInstanceId))
+                if (useOptions)
+                {
+                    string requestedInstanceId = queryNameValuePairs[NewInstanceIdParameter];
+                    if (string.IsNullOrEmpty(requestedInstanceId))
+                    {
+                        return request.CreateErrorResponse(HttpStatusCode.BadRequest, "A new orchestration instance ID must be provided.");
+                    }
+
+                    if (client is not DurableClient durableClient)
+                    {
+                        return request.CreateErrorResponse(HttpStatusCode.NotImplemented, "The Durable Functions client does not support restart options.");
+                    }
+
+                    string version = queryNameValuePairs[VersionParameter];
+                    newInstanceId = await durableClient.RestartWithOptionsAsync(instanceId, requestedInstanceId, version);
+                }
+                else if (TryGetBooleanQueryParameterValue(queryNameValuePairs, RestartWithNewInstanceId, out bool restartWithNewInstanceId))
                 {
                     newInstanceId = await client.RestartAsync(instanceId, restartWithNewInstanceId);
                 }
@@ -1090,7 +1113,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 TryGetTimeSpanQueryParameterValue(queryNameValuePairs, PollingInterval, out TimeSpan? pollingInterval);
 
                 // for durability providers that support poll-free waiting, we override the specified polling interval
-                if (client is DurableClient durableClient && durableClient.DurabilityProvider.SupportsPollFreeWait)
+                if (client is DurableClient pollingClient && pollingClient.DurabilityProvider.SupportsPollFreeWait)
                 {
                     pollingInterval = timeout;
                 }
@@ -1105,6 +1128,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 }
             }
             catch (OrchestratorFunctionUnavailableException e)
+            {
+                return request.CreateErrorResponse(HttpStatusCode.BadRequest, e.Message, e);
+            }
+            catch (ArgumentException e) when (useOptions && e.ParamName == "newInstanceId")
             {
                 return request.CreateErrorResponse(HttpStatusCode.BadRequest, e.Message, e);
             }

--- a/test/FunctionsV2/Tests/Unit/DurableClientBaseTests.cs
+++ b/test/FunctionsV2/Tests/Unit/DurableClientBaseTests.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
 using DurableTask.Core;
+using DurableTask.Core.History;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.WebJobs.Extensions.DurableTask.Options;
@@ -16,6 +17,7 @@ using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Primitives;
 using Moq;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using Xunit;
 using Xunit.Abstractions;
 using static Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests.HttpApiHandlerTests;
@@ -257,6 +259,69 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             serviceClient.Verify(
                 x => x.CreateTaskOrchestrationAsync(It.IsAny<TaskMessage>(), It.IsAny<OrchestrationStatus[]>()),
                 Times.Never());
+        }
+
+        [Theory]
+        [InlineData("2.0", "2.0")]
+        [InlineData(null, "default-version")]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public async Task RestartWithOptionsAsync_UsesRequestedInstanceIdAndVersion(
+            string version,
+            string expectedVersion)
+        {
+            const string SourceInstanceId = "source-instance";
+            const string NewInstanceId = "new-instance";
+            const string FunctionName = "RestartedOrchestrator";
+            const string Input = "{\"value\":42}";
+            var tags = new Dictionary<string, string> { ["source"] = "restart-test" };
+            ExecutionStartedEvent capturedEvent = null;
+            var serviceClient = new Mock<IOrchestrationServiceClient>();
+            serviceClient
+                .Setup(x => x.GetOrchestrationStateAsync(SourceInstanceId, false))
+                .ReturnsAsync(
+                    new List<OrchestrationState>
+                    {
+                        new OrchestrationState
+                        {
+                            Name = FunctionName,
+                            Input = Input,
+                            Tags = tags,
+                            OrchestrationInstance = new OrchestrationInstance { InstanceId = SourceInstanceId },
+                            OrchestrationStatus = OrchestrationStatus.Completed,
+                        },
+                    });
+            serviceClient
+                .Setup(x => x.CreateTaskOrchestrationAsync(It.IsAny<TaskMessage>(), It.IsAny<OrchestrationStatus[]>()))
+                .Callback<TaskMessage, OrchestrationStatus[]>((message, _) =>
+                {
+                    capturedEvent = message.Event as ExecutionStartedEvent;
+                })
+                .Returns(Task.CompletedTask);
+            var storageProvider = new DurabilityProvider(
+                "clientProvider",
+                new Mock<IOrchestrationService>().Object,
+                serviceClient.Object,
+                TestConstants.ConnectionName);
+            var extension = GetDurableTaskConfig();
+            extension.Options.DefaultVersion = "default-version";
+            extension.RegisterOrchestrator(
+                new FunctionName(FunctionName),
+                new RegisteredFunctionInfo(executor: null, isOutOfProc: true));
+            var client = new DurableClient(
+                storageProvider,
+                extension,
+                extension.HttpApiHandler,
+                new DurableClientAttribute());
+
+            string result = await client.RestartWithOptionsAsync(SourceInstanceId, NewInstanceId, version);
+
+            Assert.Equal(NewInstanceId, result);
+            Assert.NotNull(capturedEvent);
+            Assert.Equal(FunctionName, capturedEvent.Name);
+            Assert.Equal(NewInstanceId, capturedEvent.OrchestrationInstance.InstanceId);
+            Assert.Equal(expectedVersion, capturedEvent.Version);
+            Assert.True(JToken.DeepEquals(JToken.Parse(Input), JToken.Parse(capturedEvent.Input)));
+            Assert.Equal(tags, capturedEvent.Tags);
         }
 
         [Theory]

--- a/test/FunctionsV2/Tests/Unit/HttpApiHandlerTests.cs
+++ b/test/FunctionsV2/Tests/Unit/HttpApiHandlerTests.cs
@@ -1348,6 +1348,79 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
             Assert.Equal(status["resumePostUri"], testResumePostUri);
         }
 
+        [Theory]
+        [InlineData("2.0", "2.0")]
+        [InlineData(null, "default-version")]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        public async Task RestartInstanceWithOptions_Is_Success(string version, string expectedVersion)
+        {
+            const string SourceInstanceId = "source-instance";
+            const string NewInstanceId = "new-instance";
+            const string FunctionName = "RestartedOrchestrator";
+            const string Input = "{\"value\":42}";
+            var tags = new Dictionary<string, string> { ["source"] = "restart-test" };
+            string versionQuery = version == null ? string.Empty : $"&version={Uri.EscapeDataString(version)}";
+            var requestUri = new Uri(
+                $"http://localhost/runtime/webhooks/durabletask/instances/{SourceInstanceId}/restartWithOptions?newInstanceId={NewInstanceId}{versionQuery}");
+            ExecutionStartedEvent capturedEvent = null;
+            var orchestrationService = new Mock<IOrchestrationService>(MockBehavior.Strict);
+            var orchestrationServiceClient = new Mock<IOrchestrationServiceClient>();
+            orchestrationServiceClient
+                .Setup(client => client.GetOrchestrationStateAsync(SourceInstanceId, false))
+                .ReturnsAsync(
+                    new List<OrchestrationState>
+                    {
+                        new OrchestrationState
+                        {
+                            Name = FunctionName,
+                            Input = Input,
+                            Tags = tags,
+                            OrchestrationInstance = new OrchestrationInstance { InstanceId = SourceInstanceId },
+                            OrchestrationStatus = OrchestrationStatus.Completed,
+                        },
+                    });
+            orchestrationServiceClient
+                .Setup(client => client.CreateTaskOrchestrationAsync(
+                    It.IsAny<TaskMessage>(),
+                    It.IsAny<OrchestrationStatus[]>()))
+                .Callback<TaskMessage, OrchestrationStatus[]>((message, _) =>
+                {
+                    capturedEvent = message.Event as ExecutionStartedEvent;
+                })
+                .Returns(Task.CompletedTask);
+            var durabilityProvider = new DurabilityProvider(
+                "storageProviderName",
+                orchestrationService.Object,
+                orchestrationServiceClient.Object,
+                TestConstants.ConnectionName);
+            var options = new DurableTaskOptions
+            {
+                WebhookUriProviderOverride = () => new Uri("http://localhost/runtime/webhooks/durabletask"),
+                HubName = TestConstants.TaskHub,
+                DefaultVersion = "default-version",
+            };
+            var extension = TestDurableTaskExtension.CreateWithProvider(options, durabilityProvider);
+            extension.RegisterOrchestrator(
+                new FunctionName(FunctionName),
+                new RegisteredFunctionInfo(executor: null, isOutOfProc: true));
+            var httpApiHandler = new HttpApiHandler(extension, NullLogger.Instance);
+
+            HttpResponseMessage response = await httpApiHandler.HandleRequestAsync(
+                new HttpRequestMessage(HttpMethod.Post, requestUri),
+                CancellationToken.None);
+
+            Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
+            string content = await response.Content.ReadAsStringAsync();
+            var payload = JsonConvert.DeserializeObject<JObject>(content);
+            Assert.Equal(NewInstanceId, payload["id"]);
+            Assert.NotNull(capturedEvent);
+            Assert.Equal(FunctionName, capturedEvent.Name);
+            Assert.Equal(NewInstanceId, capturedEvent.OrchestrationInstance.InstanceId);
+            Assert.Equal(expectedVersion, capturedEvent.Version);
+            Assert.True(JToken.DeepEquals(JToken.Parse(Input), JToken.Parse(capturedEvent.Input)));
+            Assert.Equal(tags, capturedEvent.Tags);
+        }
+
         [Fact]
         [Trait("Category", PlatformSpecificHelpers.TestCategory)]
         public async Task RestartInstance_Returns_HTTP_400_On_Invalid_InstanceId()


### PR DESCRIPTION
# Summary

## What changed?

- Added a dedicated `restartWithOptions` HTTP management operation that accepts an exact target instance ID and optional orchestration version.
- Added an internal `DurableClient.RestartWithOptionsAsync` path without changing the public .NET client interfaces.
- Reused the existing restart creation path so the source orchestration's name, serialized input, tags, tracing behavior, and instance reuse policy are preserved.
- Added validation for target instance IDs and consistent HTTP responses for missing sources, invalid targets, disabled orchestrators, and instance ID conflicts.
- Preserved the existing `/restart?restartWithNewInstanceId={boolean}` behavior without changes.
- Added unit coverage for the internal restart behavior and the HTTP management operation.

## Why is this change needed?

The classic Durable Functions JavaScript SDK needs to restart an existing orchestration while specifying both the target instance ID and orchestration version. The existing Restart API only supports reusing the source ID or generating a random ID.

A dedicated route prevents older extensions from silently ignoring the new options and executing the legacy restart behavior.

### Related PR:
- https://github.com/Azure/azure-functions-durable-js/pull/728

---

# Project checklist
- [ ] Documentation changes are not required
  - [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
- [ ] Release notes are not required for the next release
  - [ ] Otherwise: Notes added to `release_notes.md`
- [x] Backport is not required
  - [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
- [x] All required tests have been added/updated (unit tests, E2E tests)
- [ ] No extra work is required to be leveraged by OutOfProc SDKs
  - [ ] Otherwise: Work tracked here: #issue_or_pr_in_each_sdk
- [x] No change to the version of the `WebJobs.Extensions.DurableTask` package
  - [ ] Otherwise: Major/minor updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
- [x] No EventIds were added to `EventSource` logs
  - [ ] Otherwise: Ensure EventIds are within the supported range in the existing Windows infrastructure (validate via deployed telemetry). If needed, extend the range via a PR such as https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files
- [ ] This change should be added to the `v2.x` branch
  - [x] Otherwise: This change applies exclusively to `WebJobs.Extensions.DurableTask` v3.x and will be retained only in the `dev` and `main` branches
- [ ] Breaking change?
  - [ ] If yes:
    - Impact:
    - Migration guidance:
---

# AI-assisted code disclosure

## Was an AI tool used?
- [x] Yes, an AI agent generated most of this PR
Tool(s): GitHub Copilot CLI
AI-assisted areas/files:
- `ContextImplementations/DurableClient.cs`
- `HttpApiHandler.cs`
- `DurableClientBaseTests.cs`
- `HttpApiHandlerTests.cs`

## AI verification

- [x] I understand the code and can explain it
- [x] I verified referenced APIs and types
- [x] I reviewed edge cases and failure paths
- [x] I reviewed concurrency and asynchronous behavior
- [x] I checked for unintended behavior changes

---

# Testing
## Automated tests
- `dotnet build src/WebJobs.Extensions.DurableTask/WebJobs.Extensions.DurableTask.csproj --no-restore`
- `dotnet test test/FunctionsV2/WebJobs.Extensions.DurableTask.Tests.V2.csproj --no-restore --filter "FullyQualifiedName~DurableClientBaseTests|FullyQualifiedName~HttpApiHandlerTests"`
- Result: 138 tests passed on .NET 8 and 138 tests passed on .NET 10.
