### PR TITLE
Fix JSON console logging for Kubernetes managed hosting

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -23,6 +23,7 @@
 ### New Features
 
 - Allow overriding orchestration version when starting orchestrations via APIs in PowerShell, Python, and Node.js (https://github.com/Azure/azure-functions-durable-extension/pull/3213)
+- Emit single-line JSON console diagnostics in Kubernetes managed hosting, using an `EventType` field instead of a text prefix. Existing Linux Consumption, Dedicated, and Managed App logging formats are unchanged. (#1794)
 - Added `ClientOperationReceived` trace event to `DurableFunctionsEvents` for correlating out-of-process worker invocations with orchestration events. The event includes `FunctionInvocationId`, `OperationType`, and `InstanceId` fields for cross-log correlation. (#3317)
 - Existing extension-generated `FunctionScheduled` trace events now include a `TargetInstanceId` field for entity, sub-orchestration, and Durable Client scheduling paths when the target ID is known. Sub-orchestrations without an explicit ID report the target as not supplied because DTFx generates it downstream. This change does not add `FunctionScheduled` events to modern gRPC worker middleware paths, which do not currently emit that event. (#1496)
 

--- a/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
+++ b/src/WebJobs.Extensions.DurableTask/DurableTaskExtension.cs
@@ -381,11 +381,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         /// <param name="context">Extension context provided by WebJobs.</param>
         void IExtensionConfigProvider.Initialize(ExtensionConfigContext context)
         {
-            // Functions V1 is not supported in linux, so this is conditionally compiled
+            // Match the Functions host's Kubernetes managed-hosting detection without changing IPlatformInformation.
+            bool isKubernetesManagedHosting =
+                !string.IsNullOrEmpty(this.nameResolver.Resolve("KUBERNETES_SERVICE_HOST")) &&
+                !string.IsNullOrEmpty(this.nameResolver.Resolve("POD_NAMESPACE")) &&
+                !this.PlatformInformationService.IsManagedAppEnvironment();
+
             // We initialize linux logging early on in case any initialization steps below were to trigger a log event.
-            if (this.PlatformInformationService.GetOperatingSystem() == OperatingSystem.Linux)
+            if (this.PlatformInformationService.GetOperatingSystem() == OperatingSystem.Linux || isKubernetesManagedHosting)
             {
-                this.InitializeLinuxLogging();
+                this.InitializeLinuxLogging(isKubernetesManagedHosting);
             }
 
             ConfigureLoaderHooks();
@@ -570,10 +575,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         }
 
         /// <summary>
-        /// Initializes the logging service for App Service if it detects that we are running in
-        /// the linux platform.
+        /// Initializes the logging service for Linux App Service and Kubernetes managed hosting.
         /// </summary>
-        private void InitializeLinuxLogging()
+        /// <param name="isKubernetesManagedHosting">Whether to emit unprefixed JSON console logs for Kubernetes.</param>
+        private void InitializeLinuxLogging(bool isKubernetesManagedHosting)
         {
             // Determine host platform
             bool inConsumption = this.PlatformInformationService.IsInConsumptionPlan();
@@ -583,9 +588,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             string stampName = this.PlatformInformationService.GetLinuxStampName();
             string containerName = this.PlatformInformationService.GetContainerName();
 
-            // in linux consumption, logs are emitted to the console.
+            // In Linux Consumption, Managed App environments, and Kubernetes, logs are emitted to the console.
             // In other linux plans, they are emitted to a logfile.
-            var linuxLogger = new LinuxAppServiceLogger(writeToConsole: inConsumption || isManagedAppEnvironment, containerName, tenant, stampName);
+            var linuxLogger = new LinuxAppServiceLogger(
+                writeToConsole: inConsumption || isManagedAppEnvironment || isKubernetesManagedHosting,
+                containerName,
+                tenant,
+                stampName,
+                isKubernetesManagedHosting);
 
             // The logging service for linux works by capturing EventSource messages,
             // which our linux platform does not recognize, and logging them via a

--- a/src/WebJobs.Extensions.DurableTask/LinuxAppServiceLogger.cs
+++ b/src/WebJobs.Extensions.DurableTask/LinuxAppServiceLogger.cs
@@ -12,8 +12,9 @@ using Newtonsoft.Json.Linq;
 namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
 {
     /// <summary>
-    /// In charge of logging services for our linux App Service offerings: Consumption and Dedicated.
+    /// In charge of logging services for Linux App Service and Kubernetes managed hosting.
     /// In Consumption, we log to the console and identify our log by a prefix.
+    /// In Kubernetes managed hosting, we log JSON to the console and identify our log by an EventType field.
     /// In Dedicated, we log asynchronously to a pre-defined logging path.
     /// This class is utilized by <c>EventSourceListener</c> to write logs corresponding to
     /// specific EventSource providers.
@@ -33,26 +34,30 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
         private readonly string stamp;
         private readonly string primaryStamp;
 
-        // if true, we write to console (linux consumption), else to a file (linux dedicated).
+        // If true, we write to console; otherwise, to a file (Linux Dedicated).
         private readonly bool writeToConsole;
+        private readonly bool isKubernetesManagedHosting;
 
         private readonly LinuxAppServiceFileLogger fileLogger;
 
         /// <summary>
         /// Create a LinuxAppServiceLogger instance.
         /// </summary>
-        /// <param name="writeToConsole">If true, write to console (linux consumption) else to a file (dedicated).</param>
+        /// <param name="writeToConsole">If true, write to console; otherwise, to a file (Dedicated).</param>
         /// <param name="containerName">The app's container name.</param>
         /// <param name="tenant">The app's tenant.</param>
         /// <param name="stampName">The app's stamp.</param>
+        /// <param name="isKubernetesManagedHosting">Whether to use an EventType field instead of a console prefix.</param>
         public LinuxAppServiceLogger(
             bool writeToConsole,
             string containerName,
             string tenant,
-            string stampName)
+            string stampName,
+            bool isKubernetesManagedHosting = false)
         {
             // Initializing fixed logging metadata
             this.writeToConsole = writeToConsole;
+            this.isKubernetesManagedHosting = isKubernetesManagedHosting;
 
             // Since the values below are obtained via a NameResolver, they might be null.
             // Attempting to serialize a null value results in exceptions, or even worse, wrong logs,
@@ -115,6 +120,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
                 { "ExtensionGUID", extensionGuid },
             };
 
+            if (this.isKubernetesManagedHosting)
+            {
+                json.Add("EventType", ConsolePrefix);
+            }
+
             if (!string.IsNullOrEmpty(this.stamp) && !string.IsNullOrEmpty(this.primaryStamp))
             {
                 json.Add("EventStampName", this.stamp);
@@ -134,7 +144,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             // Add payload elements
             for (int i = 0; i < values.Count; i++)
             {
-                json.Add(keys[i], JToken.FromObject(values[i]));
+                // DTFx events also use EventType; retain it without overwriting the Kubernetes routing field.
+                string key = this.isKubernetesManagedHosting && keys[i] == "EventType" ? "TaskEventType" : keys[i];
+                json.Add(key, JToken.FromObject(values[i]));
             }
 
             // Add ActivityId and RelatedActivityId, if non-null
@@ -166,11 +178,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DurableTask
             // Generate JSON string to log based on the EventSource message
             string jsonString = this.GenerateLogStr(eventData, extensionGuid);
 
-            // We write to console in Linux Consumption
+            // Kubernetes log collectors require the entire line to be valid JSON.
             if (this.writeToConsole)
             {
                 // We're ignoring exceptions in the unobserved Task
-                string consoleLine = ConsolePrefix + " " + jsonString;
+                string consoleLine = this.isKubernetesManagedHosting ? jsonString : ConsolePrefix + " " + jsonString;
                 _ = Console.Out.WriteLineAsync(consoleLine);
             }
             else

--- a/src/WebJobs.Extensions.DurableTask/README.md
+++ b/src/WebJobs.Extensions.DurableTask/README.md
@@ -38,6 +38,14 @@ Azure Storage is the default backend for Durable Functions. The `DurabilityProvi
 
 The `Scale/` folder provides **runtime scaling support**, integrated via `DurableTaskListener`.
 
+## Platform Diagnostic Logs
+
+In Kubernetes managed hosting (`KUBERNETES_SERVICE_HOST` and `POD_NAMESPACE` are nonempty, and `MANAGED_ENVIRONMENT` is absent or empty), Durable EventSource diagnostics are emitted as single-line JSON to standard output. Each record contains `"EventType":"MS_DURABLE_FUNCTION_EVENTS_LOGS"` instead of a text prefix, so log collectors can parse the entire line as JSON.
+
+Provider payload fields named `EventType` (for example, `ExecutionStarted`) are preserved as `TaskEventType` in Kubernetes JSON, avoiding a collision with the routing field. Other payload and correlation fields are unchanged, and `tracing.allowVerboseLinuxTelemetry` continues to control verbose DurableTask-Core events.
+
+Linux Consumption and Managed App environments retain their prefixed console logs. Linux Dedicated retains file logging. Their payload field names are unchanged.
+
 ## Extension Bundle Compatibility
 
 This extension is distributed as part of [Azure Functions extension bundles](https://learn.microsoft.com/azure/azure-functions/functions-bindings-register#extension-bundles), which are used by non-.NET language SDKs. Changes to public APIs and package dependencies must remain compatible with the extension bundle dependency graph. Breaking changes to package references can cause runtime failures for all non-.NET Durable Functions users.

--- a/test/FunctionsV2/Tests/Unit/LinuxLoggingTests.cs
+++ b/test/FunctionsV2/Tests/Unit/LinuxLoggingTests.cs
@@ -1,0 +1,208 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.Tracing;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Host.TestCommon;
+using Newtonsoft.Json.Linq;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.Azure.WebJobs.Extensions.DurableTask.Tests
+{
+    [Collection("Non-Parallel Collection")]
+    public class LinuxLoggingTests
+    {
+        private const string LogStreamName = "MS_DURABLE_FUNCTION_EVENTS_LOGS";
+        private const string Details = "First line\r\nSecond line with \"quotes\" and a \\backslash";
+        private readonly ITestOutputHelper output;
+
+        public LinuxLoggingTests(ITestOutputHelper output)
+        {
+            this.output = output;
+        }
+
+        [Theory]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        [InlineData(null, null, null, null, null)]
+        [InlineData("host", null, null, null, null)]
+        [InlineData(null, "namespace", null, null, null)]
+        [InlineData("", "namespace", null, null, null)]
+        [InlineData("host", "", null, null, null)]
+        [InlineData("host", "namespace", null, null, "")]
+        [InlineData("host", "namespace", "", null, "")]
+        [InlineData("host", "namespace", null, "container", "")]
+        [InlineData(null, null, null, "container", LogStreamName + " ")]
+        [InlineData("host", null, null, "container", LogStreamName + " ")]
+        [InlineData(null, null, "managed", null, LogStreamName + " ")]
+        [InlineData("host", "namespace", "managed", null, LogStreamName + " ")]
+        public async Task ConsoleLoggingMatchesHostingEnvironment(
+            string kubernetesServiceHost,
+            string podNamespace,
+            string managedEnvironment,
+            string containerName,
+            string expectedPrefix)
+        {
+            var settings = new Dictionary<string, string>
+            {
+                { "KUBERNETES_SERVICE_HOST", kubernetesServiceHost },
+                { "POD_NAMESPACE", podNamespace },
+                { "MANAGED_ENVIRONMENT", managedEnvironment },
+                { "CONTAINER_NAME", containerName },
+                { "FUNCTIONS_WORKER_RUNTIME", "dotnet" },
+            };
+            string instanceId = Guid.NewGuid().ToString();
+            TextWriter originalConsole = Console.Out;
+            using var console = new StringWriter();
+            try
+            {
+                Console.SetOut(console);
+                await this.EmitLogAsync(settings, instanceId);
+            }
+            finally
+            {
+                Console.SetOut(originalConsole);
+            }
+
+            string[] lines = console.ToString().Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
+            if (expectedPrefix == null)
+            {
+                Assert.Empty(lines);
+                return;
+            }
+
+            Assert.NotEmpty(lines);
+            var logs = lines.Select(line =>
+            {
+                Assert.StartsWith(expectedPrefix, line);
+                return JObject.Parse(line.Substring(expectedPrefix.Length));
+            }).ToArray();
+            JObject log = Assert.Single(logs, json => (string)json["InstanceId"] == instanceId);
+            AssertLogPayload(log);
+            Assert.Equal(expectedPrefix.Length == 0 ? LogStreamName : null, (string)log["EventType"]);
+            AssertProviderPayload(logs, instanceId, kubernetes: expectedPrefix.Length == 0);
+            Assert.Equal(containerName == null ? null : "App-" + containerName, (string)log["RoleInstance"]);
+            Assert.Null(log["Tenant"]);
+            Assert.Null(log["EventStampName"]);
+        }
+
+        [Theory]
+        [Trait("Category", PlatformSpecificHelpers.TestCategory)]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task KubernetesLoggingTakesPrecedenceOverDedicatedLogging(bool kubernetes)
+        {
+            var settings = new Dictionary<string, string>
+            {
+                { "WEBSITE_INSTANCE_ID", "instance" },
+                { "FUNCTIONS_LOGS_MOUNT_PATH", "logs" },
+                { "FUNCTIONS_WORKER_RUNTIME", "dotnet" },
+                { "WEBSITE_STAMP_DEPLOYMENT_ID", "tenant" },
+                { "WEBSITE_HOME_STAMPNAME", "stamp01a" },
+                { "KUBERNETES_SERVICE_HOST", kubernetes ? "host" : null },
+                { "POD_NAMESPACE", kubernetes ? "namespace" : null },
+            };
+            string instanceId = Guid.NewGuid().ToString();
+            string logDirectory = Path.Combine(Path.GetTempPath(), "DurableLoggingTests", instanceId);
+            string logPath = Path.Combine(logDirectory, "events.log");
+            string originalLoggingPath = LinuxAppServiceLogger.LoggingPath;
+            TextWriter originalConsole = Console.Out;
+            using var console = new StringWriter();
+            try
+            {
+                LinuxAppServiceLogger.LoggingPath = logPath;
+                Console.SetOut(console);
+                await this.EmitLogAsync(settings, instanceId);
+
+                string[] lines;
+                if (kubernetes)
+                {
+                    Assert.False(File.Exists(logPath));
+                    lines = console.ToString().Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
+                }
+                else
+                {
+                    Assert.Equal(string.Empty, console.ToString());
+                    await TestHelpers.WaitUntilTrue(
+                        () => File.Exists(logPath) && TestHelpers.WriteSafeReadAllLines(logPath).Any(line => line.Contains(instanceId)),
+                        conditionDescription: "Dedicated log is flushed",
+                        timeout: TimeSpan.FromSeconds(40),
+                        output: this.output);
+                    lines = TestHelpers.WriteSafeReadAllLines(logPath).ToArray();
+                }
+
+                JObject[] logs = lines.Select(JObject.Parse).ToArray();
+                JObject log = Assert.Single(logs, json => (string)json["InstanceId"] == instanceId);
+                AssertLogPayload(log);
+                AssertProviderPayload(logs, instanceId, kubernetes);
+                Assert.Equal(kubernetes ? LogStreamName : null, (string)log["EventType"]);
+                Assert.Equal("tenant", (string)log["Tenant"]);
+                Assert.Equal("stamp01a", (string)log["EventStampName"]);
+                Assert.Equal("stamp01", (string)log["EventPrimaryStampName"]);
+            }
+            finally
+            {
+                Console.SetOut(originalConsole);
+                LinuxAppServiceLogger.LoggingPath = originalLoggingPath;
+                if (Directory.Exists(logDirectory))
+                {
+                    Directory.Delete(logDirectory, recursive: true);
+                }
+            }
+        }
+
+        private static void AssertLogPayload(JObject log)
+        {
+            Assert.Equal("WebJobs-Extensions-DurableTask", (string)log["ProviderName"]);
+            Assert.Equal("ExtensionInformationalEvent", (string)log["TaskName"]);
+            Assert.Equal(213, (int)log["EventId"]);
+            Assert.Equal((int)EventLevel.Informational, (int)log["Level"]);
+            Assert.Equal(Details, (string)log["Details"]);
+            Assert.Equal(JTokenType.Date, log["EventTimestamp"].Type);
+            Assert.True((int)log["Pid"] > 0);
+            Assert.True((int)log["Tid"] > 0);
+            Assert.NotEqual(Guid.Empty, Guid.Parse((string)log["ExtensionGUID"]));
+            Assert.Equal((string)log["InstanceId"], (string)log["ActivityId"]);
+        }
+
+        private static void AssertProviderPayload(JObject[] logs, string instanceId, bool kubernetes)
+        {
+            JObject providerLog = Assert.Single(logs, json => (string)json["MessageId"] == instanceId);
+            Assert.Equal("DurableTask-CustomSource", (string)providerLog["ProviderName"]);
+            Assert.Equal(kubernetes ? LogStreamName : "ExecutionStarted", (string)providerLog["EventType"]);
+            Assert.Equal(kubernetes ? "ExecutionStarted" : null, (string)providerLog["TaskEventType"]);
+            if (kubernetes)
+            {
+                Assert.All(logs, json => Assert.Equal(LogStreamName, (string)json["EventType"]));
+            }
+        }
+
+        private async Task EmitLogAsync(Dictionary<string, string> settings, string instanceId)
+        {
+            using var host = TestHelpers.GetJobHost(
+                new TestLoggerProvider(this.output),
+                nameof(LinuxLoggingTests),
+                enableExtendedSessions: false,
+                nameResolver: new SimpleNameResolver(settings),
+                durabilityProviderFactoryType: typeof(CustomEtwDurabilityProviderFactory),
+                types: Type.EmptyTypes);
+            await host.StartAsync();
+            EventSource.SetCurrentThreadActivityId(Guid.Parse(instanceId), out Guid originalActivityId);
+            try
+            {
+                EtwEventSource.Instance.ExtensionInformationalEvent("hub", "app", "slot", "function", instanceId, Details, "version");
+                EtwSource.Current.Write("TaskMessage", new { EventType = "ExecutionStarted", MessageId = instanceId });
+            }
+            finally
+            {
+                EventSource.SetCurrentThreadActivityId(originalActivityId);
+            }
+
+            await host.StopAsync();
+        }
+    }
+}


### PR DESCRIPTION
# Summary
## What changed?
- Detect Kubernetes managed hosting using the Functions host's existing signals: nonempty `KUBERNETES_SERVICE_HOST` and `POD_NAMESPACE`, excluding `MANAGED_ENVIRONMENT`.
- Reuse the Linux EventSource logger to emit single-line JSON to stdout with `"EventType":"MS_DURABLE_FUNCTION_EVENTS_LOGS"`, rather than a text prefix.
- Preserve provider payloads named `EventType` as `TaskEventType` in Kubernetes output. Both DurableTask-Core and Azure Storage use this payload field, so simply adding the routing marker would otherwise drop events on duplicate-key errors.
- Preserve existing Linux Consumption, Dedicated, and Managed App formats, optional metadata, and correlation fields. No public interface or dependency changes.
- Add 14 host-initialization regression cases, repository documentation, and release notes.

## Why is this change needed?
Kubernetes managed hosts are not currently recognized by the Linux logging initialization gate unless they also advertise another Linux hosting environment. Existing console logging adds a non-JSON prefix that Kubernetes log collectors cannot parse as a JSON record.

## Issues / work items
- Resolves #1794
- Related: Azure/azure-functions-host#7297

---

# Project checklist
- [x] Documentation changes are not required outside this repository; platform logging documentation is updated in `src/WebJobs.Extensions.DurableTask/README.md`.
  - [ ] Otherwise: Documentation PR is ready to merge and referenced in `pending_docs.md`
- [ ] Release notes are not required for the next release
  - [x] Otherwise: Notes added to `release_notes.md`
- [x] Backport is not required for this PR; it targets `dev`.
  - [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
- [x] All required tests have been added/updated (unit tests, E2E tests)
- [x] No extra work is required to be leveraged by OutOfProc SDKs
  - [ ] Otherwise: Work tracked here: #issue_or_pr_in_each_sdk
- [x] No change to the version of the `WebJobs.Extensions.DurableTask` package
  - [ ] Otherwise: Major/minor updates are reflected in `/src/Worker.Extensions.DurableTask/AssemblyInfo.cs`
- [x] No EventIds were added to `EventSource` logs
  - [ ] Otherwise: Ensure EventIds are within the supported range in the existing Windows infrastructure (validate via deployed telemetry). If needed, extend the range via a PR such as https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/7463263?_a=files
- [ ] This change should be added to the `v2.x` branch — maintainer decision; no backport included here.
  - [ ] Otherwise: This change applies exclusively to `WebJobs.Extensions.DurableTask` v3.x and will be retained only in the `dev` and `main` branches
- [ ] Breaking change?
  - [ ] If yes:
    - Impact: Existing hosting formats and public APIs are unchanged. Kubernetes managed hosting uses the new documented JSON format.
    - Migration guidance: Kubernetes consumers should use `EventType` for routing and `TaskEventType` for the original provider event type.

---

# AI-assisted code disclosure (required)
## Was an AI tool used? (select one)
- [ ] No
- [ ] Yes, AI helped write parts of this PR (e.g., GitHub Copilot)
- [x] Yes, an AI agent generated most of this PR

If AI was used:
- Tool(s): GitHub Copilot CLI.
- AI-assisted areas/files: All five changed files.
- What you changed after AI output: No human edits are claimed. During implementation, the agent discovered and corrected the provider `EventType` collision and added regression coverage for it.

AI verification (required if AI was used):

The following work was performed by the agent; author/maintainer review is still needed.
- [x] I understand the code and can explain it
- [x] I verified referenced APIs/types exist and are correct
- [x] I reviewed edge cases/failure paths (timeouts, retries, cancellation, exceptions)
- [x] I reviewed concurrency/async behavior
- [x] I checked for unintended breaking or behavior changes

---

# Testing
## Automated tests
- Result: **Passed — 33 cases on net8.0 and 33 cases on net10.0, Release configuration.**
- Command:
  ```powershell
  dotnet test .\test\FunctionsV2\WebJobs.Extensions.DurableTask.Tests.V2.csproj --no-restore --configuration Release --filter 'FullyQualifiedName~LinuxLoggingTests|FullyQualifiedName~EndToEndTraceHelperTests|FullyQualifiedName~TestFrameworkTests' --verbosity minimal --nologo
  ```
- The 14 new cases exercise real WebJobs host initialization with the existing in-memory custom durability provider, without requiring Azure Storage. Coverage includes missing/empty hosting signals, Kubernetes precedence, Managed App exclusion, legacy console/file formats, multiline payload escaping, optional metadata, activity correlation, custom provider forwarding, and preservation of provider `EventType` values.
- Before the fix, four Kubernetes cases failed while ten compatibility cases passed. A separate regression reproduced the provider `EventType` collision before that was fixed.
- Console output and the static file-log path are restored, temporary log files are removed, and the new tests run in the existing non-parallel collection.

## Manual validation (only if runtime/behavior changed)
**Live Azure integration passed on September 14, 2026, for head `2d200f044243975364bdd266ee5e27438e32bb1d`.**

- Environment: temporary AKS 1.35.7 on Azure Linux 3.0, .NET 8 Functions container, real Azure Storage durability provider, and Azure Monitor Container insights/Log Analytics. No emulator or in-memory provider was used in this deployment.
- Build identity: the extension DLL in the running pod matched the PR build and published DLL, SHA256 `D33E87DE299F49923290D13410ECF1EC324616665FE262B345DA065BA88ECBDF`.
- Hosting signals: Kubernetes injected `KUBERNETES_SERVICE_HOST`; `POD_NAMESPACE` came from actual pod metadata through the Downward API. `MANAGED_ENVIRONMENT` and the unrelated Linux Consumption signal `CONTAINER_NAME` were absent.
- Execution: six real orchestrations completed (three basic activity cases and three external-event cases), with exact quoted/newline output. Azure Table entities independently confirmed the enhanced cases' persisted `Completed` status and output.
- Raw stdout: all 261 captured Durable records in the enhanced run were prefix-free JSON, with no duplicate fields. The 156 directly instance-correlated records included extension, DurableTask-Core, and Azure Storage providers; 134 retained nonempty activity IDs.
- Schema and escaping: routing `EventType` remained `MS_DURABLE_FUNCTION_EVENTS_LOGS`; provider values `ExecutionStarted`, `EventRaised`, `TaskScheduled`, and `TaskCompleted` survived as `TaskEventType`. Each enhanced instance emitted its exact external `EventName` containing double quotes and an actual newline within a single physical JSON log line. Input/output telemetry redaction was not disabled.
- Actual collector ingestion: Azure Monitor stored these records as native JSON dictionaries in `ContainerLogV2`. The three enhanced instances had 48, 54, and 54 collected Durable records, matching the 156 directly instance-correlated stdout records. All three providers, exact event names, provider event types, and activity correlation survived ingestion.
- Scope: this validates the PR's logging contract on real AKS plus Azure Storage and Azure Monitor. It is not certification of the retired App Service-on-Arc offering or every Microsoft-managed Functions collector.
- CI is separate: pipeline run 304005 remains red in the Azure Storage scale-test job; this live result does not claim the full CI pipeline is green.

---

# Notes for reviewers
- `IPlatformInformation` is public and obsolete; the new hosting check intentionally does not add an interface member or require third-party implementations to change.
- Review the Kubernetes schema mapping: top-level `EventType` identifies the Durable log stream; the original provider `EventType` payload is retained as `TaskEventType`. This is limited to the new Kubernetes format.
- Verbose DurableTask-Core filtering remains in the existing `EventSourceListener` path unchanged.