### PR TITLE
Clarify entity rollback versus retries and add isolated regression coverage

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/ContextInterfaces/IDurableEntityClient.cs
+++ b/src/WebJobs.Extensions.DurableTask/ContextInterfaces/IDurableEntityClient.cs
@@ -10,6 +10,18 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
     /// <summary>
     /// Provides functionality available to durable entity clients.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Signal tasks complete when the operation message has been reliably enqueued, not when the
+    /// entity operation has executed. Signals are one-way: an exception in the entity operation is
+    /// not returned to the client that sent the signal.
+    /// </para>
+    /// <para>
+    /// Entity operations that fail with an unhandled application exception are not automatically
+    /// retried, even when their state changes are rolled back. Applications that require retries
+    /// must implement them explicitly.
+    /// </para>
+    /// </remarks>
     public interface IDurableEntityClient
     {
         /// <summary>

--- a/src/WebJobs.Extensions.DurableTask/Options/DurableTaskOptions.cs
+++ b/src/WebJobs.Extensions.DurableTask/Options/DurableTaskOptions.cs
@@ -229,6 +229,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// This setting can affect serialization overhead: if true, the entity state is serialized
         /// after each individual operation. If false, the entity state is serialized
         /// only after an entire batch of operations completes.
+        /// <para>
+        /// Rolling back an operation does not requeue its input or retry it. An unhandled application
+        /// exception completes the operation as a failure. Applications that require retries must
+        /// implement them explicitly, accounting for external effects that are not rolled back.
+        /// </para>
         /// </remarks>
         public bool RollbackEntityOperationsOnExceptions { get; set; } = true;
 

--- a/src/Worker.Extensions.DurableTask/TaskEntityDispatcher.cs
+++ b/src/Worker.Extensions.DurableTask/TaskEntityDispatcher.cs
@@ -16,6 +16,16 @@ namespace Microsoft.Azure.Functions.Worker;
 /// </summary>
 /// <remarks>
 /// This type is used to aid in dispatching a <see cref="EntityTriggerAttribute"/> to the operation receiver object.
+/// <para>
+/// An unhandled application exception fails the individual entity operation; it does not automatically
+/// retry the operation or requeue its input. For an entity call, the failure is propagated to the calling
+/// orchestrator as an <see cref="EntityOperationFailedException"/>. A signal is one-way and does not
+/// return the failure to its sender.
+/// </para>
+/// <para>
+/// Applications that require retries must implement them explicitly. Entity-state rollback does not
+/// undo external effects, such as HTTP requests or database writes, which a retry might repeat.
+/// </para>
 /// </remarks>
 public sealed class TaskEntityDispatcher
 {

--- a/test/Worker.Extensions.DurableTask.Tests/TaskEntityDispatcherTests.cs
+++ b/test/Worker.Extensions.DurableTask.Tests/TaskEntityDispatcherTests.cs
@@ -1,0 +1,110 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Text.Json;
+using Google.Protobuf;
+using Microsoft.DurableTask.Entities;
+using Microsoft.DurableTask.Worker;
+using Microsoft.Extensions.DependencyInjection;
+using P = Microsoft.DurableTask.Protobuf;
+
+namespace Microsoft.Azure.Functions.Worker.Tests;
+
+public class TaskEntityDispatcherTests
+{
+    [Theory]
+    [InlineData(null, 0)]
+    [InlineData("10", 10)]
+    public async Task DispatchAsync_ApplicationException_RollsBackWithoutRetrying(
+        string? initialState, int initialValue)
+    {
+        using var services = new ServiceCollection().AddLogging().AddOptions().BuildServiceProvider();
+        using var cache = new ExtendedSessionsCache();
+        var inputs = new List<int>();
+        var observedStates = new List<int>();
+        var request = new P.EntityBatchRequest
+        {
+            InstanceId = "@counter@failure",
+            EntityState = initialState,
+            Operations =
+            {
+                new P.OperationRequest { Operation = "add", Input = "99", RequestId = Guid.NewGuid().ToString() },
+                new P.OperationRequest { Operation = "get", RequestId = Guid.NewGuid().ToString() },
+            },
+        };
+
+        ValueTask<object?> HandleOperation(TaskEntityOperation operation)
+        {
+            if (operation.Name == "get")
+            {
+                return new(operation.State.GetState<int>());
+            }
+
+            Assert.Equal("add", operation.Name);
+            int input = operation.GetInput<int>();
+            int state = operation.State.GetState<int>();
+            inputs.Add(input);
+            observedStates.Add(state);
+            operation.State.SetState(state + input);
+            operation.Context.SignalEntity(new EntityInstanceId("observer", "failure"), "add", input);
+
+            // Keep the attempt count outside entity state so rollback cannot hide a retry.
+            if (inputs.Count == 1)
+            {
+                throw new InvalidOperationException("application failure");
+            }
+
+            return new(operation.State.GetState<int>());
+        }
+
+        async Task<P.EntityBatchResult> DispatchAsync(P.EntityBatchRequest batch)
+        {
+            var dispatcher = new TaskEntityDispatcher(
+                Convert.ToBase64String(batch.ToByteArray()), services, cache);
+            await dispatcher.DispatchAsync(HandleOperation);
+            return P.EntityBatchResult.Parser.ParseFrom(Convert.FromBase64String(dispatcher.Result));
+        }
+
+        P.EntityBatchResult result = await DispatchAsync(request);
+
+        Assert.Equal(new[] { 99 }, inputs);
+        Assert.Equal(new[] { initialValue }, observedStates);
+        Assert.False(result.RequiresState);
+        Assert.Null(result.FailureDetails);
+        Assert.Equal(initialState, result.EntityState);
+        Assert.Empty(result.Actions);
+        Assert.Collection(
+            result.Results,
+            failed =>
+            {
+                Assert.Equal(P.OperationResult.ResultTypeOneofCase.Failure, failed.ResultTypeCase);
+                Assert.Equal(typeof(InvalidOperationException).FullName, failed.Failure.FailureDetails.ErrorType);
+                Assert.Equal("application failure", failed.Failure.FailureDetails.ErrorMessage);
+            },
+            read =>
+            {
+                Assert.Equal(P.OperationResult.ResultTypeOneofCase.Success, read.ResultTypeCase);
+                Assert.Equal(JsonSerializer.Serialize(initialValue), read.Success.Result);
+            });
+
+        // Only a new, explicitly submitted operation retries the input.
+        var retry = new P.EntityBatchRequest
+        {
+            InstanceId = request.InstanceId,
+            EntityState = result.EntityState,
+            Operations =
+            {
+                new P.OperationRequest { Operation = "add", Input = "99", RequestId = Guid.NewGuid().ToString() },
+            },
+        };
+
+        P.EntityBatchResult retried = await DispatchAsync(retry);
+
+        Assert.Equal(new[] { 99, 99 }, inputs);
+        Assert.Equal(new[] { initialValue, initialValue }, observedStates);
+        Assert.Null(retried.FailureDetails);
+        Assert.Equal(P.OperationResult.ResultTypeOneofCase.Success, Assert.Single(retried.Results).ResultTypeCase);
+        Assert.Equal(JsonSerializer.Serialize(initialValue + 99), retried.EntityState);
+        Assert.Single(retried.Actions);
+    }
+}


### PR DESCRIPTION
# Summary
## What changed?
- Clarify the entity-client API contract: signal completion acknowledges reliable enqueueing, not successful operation execution, and operation exceptions are not returned to the sender.
- Clarify that `RollbackEntityOperationsOnExceptions` does not requeue input or automatically retry application exceptions.
- Document the same contract on the .NET isolated `TaskEntityDispatcher`, including caller-side exception wrapping and the risk of repeating external side effects.
- Add real-dispatcher characterization tests for absent/existing state: input delivery, operation-scoped failure, state and outgoing-signal rollback, continued processing of a following read, and a separately submitted explicit retry.

## Why is this change needed?
Issue #1751 expects rollback to imply input retry. Reproduction on **both latest stable releases**—WebJobs Durable **3.15.0** and Worker Durable **1.19.0**—matches the existing design, not a runtime regression. The API documentation does not make this distinction sufficiently explicit.

**This is a documentation and regression-coverage change, not a runtime retry fix.** It does not introduce automatic retries or change any runtime behavior, public signatures, defaults, dependencies, or versions. Automatically requeueing arbitrary application failures would change established failure propagation and could repeat external side effects.

## Issues / work items
- Related #1751
- In-process Azure reproduction: https://github.com/Azure/azure-functions-durable-extension/issues/1751#issuecomment-5610047012
- Isolated Azure reproduction: https://github.com/Azure/azure-functions-durable-extension/issues/1751#issuecomment-5622547872
- No automatic issue-closing keyword: #1751 remains open for a maintainer disposition of the existing by-design behavior.

---

# Project checklist
- [ ] Documentation changes are not required
  - [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
  - API documentation changes are included in this PR; no separate documentation repository changes are needed for this scope.
- [x] Release notes are not required for the next release
  - [ ] Otherwise: Notes added to `release_notes.md`
- [x] Backport is not required
  - [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
- [x] All required tests have been added/updated (unit tests, E2E tests)
- [x] No extra work is required to be leveraged by OutOfProc SDKs
  - [ ] Otherwise: Work tracked here: #issue_or_pr_in_each_sdk
- [x] No change to the version of the `WebJobs.Extensions.DurableTask` package
  - [ ] Otherwise: Major/minor updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
- [x] No EventIds were added to `EventSource` logs
  - [ ] Otherwise: Ensure EventIds are within the supported range in the existing Windows infrastructure (validate via deployed telemetry). If needed, extend the range via a PR such as https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files
- [ ] This change should be added to the `v2.x` branch
  - [x] Otherwise: This change applies exclusively to `WebJobs.Extensions.DurableTask` v3.x and will be retained only in the `dev` and `main` branches
- [ ] Breaking change?
  - [ ] If yes:
    - Impact: N/A
    - Migration guidance: N/A
---

# AI-assisted code disclosure (required)
## Was an AI tool used? (select one)
- [ ] No
- [ ] Yes, AI helped write parts of this PR (e.g., GitHub Copilot)
- [x] Yes, an AI agent generated most of this PR

If AI was used:
- Tool(s): GitHub Copilot CLI.
- AI-assisted areas/files: All four changed files: entity-client, rollback-option and isolated-dispatcher XML comments, plus `TaskEntityDispatcherTests.cs`.
- What you changed after AI output: Corrected test assertions to use the actual protobuf operation-result success/failure union. Kept production changes limited to documentation after comparing the issue, implementation, existing tests, and deployed Azure behavior.

AI verification (required if AI was used):
- [x] I understand the code and can explain it
- [x] I verified referenced APIs/types exist and are correct
- [x] I reviewed edge cases/failure paths (timeouts, retries, cancellation, exceptions)
- [x] I reviewed concurrency/async behavior
- [x] I checked for unintended breaking or behavior changes

---

# Testing
## Automated tests
- Command: `dotnet test test\Worker.Extensions.DurableTask.Tests\Worker.Extensions.DurableTask.Tests.csproj --no-restore --filter FullyQualifiedName~TaskEntityDispatcherTests --nologo -v minimal`
- Result: **Passed: 2/2 on net8.0 and 2/2 on net10.0**.
- The tests invoke the actual dispatcher and SDK runner, not a mock of the documented behavior. Attempt counters live outside entity state so rollback cannot hide a repeated execution.
- Generated isolated-worker XML documentation includes the new remarks and resolves the `EntityOperationFailedException` reference. `git diff --check` passed.
- Build emitted the existing SDK analyzer warning `AD0001` for duplicate `TestActivity` names elsewhere in this test project; this does not affect the focused test results.

## Manual validation (only if runtime/behavior changed)
- Runtime/behavior changed: **No**. The previously recorded Azure reproductions establish the existing provider-level behavior; the new unit test does not claim to test queue acknowledgement or Azure persistence.
- Environment (OS, .NET version, components): Azure Windows Consumption, real Azure Storage, .NET 8.0.30; in-process Durable 3.15.0 and isolated Durable 1.19.0.
- Steps + observed results:
  1. Signal existing/new entities with an operation that reads input, changes state, then throws: the input is delivered and state rolls back.
  2. Call the failing operation from an orchestrator, and separately send 50 ordered signals with #25 failing: the caller fails; the other 49 updates persist.
  3. Observe execution records and queues for 120 seconds, then stop/start the app: each of eight failed operations executes once, queues drain, and state remains correct.
- Evidence: Linked issue comments above. Temporary Azure resources were removed after each reproduction.

---

# Notes for reviewers
- No production executable statements changed. The regression test intentionally preserves the existing no-automatic-retry contract.
- A bounded opt-in retry policy would be a separate feature requiring explicit decisions about idempotency, ordering, limits, failure delivery, and compatibility.

Fixes: #1751